### PR TITLE
Fix t3c diff for empty files

### DIFF
--- a/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
+++ b/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
@@ -1,0 +1,65 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/util"
+)
+
+func TestT3cCreateEmptyFile(t *testing.T) {
+	// t3c must create semantically blank files. Failing to do so will cause other config files that reference them to fail.
+	t.Logf("------------- Starting TestT3cCreateEmptyFile ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		err := t3cUpdateGit("atlanta-edge-03", "badass")
+		if err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		const emptyFileName = `empty-file.config`
+
+		filePath := test_config_dir + "/" + emptyFileName
+
+		if !util.FileExists(filePath) {
+			t.Fatalf("ERROR: missing empty config file, %s,  empty files must still be created", filePath)
+		}
+
+		emptyFile, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("reading file '%v': %v\n", filePath, err)
+		}
+		emptyFile = bytes.TrimSpace(emptyFile)
+
+		lines := strings.Split(string(emptyFile), "\n")
+		if len(lines) > 0 && !strings.HasPrefix(lines[0], `#`) {
+			t.Errorf("expected file '%v' to be empty except for comment, actual '%v'\n", filePath, string(emptyFile))
+		}
+		if len(lines) > 1 {
+			t.Errorf("expected file '%v' to be empty for testing, actual '%v'\n", filePath, string(emptyFile))
+		}
+	})
+	t.Logf("------------- End of TestT3cCreateEmptyFile ---------------")
+}

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -1764,6 +1764,12 @@
             	      "value": "*"
         	      },
                 {
+                    "configFile": "empty-file.config",
+                    "name": "location",
+                    "secure": false,
+                    "value": "/opt/trafficserver/etc/trafficserver/"
+                },
+                {
                     "configFile": "remap.config",
                     "name": "location",
             	      "secure": false,


### PR DESCRIPTION
Fixes t3c-diff to report a diff for a new semantically empty file, which causes t3c-apply to create it.

This was a bug, because if another config (like remap.config plugins) references the file, it may be legal to be empty, but ATS will fail to load if it doesn't exist.

No docs, no changelog, no interface change and bug isn't in a release.
Includes tests.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run ORT integration tests. Create an empy file in Traffic Ops such as with a location param to a custom file with no other parameters, ensure t3c-apply creates the file.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
