### PR TITLE
Update the default TM write timeout to 20s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated Traffic Ops supported database version from PostgreSQL 9.6 to 13.2
 - Set Traffic Router to also accept TLSv1.3 protocols by default in server.xml
 - Disabled TLSv1.1 for Traffic Router in Ansible role by default
+- Updated the Traffic Monitor Ansible role to set `serve_write_timeout_ms` to `20000` by default because 10 seconds can be too short for relatively large CDNs.
 - Refactored the Traffic Ops - Traffic Vault integration to more easily support the development of new Traffic Vault backends
 - Updated Apache Tomcat from 8.5.63 to 9.0.43
 - Delivery Service Requests now keep a record of the changes they make.

--- a/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
@@ -41,7 +41,7 @@ tm_log_location_debug: "null"
 tm_log_location_event: "{{ tm_log_dir }}/event.log"
 tm_stat_flush_interval_ms: 20
 tm_serve_read_timeout_ms: 10000
-tm_serve_write_timeout_ms: 10000
+tm_serve_write_timeout_ms: 20000
 tm_http_poll_no_sleep: false
 tm_http_polling_format: "text/json"
 tm_to_min_retry_interval: 100


### PR DESCRIPTION
## What does this PR (Pull Request) do?
On relatively large CDNs, TM can take longer than 10s to serve
cache stats.

## Which Traffic Control components are affected by this PR?
- ansible automation (for Traffic Monitor)

## What is the best way to verify this PR?
Run the ansible automation to deploy TM, verify that the default write timeout is updated to `20000`.

## The following criteria are ALL met by this PR
- [x] Ansible roles don't have their own tests
- [x] Default value change, no related docs
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
