### PR TITLE
Add cache config strategies.yaml generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Vault: Added additional flag to TV Riak (Deprecated) Util
 - Added Traffic Vault Postgres columns, a Traffic Ops API endpoint, and Traffic Portal page to show SSL certificate expiration information.
 - Added cache config `__CACHEGROUP__` preprocess directive, to allow injecting the local server's cachegroup name into any config file
+- Added t3c experimental strategies generation.
 - Added support for a DS profile parameter 'LastRawRemapPre' and 'LastRawRemapPost' which allows raw text lines to be pre or post pended to remap.config.
 
 ### Fixed

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -82,6 +82,7 @@ type Cfg struct {
 	Retries             int
 	ReverseProxyDisable bool
 	SkipOSCheck         bool
+	UseStrategies       t3cutil.UseStrategiesFlag
 	TOInsecure          bool
 	TOTimeoutMS         time.Duration
 	TOUser              string
@@ -273,6 +274,10 @@ func GetCfg(appVersion string, gitRevision string) (Cfg, error) {
 	const updateIPAllowFlagName = "update-ipallow"
 	updateIPAllowPtr := getopt.BoolLong(updateIPAllowFlagName, 'A', "Whether ipallow file will be updated if necessary. This exists because ATS had a bug where reloading after changing ipallow would block everything. Default is false.")
 
+	const useStrategiesFlagName = "use-strategies"
+	const defaultUseStrategies = t3cutil.UseStrategiesFlagFalse
+	useStrategiesPtr := getopt.EnumLong(useStrategiesFlagName, 0, []string{string(t3cutil.UseStrategiesFlagTrue), string(t3cutil.UseStrategiesFlagCore), string(t3cutil.UseStrategiesFlagCore), ""}, "", "[true | core| false] whether to generate config using strategies.yaml instead of parent.config. If true use the parent_select plugin, if 'core' use ATS core strategies, if false use parent.config.")
+
 	const runModeFlagName = "run-mode"
 	runModePtr := getopt.StringLong(runModeFlagName, 'm', "", `[badass | report | revalidate | syncds] run mode. Optional, convenience flag which sets other flags for common usage scenarios.
 syncds     keeps the defaults:
@@ -360,6 +365,10 @@ If any of the related flags are also set, they override the mode's default behav
 		*filesPtr = defaultFiles.String()
 	}
 
+	if !getopt.IsSet(useStrategiesFlagName) {
+		*useStrategiesPtr = defaultUseStrategies.String()
+	}
+
 	logLocationError := log.LogLocationStderr
 	logLocationWarn := log.LogLocationNull
 	logLocationInfo := log.LogLocationNull
@@ -401,6 +410,7 @@ If any of the related flags are also set, they override the mode's default behav
 	retries := *retriesPtr
 	reverseProxyDisable := *reverseProxyDisablePtr
 	skipOsCheck := *skipOSCheckPtr
+	useStrategies := t3cutil.UseStrategiesFlag(*useStrategiesPtr)
 	toInsecure := *toInsecurePtr
 	toTimeoutMS := time.Millisecond * time.Duration(*toTimeoutMSPtr)
 	toURL := *toURLPtr
@@ -498,6 +508,7 @@ If any of the related flags are also set, they override the mode's default behav
 		Retries:                     retries,
 		ReverseProxyDisable:         reverseProxyDisable,
 		SkipOSCheck:                 skipOsCheck,
+		UseStrategies:               useStrategies,
 		TOInsecure:                  toInsecure,
 		TOTimeoutMS:                 toTimeoutMS,
 		TOUser:                      toUser,

--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -82,6 +82,7 @@ func generate(cfg config.Cfg) ([]t3cutil.ATSConfigFile, error) {
 	args = append(args, "--via-string-release="+strconv.FormatBool(!cfg.OmitViaStringRelease))
 	args = append(args, "--no-outgoing-ip="+strconv.FormatBool(cfg.NoOutgoingIP))
 	args = append(args, "--disable-parent-config-comments="+strconv.FormatBool(cfg.DisableParentConfigComments))
+	args = append(args, "--use-strategies="+cfg.UseStrategies.String())
 
 	generatedFiles, stdErr, code := t3cutil.DoInput(configData, config.GenerateCmd, args...)
 	if code != 0 {

--- a/cache-config/t3c-generate/cfgfile/routing.go
+++ b/cache-config/t3c-generate/cfgfile/routing.go
@@ -99,6 +99,7 @@ var configFileLiteralFuncs = []ConfigFileLiteralFunc{
 	{"ssl_multicert.config", MakeSSLMultiCertDotConfig},
 	{"ssl_server_name.yaml", MakeSSLServerNameYAML},
 	{"sni.yaml", MakeSNIDotYAML},
+	{"strategies.yaml", MakeStrategiesDotYAML},
 	{"storage.config", MakeStorageDotConfig},
 	{"sysctl.conf", MakeSysCtlDotConf},
 	{"volume.config", MakeVolumeDotConfig},

--- a/cache-config/t3c-generate/cfgfile/wrappers.go
+++ b/cache-config/t3c-generate/cfgfile/wrappers.go
@@ -217,7 +217,6 @@ func MakeRegexRevalidateDotConfig(toData *t3cutil.ConfigData, fileName string, h
 }
 
 func MakeRemapDotConfig(toData *t3cutil.ConfigData, fileName string, hdrCommentTxt string, cfg config.Cfg) (atscfg.Cfg, error) {
-	opts := &atscfg.RemapDotConfigOpts{HdrComment: hdrCommentTxt}
 	return atscfg.MakeRemapDotConfig(
 		toData.Server,
 		toData.DeliveryServices,
@@ -230,7 +229,13 @@ func MakeRemapDotConfig(toData *t3cutil.ConfigData, fileName string, hdrCommentT
 		toData.CacheGroups,
 		toData.ServerCapabilities,
 		toData.DSRequiredCapabilities,
-		opts,
+		cfg.Dir,
+		&atscfg.RemapDotConfigOpts{
+			HdrComment:        hdrCommentTxt,
+			VerboseComments:   true,
+			UseStrategies:     cfg.UseStrategies == t3cutil.UseStrategiesFlagTrue || cfg.UseStrategies == t3cutil.UseStrategiesFlagCore,
+			UseStrategiesCore: cfg.UseStrategies == t3cutil.UseStrategiesFlagCore,
+		},
 	)
 }
 
@@ -288,6 +293,26 @@ func MakeURLSigConfig(toData *t3cutil.ConfigData, fileName string, hdrCommentTxt
 
 func MakeURISigningConfig(toData *t3cutil.ConfigData, fileName string, hdrCommentTxt string, cfg config.Cfg) (atscfg.Cfg, error) {
 	return atscfg.MakeURISigningConfig(fileName, toData.URISigningKeys, nil)
+}
+
+func MakeStrategiesDotYAML(toData *t3cutil.ConfigData, fileName string, hdrCommentTxt string, cfg config.Cfg) (atscfg.Cfg, error) {
+	return atscfg.MakeStrategiesDotYAML(
+		toData.DeliveryServices,
+		toData.Server,
+		toData.Servers,
+		toData.Topologies,
+		toData.ServerParams,
+		toData.ParentConfigParams,
+		toData.ServerCapabilities,
+		toData.DSRequiredCapabilities,
+		toData.CacheGroups,
+		toData.DeliveryServiceServers,
+		toData.CDN,
+		&atscfg.StrategiesYAMLOpts{
+			HdrComment:      hdrCommentTxt,
+			VerboseComments: cfg.ParentComments, // TODO add a CLI flag?
+		},
+	)
 }
 
 func MakeUnknownConfig(toData *t3cutil.ConfigData, fileName string, hdrCommentTxt string, cfg config.Cfg) (atscfg.Cfg, error) {

--- a/cache-config/t3cutil/enum.go
+++ b/cache-config/t3cutil/enum.go
@@ -82,6 +82,31 @@ func StrToApplyServiceActionFlag(str string) ApplyServiceActionFlag {
 	}
 }
 
+type UseStrategiesFlag string
+
+const (
+	UseStrategiesFlagTrue    UseStrategiesFlag = "true"
+	UseStrategiesFlagCore    UseStrategiesFlag = "core"
+	UseStrategiesFlagFalse   UseStrategiesFlag = "false"
+	UseStrategiesFlagInvalid UseStrategiesFlag = ""
+)
+
+func (fl UseStrategiesFlag) String() string { return string(fl) }
+
+func StrToUseStrategiesFlag(str string) UseStrategiesFlag {
+	str = strings.ToLower(strings.TrimSpace(str))
+	switch UseStrategiesFlag(str) {
+	case UseStrategiesFlagTrue:
+		return UseStrategiesFlagTrue
+	case UseStrategiesFlagCore:
+		return UseStrategiesFlagCore
+	case UseStrategiesFlagFalse:
+		return UseStrategiesFlagFalse
+	default:
+		return UseStrategiesFlagInvalid
+	}
+}
+
 type ApplyFilesFlag string
 
 const (

--- a/cache-config/testing/ort-tests/baseline-configs/parent.config
+++ b/cache-config/testing/ort-tests/baseline-configs/parent.config
@@ -1,5 +1,5 @@
 # DO NOT EDIT - Generated for atlanta-edge-03 by t3c-generate/0.2 from https://to_server:443 ips (172.28.0.5:443) on 2021-01-13T16:46:07.704055764Z
 # ds 'ds-top' topology 'mso-topology'
-dest_domain=origin.topology.example.net port=80 parent="atlanta-mid-16.ga.atlanta.kabletown.net:80|0.999" round_robin=consistent_hash go_direct=false qstring=ignore
+dest_domain=origin.topology.example.net port=80 parent="atlanta-mid-16.ga.atlanta.kabletown.net:80|0.999" round_robin=consistent_hash go_direct=false qstring=ignore parent_is_proxy=true
 # ds '' topology ''
-dest_domain=. parent="atlanta-mid-16.ga.atlanta.kabletown.net:80|0.999;" round_robin=consistent_hash go_direct=false
+dest_domain=. parent="atlanta-mid-16.ga.atlanta.kabletown.net:80|0.999" round_robin=consistent_hash go_direct=false qstring=consider parent_is_proxy=true

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -37,6 +37,7 @@ const DefaultATSVersion = "5" // TODO Emulates Perl; change to 6? ATC no longer 
 // todo also unused
 const HeaderCommentDateFormat = "Mon Jan 2 15:04:05 MST 2006"
 const ContentTypeTextASCII = `text/plain; charset=us-ascii`
+
 const LineCommentHash = "#"
 const ConfigSuffix = ".config"
 const TsDefaultRequestHeaderMaxSize = 131072
@@ -727,4 +728,16 @@ func JobToInvalidationJob(jb tc.Job) (InvalidationJob, error) {
 		InvalidationType: invalType,
 		StartTime:        startTime.Time,
 	}, nil
+}
+
+// FilterServers returns the servers for which filter returns true
+func FilterServers(servers []Server, filter func(sv *Server) bool) []Server {
+	// TODO add warning/error feature?
+	filteredServers := []Server{}
+	for _, sv := range servers {
+		if filter(&sv) {
+			filteredServers = append(filteredServers, sv)
+		}
+	}
+	return filteredServers
 }

--- a/lib/go-atscfg/ipallowdotyaml.go
+++ b/lib/go-atscfg/ipallowdotyaml.go
@@ -31,7 +31,7 @@ import (
 )
 
 const IPAllowYamlFileName = `ip_allow.yaml`
-const ContentTypeIPAllowDotYAML = "application/yaml; charset=us-ascii" // Note YAML has no IANA standard mime type. This is one of several common usages, and is likely to be the standardized value. If you're reading this, please check IANA to see if YAML has been added, and change this to the IANA definition if so. Also note we include 'charset=us-ascii' because YAML is commonly UTF-8, but ATS is likely to be unable to handle UTF.
+const ContentTypeIPAllowDotYAML = ContentTypeYAML
 const LineCommentIPAllowDotYAML = LineCommentHash
 
 // const ParamPurgeAllowIP = "purge_allow_ip"

--- a/lib/go-atscfg/loggingdotyaml.go
+++ b/lib/go-atscfg/loggingdotyaml.go
@@ -28,7 +28,7 @@ import (
 )
 
 const LoggingYAMLFileName = "logging.yaml"
-const ContentTypeLoggingDotYAML = "application/yaml; charset=us-ascii" // Note YAML has no IANA standard mime type. This is one of several common usages, and is likely to be the standardized value. If you're reading this, please check IANA to see if YAML has been added, and change this to the IANA definition if so. Also note we include 'charset=us-ascii' because YAML is commonly UTF-8, but ATS is likely to be unable to handle UTF.
+const ContentTypeLoggingDotYAML = ContentTypeYAML
 const LineCommentLoggingDotYAML = LineCommentHash
 
 // LoggingDotYAMLOpts contains settings to configure generation options.

--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -462,6 +462,7 @@ func requiredFiles9() []string {
 		"sni.yaml",
 		"storage.config",
 		"volume.config",
+		"strategies.yaml",
 	}
 }
 

--- a/lib/go-atscfg/parentabstraction.go
+++ b/lib/go-atscfg/parentabstraction.go
@@ -1,0 +1,382 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// ParentAbstraction contains all the data necessary to build either parent.config or strategies.yaml.
+type ParentAbstraction struct {
+	Services []*ParentAbstractionService
+}
+
+// ParentAbstractionService represents a single delivery service's parent data.
+// For parent.config, this becomes a single dest_domain= line.
+// For strategies, this becomes a strategy along with its corresponding groups and hosts.
+type ParentAbstractionService struct {
+	// Name is a unique name for the service.
+	// It can be anything unique, but should probably be the Traffic ops Delivery Service name.
+	Name string
+	// Comment is a text comment about the service, not including the comment syntax (e.g. # or //).
+	// Should be empty if !opt.AddComments.
+	Comment string
+	// DestDomain is the FQDN of the remap.config target.
+	// Becomes parent.config dest_domain directive
+	// Becomes strategies.yaml TODO
+	DestDomain string
+
+	// Port is the port of the remap.config target,
+	// which MUST be valid, and is implicitly 80 for http targets and 443 for https targets.
+	// Becomes parent.config port directive
+	// Becomes strategies.yaml TODO
+	Port int
+
+	// Parents is the list of parents, either parent proxy caches or origins.
+	// This is a sorted array. Parents will be inserted into the config file in the order they appear.
+	// Becomes parent.config parent= directive members
+	// Becomes strategies.yaml TODO
+	Parents []*ParentAbstractionServiceParent
+
+	// Parents is the list of secondary parents, either parent proxy caches or origins,
+	// to be used if the primary parents fail. See SecondaryMode.
+	// Becomes parent.config secondary_parent= directive members
+	// Becomes strategies.yaml TODO
+	SecondaryParents []*ParentAbstractionServiceParent
+
+	// SecondaryMode is how to try SecondaryParents if primary Parents fail.
+	// Becomes parent.config secondary_mode directive
+	// Becomes strategies.yaml TODO
+	SecondaryMode ParentAbstractionServiceParentSecondaryMode
+
+	// GoDirect is whether to go direct to parents via normal HTTP requests.
+	// False means to make proxy requests to the parents.
+	// Becomes parent.config go_direct and parent_is_proxy directives
+	// Becomes strategies.yaml TODO
+	GoDirect bool
+
+	// IgnoreQueryStringInParentSelection is whether to use the query string of the request
+	// when selecting a parent, e.g. via Consistent Hash.
+	// Becomes parent.config qstring directive
+	// Becomes strategies.yaml TODO
+	IgnoreQueryStringInParentSelection bool
+
+	// MarkdownResponseCodes is the list of HTTP response codes from the parent
+	// to consider as errors and mark the parent as unhealthy. Typically 5xx codes.
+	// Becomes parent.config unavailable_server_retry_responses directive
+	// Becomes strategies.yaml TODO
+	MarkdownResponseCodes []int
+
+	// ErrorResponseCodes is the list of HTTP response codes from the parent
+	// to consider as errors, but NOT mark the parent unhealthy. Typically 4xx codes.
+	// Becomes parent.config unavailable_server_retry_responses directive
+	// Becomes strategies.yaml TODO
+	ErrorResponseCodes []int
+
+	// MaxSimpleRetries is the maximum number of non-markdown errors to attempt
+	// before returning the error to the client. See ErrorResponseCodes
+	// Becomes parent.config max_simple_retries
+	// Becomes strategies.yaml TODO
+	MaxSimpleRetries int
+
+	// MaxMarkdownRetries is the maximum number of markdown errors to attempt
+	// before returning the error to the client. See MarkdownResponseCodes
+	// Becomes parent.config max_unavailable_server_retries
+	// Becomes strategies.yaml TODO
+	MaxMarkdownRetries int
+
+	// RetryPolicy is how to retry primary versus secondary parents.
+	// Becomes parent.config round_robin directive
+	// Becomes strategies.yaml TODO
+	RetryPolicy ParentAbstractionServiceRetryPolicy
+
+	// Weight is the weight of this parent relative to other parents in consistent hash (and potentially other non-sequential) parent selection. The default is 0.999
+	// Becomes parent.config weight directive
+	// Becomes strategies.yaml TODO
+	Weight float64
+}
+
+// ParentAbstractionServices implements sort.Interface
+type ParentAbstractionServices []*ParentAbstractionService
+
+func (ps ParentAbstractionServices) Len() int      { return len(ps) }
+func (ps ParentAbstractionServices) Swap(i, j int) { ps[i], ps[j] = ps[j], ps[i] }
+func (ps ParentAbstractionServices) Less(i, j int) bool {
+	if ps[i].DestDomain != ps[j].DestDomain {
+		return ps[i].DestDomain < ps[j].DestDomain
+	}
+	return ps[i].Port < ps[j].Port
+}
+
+type ParentAbstractionServiceParentSecondaryMode string
+
+const ParentAbstractionServiceParentSecondaryModeExhaust = ParentAbstractionServiceParentSecondaryMode("exhaust")
+const ParentAbstractionServiceParentSecondaryModeAlternate = ParentAbstractionServiceParentSecondaryMode("alternate")
+const ParentAbstractionServiceParentSecondaryModeInvalid = ParentAbstractionServiceParentSecondaryMode("")
+
+const ParentAbstractionServiceParentSecondaryModeDefault = ParentAbstractionServiceParentSecondaryModeAlternate
+
+// ToParentDotConfigVal returns the ATS parent.config secondary_mode= value for the enum.
+// If the mode is invalid, ParentAbstractionServiceParentSecondaryModeDefault is returned without error.
+func (mo ParentAbstractionServiceParentSecondaryMode) ToParentDotConfigVal() string {
+	switch mo {
+	case ParentAbstractionServiceParentSecondaryModeExhaust:
+		return "2"
+	case ParentAbstractionServiceParentSecondaryModeAlternate:
+		return "1"
+	default:
+		return ParentAbstractionServiceParentSecondaryModeDefault.ToParentDotConfigVal()
+	}
+}
+
+type ParentAbstractionServiceRetryPolicy string
+
+const ParentAbstractionServiceRetryPolicyRoundRobinIP = ParentAbstractionServiceRetryPolicy("round_robin_ip")
+const ParentAbstractionServiceRetryPolicyRoundRobinStrict = ParentAbstractionServiceRetryPolicy("round_robin_strict")
+const ParentAbstractionServiceRetryPolicyFirst = ParentAbstractionServiceRetryPolicy("first")
+const ParentAbstractionServiceRetryPolicyLatched = ParentAbstractionServiceRetryPolicy("latched")
+const ParentAbstractionServiceRetryPolicyConsistentHash = ParentAbstractionServiceRetryPolicy("consistent_hash")
+const ParentAbstractionServiceRetryPolicyInvalid = ParentAbstractionServiceRetryPolicy("")
+
+const DefaultParentAbstractionServiceRetryPolicy = ParentAbstractionServiceRetryPolicyConsistentHash
+
+func ParentSelectAlgorithmToParentAbstractionServiceRetryPolicy(alg string) ParentAbstractionServiceRetryPolicy {
+	switch strings.TrimSpace(strings.ToLower(alg)) {
+	case "true":
+		return ParentAbstractionServiceRetryPolicyRoundRobinIP
+	case "strict":
+		return ParentAbstractionServiceRetryPolicyRoundRobinStrict
+	case "false":
+		return ParentAbstractionServiceRetryPolicyFirst
+	case "consistent_hash":
+		return ParentAbstractionServiceRetryPolicyConsistentHash
+	case "latched":
+		return ParentAbstractionServiceRetryPolicyLatched
+	default:
+		return ParentAbstractionServiceRetryPolicyInvalid
+	}
+}
+
+// ToParentDotConfigFormat returns the ATS parent.config round_robin= value for the policy.
+// If the policy is invalid, the default is returned without error.
+func (po ParentAbstractionServiceRetryPolicy) ToParentDotConfigFormat() string {
+	switch po {
+	case ParentAbstractionServiceRetryPolicyRoundRobinIP:
+		return "true"
+	case ParentAbstractionServiceRetryPolicyRoundRobinStrict:
+		return "strict"
+	case ParentAbstractionServiceRetryPolicyFirst:
+		return "false"
+	case ParentAbstractionServiceRetryPolicyLatched:
+		return "latched"
+	case ParentAbstractionServiceRetryPolicyConsistentHash:
+		return "consistent_hash"
+	default:
+		return "consistent_hash"
+	}
+}
+
+// ParentSelectParamQStringHandlingToBool returns whether the param is to use the query string in the parent select algorithm or not.
+// If the parameter value is not valid, returns nil.
+func ParentSelectParamQStringHandlingToBool(paramVal string) *bool {
+	switch strings.TrimSpace(strings.ToLower(paramVal)) {
+	case "consider":
+		v := true
+		return &v
+	case "ignore":
+		v := false
+		return &v
+	}
+	return nil
+}
+
+type ParentAbstractionServiceParent struct {
+	// FQDN is the parent FQDN that ATS will use. Note this may be an IP.
+	FQDN   string
+	Port   int
+	Weight float64
+}
+
+// Key returns a unique key that can be used to compare parents for equality.
+func (sp ParentAbstractionServiceParent) Key() string {
+	return sp.FQDN + ":" + strconv.Itoa(sp.Port)
+}
+
+func RemoveParentDuplicates(inputs []*ParentAbstractionServiceParent, seens map[string]struct{}) ([]*ParentAbstractionServiceParent, map[string]struct{}) {
+	if seens == nil {
+		seens = make(map[string]struct{})
+	}
+	uniques := []*ParentAbstractionServiceParent{}
+	for _, input := range inputs {
+		key := input.Key()
+		if _, ok := seens[key]; !ok {
+			uniques = append(uniques, input)
+			seens[key] = struct{}{}
+		}
+	}
+	return uniques, seens
+}
+
+func ParseRetryResponses(resp string) ([]int, error) {
+	resp = strings.TrimSpace(resp)
+	if len(resp) > 2 && resp[0] == '"' {
+		resp = resp[1 : len(resp)-1]
+	}
+	codes := []int{}
+	codeStrs := strings.Split(resp, ",")
+	for _, codeStr := range codeStrs {
+		codeStr = strings.TrimSpace(codeStr)
+		if codeStr == "" {
+			continue
+		}
+		code, err := strconv.Atoi(codeStr)
+		if err != nil {
+			return nil, errors.New("malformed")
+		}
+		codes = append(codes, code)
+	}
+	return codes, nil
+}
+
+var DefaultSimpleRetryCodes = []int{404}
+var DefaultUnavailableServerRetryCodes = []int{503}
+
+const DefaultIgnoreQueryStringInParentSelection = false
+
+func parentAbstractionToParentDotConfig(pa *ParentAbstraction, opt *ParentConfigOpts, atsMajorVersion int) (string, []string, error) {
+	warnings := []string{}
+	txt := ""
+
+	// parent.config dest_domain directives must be unique.
+	// This is the "duplicate origin problem"
+	processedOriginsToDSNames := map[string]string{}
+
+	for _, svc := range pa.Services {
+		if existingDS, ok := processedOriginsToDSNames[svc.DestDomain]; ok {
+			warnings = append(warnings, "duplicate origin! DS '"+svc.Name+"' and '"+existingDS+"' share origin '"+svc.DestDomain+"': skipping '"+svc.Name+"'!")
+			continue
+		}
+
+		svcLine, svcWarns, err := svc.ToParentDotConfigLine(opt, atsMajorVersion)
+		warnings = append(warnings, svcWarns...)
+		if err != nil {
+			// TODO add DS name
+			// TODO don't error? No single delivery service should be able to break others.
+			return "", warnings, errors.New("creating parent.config line from service: " + err.Error())
+		}
+		txt += svcLine + "\n"
+
+		processedOriginsToDSNames[svc.DestDomain] = svc.Name
+	}
+	return txt, warnings, nil
+}
+
+func (svc *ParentAbstractionService) ToParentDotConfigLine(opt *ParentConfigOpts, atsMajorVersion int) (string, []string, error) {
+	warnings := []string{}
+	txt := ""
+	if opt.AddComments && svc.Comment != "" {
+		txt += LineCommentParentDotConfig + " " + svc.Comment + "\n"
+	}
+	txt += `dest_domain=` + svc.DestDomain
+	if svc.Port != 0 {
+		txt += ` port=` + strconv.Itoa(svc.Port)
+	}
+
+	if atsMajorVersion >= 6 && svc.RetryPolicy == ParentAbstractionServiceRetryPolicyConsistentHash && len(svc.SecondaryParents) > 0 {
+		// TODO add quotes
+		txt += ` parent="` + ParentAbstractionServiceParentsToParentDotConfigLine(svc.Parents) + `"`
+		txt += ` secondary_parent="` + ParentAbstractionServiceParentsToParentDotConfigLine(svc.SecondaryParents) + `"`
+		txt += ` secondary_mode=` + svc.SecondaryMode.ToParentDotConfigVal()
+	} else {
+		parents := []*ParentAbstractionServiceParent{}
+		for _, pa := range svc.Parents {
+			parents = append(parents, pa)
+		}
+		for _, pa := range svc.SecondaryParents {
+			parents = append(parents, pa)
+		}
+		txt += ` parent="` + ParentAbstractionServiceParentsToParentDotConfigLine(parents) + `"`
+	}
+
+	txt += ` round_robin=` + svc.RetryPolicy.ToParentDotConfigFormat()
+	txt += ` go_direct=` + strconv.FormatBool(svc.GoDirect)
+	txt += ` qstring=`
+	if !svc.IgnoreQueryStringInParentSelection {
+		txt += `consider`
+	} else {
+		txt += `ignore`
+	}
+	txt += ` parent_is_proxy=` + strconv.FormatBool(!svc.GoDirect)
+
+	if svc.MaxSimpleRetries > 0 && svc.MaxMarkdownRetries > 0 {
+		txt += ` parent_retry=both`
+	} else if svc.MaxSimpleRetries > 0 {
+		txt += ` parent_retry=simple_retry`
+	} else if svc.MaxMarkdownRetries > 0 {
+		txt += ` parent_retry=unavailable_server_retry`
+	}
+
+	if svc.MaxSimpleRetries > 0 {
+		txt += ` max_simple_retries=` + strconv.Itoa(svc.MaxSimpleRetries)
+	}
+	if svc.MaxMarkdownRetries > 0 {
+		txt += ` max_unavailable_server_retries=` + strconv.Itoa(svc.MaxMarkdownRetries)
+	}
+
+	if len(svc.ErrorResponseCodes) > 0 {
+		if atsMajorVersion >= 9 {
+			txt += ` simple_server_retry_responses="` + strings.Join(intsToStrs(svc.ErrorResponseCodes), `,`) + `"`
+		} else {
+			warnings = append(warnings, "Service '"+svc.Name+"' had simple retry codes '"+strings.Join(intsToStrs(svc.ErrorResponseCodes), ",")+"' but ATS version "+strconv.Itoa(atsMajorVersion)+" < 9 does not support custom simple retry codes, omitting!")
+		}
+	}
+
+	if len(svc.MarkdownResponseCodes) > 0 {
+		txt += ` unavailable_server_retry_responses="` + strings.Join(intsToStrs(svc.MarkdownResponseCodes), `,`) + `"`
+	}
+
+	// 	txt += ` unavailable_server_retry_responses=` + unavailableServerRetryResponses
+
+	return txt, warnings, nil
+}
+
+func intsToStrs(is []int) []string {
+	strs := []string{}
+	for _, i := range is {
+		strs = append(strs, strconv.Itoa(i))
+	}
+	return strs
+}
+
+func (pa *ParentAbstractionServiceParent) ToParentDotConfigFormat() string {
+	return pa.FQDN + ":" + strconv.Itoa(pa.Port) + "|" + strconv.FormatFloat(pa.Weight, 'f', -1, 64)
+}
+
+const ParentDotConfigParentSeparator = `;`
+
+func ParentAbstractionServiceParentsToParentDotConfigLine(parents []*ParentAbstractionServiceParent) string {
+	parentStrs := []string{}
+	for _, parent := range parents {
+		parentStrs = append(parentStrs, parent.ToParentDotConfigFormat())
+	}
+	return strings.Join(parentStrs, ParentDotConfigParentSeparator)
+}

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -140,8 +140,8 @@ func TestMakeParentDotConfig(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected malformed qstring 'myQstringParam' in warnings, actual: '%v' val '%v'", cfg.Warnings, txt)
 	}
 }
 
@@ -536,8 +536,8 @@ func TestMakeParentDotConfigTopologies(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
 	if strings.Contains(txt, "# topology") {
 		// ATS doesn't support inline comments in parent.config
@@ -968,8 +968,8 @@ func TestMakeParentDotConfigTopologiesOmitOfflineParents(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
 
 	if strings.Contains(txt, "should-omit") {
@@ -1112,8 +1112,8 @@ func TestMakeParentDotConfigTopologiesOmitDifferentCDNParents(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
 
 	if strings.Contains(txt, "should-omit") {
@@ -1511,7 +1511,7 @@ func TestMakeParentDotConfigMSOWithCapabilities(t *testing.T) {
 	testComment(t, txt, hdr.HdrComment)
 
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
-		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
+		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v' warnings %+v", txt, cfg.Warnings)
 	}
 	if !strings.Contains(txt, "myorigin0") {
 		t.Errorf("expected origin0 with DeliveryServiceServer assigned to this DS, actual: '%v'", txt)
@@ -2007,8 +2007,8 @@ func TestMakeParentDotConfigTopologiesNonStandardServerTypes(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
 	if strings.Contains(txt, "# topology") {
 		// ATS doesn't support inline comments in parent.config
@@ -2170,8 +2170,8 @@ func TestMakeParentDotConfigSecondaryMode(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
 	if strings.Count(txt, "secondary_mode=2") != 2 {
 		t.Errorf("expected secondary_mode=2 for both Topology and DSS DSes with ParentConfigParamSecondaryMode parameter and secondary parents, actual: '%v'", txt)
@@ -2325,11 +2325,11 @@ func TestMakeParentDotConfigNoSecondaryMode(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
-	if strings.Contains(txt, "secondary_mode") {
-		t.Errorf("expected no secondary_mode for DSes without ParentConfigParamSecondaryMode parameter, actual: '%v'", txt)
+	if !strings.Contains(txt, "secondary_mode=1") {
+		t.Errorf("expected default secondary_mode=1 for DSes without ParentConfigParamSecondaryMode parameter, actual: '%v'", txt)
 	}
 
 	if strings.Contains(txt, `topology 't0'`) {
@@ -2453,8 +2453,8 @@ func TestMakeParentDotConfigComments(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds0.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQstringParam") {
+		t.Errorf("expected warning for malformed myQstringParam', actual: '%+v'", cfg.Warnings)
 	}
 	if !strings.Contains(txt, "# ds 'ds1'") {
 		t.Errorf("expected comment with delivery service name, actual: '%v'", txt)
@@ -2608,11 +2608,12 @@ func TestMakeParentDotConfigCommentTopology(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds1.example.net") {
 		t.Errorf("expected parent 'dest_domain=ds1.example.net', actual: '%v'", txt)
 	}
-	if !strings.Contains(txt, "qstring=myQStringHandlingParam") {
-		t.Errorf("expected qstring from param 'qstring=myQStringHandlingParam', actual: '%v'", txt)
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected warning for malformed myQStringHandlingParam', actual: '%+v'", cfg.Warnings)
 	}
-	if strings.Contains(txt, "secondary_mode") {
-		t.Errorf("expected no secondary_mode for DSes without ParentConfigParamSecondaryMode parameter, actual: '%v'", txt)
+
+	if !strings.Contains(txt, "secondary_mode=1") {
+		t.Errorf("expected default secondary_mode=1 for DSes without ParentConfigParamSecondaryMode parameter, actual: '%v'", txt)
 	}
 	if !strings.Contains(txt, `# ds 'ds1' topology 't0'`) {
 		t.Errorf("expected comment with delivery service and topology, actual: '%v'", txt)
@@ -2875,6 +2876,17 @@ func TestMakeParentDotConfigHTTPSOriginTopology(t *testing.T) {
 	if !strings.Contains(txt, "dest_domain=ds0.example.net port=80") {
 		t.Errorf("expected topology parent.config of https origin to be http/80 not https/443, actual: '%v'", txt)
 	}
+}
+
+// warnsContains returns whether the given warnings has str as a substring of any warning.
+// Note this is different than lib/go-util.ContainsStr, which only returns if the array has the exact value as one of its values.
+func warningsContains(warnings []string, str string) bool {
+	for _, warn := range warnings {
+		if strings.Contains(warn, str) {
+			return true
+		}
+	}
+	return false
 }
 
 func makeTestParentServer() *Server {

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -22,6 +22,7 @@ package atscfg
 import (
 	"errors"
 	"github.com/apache/trafficcontrol/lib/go-log"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -38,10 +39,21 @@ const RemapConfigRangeDirective = `__RANGE_DIRECTIVE__`
 
 // RemapDotConfigOpts contains settings to configure generation options.
 type RemapDotConfigOpts struct {
+	// VerboseComments is whether to add informative comments to the generated file, about what was generated and why.
+	// Note this does not include the header comment, which is configured separately with HdrComment.
+	// These comments are human-readable and not guarnateed to be consistent between versions. Automating anything based on them is strongly discouraged.
+	VerboseComments bool
+
 	// HdrComment is the header comment to include at the beginning of the file.
 	// This should be the text desired, without comment syntax (like # or //). The file's comment syntax will be added.
 	// To omit the header comment, pass the empty string.
 	HdrComment string
+
+	// UseStrategies is whether to use strategies.yaml rather than parent.config.
+	UseStrategies bool
+	// UseCoreStrategies is whether to use the ATS core strategies, rather than the parent_select plugin.
+	// This has no effect if UseStrategies is false.
+	UseStrategiesCore bool
 }
 
 func MakeRemapDotConfig(
@@ -56,12 +68,18 @@ func MakeRemapDotConfig(
 	cacheGroupArr []tc.CacheGroupNullable,
 	serverCapabilities map[int]map[ServerCapability]struct{},
 	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
+	configDir string,
 	opt *RemapDotConfigOpts,
 ) (Cfg, error) {
 	if opt == nil {
 		opt = &RemapDotConfigOpts{}
 	}
 	warnings := []string{}
+
+	if !opt.UseStrategies && opt.UseStrategiesCore {
+		warnings = append(warnings, "opt.UseStrategies was false, but opt.UseStrategiesCore was set, which has no effect! Not using strategies, per opt.UseStrategies.")
+	}
+
 	if server.HostName == nil {
 		return Cfg{}, makeErr(warnings, "server HostName missing")
 	} else if server.ID == nil {
@@ -99,9 +117,9 @@ func MakeRemapDotConfig(
 	txt := ""
 	typeWarns := []string{}
 	if tc.CacheTypeFromString(server.Type) == tc.CacheTypeMid {
-		txt, typeWarns, err = getServerConfigRemapDotConfigForMid(atsMajorVersion, dsProfilesConfigParams, dses, dsRegexes, hdr, server, nameTopologies, cacheGroups, serverCapabilities, dsRequiredCapabilities)
+		txt, typeWarns, err = getServerConfigRemapDotConfigForMid(atsMajorVersion, dsProfilesConfigParams, dses, dsRegexes, hdr, server, nameTopologies, cacheGroups, serverCapabilities, dsRequiredCapabilities, configDir, opt)
 	} else {
-		txt, typeWarns, err = getServerConfigRemapDotConfigForEdge(dsProfilesConfigParams, serverPackageParamData, dses, dsRegexes, atsMajorVersion, hdr, server, nameTopologies, cacheGroups, serverCapabilities, dsRequiredCapabilities, cdnDomain)
+		txt, typeWarns, err = getServerConfigRemapDotConfigForEdge(dsProfilesConfigParams, serverPackageParamData, dses, dsRegexes, atsMajorVersion, hdr, server, nameTopologies, cacheGroups, serverCapabilities, dsRequiredCapabilities, cdnDomain, configDir, opt)
 	}
 	warnings = append(warnings, typeWarns...)
 	if err != nil {
@@ -236,6 +254,8 @@ func getServerConfigRemapDotConfigForMid(
 	cacheGroups map[tc.CacheGroupName]tc.CacheGroupNullable,
 	serverCapabilities map[int]map[ServerCapability]struct{},
 	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
+	configDir string,
+	opts *RemapDotConfigOpts,
 ) (string, []string, error) {
 	warnings := []string{}
 	midRemaps := map[string]string{}
@@ -273,6 +293,8 @@ func getServerConfigRemapDotConfigForMid(
 		}
 
 		midRemap := ""
+
+		midRemap += strategyDirective(getStrategyName(*ds.XMLID), configDir, opts)
 
 		if *ds.Topology != "" {
 			topoTxt, err := makeDSTopologyHeaderRewriteTxt(ds, tc.CacheGroupName(*server.Cachegroup), topology, cacheGroups)
@@ -365,6 +387,8 @@ func getServerConfigRemapDotConfigForEdge(
 	serverCapabilities map[int]map[ServerCapability]struct{},
 	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
 	cdnDomain string,
+	configDir string,
+	opts *RemapDotConfigOpts,
 ) (string, []string, error) {
 	warnings := []string{}
 	textLines := []string{}
@@ -417,7 +441,7 @@ func getServerConfigRemapDotConfigForEdge(
 				}
 				remapWarns := []string{}
 				dsLines := RemapLines{}
-				dsLines, remapWarns, err = buildEdgeRemapLine(atsMajorVersion, server, serverPackageParamData, remapText, ds, line.From, line.To, profileremapConfigParams, cacheGroups, nameTopologies)
+				dsLines, remapWarns, err = buildEdgeRemapLine(atsMajorVersion, server, serverPackageParamData, remapText, ds, line.From, line.To, profileremapConfigParams, cacheGroups, nameTopologies, configDir, opts)
 				warnings = append(warnings, remapWarns...)
 				remapText = dsLines.Text
 
@@ -472,6 +496,8 @@ func buildEdgeRemapLine(
 	remapConfigParams []tc.Parameter,
 	cacheGroups map[tc.CacheGroupName]tc.CacheGroupNullable,
 	nameTopologies map[TopologyName]tc.Topology,
+	configDir string,
+	opts *RemapDotConfigOpts,
 ) (RemapLines, []string, error) {
 	warnings := []string{}
 	remapLines := RemapLines{}
@@ -490,10 +516,14 @@ func buildEdgeRemapLine(
 		mapTo = strings.Replace(mapTo, `https://`, `http://`, -1)
 	}
 
+	text += "map	" + mapFrom + "     " + mapTo
+
+	text += strategyDirective(getStrategyName(*ds.XMLID), configDir, opts)
+
 	if _, hasDSCPRemap := pData["dscp_remap"]; hasDSCPRemap {
-		text += "map	" + mapFrom + "     " + mapTo + ` @plugin=dscp_remap.so @pparam=` + strconv.Itoa(*ds.DSCP)
+		text += ` @plugin=dscp_remap.so @pparam=` + strconv.Itoa(*ds.DSCP)
 	} else {
-		text += "map	" + mapFrom + "     " + mapTo + ` @plugin=header_rewrite.so @pparam=dscp/set_dscp_` + strconv.Itoa(*ds.DSCP) + ".config"
+		text += ` @plugin=header_rewrite.so @pparam=dscp/set_dscp_` + strconv.Itoa(*ds.DSCP) + ".config"
 	}
 
 	if *ds.Topology != "" {
@@ -594,6 +624,16 @@ func buildEdgeRemapLine(
 	}
 
 	return remapLines, warnings, nil
+}
+
+func strategyDirective(strategyName string, configDir string, opt *RemapDotConfigOpts) string {
+	if !opt.UseStrategies {
+		return ""
+	}
+	if !opt.UseStrategiesCore {
+		return ` @plugin=parent_select.so @pparam=` + filepath.Join(configDir, "strategies.yaml") + ` @pparam=` + strategyName
+	}
+	return ` @strategy=` + strategyName
 }
 
 // makeDSTopologyHeaderRewriteTxt returns the appropriate header rewrite remap line text for the given DS on the given server, and any error.

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -128,9 +128,9 @@ func TestMakeRemapDotConfig0(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
-
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -246,8 +246,9 @@ func TestMakeRemapDotConfigMidLiveLocalExcluded(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -346,8 +347,9 @@ func TestMakeRemapDotConfigMid(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -460,9 +462,9 @@ func TestMakeRemapDotConfigNilOrigin(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
-
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,9 +563,9 @@ func TestMakeRemapDotConfigEmptyOrigin(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
-
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -700,8 +702,9 @@ func TestMakeRemapDotConfigDuplicateOrigins(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -799,8 +802,9 @@ func TestMakeRemapDotConfigNilMidRewrite(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -900,8 +904,9 @@ func TestMakeRemapDotConfigMidHasNoEdgeRewrite(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1014,8 +1019,9 @@ func TestMakeRemapDotConfigMidProfileCacheKey(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1051,7 +1057,7 @@ func TestMakeRemapDotConfigMidProfileCacheKey(t *testing.T) {
 		t.Errorf("expected to contain cachekey.config param, actual '%v'", txt)
 	}
 
-	if 1 != len(cfg.Warnings) || !strings.Contains(cfg.Warnings[0], "Both new cachekey.pparam and old cachekey.config parameters assigned") {
+	if !warningsContains(cfg.Warnings, "Both new cachekey.pparam and old cachekey.config parameters assigned") {
 		t.Errorf("expected to contain warning about using both cachekey.config and cachekey.pparam, actual '%v', '%v'", cfg.Warnings, txt)
 	}
 }
@@ -1164,8 +1170,9 @@ func TestMakeRemapDotConfigMidBgFetchHandling(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1280,8 +1287,9 @@ func TestMakeRemapDotConfigMidRangeRequestHandling(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1420,8 +1428,9 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1561,8 +1570,9 @@ func TestMakeRemapDotConfigAnyMap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1958,8 +1968,9 @@ func TestMakeRemapDotConfigEdgeMissingRemapData(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2062,8 +2073,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacement(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2183,8 +2195,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTP(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2304,8 +2317,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPS(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2425,8 +2439,9 @@ func TestMakeRemapDotConfigEdgeHostRegexReplacementHTTPToHTTPS(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2546,8 +2561,9 @@ func TestMakeRemapDotConfigEdgeRemapUnderscoreHTTPReplace(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2669,8 +2685,9 @@ func TestMakeRemapDotConfigEdgeDSCPRemap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2792,8 +2809,9 @@ func TestMakeRemapDotConfigEdgeNoDSCPRemap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2915,8 +2933,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewrite(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3042,8 +3061,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteEmpty(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3169,8 +3189,9 @@ func TestMakeRemapDotConfigEdgeHeaderRewriteNil(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3302,8 +3323,9 @@ func TestMakeRemapDotConfigEdgeSigningURLSig(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3429,8 +3451,9 @@ func TestMakeRemapDotConfigEdgeSigningURISigning(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3551,8 +3574,9 @@ func TestMakeRemapDotConfigEdgeSigningNone(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3673,8 +3697,9 @@ func TestMakeRemapDotConfigEdgeSigningEmpty(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3795,8 +3820,9 @@ func TestMakeRemapDotConfigEdgeSigningWrong(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3917,8 +3943,9 @@ func TestMakeRemapDotConfigEdgeQStringDropAtEdge(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4037,8 +4064,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUp(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4172,8 +4200,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpWithCacheKeyParameter(t *testi
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4209,7 +4238,7 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpWithCacheKeyParameter(t *testi
 		t.Errorf("expected cachekey plugin to have '--ckeycc=', actual '%v'", txt)
 	}
 
-	if 1 != len(cfg.Warnings) || !strings.Contains(cfg.Warnings[0], "Both new cachekey.pparam and old cachekey.config parameters assigned") {
+	if !warningsContains(cfg.Warnings, "Both new cachekey.pparam and old cachekey.config parameters assigned") {
 		t.Errorf("expected to contain warning about using both cachekey.config and cachekey.pparam, actual '%v', '%v'", cfg.Warnings, txt)
 	}
 }
@@ -4299,8 +4328,9 @@ func TestMakeRemapDotConfigEdgeQStringIgnorePassUpCacheURLParamCacheURL(t *testi
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4434,8 +4464,9 @@ func TestMakeRemapDotConfigEdgeCacheKeyParams(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4560,8 +4591,9 @@ func TestMakeRemapDotConfigEdgeRegexRemap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4683,8 +4715,9 @@ func TestMakeRemapDotConfigEdgeRegexRemapEmpty(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4802,8 +4835,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestNil(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -4941,8 +4975,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestDontCache(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5084,8 +5119,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestBGFetch(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5116,7 +5152,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestBGFetch(t *testing.T) {
 		t.Errorf("expected remap on edge server to contain repeated background fetch parameter for log, actual '%v'", txt)
 	}
 
-	if 0 == len(cfg.Warnings) || !strings.Contains(cfg.Warnings[0], "Multiple repeated arguments") {
+	if !warningsContains(cfg.Warnings, "Multiple repeated arguments") {
 		t.Errorf("expected multiple releated arguments warning, actual '%v'", cfg.Warnings)
 	}
 
@@ -5217,8 +5253,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5351,8 +5388,9 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5495,8 +5533,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5635,8 +5674,9 @@ func TestMakeRemapDotConfigRawRemapRangeDirective(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5780,8 +5820,9 @@ func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -5918,8 +5959,9 @@ func TestMakeRemapDotConfigEdgeRangeRequestCache(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6045,8 +6087,9 @@ func TestMakeRemapDotConfigEdgeFQPacingNil(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6164,8 +6207,9 @@ func TestMakeRemapDotConfigEdgeFQPacingNegative(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6283,8 +6327,9 @@ func TestMakeRemapDotConfigEdgeFQPacingZero(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6402,8 +6447,9 @@ func TestMakeRemapDotConfigEdgeFQPacingPositive(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6525,8 +6571,9 @@ func TestMakeRemapDotConfigEdgeDNS(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6644,8 +6691,9 @@ func TestMakeRemapDotConfigEdgeDNSNoRoutingName(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6753,8 +6801,9 @@ func TestMakeRemapDotConfigEdgeRegexTypeNil(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6867,8 +6916,9 @@ func TestMakeRemapDotConfigNoHeaderRewrite(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -6986,8 +7036,9 @@ func TestMakeRemapDotConfigMidNoHeaderRewrite(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7105,8 +7156,9 @@ func TestMakeRemapDotConfigMidNoNoCacheRemapLine(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7220,8 +7272,9 @@ func TestMakeRemapDotConfigEdgeHTTPSOriginHTTPRemap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7351,8 +7404,9 @@ func TestMakeRemapDotConfigMidHTTPSOriginHTTPRemap(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7523,8 +7577,9 @@ func TestMakeRemapDotConfigEdgeHTTPSOriginHTTPRemapTopology(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *mCG2}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7707,8 +7762,9 @@ func TestMakeRemapDotConfigMidHTTPSOriginHTTPRemapTopology(t *testing.T) {
 	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *mCG2}
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7904,7 +7960,9 @@ func TestMakeRemapDotConfigMidLastRawRemap(t *testing.T) {
 	serverCapabilities := map[int]map[ServerCapability]struct{}{}
 	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
 
-	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, &RemapDotConfigOpts{HdrComment: hdr})
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -7940,5 +7998,392 @@ func TestMakeRemapDotConfigMidLastRawRemap(t *testing.T) {
 		if !strings.Contains(penstr, "penraw") {
 			t.Fatalf("expected [-1] with 'penraw', actual: '%v' got %v", txt, penstr)
 		}
+	}
+}
+
+func TestMakeRemapDotConfigStrategies(t *testing.T) {
+	opt := &RemapDotConfigOpts{
+		HdrComment:    "myHeaderComment",
+		UseStrategies: true,
+	}
+
+	server := makeTestRemapServer()
+	server.Type = "MID"
+	server.Cachegroup = util.StrPtr("midCG")
+
+	ds := DeliveryService{}
+	ds.ID = util.IntPtr(48)
+	dsType := tc.DSType("DNS")
+	ds.Type = &dsType
+	ds.OrgServerFQDN = util.StrPtr("http://origin.example.test")
+	/*
+		ds.RangeRequestHandling = util.IntPtr(tc.RangeRequestHandlingCacheRangeRequest)
+		ds.RemapText = util.StrPtr("@plugin=tslua.so @pparam=my-range-manipulator.lua")
+	*/
+	ds.SigningAlgorithm = util.StrPtr("foo")
+	ds.XMLID = util.StrPtr("mydsname")
+	ds.QStringIgnore = util.IntPtr(int(tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp))
+	ds.RegexRemap = util.StrPtr("")
+	ds.FQPacingRate = util.IntPtr(314159)
+	ds.DSCP = util.IntPtr(0)
+	ds.RoutingName = util.StrPtr("myroutingname")
+	ds.MultiSiteOrigin = util.BoolPtr(false)
+	ds.OriginShield = util.StrPtr("myoriginshield")
+	ds.ProfileID = util.IntPtr(49)
+	ds.ProfileName = util.StrPtr("dsprofile")
+	ds.Protocol = util.IntPtr(int(tc.DSProtocolHTTP))
+	ds.AnonymousBlockingEnabled = util.BoolPtr(false)
+	ds.Active = util.BoolPtr(true)
+	ds.Topology = util.StrPtr("t0")
+
+	// non-nil default values should not trigger header rewrite plugin directive
+	ds.EdgeHeaderRewrite = util.StrPtr("")
+	ds.MidHeaderRewrite = util.StrPtr("")
+	ds.ServiceCategory = util.StrPtr("")
+	ds.MaxOriginConnections = util.IntPtr(0)
+
+	dses := []DeliveryService{ds}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds.ID,
+		},
+	}
+
+	dsRegexes := []tc.DeliveryServiceRegexes{
+		tc.DeliveryServiceRegexes{
+			DSName: *ds.XMLID,
+			Regexes: []tc.DeliveryServiceRegex{
+				tc.DeliveryServiceRegex{
+					Type:      string(tc.DSMatchTypeHostRegex),
+					SetNumber: 0,
+					Pattern:   `.*\.mypattern\..*`,
+				},
+			},
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       "serverpkgval",
+			ConfigFile: "package",
+			Value:      "serverpkgval __HOSTNAME__ foo",
+			Profiles:   []byte(*server.Profile),
+		},
+		tc.Parameter{
+			Name:       "dscp_remap_no",
+			ConfigFile: "package",
+			Value:      "notused",
+			Profiles:   []byte(*server.Profile),
+		},
+	}
+
+	remapConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "not_location",
+			ConfigFile: "cachekey.config",
+			Value:      "notinconfig",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPost",
+			ConfigFile: "remap.config",
+			Value:      "remap http://penraw/ http://penraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPost",
+			ConfigFile: "remap.config",
+			Value:      "remap http://lastraw/ http://lastraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPre",
+			ConfigFile: "remap.config",
+			Value:      "map_with_recp_port http://firstraw:8000/ http://firstraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+	}
+
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	topologies := []tc.Topology{
+		{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1, 2},
+				},
+				{
+					Cachegroup: "midCG",
+				},
+				{
+					Cachegroup: "midCG2",
+				},
+			},
+		},
+	}
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.HostName = util.StrPtr("mymid0")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCG.SecondaryParentName = mid1.Cachegroup
+	eCG.SecondaryParentCachegroupID = mid1.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	mCG2 := &tc.CacheGroupNullable{}
+	mCG2.Name = mid1.Cachegroup
+	mCG2.ID = mid1.CachegroupID
+	mCGType2 := tc.CacheGroupMidTypeName
+	mCG2.Type = &mCGType2
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *mCG2}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, opt.HdrComment)
+
+	if !strings.Contains(txt, `@plugin=parent_select.so @pparam=/opt/trafficserver/etc/trafficserver/strategies.yaml @pparam=strategy-mydsname`) {
+		t.Fatalf("expected parent_select plugin for opt.UseStrategies, actual: %v", txt)
+	}
+}
+
+func TestMakeRemapDotConfigStrategiesFalseButCoreUnused(t *testing.T) {
+	opt := &RemapDotConfigOpts{
+		HdrComment:        "myHeaderComment",
+		UseStrategies:     false,
+		UseStrategiesCore: true,
+	}
+
+	server := makeTestRemapServer()
+	server.Type = "MID"
+	server.Cachegroup = util.StrPtr("midCG")
+
+	ds := DeliveryService{}
+	ds.ID = util.IntPtr(48)
+	dsType := tc.DSType("DNS")
+	ds.Type = &dsType
+	ds.OrgServerFQDN = util.StrPtr("http://origin.example.test")
+	/*
+		ds.RangeRequestHandling = util.IntPtr(tc.RangeRequestHandlingCacheRangeRequest)
+		ds.RemapText = util.StrPtr("@plugin=tslua.so @pparam=my-range-manipulator.lua")
+	*/
+	ds.SigningAlgorithm = util.StrPtr("foo")
+	ds.XMLID = util.StrPtr("mydsname")
+	ds.QStringIgnore = util.IntPtr(int(tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp))
+	ds.RegexRemap = util.StrPtr("")
+	ds.FQPacingRate = util.IntPtr(314159)
+	ds.DSCP = util.IntPtr(0)
+	ds.RoutingName = util.StrPtr("myroutingname")
+	ds.MultiSiteOrigin = util.BoolPtr(false)
+	ds.OriginShield = util.StrPtr("myoriginshield")
+	ds.ProfileID = util.IntPtr(49)
+	ds.ProfileName = util.StrPtr("dsprofile")
+	ds.Protocol = util.IntPtr(int(tc.DSProtocolHTTP))
+	ds.AnonymousBlockingEnabled = util.BoolPtr(false)
+	ds.Active = util.BoolPtr(true)
+	ds.Topology = util.StrPtr("t0")
+
+	// non-nil default values should not trigger header rewrite plugin directive
+	ds.EdgeHeaderRewrite = util.StrPtr("")
+	ds.MidHeaderRewrite = util.StrPtr("")
+	ds.ServiceCategory = util.StrPtr("")
+	ds.MaxOriginConnections = util.IntPtr(0)
+
+	dses := []DeliveryService{ds}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds.ID,
+		},
+	}
+
+	dsRegexes := []tc.DeliveryServiceRegexes{
+		tc.DeliveryServiceRegexes{
+			DSName: *ds.XMLID,
+			Regexes: []tc.DeliveryServiceRegex{
+				tc.DeliveryServiceRegex{
+					Type:      string(tc.DSMatchTypeHostRegex),
+					SetNumber: 0,
+					Pattern:   `.*\.mypattern\..*`,
+				},
+			},
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       "serverpkgval",
+			ConfigFile: "package",
+			Value:      "serverpkgval __HOSTNAME__ foo",
+			Profiles:   []byte(*server.Profile),
+		},
+		tc.Parameter{
+			Name:       "dscp_remap_no",
+			ConfigFile: "package",
+			Value:      "notused",
+			Profiles:   []byte(*server.Profile),
+		},
+	}
+
+	remapConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "not_location",
+			ConfigFile: "cachekey.config",
+			Value:      "notinconfig",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPost",
+			ConfigFile: "remap.config",
+			Value:      "remap http://penraw/ http://penraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPost",
+			ConfigFile: "remap.config",
+			Value:      "remap http://lastraw/ http://lastraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+		tc.Parameter{
+			Name:       "LastRawRemapPre",
+			ConfigFile: "remap.config",
+			Value:      "map_with_recp_port http://firstraw:8000/ http://firstraw0/",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+	}
+
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	topologies := []tc.Topology{
+		{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1, 2},
+				},
+				{
+					Cachegroup: "midCG",
+				},
+				{
+					Cachegroup: "midCG2",
+				},
+			},
+		},
+	}
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.HostName = util.StrPtr("mymid0")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCG.SecondaryParentName = mid1.Cachegroup
+	eCG.SecondaryParentCachegroupID = mid1.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	mCG2 := &tc.CacheGroupNullable{}
+	mCG2.Name = mid1.Cachegroup
+	mCG2.ID = mid1.CachegroupID
+	mCGType2 := tc.CacheGroupMidTypeName
+	mCG2.Type = &mCGType2
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *mCG2}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, opt.HdrComment)
+
+	if strings.Contains(txt, `strategy`) {
+		t.Fatalf("expected no strategy core directive for !opt.UseStrategies but useless opt.UseStrategiesCores, actual: %v", txt)
+	}
+
+	if strings.Contains(txt, `parent_select`) {
+		t.Fatalf("expected no strategy plugin directive for !opt.UseStrategies but useless opt.UseStrategiesCores, actual: %v", txt)
+	}
+
+	if !warningsContains(cfg.Warnings, "ot using strategies") {
+		t.Errorf("expected warning about not using strategies with useless opt UseStrategiesCore but no UseStrategies, actual '%v'", cfg.Warnings)
 	}
 }

--- a/lib/go-atscfg/strategiesdotconfig.go
+++ b/lib/go-atscfg/strategiesdotconfig.go
@@ -1,0 +1,270 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	//	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+const ContentTypeStrategiesDotYAML = ContentTypeYAML
+const LineCommentStrategiesDotYAML = LineCommentHash
+
+// StrategiesYAMLOpts contains settings to configure strategies.config generation options.
+type StrategiesYAMLOpts struct {
+	// VerboseComments is whether to add informative comments to the generated file, about what was generated and why.
+	// Note this does not include the header comment, which is configured separately with HdrComment.
+	// These comments are human-readable and not guarnateed to be consistent between versions. Automating anything based on them is strongly discouraged.
+	VerboseComments bool
+
+	// HdrComment is the header comment to include at the beginning of the file.
+	// This should be the text desired, without comment syntax (like # or //). The file's comment syntax will be added.
+	// To omit the header comment, pass the empty string.
+	HdrComment string
+}
+
+func MakeStrategiesDotYAML(
+	dses []DeliveryService,
+	server *Server,
+	servers []Server,
+	topologies []tc.Topology,
+	tcServerParams []tc.Parameter,
+	tcParentConfigParams []tc.Parameter,
+	serverCapabilities map[int]map[ServerCapability]struct{},
+	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
+	cacheGroupArr []tc.CacheGroupNullable,
+	dss []DeliveryServiceServer,
+	cdn *tc.CDN,
+	opt *StrategiesYAMLOpts,
+) (Cfg, error) {
+	if opt == nil {
+		opt = &StrategiesYAMLOpts{}
+	}
+	parentAbstraction, warnings, err := makeParentDotConfigData(
+		dses,
+		server,
+		servers,
+		topologies,
+		tcServerParams,
+		tcParentConfigParams,
+		serverCapabilities,
+		dsRequiredCapabilities,
+		cacheGroupArr,
+		dss,
+		cdn,
+		&ParentConfigOpts{
+			AddComments: opt.VerboseComments,
+			HdrComment:  opt.HdrComment,
+		}, // TODO change makeParentDotConfigData to its own opt?
+	)
+	if err != nil {
+		return Cfg{}, makeErr(warnings, err.Error())
+	}
+
+	atsMajorVer, verWarns := getATSMajorVersion(tcServerParams)
+	warnings = append(warnings, verWarns...)
+
+	text, paWarns, err := parentAbstractionToStrategiesDotYaml(parentAbstraction, opt, atsMajorVer)
+	warnings = append(warnings, paWarns...)
+	if err != nil {
+		return Cfg{}, makeErr(warnings, err.Error())
+	}
+
+	hdr := ""
+	if opt.HdrComment != "" {
+		hdr = makeHdrComment(opt.HdrComment)
+	}
+
+	return Cfg{
+		Text:        hdr + text,
+		ContentType: ContentTypeParentDotConfig,
+		LineComment: LineCommentParentDotConfig,
+		Warnings:    warnings,
+	}, nil
+}
+
+// YAMLDocumentStart is the YAML document start directive
+const YAMLDocumentStart = "---"
+const YAMLDocumentEnd = "..."
+
+func parentAbstractionToStrategiesDotYaml(pa *ParentAbstraction, opt *StrategiesYAMLOpts, atsMajorVersion int) (string, []string, error) {
+	warnings := []string{}
+	txt := YAMLDocumentStart +
+		getStrategyHostsSection(pa) +
+		getStrategyGroupsSection(pa) +
+		getStrategyStrategiesSection(pa) +
+		"\n" + YAMLDocumentEnd +
+		"\n"
+	return txt, warnings, nil
+}
+
+// getStrategyPolicy returns the strategies.config text for the retry policy.
+// Returns the default policy if policy is invalid, without error.
+func getStrategyPolicy(policy ParentAbstractionServiceRetryPolicy) string {
+	switch policy {
+	case ParentAbstractionServiceRetryPolicyConsistentHash:
+		return `consistent_hash`
+	case ParentAbstractionServiceRetryPolicyRoundRobinIP:
+		return `rr_ip`
+	case ParentAbstractionServiceRetryPolicyRoundRobinStrict:
+		return `rr_strict`
+	case ParentAbstractionServiceRetryPolicyFirst:
+		return `first_live`
+	case ParentAbstractionServiceRetryPolicyLatched:
+		return `latched`
+	default:
+		return getStrategyPolicy(DefaultParentAbstractionServiceRetryPolicy)
+	}
+}
+
+func getStrategyName(dsName string) string {
+	return "strategy-" + dsName
+}
+
+func getStrategySecondaryMode(mode ParentAbstractionServiceParentSecondaryMode) string {
+	switch mode {
+	case ParentAbstractionServiceParentSecondaryModeExhaust:
+		return `exhaust_ring`
+	case ParentAbstractionServiceParentSecondaryModeAlternate:
+		return `alternate_ring`
+	default:
+		return getStrategySecondaryMode(ParentAbstractionServiceParentSecondaryModeDefault)
+	}
+}
+
+func getStrategyErrorCodes(codes []int) string {
+	str := ""
+	for _, code := range codes {
+		str += "\n" + `        - ` + strconv.Itoa(code)
+	}
+	return str
+}
+
+func getStrategyGroups(svc *ParentAbstractionService) string {
+	txt := ""
+	if len(svc.Parents) != 0 {
+		txt += "\n" + `      - *group_parents_` + svc.Name
+	}
+	if len(svc.SecondaryParents) != 0 {
+		txt += "\n" + `      - *group_secondary_parents_` + svc.Name
+	}
+	return txt
+}
+
+func getStrategyStrategiesSection(pa *ParentAbstraction) string {
+	txt := "\n" + `strategies:`
+	for _, svc := range pa.Services {
+		txt += "\n" + `  - strategy: '` + getStrategyName(svc.Name) + `'`
+		txt += "\n" + `    policy: ` + getStrategyPolicy(svc.RetryPolicy)
+		if !svc.IgnoreQueryStringInParentSelection {
+			txt += "\n" + `    hash_key: path+query`
+		} else {
+			txt += "\n" + `    hash_key: path`
+		}
+		txt += "\n" + `    go_direct: ` + strconv.FormatBool(svc.GoDirect)
+		txt += "\n" + `    groups:`
+		txt += getStrategyGroups(svc)
+		// TODO make strategies for both? add to parent?
+		//      Ask John why this exists. Since it's specified on the remap, shouldn't it use the
+		//      remap target's scheme?
+		// txt += "\n" + `    scheme: http`
+		txt += "\n" + `    failover:`
+		txt += "\n" + `      ring_mode: ` + getStrategySecondaryMode(svc.SecondaryMode)
+		if len(svc.ErrorResponseCodes) > 0 {
+			txt += "\n" + `      max_simple_retries: ` + strconv.Itoa(svc.MaxSimpleRetries)
+			txt += "\n" + `      response_codes:`
+			txt += getStrategyErrorCodes(svc.ErrorResponseCodes)
+		}
+		if len(svc.MarkdownResponseCodes) > 0 {
+			txt += "\n" + `      max_unavailable_retries: ` + strconv.Itoa(svc.MaxMarkdownRetries)
+			txt += "\n" + `      markdown_codes:`
+			txt += getStrategyErrorCodes(svc.MarkdownResponseCodes)
+		}
+		txt += "\n" + `      health_check:`
+		txt += "\n" + `        - passive`
+	}
+	return txt
+}
+
+func serviceGroupParentsName(pa *ParentAbstractionService) string {
+	anchorSvcName := pa.Name
+	anchorSvcName = strings.Replace(anchorSvcName, `.`, `-dot-`, -1)
+	return `group_parents_` + anchorSvcName
+}
+
+func serviceGroupSecondaryParentsName(pa *ParentAbstractionService) string {
+	anchorSvcName := pa.Name
+	anchorSvcName = strings.Replace(anchorSvcName, `.`, `-dot-`, -1)
+	return `group_secondary_parents_` + anchorSvcName
+}
+
+func getStrategyGroupsSection(pa *ParentAbstraction) string {
+	txt := "\n" + `groups:`
+	for _, svc := range pa.Services {
+		if len(svc.Parents) != 0 {
+			txt += "\n" + `  - &` + serviceGroupParentsName(svc)
+		}
+		for _, parent := range svc.Parents {
+			txt += "\n" + `    - <<: *` + getStrategyParentHostEntryName(svc, parent)
+			txt += "\n" + `      weight: ` + strconv.FormatFloat(parent.Weight, 'f', 3, 64)
+		}
+
+		if len(svc.SecondaryParents) != 0 {
+			txt += "\n" + `  - &` + serviceGroupSecondaryParentsName(svc)
+		}
+		for _, parent := range svc.SecondaryParents {
+			txt += "\n" + `    - <<: *` + getStrategyParentHostEntryName(svc, parent)
+			txt += "\n" + `      weight: ` + strconv.FormatFloat(parent.Weight, 'f', 3, 64)
+		}
+	}
+	return txt
+}
+
+func getStrategyParentHostEntryName(svc *ParentAbstractionService, parent *ParentAbstractionServiceParent) string {
+	// fqdn characters are valid yaml anchor characters except for '.'
+	anchorFQDN := strings.Replace(parent.FQDN, `.`, `-dot-`, -1)
+	return `host__` + svc.Name + `__parent__` + anchorFQDN + "__" + strconv.Itoa(parent.Port)
+}
+
+func getStrategyHostsSection(pa *ParentAbstraction) string {
+	txt := "\n" + `hosts:`
+	for _, svc := range pa.Services {
+		for _, parent := range svc.Parents {
+			txt += getStrategyHostsSectionHost(svc, parent)
+		}
+		for _, parent := range svc.SecondaryParents {
+			txt += getStrategyHostsSectionHost(svc, parent)
+		}
+	}
+	return txt
+}
+
+func getStrategyHostsSectionHost(svc *ParentAbstractionService, parent *ParentAbstractionServiceParent) string {
+	txt := ""
+	txt += "\n" + `  - &` + getStrategyParentHostEntryName(svc, parent)
+	txt += "\n" + `    host: ` + parent.FQDN
+	txt += "\n" + `    protocol:`
+	// txt += "\n" + `      - scheme: http` // TODO fix?
+	txt += "\n" + `      - port: ` + strconv.Itoa(parent.Port)
+	return txt
+}

--- a/lib/go-atscfg/strategiesdotconfig_test.go
+++ b/lib/go-atscfg/strategiesdotconfig_test.go
@@ -1,0 +1,448 @@
+package atscfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestMakeStrategiesDotConfig(t *testing.T) {
+	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
+
+	ds0 := makeParentDS()
+	ds0.XMLID = util.StrPtr("ds0")
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+
+	ds1 := makeParentDS()
+	ds1.XMLID = util.StrPtr("ds1")
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+
+	dses := []DeliveryService{*ds0, *ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.HostName = util.StrPtr("mymid0")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	servers := []Server{*server, *mid0, *mid1}
+
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds0.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds1.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	cfg, err := MakeStrategiesDotYAML(dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, opt.HdrComment)
+
+	expecteds := []string{
+		"strategy:'strategy-ds0'",
+		"strategy:'strategy-ds1'",
+		"host__ds0__parent__mymid0-dot-mydomain-dot-example-dot-net__80\nhost:mymid0.mydomain.example.net",
+		"host__ds0__parent__mymid1-dot-mydomain-dot-example-dot-net__80\nhost:mymid1.mydomain.example.net",
+		"host__ds1__parent__mymid0-dot-mydomain-dot-example-dot-net__80\nhost:mymid0.mydomain.example.net",
+		"host__ds1__parent__mymid1-dot-mydomain-dot-example-dot-net__80\nhost:mymid1.mydomain.example.net",
+	}
+	txt = strings.Replace(txt, " ", "", -1)
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected parent '''%v''', actual: '''%v'''", expected, txt)
+		}
+	}
+	if !warningsContains(cfg.Warnings, "myQStringHandlingParam") {
+		t.Errorf("expected malformed qstring 'myQstringParam' in warnings, actual: '%v' val '%v'", cfg.Warnings, txt)
+	}
+}
+
+func TestMakeStrategiesTopologiesParams(t *testing.T) {
+	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+	ds1.ProfileName = util.StrPtr("ds1Profile")
+	ds1.ProfileID = util.IntPtr(994)
+	ds1.MultiSiteOrigin = util.BoolPtr(true)
+
+	dses := []DeliveryService{*ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      "consistent_hash",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamParentRetry,
+			ConfigFile: "parent.config",
+			Value:      "both",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamUnavailableServerRetryResponses,
+			ConfigFile: "parent.config",
+			Value:      `"400,503"`,
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxSimpleRetries,
+			ConfigFile: "parent.config",
+			Value:      "14",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxUnavailableServerRetries,
+			ConfigFile: "parent.config",
+			Value:      "9",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "8",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+
+	origin1 := makeTestParentServer()
+	origin1.Cachegroup = util.StrPtr("originCG")
+	origin1.CachegroupID = util.IntPtr(500)
+	origin1.HostName = util.StrPtr("myorigin1")
+	origin1.ID = util.IntPtr(46)
+	setIP(origin1, "192.168.2.3")
+	origin1.Type = tc.OriginTypeName
+	origin1.TypeID = util.IntPtr(991)
+
+	servers := []Server{*server, *origin0, *origin1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "originCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *origin0.ID,
+			DeliveryService: *ds1.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	cfg, err := MakeStrategiesDotYAML(dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, opt.HdrComment)
+
+	txt = strings.Replace(txt, " ", "", -1)
+
+	expecteds := []string{
+		"strategy:'strategy-ds1'",
+		"max_simple_retries:14",
+		"max_unavailable_retries:9",
+		"response_codes:\n-404",
+		"markdown_codes:\n-400\n-503",
+		"host__ds1__parent__myorigin0-dot-mydomain-dot-example-dot-net__80\nhost:myorigin0.mydomain.example.net",
+	}
+
+	for _, expected := range expecteds {
+		if !strings.Contains(txt, expected) {
+			t.Errorf("expected parent '''%v''', actual: '''%v'''", expected, txt)
+		}
+	}
+}
+
+func TestMakeStrategiesHTTPSOrigin(t *testing.T) {
+	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
+
+	ds0 := makeParentDS()
+	ds0.XMLID = util.StrPtr("ds0")
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("https://ds0.example.net")
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+
+	dses := []DeliveryService{*ds0, *ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+
+	mid0 := makeTestParentServer()
+	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.HostName = util.StrPtr("mymid0")
+	mid0.ID = util.IntPtr(45)
+	setIP(mid0, "192.168.2.2")
+
+	mid1 := makeTestParentServer()
+	mid1.Cachegroup = util.StrPtr("midCG")
+	mid1.HostName = util.StrPtr("mymid1")
+	mid1.ID = util.IntPtr(46)
+	setIP(mid1, "192.168.2.3")
+
+	servers := []Server{*server, *mid0, *mid1}
+
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = mid0.Cachegroup
+	eCG.ParentCachegroupID = mid0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid0.Cachegroup
+	mCG.ID = mid0.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds0.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds1.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	cfg, err := MakeStrategiesDotYAML(dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, opt.HdrComment)
+
+	txt = strings.Replace(txt, " ", "", -1)
+
+	// this is an Edge, and all traffic is internal to a Mid
+	// So even though the Origin is HTTPS, all traffic should be 80=HTTP
+
+	if !strings.Contains(txt, "protocol:\n-port:80") {
+		t.Errorf("expected edge parent.config of https origin to use internal http port 80 (not https/443), actual: '%v'", txt)
+	}
+	if strings.Contains(txt, "port: 443") {
+		t.Errorf("expected edge parent.config of https origin to use internal http port 80 and not https/443, actual: '%v'", txt)
+	}
+}


### PR DESCRIPTION
Adds t3c strategies.yaml config generation. The file is always created (as is parent.config), but by default it isn't used. A new flag is added to `t3c-apply`, `--use-strategies` to specify using the parent_select plugin or core Strategies. This flag should be considered experimental.

- [x] This PR fixes #5804

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run unit tests. Run t3c, verify all config files are generated as-expected without strategies. Pass `--use-strategies`, verify remap.config has strategy directives. Verify generated strategies file is correct.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information