### PR TITLE
5.1.x Add Mid and Topology Service Category Config Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the return error for GET api `cdns/routing` to avoid incorrect success response.
 - [#5712](https://github.com/apache/trafficcontrol/issues/5712) - Ensure that 5.x Traffic Stats is compatible with 5.x Traffic Monitor and 5.x Traffic Ops, and that it doesn't log all 0's for `cache_stats`
 - Fixed ORT being unable to update URLSIG keys for Delivery Services
+- Fixed ORT service category header rewrite for mids and topologies.
 - Fixed an issue where Traffic Ops becoming unavailable caused Traffic Monitor to segfault and crash
 - [#5754](https://github.com/apache/trafficcontrol/issues/5754) - Ensure Health Threshold Parameters use legacy format for legacy Monitoring Config handler
 - [#5695](https://github.com/apache/trafficcontrol/issues/5695) - Ensure vitals are calculated only against monitored interfaces

--- a/lib/go-atscfg/headerrewritemiddotconfig.go
+++ b/lib/go-atscfg/headerrewritemiddotconfig.go
@@ -157,13 +157,12 @@ func MakeHeaderRewriteMidDotConfig(
 		}
 		if dsOnlineMidCount > 0 {
 			maxOriginConnectionsPerMid := int(math.Round(float64(ds.MaxOriginConnections) / float64(dsOnlineMidCount)))
-			text += "cond %{REMAP_PSEUDO_HOOK}\nset-config proxy.config.http.origin_max_connections " + strconv.Itoa(maxOriginConnectionsPerMid)
-			if ds.MidHeaderRewrite == "" {
-				text += " [L]"
-			} else {
-				text += "\n"
-			}
+			text += "cond %{REMAP_PSEUDO_HOOK}\nset-config proxy.config.http.origin_max_connections " + strconv.Itoa(maxOriginConnectionsPerMid) + "\n"
 		}
+	}
+
+	if !strings.Contains(ds.MidHeaderRewrite, ServiceCategoryHeader) && ds.ServiceCategory != "" {
+		text += "cond %{REMAP_PSEUDO_HOOK}\nset-header " + ServiceCategoryHeader + ` "` + dsName + "|" + ds.ServiceCategory + `"` + "\n"
 	}
 
 	// write the contents of ds.MidHeaderRewrite to hdr_rw_mid_xml-id.config replacing any instances of __RETURN__ (surrounded by spaces or not) with \n

--- a/lib/go-atscfg/headerrewritemiddotconfig_test.go
+++ b/lib/go-atscfg/headerrewritemiddotconfig_test.go
@@ -205,4 +205,7 @@ func TestMakeHeaderRewriteMidDotConfigNoMaxConns(t *testing.T) {
 	if strings.Contains(txt, "origin_max_connections") {
 		t.Errorf("expected no origin_max_connections on edge-only DS, actual '%v'\n", txt)
 	}
+	if !strings.Contains(txt, "ds0|servicecategory") {
+		t.Errorf("expected 'ds0|servicecategory' actual '%v'\n", txt)
+	}
 }

--- a/lib/go-atscfg/topologyheaderrewritedotconfig.go
+++ b/lib/go-atscfg/topologyheaderrewritedotconfig.go
@@ -144,12 +144,11 @@ func MakeTopologyHeaderRewriteDotConfig(
 			maxOriginConnectionsPerServer = 1
 		}
 
-		text += "cond %{REMAP_PSEUDO_HOOK}\nset-config proxy.config.http.origin_max_connections " + strconv.Itoa(maxOriginConnectionsPerServer)
-		if headerRewrite == nil || *headerRewrite == "" {
-			text += " [L]"
-		} else {
-			text += "\n"
-		}
+		text += "cond %{REMAP_PSEUDO_HOOK}\nset-config proxy.config.http.origin_max_connections " + strconv.Itoa(maxOriginConnectionsPerServer) + "\n"
+	}
+
+	if (headerRewrite == nil || !strings.Contains(*headerRewrite, ServiceCategoryHeader)) && ds.ServiceCategory != nil && *ds.ServiceCategory != "" {
+		text += "cond %{REMAP_PSEUDO_HOOK}\nset-header " + ServiceCategoryHeader + ` "` + dsName + "|" + *ds.ServiceCategory + `"` + "\n"
 	}
 
 	if headerRewrite != nil && *headerRewrite != "" {


### PR DESCRIPTION
Adds 5.1.x Mid and Topology Service Category Config Generation. This is already in `master`.

Includes tests.
No docs, no interface change.
Includes changelog.

- [x] This PR fixes #5809 OR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Run ORT or t3c and verify delivery services with service categories have mid and topology header rewrites as appropriate.

## If this is a bug fix, what versions of Traffic Control are affected?
- 5.x releases

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information