### PR TITLE
Fix enroller build error due to out-of-scope ARG

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -16,7 +16,6 @@
 # under the License.
 
 FROM debian:buster AS enroller-dependencies
-ARG ENROLLER_DEBUG_BUILD=false
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -34,6 +34,8 @@ RUN go_version=$(cat /GO_VERSION) && \
 ENV GOPATH=/go
 
 FROM enroller-dependencies AS enroller-builder
+ARG ENROLLER_DEBUG_BUILD=false
+
 # enroller source and dependencies
 COPY ./lib/ /go/src/github.com/apache/trafficcontrol/lib/
 COPY ./go.mod ./go.sum /go/src/github.com/apache/trafficcontrol/
@@ -43,7 +45,7 @@ COPY ./traffic_ops/v4-client/ /go/src/github.com/apache/trafficcontrol/traffic_o
 COPY ./infrastructure/cdn-in-a-box/ /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/
 
 WORKDIR /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/enroller
-RUN set -o errexit; \
+RUN set -o errexit -o nounset; \
     go clean; \
     go mod vendor -v; \
     gcflags= ldflags=; \

--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -43,7 +43,7 @@ COPY ./traffic_ops/v4-client/ /go/src/github.com/apache/trafficcontrol/traffic_o
 COPY ./infrastructure/cdn-in-a-box/ /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/
 
 WORKDIR /go/src/github.com/apache/trafficcontrol/infrastructure/cdn-in-a-box/enroller
-RUN set -o errexit -o nounset; \
+RUN set -o errexit; \
     go clean; \
     go mod vendor -v; \
     gcflags= ldflags=; \


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes a bug in the CDN-in-a-Box build system where the enroller's Dockerfile uses an `ARG` that was defined in a previous build stage. From the Dockerfile reference:

> _"An `ARG` instruction goes out of scope at the end of the build stage where it was defined. To use an arg in multiple stages, each stage must include the `ARG` instruction."_

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Verify that the enroller image can build (may need to clean up Docker cache).

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**