### PR TITLE
Fix t3c unsetting to update flag

### DIFF
--- a/cache-config/testing/ort-tests/t3c-apply-unset-update_test.go
+++ b/cache-config/testing/ort-tests/t3c-apply-unset-update_test.go
@@ -1,0 +1,128 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestT3cUnsetsUpdateFlag(t *testing.T) {
+	fmt.Println("------------- Starting TestT3cUnsetsUpdateFlag tests ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		const cacheHostName = `atlanta-edge-03`
+		const cmdUpdateStatus = `update-status`
+
+		t.Logf("DEBUG TestT3cReload calling badass")
+		if stdOut, exitCode := t3cUpdateUnsetFlag(cacheHostName, "badass"); exitCode != 0 {
+			t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+		}
+
+		// delete a file that we know should trigger a reload.
+		fileNameToRemove := filepath.Join(test_config_dir, "hdr_rw_first_ds-top.config")
+		if err := os.Remove(fileNameToRemove); err != nil {
+			t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+		}
+
+		t.Logf("DEBUG TestT3cReload setting upate flag")
+		// set the update flag, so syncds will run
+		if err := ExecTOUpdater(cacheHostName, false, true); err != nil {
+			t.Fatalf("t3c-update failed: %v\n", err)
+		}
+
+		{
+			// verify update status is now true
+
+			output, err := runRequest(cacheHostName, cmdUpdateStatus)
+			if err != nil {
+				t.Fatalf("ERROR: to_requester run failed: %v\n", err)
+			}
+			serverStatus := tc.ServerUpdateStatus{}
+			if err = json.Unmarshal([]byte(output), &serverStatus); err != nil {
+				t.Fatalf("ERROR unmarshalling json output: " + err.Error())
+			}
+			if serverStatus.HostName != cacheHostName {
+				t.Fatalf("expected request update-status host '%v' actual %v", cacheHostName, serverStatus.HostName)
+			} else if serverStatus.RevalPending {
+				t.Fatal("expected RevalPending false after update")
+			} else if !serverStatus.UpdatePending {
+				t.Fatal("expected UpdatePending true after update")
+			}
+		}
+
+		_, _ = t3cUpdateUnsetFlag(cacheHostName, "syncds")
+		// Ignore the exit code error for now, because the ORT Integration Test Framework doesn't currently start ATS.
+		// TODO check err, after running ATS is added to the tests.
+		// if err != nil {
+		// 	t.Fatalf("t3c syncds failed: %v\n", err)
+		// }
+
+		{
+			// verify update status after syncds is now false
+
+			output, err := runRequest(cacheHostName, cmdUpdateStatus)
+			if err != nil {
+				t.Fatalf("t3c-request failed: %v\n", err)
+			}
+			serverStatus := tc.ServerUpdateStatus{}
+			if err = json.Unmarshal([]byte(output), &serverStatus); err != nil {
+				t.Fatalf("unmarshalling request update-status json: " + err.Error())
+			}
+			if serverStatus.HostName != cacheHostName {
+				t.Errorf("expected update-status host '%v' actual %v", cacheHostName, serverStatus.HostName)
+			} else if serverStatus.RevalPending {
+				t.Error("expected RevalPending false after syncds run")
+			} else if serverStatus.UpdatePending {
+				t.Error("expected UpdatePending false after syncds run")
+			}
+		}
+	})
+	fmt.Println("------------- End of TestT3cTOUpdates tests ---------------")
+}
+
+func t3cUpdateUnsetFlag(host string, runMode string) (string, int) {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"--log-location-error=stdout",
+		"--log-location-info=stdout",
+		"--log-location-debug=test.log",
+		"--omit-via-string-release=true",
+		"--git=no",
+		"--run-mode=" + runMode,
+	}
+	stdOut, _, exitCode := t3cutil.Do("t3c", args...) // should be no stderr, we told it to log to stdout
+	return string(stdOut), exitCode
+}

--- a/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
+++ b/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
@@ -16,7 +16,9 @@ package orttest
 
 import (
 	"bytes"
+	"errors"
 	"io/ioutil"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -34,7 +36,7 @@ func TestT3cCreateEmptyFile(t *testing.T) {
 		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
 		tcdata.DeliveryServices}, func() {
 
-		err := t3cUpdateGit("atlanta-edge-03", "badass")
+		err := t3cUpdateCreateEmptyFile("atlanta-edge-03", "badass")
 		if err != nil {
 			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
 		}
@@ -62,4 +64,35 @@ func TestT3cCreateEmptyFile(t *testing.T) {
 		}
 	})
 	t.Logf("------------- End of TestT3cCreateEmptyFile ---------------")
+}
+
+func t3cUpdateCreateEmptyFile(host string, run_mode string) error {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"--log-location-error=test.log",
+		"--log-location-info=test.log",
+		"--log-location-debug=test.log",
+		"--log-location-debug=test.log",
+		"--omit-via-string-release=true",
+		"--run-mode=" + run_mode,
+		"--git=no",
+	}
+	cmd := exec.Command("t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return nil
 }

--- a/cache-config/testing/ort-tests/t3c-dns-local-bind_test.go
+++ b/cache-config/testing/ort-tests/t3c-dns-local-bind_test.go
@@ -66,6 +66,7 @@ func t3cUpdateDNSLocalBind(host string, run_mode string) error {
 		"--log-location-info=test.log",
 		"--log-location-debug=test.log",
 		"--run-mode=" + run_mode,
+		"--git=no",
 		"--dns-local-bind",
 	}
 	cmd := exec.Command("t3c", args...)

--- a/cache-config/testing/ort-tests/t3c-git_test.go
+++ b/cache-config/testing/ort-tests/t3c-git_test.go
@@ -36,7 +36,7 @@ func TestT3cGit(t *testing.T) {
 		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
 		tcdata.DeliveryServices}, func() {
 
-		if err := util.RMGit(base_line_dir); err != nil {
+		if err := util.RMGit(test_config_dir); err != nil {
 			t.Fatalf("removing existing git directory: %v", err)
 		}
 

--- a/cache-config/testing/ort-tests/traffic_ops_ort_test.go
+++ b/cache-config/testing/ort-tests/traffic_ops_ort_test.go
@@ -180,6 +180,7 @@ func runApply(host string, run_mode string) error {
 		"--log-location-info=test.log",
 		"--log-location-debug=test.log",
 		"--omit-via-string-release=true",
+		"--git=no",
 		"--run-mode=" + run_mode,
 	}
 	cmd := exec.Command("t3c", args...)


### PR DESCRIPTION
Fixes t3c not unsetting the update flag correctly.

This was fixed before, it seems the t3c-reload PR had a bad merge and
undid that. This is just re-applying the same code.

Also adds an integration test, so it hopefully doesn't happen again.

Includes tests.
No changelog, no docs, no interface change and bug isn't in a release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run integration tests. Run t3c in syncds mode, verify Traffic Ops update flag is unset properly.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
