### PR TITLE
Only copy Transport exported fields

### DIFF
--- a/.github/workflows/go.vet.yml
+++ b/.github/workflows/go.vet.yml
@@ -48,8 +48,4 @@ jobs:
     - name: Install modules
       run: go mod vendor -v
     - name: go vet
-      run: |
-        skip_analyzers=(
-          -copylocks=false
-        )
-        go vet "${skip_analyzers[@]}" ./...
+      run: go vet ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,8 +29,3 @@ linters:
   disable-all: true
   enable:
     - govet
-
-linters-settings:
-  govet:
-    disable:
-      - copylocks

--- a/grove/remap/remap.go
+++ b/grove/remap/remap.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/trafficcontrol/grove/plugin"
 	"github.com/apache/trafficcontrol/grove/remapdata"
 	"github.com/apache/trafficcontrol/grove/web"
+
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 )

--- a/grove/remap/remap.go
+++ b/grove/remap/remap.go
@@ -30,7 +30,6 @@ import (
 	"github.com/apache/trafficcontrol/grove/plugin"
 	"github.com/apache/trafficcontrol/grove/remapdata"
 	"github.com/apache/trafficcontrol/grove/web"
-
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
@@ -497,7 +496,8 @@ func makeTo(tosJSON []RemapRuleToJSON, rule remapdata.RemapRule, baseTransport *
 				return nil, fmt.Errorf("error parsing to %v proxy_url: %v", to.URL, toJSON.ProxyURL)
 			}
 			to.ProxyURL = proxyURL
-			newTransport := *baseTransport
+			// See b7953cc239 for the reasoning behind copying the Transport.
+			newTransport := *baseTransport.Clone()
 			if proxyURL != nil && proxyURL.Host != "" {
 				newTransport.Proxy = http.ProxyURL(proxyURL)
 			}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
- [x] <strike>This PR fixes #5758 by copying a struct containing locks using unsafe Go.</strike><!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
- [x] This PR fixes #5758 only copying the exported fields of `http.Transport`.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Grove

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run `go vet -copylocks ./...`

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (5b9e199244)
- 5.1.1
- 5.1.2 (RC3)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Effect of struct copy is unchanged, tests are unnecessary
- [x] Behavior is unchanged, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

