### PR TITLE
Remove STATSSUMMARY from Portal change log

### DIFF
--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -154,8 +154,8 @@ func CreateStatsSummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	successMsg := "Stats Summary was successfully created"
-	logMsg := fmt.Sprintf("STATSSUMMARY: %v, ID: %v, ACTION: create stats_summary", *ss.StatName, id)
-	api.CreateChangeLogRawTx(api.ApiChange, logMsg, inf.User, inf.Tx.Tx)
+	// logMsg := fmt.Sprintf("STATSSUMMARY: %v, ID: %v, ACTION: create stats_summary", *ss.StatName, id)
+	// api.CreateChangeLogRawTx(api.ApiChange, logMsg, inf.User, inf.Tx.Tx)
 	api.WriteRespAlert(w, r, tc.SuccessLevel, successMsg)
 }
 

--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -154,8 +154,6 @@ func CreateStatsSummary(w http.ResponseWriter, r *http.Request) {
 	}
 
 	successMsg := "Stats Summary was successfully created"
-	// logMsg := fmt.Sprintf("STATSSUMMARY: %v, ID: %v, ACTION: create stats_summary", *ss.StatName, id)
-	// api.CreateChangeLogRawTx(api.ApiChange, logMsg, inf.User, inf.Tx.Tx)
 	api.WriteRespAlert(w, r, tc.SuccessLevel, successMsg)
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This simply removes the nightly STATSSUMMARY entry lines from the Portal change log.
No changelog or test necessary.

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Ops

## What is the best way to verify this PR?

Wait until Traffic stats writes the Daily Summary. Should not see any log entries for  STATSSUMMARY

## The following criteria are ALL met by this PR

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
