### PR TITLE
t3c-apply: ensure files and directories are created with ats uid/gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed server creation through legacy API versions to default `monitor` to `true`.
 - Fixed Traffic Monitor to report `ONLINE` caches as available.
 - [#5754](https://github.com/apache/trafficcontrol/issues/5754) - Ensure Health Threshold Parameters use legacy format for legacy Monitoring Config handler
+- Fixed t3c to create config files and directories as ats.ats
 
 ### Changed
 - Updated the Traffic Ops Python client to 3.0

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -189,7 +189,7 @@ func (r *TrafficOpsReq) checkConfigFile(cfg *ConfigFile, filesAdding []string) e
 		return nil
 	}
 
-	if !util.MkDir(cfg.Dir, r.Cfg) {
+	if !util.MkDirWithOwner(cfg.Dir, r.Cfg, cfg.Uid, cfg.Gid) {
 		return errors.New("Unable to create the directory '" + cfg.Dir + " for " + "'" + cfg.Name + "'")
 	}
 
@@ -466,7 +466,7 @@ func (r *TrafficOpsReq) replaceCfgFile(cfg *ConfigFile) error {
 	// If we just wrote to the real location and the app or OS or anything crashed,
 	// we'd end up with malformed files.
 
-	if err := ioutil.WriteFile(tmpFileName, cfg.Body, 0644); err != nil {
+	if _, err := util.WriteFileWithOwner(tmpFileName, cfg.Body, cfg.Uid, cfg.Gid, 0644); err != nil {
 		return errors.New("Failed to write temp config file '" + tmpFileName + "': " + err.Error())
 	}
 

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -189,7 +189,7 @@ func (r *TrafficOpsReq) checkConfigFile(cfg *ConfigFile, filesAdding []string) e
 		return nil
 	}
 
-	if !util.MkDirWithOwner(cfg.Dir, r.Cfg, cfg.Uid, cfg.Gid) {
+	if !util.MkDirWithOwner(cfg.Dir, r.Cfg, &cfg.Uid, &cfg.Gid) {
 		return errors.New("Unable to create the directory '" + cfg.Dir + " for " + "'" + cfg.Name + "'")
 	}
 
@@ -466,7 +466,7 @@ func (r *TrafficOpsReq) replaceCfgFile(cfg *ConfigFile) error {
 	// If we just wrote to the real location and the app or OS or anything crashed,
 	// we'd end up with malformed files.
 
-	if _, err := util.WriteFileWithOwner(tmpFileName, cfg.Body, cfg.Uid, cfg.Gid, 0644); err != nil {
+	if _, err := util.WriteFileWithOwner(tmpFileName, cfg.Body, &cfg.Uid, &cfg.Gid, 0644); err != nil {
 		return errors.New("Failed to write temp config file '" + tmpFileName + "': " + err.Error())
 	}
 

--- a/cache-config/t3c-apply/util/util.go
+++ b/cache-config/t3c-apply/util/util.go
@@ -193,7 +193,7 @@ func ServiceStart(service string, cmd string) (bool, error) {
 	return false, nil
 }
 
-func WriteFileWithOwner(fn string, data []byte, uid int, gid int, perm os.FileMode) (int, error) {
+func WriteFileWithOwner(fn string, data []byte, uid *int, gid *int, perm os.FileMode) (int, error) {
 	fd, err := os.OpenFile(fn, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return 0, errors.New("unable to open '" + fn + "' for writing: " + err.Error())
@@ -205,8 +205,8 @@ func WriteFileWithOwner(fn string, data []byte, uid int, gid int, perm os.FileMo
 	}
 	fd.Close()
 
-	if uid > -1 && gid > -1 {
-		err = os.Chown(fn, uid, gid)
+	if uid != nil && gid != nil {
+		err = os.Chown(fn, *uid, *gid)
 		if err != nil {
 			return 0, errors.New("error changing ownership on '" + fn + "': " + err.Error())
 		}
@@ -379,18 +379,18 @@ func CleanTmpDir(cfg config.Cfg) bool {
 }
 
 func MkDir(name string, cfg config.Cfg) bool {
-	return doMkDirWithOwner(name, cfg, -1, -1, false)
+	return doMkDirWithOwner(name, cfg, nil, nil, false)
 }
 
 func MkDirAll(name string, cfg config.Cfg) bool {
-	return doMkDirWithOwner(name, cfg, -1, -1, true)
+	return doMkDirWithOwner(name, cfg, nil, nil, true)
 }
 
-func MkDirWithOwner(name string, cfg config.Cfg, uid int, gid int) bool {
+func MkDirWithOwner(name string, cfg config.Cfg, uid *int, gid *int) bool {
 	return doMkDirWithOwner(name, cfg, uid, gid, false)
 }
 
-func doMkDirWithOwner(name string, cfg config.Cfg, uid int, gid int, all bool) bool {
+func doMkDirWithOwner(name string, cfg config.Cfg, uid *int, gid *int, all bool) bool {
 	fileInfo, err := os.Stat(name)
 	if err == nil && fileInfo.Mode().IsDir() {
 		log.Debugf("the directory '%s' already exists", name)
@@ -409,8 +409,8 @@ func doMkDirWithOwner(name string, cfg config.Cfg, uid int, gid int, all bool) b
 					return false
 				}
 
-				if uid > -1 && gid > -1 {
-					err = os.Chown(name, uid, gid)
+				if uid != nil && gid != nil {
+					err = os.Chown(name, *uid, *gid)
 					if err != nil {
 						log.Errorf("unable to chown directory uid/gid, '%s': %v", name, err)
 						return false

--- a/cache-config/testing/ort-tests/tcdata/todb.go
+++ b/cache-config/testing/ort-tests/tcdata/todb.go
@@ -36,7 +36,7 @@ func (r *TCData) OpenConnection() (*sql.DB, error) {
 		sslStr = "disable"
 	}
 
-	fmt.Printf("User: %s, Password: len %s, Hostname: %s, DB: %s\n", r.Config.TrafficOpsDB.User, len(r.Config.TrafficOpsDB.Password), r.Config.TrafficOpsDB.Hostname, r.Config.TrafficOpsDB.Name)
+	fmt.Printf("User: %s, Password: len %d, Hostname: %s, DB: %s\n", r.Config.TrafficOpsDB.User, len(r.Config.TrafficOpsDB.Password), r.Config.TrafficOpsDB.Hostname, r.Config.TrafficOpsDB.Name)
 	db, err = sql.Open("postgres", fmt.Sprintf("postgres://%s:%s@%s/%s?sslmode=%s", r.Config.TrafficOpsDB.User, r.Config.TrafficOpsDB.Password, r.Config.TrafficOpsDB.Hostname, r.Config.TrafficOpsDB.Name, sslStr))
 
 	if err != nil {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5035 <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This fixes a new issue where the new t3c-apply does not set ats uid/gid for hdr_rw_*, url_sig_*, etc files.
This won't fix directories created by an ats install (like body_factory)

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops ORT

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Run badass and inspect permissions assigned to files and directoris in /opt/ats/etc/
Only the body_factory subdirectory will still be root as that is created by the ats rpm.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
