### PR TITLE
Update t3c-apply to not pass the user, password, and url command when the environment variables are used.

### DIFF
--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -259,12 +259,18 @@ func GetCfg() (Cfg, error) {
 	if toURL == "" {
 		urlSourceStr = "environment variable"
 		toURL = os.Getenv("TO_URL")
+	} else {
+		os.Setenv("TO_URL", toURL)
 	}
 	if toUser == "" {
 		toUser = os.Getenv("TO_USER")
+	} else {
+		os.Setenv("TO_USER", toUser)
 	}
 	if *toPassPtr == "" {
 		toPass = os.Getenv("TO_PASS")
+	} else {
+		os.Setenv("TO_PASS", toPass)
 	}
 
 	// set TSHome


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Update t3c-apply to not pass the user, password, and url command
line options to t3c-request or t3c-update when the environment variables 
are used.  This will protect credential information from being viewed with the 'ps'
command.

- [ ] This PR fixes #REPLACE_ME OR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT
- CI tests

## What is the best way to verify this PR?
Run the trafficcontrol-cache-config integration tests and ensure
that they pass

- [ ] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [ ] This PR includes any and all required license headers
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information


<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
