### PR TITLE
Implement DNSSEC key methods for Postgres Traffic Vault backend

### DIFF
--- a/lib/go-tc/cdns_dnssec.go
+++ b/lib/go-tc/cdns_dnssec.go
@@ -46,6 +46,8 @@ type GenerateCDNDNSSECKeysResponse struct {
 
 type DeleteCDNDNSSECKeysResponse GenerateCDNDNSSECKeysResponse
 
+type RefreshDNSSECKeysResponse GenerateCDNDNSSECKeysResponse
+
 // DNSSECKeys is the DNSSEC keys as stored in Riak, plus the DS record text.
 type DNSSECKeys map[string]DNSSECKeySet
 

--- a/traffic_ops/v4-client/cdn_dnssec.go
+++ b/traffic_ops/v4-client/cdn_dnssec.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	apiCDNsDNSSECKeysGenerate = "/cdns/dnsseckeys/generate"
-	apiCDNsNameDNSSECKeys     = "cdns/name/%s/dnsseckeys"
+	apiCDNsDNSSECKeysGenerate    = "/cdns/dnsseckeys/generate"
+	apiCDNsNameDNSSECKeys        = "/cdns/name/%s/dnsseckeys"
+	apiCDNsDNSSECRefresh         = "/cdns/dnsseckeys/refresh"
+	apiCDNsDNSSECKeysKSKGenerate = "/cdns/%s/dnsseckeys/ksk/generate"
 )
 
 // GenerateCDNDNSSECKeys generates DNSSEC keys for the given CDN.
@@ -47,5 +49,20 @@ func (to *Session) DeleteCDNDNSSECKeys(name string, header http.Header) (tc.Dele
 	route := fmt.Sprintf(apiCDNsNameDNSSECKeys, name)
 	var resp tc.DeleteCDNDNSSECKeysResponse
 	reqInf, err := to.del(route, header, &resp)
+	return resp, reqInf, err
+}
+
+// RefreshDNSSECKeys asynchronously regenerates any expired DNSSEC keys in all CDNs.
+func (to *Session) RefreshDNSSECKeys(header http.Header) (tc.RefreshDNSSECKeysResponse, toclientlib.ReqInf, error) {
+	var resp tc.RefreshDNSSECKeysResponse
+	reqInf, err := to.get(apiCDNsDNSSECRefresh, header, &resp)
+	return resp, reqInf, err
+}
+
+// GenerateCDNDNSSECKSK generates the DNSSEC KSKs (key-signing key) for the given CDN.
+func (to *Session) GenerateCDNDNSSECKSK(name string, req tc.CDNGenerateKSKReq, header http.Header) (tc.GenerateCDNDNSSECKeysResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(apiCDNsDNSSECKeysKSKGenerate, name)
+	var resp tc.GenerateCDNDNSSECKeysResponse
+	reqInf, err := to.post(route, req, header, &resp)
 	return resp, reqInf, err
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?
This PR implements the DNSSEC key methods for the Postgres Traffic Vault backend.

## Which Traffic Control components are affected by this PR?
- Traffic Control Client (Go)
- Traffic Ops
- Traffic Vault
- CI tests

## What is the best way to verify this PR?
Ensure the CI tests pass.
Configure `cdn.conf` to use the Postgres Traffic Vault backend then run the TO API v4 tests locally and ensure they pass.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] No docs necessary
- [x] No changelog necessary (already covered)
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)