### PR TITLE
Define the ENROLLER_DEBUG_BUILD arg in the enroller-builder stage

### DIFF
--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -16,7 +16,6 @@
 # under the License.
 
 FROM debian:buster AS enroller-dependencies
-ARG ENROLLER_DEBUG_BUILD=false
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -34,6 +33,7 @@ RUN go_version=$(cat /GO_VERSION) && \
 ENV GOPATH=/go
 
 FROM enroller-dependencies AS enroller-builder
+ARG ENROLLER_DEBUG_BUILD=false
 # enroller source and dependencies
 COPY ./lib/ /go/src/github.com/apache/trafficcontrol/lib/
 COPY ./go.mod ./go.sum /go/src/github.com/apache/trafficcontrol/


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This PR fixes a bug introduced by #5866 that affects older Docker versions.

#5866 defined a new build stage in the `enroller` Dockerfile, and without moving the definition for the `ENROLLER_DEBUG_BUILD` build arg, `ENROLLER_DEBUG_BUILD` is no longer set within the `enroller-builder` build stage. <strike>On newer versions, like Docker `20.10.6`, this is not a build issue, it just results in the Dockerfile never making use of `ENROLLER_DEBUG_BUILD` when it is truthy.

On older Docker versions, however, like `18.06.0-ce, build 0ffa825`,</strike> This causes a build failure:

```dockerfile
/bin/sh: 1: ENROLLER_DEBUG_BUILD: parameter not set
ERROR: Service 'enroller' failed to build : The command '/bin/sh -c set -o errexit -o nounset;     go clean;     go mod vendor -v;     gcflags= ldflags=;     tags='usergo netgo';     if [ "$ENROLLER_DEBUG_BUILD" = true ]; then         apt-get install -y --no-install-recommends gcc libstdc++-8-dev;         echo 'Building Enroller without optimization or inlining';         gcflags='all=-N -l';     else         echo 'Optimizing Enroller build';         ldflags='-s -w';     fi;     go build -ldflags "$ldflags" -gcflags "$gcflags" -tags "$tags"' returned a non-zero code: 2
```

This PR moves the `ENROLLER_DEBUG_BUILD` build arg definition to the `enroller-builder` build stage.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
In the CDN in a Box directory, <strike>using Docker version `18.06.0-ce, build 0ffa825`</strike> build the `enroller` image, make sure building it suceeds.

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (8c32ae28ee)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Building CDN in a Box is sufficient to test, no further tests necessary
- [x] Bugix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
