### PR TITLE
URL Sig Keys in Postgres and DELETE methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add a Federation to the Ansible Dataset Loader
 - Added asynchronous status to ACME certificate generation.
 - Added headers to Traffic Portal, Traffic Ops, and Traffic Monitor to opt out of tracking users via Google FLoC.
+- `DELETE` request method for `deliveryservices/xmlId/{name}/urlkeys` and `deliveryservices/{id}/urlkeys`.
+- Added URL Sig Keys support for Postgres Traffic Vault.
 
 ### Fixed
 - [#5690](https://github.com/apache/trafficcontrol/issues/5690) - Fixed github action for added/modified db migration file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added asynchronous status to ACME certificate generation.
 - Added headers to Traffic Portal, Traffic Ops, and Traffic Monitor to opt out of tracking users via Google FLoC.
 - `DELETE` request method for `deliveryservices/xmlId/{name}/urlkeys` and `deliveryservices/{id}/urlkeys`.
-- Added URL Sig Keys support for Postgres Traffic Vault.
 
 ### Fixed
 - [#5690](https://github.com/apache/trafficcontrol/issues/5690) - Fixed github action for added/modified db migration file.

--- a/docs/source/api/v4/deliveryservices_id_urlkeys.rst
+++ b/docs/source/api/v4/deliveryservices_id_urlkeys.rst
@@ -95,7 +95,7 @@ Response Structure
 
 ``DELETE``
 ==========
-.. seealso:: :ref:`to-api-deliveryservices-id-urlkeys`
+.. seealso:: :ref:`to-api-deliveryservices-xmlid-xmlid-urlkeys`
 
 Deletes URL signing keys for a :term:`Delivery Service`.
 

--- a/docs/source/api/v4/deliveryservices_id_urlkeys.rst
+++ b/docs/source/api/v4/deliveryservices_id_urlkeys.rst
@@ -91,3 +91,36 @@ Response Structure
 			"key15": "...",
 		}
 	}
+
+
+``DELETE``
+==========
+.. seealso:: :ref:`to-api-deliveryservices-id-urlkeys`
+
+Deletes URL signing keys for a :term:`Delivery Service`.
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+----------------------------------------------------------------------------------------+
+	| Name | Description                                                                            |
+	+======+========================================================================================+
+	| id   | Filter for the :term:`Delivery Service` identified by this integral, unique identifier |
+	+------+----------------------------------------------------------------------------------------+
+
+Response Structure
+------------------
+.. code-block:: json
+	:caption: Response Example
+
+	{
+		"alerts": [{
+			"level": "success",
+			"text": "Successfully deleted URL Sig keys from Traffic Vault"
+		}]
+	}

--- a/docs/source/api/v4/deliveryservices_xmlid_xmlid_urlkeys.rst
+++ b/docs/source/api/v4/deliveryservices_xmlid_xmlid_urlkeys.rst
@@ -66,3 +66,36 @@ Response Structure
 		"key14":"DtXsu8nsw04YhT0kNoKBhu2G3P9WRpQJ",
 		"key7":"cmKoIIxXGAxUMdCsWvnGLoIMGmNiuT5I"
 	}}
+
+
+``DELETE``
+==========
+.. seealso:: :ref:`to-api-deliveryservices-id-urlkeys`
+
+Deletes URL signing keys for a :term:`Delivery Service`.
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+-------+------------------------------------------------------+
+	|  Name |              Description                             |
+	+=======+======================================================+
+	| xmlid | The 'xml_id' of the desired :term:`Delivery Service` |
+	+-------+------------------------------------------------------+
+
+Response Structure
+------------------
+.. code-block:: json
+	:caption: Response Example
+
+	{
+		"alerts": [{
+			"level": "success",
+			"text": "Successfully deleted URL Sig keys from Traffic Vault"
+		}]
+	}

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -1390,12 +1390,30 @@ func CreateTestDeliveryServicesURLSigKeys(t *testing.T) {
 		t.Error("failed to create url sig keys: " + err.Error())
 	}
 
-	newKeys, _, err := TOSession.GetDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	firstKeys, _, err := TOSession.GetDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
 	if err != nil {
 		t.Error("failed to get url sig keys: " + err.Error())
 	}
-	if len(newKeys) == 0 {
+	if len(firstKeys) == 0 {
 		t.Errorf("failed to create url sig keys")
+	}
+
+	// Create new keys again and check that they are different
+	_, _, err = TOSession.CreateDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to create url sig keys: " + err.Error())
+	}
+
+	secondKeys, _, err := TOSession.GetDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to get url sig keys: " + err.Error())
+	}
+	if len(secondKeys) == 0 {
+		t.Errorf("failed to create url sig keys")
+	}
+
+	if secondKeys["key0"] == firstKeys["key0"] {
+		t.Errorf("second create did not generate new url sig keys")
 	}
 }
 

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -44,7 +44,9 @@ func TestDeliveryServices(t *testing.T) {
 
 		if includeSystemTests {
 			SSLDeliveryServiceCDNUpdateTest(t)
+			CreateTestDeliveryServicesURLSigKeys(t)
 			GetTestDeliveryServicesURLSigKeys(t)
+			DeleteTestDeliveryServicesURLSigKeys(t)
 		}
 
 		GetTestDeliveryServicesIMS(t)
@@ -1372,6 +1374,45 @@ func GetTestDeliveryServicesURLSigKeys(t *testing.T) {
 	if err != nil {
 		t.Error("failed to get url sig keys: " + err.Error())
 	}
+}
+
+func CreateTestDeliveryServicesURLSigKeys(t *testing.T) {
+	if len(testData.DeliveryServices) == 0 {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+	firstDS := testData.DeliveryServices[0]
+	if firstDS.XMLID == nil {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+
+	_, _, err := TOSession.CreateDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to create url sig keys: " + err.Error())
+	}
+
+	newKeys, _, err := TOSession.GetDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to get url sig keys: " + err.Error())
+	}
+	if len(newKeys) == 0 {
+		t.Errorf("failed to create url sig keys")
+	}
+}
+
+func DeleteTestDeliveryServicesURLSigKeys(t *testing.T) {
+	if len(testData.DeliveryServices) == 0 {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+	firstDS := testData.DeliveryServices[0]
+	if firstDS.XMLID == nil {
+		t.Fatal("couldn't get the xml ID of test DS")
+	}
+
+	_, _, err := TOSession.DeleteDeliveryServiceURLSigKeys(*firstDS.XMLID, nil)
+	if err != nil {
+		t.Error("failed to delete url sig keys: " + err.Error())
+	}
+
 }
 
 func GetDeliveryServiceByLogsEnabled(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
@@ -342,7 +342,7 @@ func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deleting URL Sig keys from Traffic Vault: "+err.Error()))
 		return
 	}
-	api.WriteRespAlert(w, r, tc.SuccessLevel, "successfully deleted URL Sig keys from Traffic Vault")
+	api.WriteRespAlert(w, r, tc.SuccessLevel, "Successfully deleted URL Sig keys from Traffic Vault")
 }
 
 // DeleteURLKeysByName deletes the URL sig keys for the delivery service identified by the xmlId in the path parameter.
@@ -383,5 +383,5 @@ func DeleteURLKeysByName(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("deleting URL Sig keys from Traffic Vault: "+err.Error()))
 		return
 	}
-	api.WriteRespAlert(w, r, tc.SuccessLevel, "successfully deleted URL Sig keys from Traffic Vault")
+	api.WriteRespAlert(w, r, tc.SuccessLevel, "Successfully deleted URL Sig keys from Traffic Vault")
 }

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -500,7 +500,9 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/xmlId/{name}/urlkeys/copyFromXmlId/{copy-name}/?$`, deliveryservice.CopyURLKeys, auth.PrivLevelOperations, Authenticated, nil, 42625010763},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/xmlId/{name}/urlkeys/generate/?$`, deliveryservice.GenerateURLKeys, auth.PrivLevelOperations, Authenticated, nil, 45304828243},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/xmlId/{name}/urlkeys/?$`, deliveryservice.GetURLKeysByName, auth.PrivLevelReadOnly, Authenticated, nil, 42027192113},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/xmlId/{name}/urlkeys/?$`, deliveryservice.DeleteURLKeysByName, auth.PrivLevelOperations, Authenticated, nil, 42027192114},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `deliveryservices/{id}/urlkeys/?$`, deliveryservice.GetURLKeysByID, auth.PrivLevelReadOnly, Authenticated, nil, 4931971143},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `deliveryservices/{id}/urlkeys/?$`, deliveryservice.DeleteURLKeysByID, auth.PrivLevelOperations, Authenticated, nil, 4931971144},
 
 		//Delivery service LetsEncrypt
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/sslkeys/generate/letsencrypt/?$`, deliveryservice.GenerateLetsEncryptCertificates, auth.PrivLevelOperations, Authenticated, nil, 4534390523},

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/disabled/disabled.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/disabled/disabled.go
@@ -81,6 +81,10 @@ func (d *Disabled) PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, c
 	return disabledErr
 }
 
+func (d *Disabled) DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) error {
+	return disabledErr
+}
+
 func (d *Disabled) GetURISigningKeys(xmlID string, tx *sql.Tx, ctx context.Context) ([]byte, bool, error) {
 	return nil, false, disabledErr
 }

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/postgres.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/postgres.go
@@ -138,7 +138,7 @@ func (p *Postgres) GetURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) 
 		return tc.URLSigKeys{}, false, err
 	}
 	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
-	return getURLSigKeys(xmlID, tvTx)
+	return getURLSigKeys(xmlID, tvTx, ctx)
 }
 
 func (p *Postgres) PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, ctx context.Context) error {
@@ -148,7 +148,7 @@ func (p *Postgres) PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, c
 	}
 	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
 
-	return putURLSigKeys(xmlID, tvTx, keys)
+	return putURLSigKeys(xmlID, tvTx, keys, ctx)
 }
 
 func (p *Postgres) DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) error {
@@ -158,7 +158,7 @@ func (p *Postgres) DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Contex
 	}
 	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
 
-	return deleteURLSigKeys(xmlID, tvTx)
+	return deleteURLSigKeys(xmlID, tvTx, ctx)
 }
 
 func (p *Postgres) GetURISigningKeys(xmlID string, tx *sql.Tx, ctx context.Context) ([]byte, bool, error) {

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/postgres.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/postgres.go
@@ -133,11 +133,32 @@ func (p *Postgres) DeleteDNSSECKeys(cdnName string, tx *sql.Tx, ctx context.Cont
 }
 
 func (p *Postgres) GetURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) (tc.URLSigKeys, bool, error) {
-	return tc.URLSigKeys{}, false, notImplementedErr
+	tvTx, dbCtx, cancelFunc, err := p.beginTransaction(ctx)
+	if err != nil {
+		return tc.URLSigKeys{}, false, err
+	}
+	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
+	return getURLSigKeys(xmlID, tvTx)
 }
 
 func (p *Postgres) PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, ctx context.Context) error {
-	return notImplementedErr
+	tvTx, dbCtx, cancelFunc, err := p.beginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
+
+	return putURLSigKeys(xmlID, tvTx, keys)
+}
+
+func (p *Postgres) DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) error {
+	tvTx, dbCtx, cancelFunc, err := p.beginTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	defer p.commitTransaction(tvTx, dbCtx, cancelFunc)
+
+	return deleteURLSigKeys(xmlID, tvTx)
 }
 
 func (p *Postgres) GetURISigningKeys(xmlID string, tx *sql.Tx, ctx context.Context) ([]byte, bool, error) {

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/url_sig_keys.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/url_sig_keys.go
@@ -1,0 +1,73 @@
+package postgres
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func getURLSigKeys(xmlID string, tvTx *sqlx.Tx) (tc.URLSigKeys, bool, error) {
+	var jsonUrlKeys string
+	if err := tvTx.QueryRow("SELECT data FROM url_sig_key WHERE deliveryservice = $1", xmlID).Scan(&jsonUrlKeys); err != nil {
+		if err == sql.ErrNoRows {
+			return tc.URLSigKeys{}, true, nil
+		}
+		return tc.URLSigKeys{}, false, err
+	}
+
+	urlSignKey := tc.URLSigKeys{}
+	err := json.Unmarshal([]byte(jsonUrlKeys), &urlSignKey)
+	if err != nil {
+		return tc.URLSigKeys{}, false, errors.New("unmarshalling keys: " + err.Error())
+	}
+
+	return urlSignKey, true, nil
+}
+
+func putURLSigKeys(xmlID string, tvTx *sqlx.Tx, keys tc.URLSigKeys) error {
+	keyJSON, err := json.Marshal(&keys)
+	if err != nil {
+		return errors.New("marshalling keys: " + err.Error())
+	}
+
+	res, err := tvTx.Exec("INSERT INTO url_sig_key (deliveryservice, data) VALUES ($1, $2)", xmlID, keyJSON)
+	if err != nil {
+		return err
+	}
+	if rowsAffected, err := res.RowsAffected(); err != nil {
+		return err
+	} else if rowsAffected == 0 {
+		return errors.New("URL Sign Keys: no keys were inserted")
+	}
+	return nil
+}
+
+func deleteURLSigKeys(xmlID string, tvTx *sqlx.Tx) error {
+	if _, err := tvTx.Exec("DELETE FROM url_sig_key WHERE deliveryservice = $1", xmlID); err != nil {
+		return err
+	}
+	return nil
+}

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/url_sig_keys.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/postgres/url_sig_keys.go
@@ -56,7 +56,9 @@ func putURLSigKeys(xmlID string, tvTx *sqlx.Tx, keys tc.URLSigKeys, ctx context.
 	}
 
 	// Delete old keys first if they exist
-	deleteURLSigKeys(xmlID, tvTx, ctx)
+	if err = deleteURLSigKeys(xmlID, tvTx, ctx); err != nil {
+		return err
+	}
 
 	res, err := tvTx.Exec("INSERT INTO url_sig_key (deliveryservice, data) VALUES ($1, $2)", xmlID, keyJSON)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/dsutil.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/dsutil.go
@@ -330,6 +330,18 @@ func putURLSigKeys(tx *sql.Tx, authOpts *riak.AuthOptions, riakPort *uint, ds tc
 	return err
 }
 
+func deleteURLSigningKeys(tx *sql.Tx, authOpts *riak.AuthOptions, riakPort *uint, ds tc.DeliveryServiceName) error {
+	cluster, err := getPooledCluster(tx, authOpts, riakPort)
+	if err != nil {
+		return errors.New("getting pooled Riak cluster: " + err.Error())
+	}
+	key := getURLSigConfigFileName(ds)
+	if err := deleteObject(key, urlSigKeysBucket, cluster); err != nil {
+		return errors.New("deleting object: " + err.Error())
+	}
+	return nil
+}
+
 const sslKeysIndex = "sslkeys"
 const cdnSSLKeysLimit = 1000 // TODO: emulates Perl; reevaluate?
 

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/riak.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/riak.go
@@ -81,6 +81,10 @@ func (r *Riak) PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, ctx c
 	return putURLSigKeys(tx, &r.cfg.AuthOptions, &r.cfg.Port, tc.DeliveryServiceName(xmlID), keys)
 }
 
+func (r *Riak) DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) error {
+	return deleteURLSigningKeys(tx, &r.cfg.AuthOptions, &r.cfg.Port, tc.DeliveryServiceName(xmlID))
+}
+
 func (r *Riak) GetURISigningKeys(xmlID string, tx *sql.Tx, ctx context.Context) ([]byte, bool, error) {
 	return getURISigningKeys(tx, &r.cfg.AuthOptions, &r.cfg.Port, xmlID)
 }

--- a/traffic_ops/traffic_ops_golang/trafficvault/trafficvault.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/trafficvault.go
@@ -69,6 +69,9 @@ type TrafficVault interface {
 	// PutURLSigKeys stores the given URL sig keys for the delivery service identified by
 	// the given xmlID.
 	PutURLSigKeys(xmlID string, keys tc.URLSigKeys, tx *sql.Tx, ctx context.Context) error
+	// DeleteURLSigKeys deletes the URL sig keys for the delivery service identified
+	// by the given xmlID.
+	DeleteURLSigKeys(xmlID string, tx *sql.Tx, ctx context.Context) error
 	// GetURISigningKeys retrieves the URI signing keys (as raw JSON bytes) for the delivery
 	// service identified by the given xmlID.
 	GetURISigningKeys(xmlID string, tx *sql.Tx, ctx context.Context) ([]byte, bool, error)

--- a/traffic_ops/v4-client/deliveryservice.go
+++ b/traffic_ops/v4-client/deliveryservice.go
@@ -340,10 +340,7 @@ func (to *Session) GetDeliveryServiceURLSigKeys(dsName string, header http.Heade
 func (to *Session) CreateDeliveryServiceURLSigKeys(dsName string, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
 	var alerts tc.Alerts
 	reqInf, err := to.post(fmt.Sprintf(APIDeliveryServicesURLSigKeysGenerate, dsName), nil, header, &alerts)
-	if err != nil {
-		return alerts, reqInf, err
-	}
-	return alerts, reqInf, nil
+	return alerts, reqInf, err
 }
 
 // DeleteDeliveryServiceURLSigKeys deletes the URL-signing keys used by the Delivery Service

--- a/traffic_ops/v4-client/deliveryservice.go
+++ b/traffic_ops/v4-client/deliveryservice.go
@@ -85,6 +85,12 @@ const (
 	// (namely the XMLID of the Delivery Service of interest).
 	APIDeliveryServicesURLSigKeys = APIDeliveryServices + "/xmlId/%s/urlkeys"
 
+	// APIDeliveryServicesURLSigKeysGenerate is the API path on which Traffic Ops provides
+	// functionality to generate new URL-signing keys used by a Delivery Service identified
+	// by its XMLID. It is intended to be used with fmt.Sprintf to insert its required path parameter
+	// (namely the XMLID of the Delivery Service of interest).
+	APIDeliveryServicesURLSigKeysGenerate = APIDeliveryServices + "/xmlId/%s/urlkeys/generate"
+
 	// APIDeliveryServicesRegexes is the API path on which Traffic Ops serves Delivery Service
 	// 'regex' (Regular Expression) information.
 	APIDeliveryServicesRegexes = "/deliveryservices_regexes"
@@ -327,6 +333,25 @@ func (to *Session) GetDeliveryServiceURLSigKeys(dsName string, header http.Heade
 		return tc.URLSigKeys{}, reqInf, err
 	}
 	return data.Response, reqInf, nil
+}
+
+// CreateDeliveryServiceURLSigKeys creates new URL-signing keys used by the Delivery Service
+// identified by the XMLID 'dsName'
+func (to *Session) CreateDeliveryServiceURLSigKeys(dsName string, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	var alerts tc.Alerts
+	reqInf, err := to.post(fmt.Sprintf(APIDeliveryServicesURLSigKeysGenerate, dsName), nil, header, &alerts)
+	if err != nil {
+		return alerts, reqInf, err
+	}
+	return alerts, reqInf, nil
+}
+
+// DeleteDeliveryServiceURLSigKeys deletes the URL-signing keys used by the Delivery Service
+// identified by the XMLID 'dsName'
+func (to *Session) DeleteDeliveryServiceURLSigKeys(dsName string, header http.Header) (tc.Alerts, toclientlib.ReqInf, error) {
+	var alerts tc.Alerts
+	reqInf, err := to.del(fmt.Sprintf(APIDeliveryServicesURLSigKeys, dsName), header, &alerts)
+	return alerts, reqInf, err
 }
 
 // GetDeliveryServiceURISigningKeys returns the URI-signing keys used by the Delivery Service


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
This PR adds support for URL Sig Keys using Postgres as the Traffic Vault backend.  It also adds DELETE functionality for URL Sig Keys for both Postgres and Riak backends.


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- Traffic Vault
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Make sure you have Traffic Vault set up to use Postgres in your test environment.
Update cdn.conf to use Postgres
Verify that all of these endpoints work as expected:
POST `deliveryservices/xmlId/{name}/urlkeys/copyFromXmlId/{copy-name}/?$`,
POST `deliveryservices/xmlId/{name}/urlkeys/generate/?$`
GET `deliveryservices/xmlId/{name}/urlkeys/?$`
DELETE 	`deliveryservices/xmlId/{name}/urlkeys/?$`
GET `deliveryservices/{id}/urlkeys/?$`
DELETE `deliveryservices/{id}/urlkeys/`

Verify that the data from those endpoints is successfully going into your TV in Postgres.
Run it again without the Postgres backend to point back to Riak.
Verify that all of those endpoints work with Riak still and that the 2 new DELETE endpoints work.
Verify that the API tests run successfully (Postgres TV in ciab is not set up yet so verify that the tests work like normal with Riak and that the new tests work locally or a non-ciab environment with Postgres)

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->


## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->
No doc updates since its using the same endpoints / format as before just a different backend.
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
