### PR TITLE
Use `jq` to set the trafficserver package version for t3c integration tests

### DIFF
--- a/.github/workflows/cache-config-tests.yml
+++ b/.github/workflows/cache-config-tests.yml
@@ -25,6 +25,7 @@ on:
       - go.mod
       - go.sum
       - GO_VERSION
+      - lib/go-atscfg/**.go
       - traffic_ops/*client/**.go
       - traffic_ops/traffic_ops_golang/**.go
       - cache-config/**.go
@@ -41,6 +42,7 @@ on:
       - go.mod
       - go.sum
       - GO_VERSION
+      - lib/go-atscfg/**.go
       - traffic_ops/*client/**.go
       - traffic_ops/toclientlib/**.go
       - lib/atscfg-go/**.go

--- a/.github/workflows/cache-config-tests.yml
+++ b/.github/workflows/cache-config-tests.yml
@@ -28,6 +28,7 @@ on:
       - traffic_ops/*client/**.go
       - traffic_ops/traffic_ops_golang/**.go
       - cache-config/**.go
+      - cache-config/testing/**
       - vendor/**.go
       - vendor/modules.txt
       - .github/actions/build-ats-test-rpm
@@ -45,6 +46,7 @@ on:
       - lib/atscfg-go/**.go
       - traffic_ops/traffic_ops_golang/**.go
       - cache-config/**.go
+      - cache-config/testing/**
       - vendor/**.go
       - vendor/modules.txt
       - .github/actions/build-ats-test-rpm

--- a/cache-config/testing/docker/docker-compose.yml
+++ b/cache-config/testing/docker/docker-compose.yml
@@ -18,9 +18,9 @@
 # Build trafficcontrol:  
 #   Copy the traffic_ops rpm to traffic_ops/traffic_ops.rpm
 #   Copy the trafficcontrol-cache-config rpm to ort_test/trafficcontrol-cache-config.rpm
-#   Copy an ATS rpm to yumserver/test-rpms and update the 
-#     ../ort-tests/tc-fixtures.json to match the rpm version
-#     string you've chosen
+#   Copy an ATS rpm to yumserver/test-rpms (the ort_tests
+#     container updates ../ort-tests/tc-fixtures.json with
+#     the corresponding version string)
 #
 #   Run: docker-compose build
 #   Run: docker-compose run ort_test

--- a/cache-config/testing/docker/ort_test/Dockerfile
+++ b/cache-config/testing/docker/ort_test/Dockerfile
@@ -34,7 +34,9 @@ MAINTAINER dev@trafficcontrol.apache.org
 RUN yum install -y \
   https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
   epel-release initscripts postgresql13.x86_64 git gcc lua-5.1.4-15.el7 lua-devel-5.1.4-15.el7 \
-  ImageMagick-c++-devel
+  ImageMagick-c++-devel && \
+  # jq is used in run.sh to update tc-fixtures.json with the ATS RPM version
+  yum install -y jq
 
 ADD ort_test/trafficcontrol-cache-config*.rpm /trafficcontrol-cache-config.rpm
 RUN yum install -y /trafficcontrol-cache-config.rpm

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -1,4689 +1,4706 @@
 {
-    "asns": [
+  "asns": [
+    {
+      "asn": 8888,
+      "cachegroupName": "originCachegroup"
+    },
+    {
+      "asn": 9999,
+      "cachegroupName": "multiOriginCachegroup"
+    }
+  ],
+  "cachegroups": [
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "originCachegroup",
+      "shortName": "og1",
+      "typeName": "ORG_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "multiOriginCachegroup",
+      "shortName": "mog1",
+      "typeName": "ORG_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "parentCachegroup",
+      "shortName": "pg1",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "parentCachegroup2",
+      "shortName": "pg2",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "secondaryCachegroup",
+      "shortName": "sg1",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "cachegroup1",
+      "parentCachegroupName": "parentCachegroup",
+      "secondaryParentCachegroupName": "secondaryCachegroup",
+      "shortName": "cg1",
+      "localizationMethods": [
+        "CZ",
+        "DEEP_CZ",
+        "GEO"
+      ],
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "fallback1",
+      "parentCachegroupName": "parentCachegroup",
+      "secondaryParentCachegroupName": "secondaryCachegroup",
+      "shortName": "fb1",
+      "localizationMethods": [
+        "CZ",
+        "DEEP_CZ",
+        "GEO"
+      ],
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "fallback2",
+      "parentCachegroupName": "parentCachegroup",
+      "secondaryParentCachegroupName": "secondaryCachegroup",
+      "shortName": "fb2",
+      "localizationMethods": [
+        "CZ",
+        "DEEP_CZ",
+        "GEO"
+      ],
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "fallback3",
+      "parentCachegroupName": "parentCachegroup",
+      "secondaryParentCachegroupName": "secondaryCachegroup",
+      "shortName": "fb3",
+      "localizationMethods": [
+        "CZ",
+        "DEEP_CZ",
+        "GEO"
+      ],
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 24.1234,
+      "longitude": -121.1234,
+      "name": "cachegroup2",
+      "parentCachegroupName": "secondaryCachegroup",
+      "secondaryParentCachegroupName": "parentCachegroup",
+      "shortName": "cg2",
+      "typeName": "EDGE_LOC",
+      "fallbacks": [
+        "fallback1",
+        "fallback2",
+        "fallback3"
+      ]
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "cachegroup3",
+      "parentCachegroupName": "parentCachegroup",
+      "secondaryParentCachegroupName": "secondaryCachegroup",
+      "shortName": "cg3",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "edge-parent1",
+      "shortName": "ep1",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "has-edge-parent1",
+      "parentCachegroupName": "edge-parent1",
+      "shortName": "hep1",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-edge-cg-01",
+      "shortName": "te1",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-edge-cg-02",
+      "shortName": "te2",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-01",
+      "shortName": "tm1",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-02",
+      "shortName": "tm2",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-03",
+      "shortName": "tm3",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-04",
+      "shortName": "tm4",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-05",
+      "shortName": "tm5",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-06",
+      "shortName": "tm6",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "topology-mid-cg-07",
+      "shortName": "tm7",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "dtrc1",
+      "shortName": "dtrc1",
+      "typeName": "MID_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "dtrc2",
+      "shortName": "dtrc2",
+      "typeName": "EDGE_LOC"
+    },
+    {
+      "latitude": 0,
+      "longitude": 0,
+      "name": "dtrc3",
+      "shortName": "dtrc3",
+      "typeName": "EDGE_LOC"
+    }
+  ],
+  "cdns": [
+    {
+      "dnssecEnabled": false,
+      "domainName": "test.cdn1.net",
+      "name": "cdn1"
+    },
+    {
+      "dnssecEnabled": false,
+      "domainName": "test.cdn2.net",
+      "name": "cdn2"
+    },
+    {
+      "dnssecEnabled": false,
+      "domainName": "test.cdn3.net",
+      "name": "cdn3"
+    },
+    {
+      "dnssecEnabled": false,
+      "domainName": "test.cdn4.net",
+      "name": "cdn4"
+    },
+    {
+      "dnssecEnabled": false,
+      "domainName": "test.bar.net",
+      "name": "bar"
+    }
+  ],
+  "deliveryServiceRequestComments": [
+    {
+      "value": "this is comment one"
+    },
+    {
+      "value": "this is comment two"
+    },
+    {
+      "value": "this is comment three"
+    },
+    {
+      "value": "this is comment four"
+    }
+  ],
+  "deliveryServiceRequests": [
+    {
+      "changeType": "create",
+      "deliveryService": {
+        "active": true,
+        "cdnName": "cdn1",
+        "ccrDnsTtl": 30,
+        "deepCachingType": "NEVER",
+        "displayName": "Good Kabletown CDN",
+        "dscp": 1,
+        "geoLimit": 1,
+        "geoProvider": 1,
+        "initialDispersion": 1,
+        "logsEnabled": true,
+        "longDesc": "long desc",
+        "regionalGeoBlocking": true,
+        "routingName": "goodroute",
+        "tenant": "tenant1",
+        "type": "HTTP",
+        "xmlId": "test-ds1"
+      },
+      "status": "draft"
+    },
+    {
+      "changeType": "create",
+      "deliveryService": {
+        "active": true,
+        "cdnName": "cdn1",
+        "ccrDnsTtl": 30,
+        "deepCachingType": "NEVER",
+        "displayName": "Bad Tenant",
+        "dscp": 0,
+        "geoLimit": 0,
+        "geoProvider": 0,
+        "initialDispersion": 3,
+        "logsEnabled": false,
+        "longDesc": "long desc",
+        "regionalGeoBlocking": false,
+        "tenant": "root",
+        "type": "HTTP",
+        "xmlId": "test-ds2"
+      },
+      "status": "draft"
+    },
+    {
+      "changeType": "create",
+      "deliveryService": {
+        "ccrDnsTtl": 30,
+        "deepCachingType": "NEVER",
+        "displayName": "Bad Test Case CDN",
+        "dscp": 0,
+        "geoLimit": 0,
+        "geoProvider": 1,
+        "infoUrl": "xxx",
+        "initialDispersion": 1,
+        "logsEnabled": true,
+        "longDesc": "long desc",
+        "orgServerFqdn": "xxx",
+        "regionalGeoBlocking": true,
+        "routingName": "x routing",
+        "tenant": "tenant1",
+        "type": "HTTP",
+        "xmlId": "test-ds3"
+      },
+      "status": "draft"
+    },
+    {
+      "changeType": "update",
+      "deliveryService": {
+        "active": false,
+        "cdnName": "cdn1",
+        "ccrDnsTtl": 30,
+        "deepCachingType": "NEVER",
+        "displayName": "Testing transitions",
+        "dscp": 3,
+        "geoLimit": 1,
+        "geoProvider": 1,
+        "initialDispersion": 1,
+        "logsEnabled": true,
+        "longDesc": "long desc",
+        "regionalGeoBlocking": true,
+        "routingName": "goodroute",
+        "tenant": "tenant1",
+        "type": "HTTP",
+        "xmlId": "test-transitions"
+      },
+      "status": "draft"
+    }
+  ],
+  "deliveryServices": [
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl1",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds1DisplayName",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "exampleURLs": [
+        "http://ccr.ds1.example.net",
+        "https://ccr.ds1.example.net"
+      ],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s 1",
+      "longDesc1": "ds1",
+      "longDesc2": "ds1",
+      "matchList": [
         {
-            "asn": 8888,
-            "cachegroupName": "originCachegroup"
-        },
-        {
-            "asn": 9999,
-            "cachegroupName": "multiOriginCachegroup"
+          "pattern": ".*\\.ds1\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
         }
-    ],
-    "cachegroups": [
+      ],
+      "maxDnsAnswers": 0,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
+      "routingName": "ccr-ds1",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "HTTP",
+      "xmlId": "ds1",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl2",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [
+        "fmt",
+        "limit",
+        "somethingelse"
+      ],
+      "deepCachingType": "NEVER",
+      "displayName": "d s 1",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "exampleURLs": [
+        "http://ccr.ds2.example.net",
+        "https://ccr.ds2x.example.net"
+      ],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s 1",
+      "longDesc1": "ds2",
+      "longDesc2": "ds2",
+      "matchList": [
         {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "originCachegroup",
-            "shortName": "og1",
-            "typeName": "ORG_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "multiOriginCachegroup",
-            "shortName": "mog1",
-            "typeName": "ORG_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "parentCachegroup",
-            "shortName": "pg1",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "parentCachegroup2",
-            "shortName": "pg2",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "secondaryCachegroup",
-            "shortName": "sg1",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "cachegroup1",
-            "parentCachegroupName": "parentCachegroup",
-            "secondaryParentCachegroupName": "secondaryCachegroup",
-            "shortName": "cg1",
-            "localizationMethods": [
-                "CZ",
-                "DEEP_CZ",
-                "GEO"
-            ],
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "fallback1",
-            "parentCachegroupName": "parentCachegroup",
-            "secondaryParentCachegroupName": "secondaryCachegroup",
-            "shortName": "fb1",
-            "localizationMethods": [
-                "CZ",
-                "DEEP_CZ",
-                "GEO"
-            ],
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "fallback2",
-            "parentCachegroupName": "parentCachegroup",
-            "secondaryParentCachegroupName": "secondaryCachegroup",
-            "shortName": "fb2",
-            "localizationMethods": [
-                "CZ",
-                "DEEP_CZ",
-                "GEO"
-            ],
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "fallback3",
-            "parentCachegroupName": "parentCachegroup",
-            "secondaryParentCachegroupName": "secondaryCachegroup",
-            "shortName": "fb3",
-            "localizationMethods": [
-                "CZ",
-                "DEEP_CZ",
-                "GEO"
-            ],
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 24.1234,
-            "longitude": -121.1234,
-            "name": "cachegroup2",
-            "parentCachegroupName": "secondaryCachegroup",
-            "secondaryParentCachegroupName": "parentCachegroup",
-            "shortName": "cg2",
-            "typeName": "EDGE_LOC",
-            "fallbacks": [
-                "fallback1",
-                "fallback2",
-                "fallback3"
-            ]
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "cachegroup3",
-            "parentCachegroupName": "parentCachegroup",
-            "secondaryParentCachegroupName": "secondaryCachegroup",
-            "shortName": "cg3",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "edge-parent1",
-            "shortName": "ep1",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "has-edge-parent1",
-            "parentCachegroupName": "edge-parent1",
-            "shortName": "hep1",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-edge-cg-01",
-            "shortName": "te1",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-edge-cg-02",
-            "shortName": "te2",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-01",
-            "shortName": "tm1",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-02",
-            "shortName": "tm2",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-03",
-            "shortName": "tm3",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-04",
-            "shortName": "tm4",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-05",
-            "shortName": "tm5",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-06",
-            "shortName": "tm6",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "topology-mid-cg-07",
-            "shortName": "tm7",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "dtrc1",
-            "shortName": "dtrc1",
-            "typeName": "MID_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "dtrc2",
-            "shortName": "dtrc2",
-            "typeName": "EDGE_LOC"
-        },
-        {
-            "latitude": 0,
-            "longitude": 0,
-            "name": "dtrc3",
-            "shortName": "dtrc3",
-            "typeName": "EDGE_LOC"
+          "pattern": ".*\\.ds2\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
         }
-    ],
-    "cdns": [
+      ],
+      "maxDnsAnswers": 0,
+      "maxOriginConnections": -1,
+      "midHeaderRewrite": "midHeader1\nmidHeader2",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin.ds2.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/ds2plugin.lua",
+      "routingName": "ccr-ds2",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant2",
+      "tenantName": "tenant2",
+      "type": "HTTP_LIVE",
+      "xmlId": "ds2",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl3",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": null,
+      "deepCachingType": "NEVER",
+      "displayName": "d s 1",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "exampleURLs": [
+        "http://ccr.ds3.example.net",
+        "https://ccr.ds3x.example.net"
+      ],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s 3",
+      "longDesc1": "ds3",
+      "longDesc2": "ds3",
+      "matchList": [
         {
-            "dnssecEnabled": false,
-            "domainName": "test.cdn1.net",
-            "name": "cdn1"
-        },
-        {
-            "dnssecEnabled": false,
-            "domainName": "test.cdn2.net",
-            "name": "cdn2"
-        },
-        {
-            "dnssecEnabled": false,
-            "domainName": "test.cdn3.net",
-            "name": "cdn3"
-        },
-        {
-            "dnssecEnabled": false,
-            "domainName": "test.cdn4.net",
-            "name": "cdn4"
-        },
-        {
-            "dnssecEnabled": false,
-            "domainName": "test.bar.net",
-            "name": "bar"
+          "pattern": ".*\\.ds3\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
         }
-    ],
-    "deliveryServiceRequestComments": [
+      ],
+      "maxDnsAnswers": 0,
+      "maxOriginConnections": 0,
+      "midHeaderRewrite": "midHeader1\nmidHeader2",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin.ds3.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/ds3plugin.lua",
+      "routingName": "ccr-ds3",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant3",
+      "tenantName": "tenant3",
+      "type": "HTTP_LIVE",
+      "xmlId": "ds3",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "deepCachingType": "NEVER",
+      "displayName": "anymap-ds",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "",
+      "exampleURLs": [],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "",
+      "longDesc1": "",
+      "longDesc2": "",
+      "matchList": [],
+      "maxDnsAnswers": 0,
+      "maxOriginConnections": 1,
+      "midHeaderRewrite": "",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://example.com",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "",
+      "regionalGeoBlocking": false,
+      "remapText": "map some raw remap text",
+      "routingName": "",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant3",
+      "tenantName": "tenant3",
+      "type": "ANY_MAP",
+      "xmlId": "anymap-ds",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl1",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [
+        "a",
+        "b",
+        "c"
+      ],
+      "consistentHashRegex": "foo",
+      "deepCachingType": "ALWAYS",
+      "displayName": "ds-test-minor-versions",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "fqPacingRate": 42,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "logsEnabled": false,
+      "longDesc": "d s 1",
+      "longDesc1": "ds1",
+      "longDesc2": "ds1",
+      "maxDnsAnswers": 0,
+      "maxOriginConnections": 1000,
+      "midHeaderRewrite": "midHeader1\nmidHeader2",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin-test-minor-version.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
+      "routingName": "cdn",
+      "signed": true,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenantId": 1,
+      "tenant": "root",
+      "trRequestHeaders": "X-Foo\nX-Bar",
+      "trResponseHeaders": "Access-Control-Allow-Origin: *\nContent-Type: text/html; charset=utf-8",
+      "type": "HTTP_LIVE",
+      "xmlId": "ds-test-minor-versions",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl1",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds1DisplayName",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "exampleURLs": [
+        "http://ccr.msods1.example.net",
+        "https://ccr.msods1.example.net"
+      ],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "mso DS 1",
+      "longDesc1": "msods1",
+      "longDesc2": "msods1",
+      "matchList": [
         {
-            "value": "this is comment one"
-        },
-        {
-            "value": "this is comment two"
-        },
-        {
-            "value": "this is comment three"
-        },
-        {
-            "value": "this is comment four"
+          "pattern": ".*\\.msods1\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
         }
-    ],
-    "deliveryServiceRequests": [
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": "midHeader1\nmidHeader2",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": true,
+      "orgServerFqdn": "http://origin.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
+      "routingName": "ccr-msods1",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "HTTP_LIVE",
+      "xmlId": "msods1",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "cacheUrl1",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds1natDisplayName",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
+      "exampleURLs": [
+        "http://ccr.ds1nat.example.net",
+        "https://ccr.ds1nat.example.net"
+      ],
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s 1",
+      "longDesc1": "ds1nat",
+      "longDesc2": "ds1nat",
+      "matchList": [
         {
-            "changeType": "create",
-            "deliveryService": {
-                "active": true,
-                "cdnName": "cdn1",
-                "ccrDnsTtl": 30,
-                "deepCachingType": "NEVER",
-                "displayName": "Good Kabletown CDN",
-                "dscp": 1,
-                "geoLimit": 1,
-                "geoProvider": 1,
-                "initialDispersion": 1,
-                "logsEnabled": true,
-                "longDesc": "long desc",
-                "regionalGeoBlocking": true,
-                "routingName": "goodroute",
-                "tenant": "tenant1",
-                "type": "HTTP",
-                "xmlId": "test-ds1"
+          "pattern": ".*\\.ds1nat\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": "midHeader1\nmidHeader2",
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": "rr1\nrr2",
+      "regionalGeoBlocking": false,
+      "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
+      "routingName": "ccr-ds1nat",
+      "signed": false,
+      "signingAlgorithm": "url_sig",
+      "sslKeyVersion": 2,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "HTTP_LIVE_NATNL",
+      "xmlId": "ds1nat",
+      "anonymousBlockingEnabled": true
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds-with-topology",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": null,
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s top",
+      "longDesc1": "ds top",
+      "longDesc2": "ds-top",
+      "matchList": [
+        {
+          "pattern": ".*\\.ds-top\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": null,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://origin.topology.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": null,
+      "regionalGeoBlocking": false,
+      "remapText": null,
+      "routingName": "cdn",
+      "signed": false,
+      "signingAlgorithm": null,
+      "sslKeyVersion": 0,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "HTTP_LIVE_NATNL",
+      "xmlId": "ds-top",
+      "anonymousBlockingEnabled": false,
+      "topology": "mso-topology",
+      "firstHeaderRewrite": "first header rewrite",
+      "innerHeaderRewrite": "inner header rewrite",
+      "lastHeaderRewrite": "last header rewrite"
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds-top-req-cap",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": null,
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "",
+      "longDesc1": "",
+      "longDesc2": "",
+      "matchList": [
+        {
+          "pattern": ".*\\.ds-top-req-cap\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": null,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://example.org",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 0,
+      "qstringIgnore": 0,
+      "rangeRequestHandling": 0,
+      "regexRemap": null,
+      "regionalGeoBlocking": false,
+      "remapText": null,
+      "routingName": "cdn",
+      "signed": false,
+      "signingAlgorithm": null,
+      "sslKeyVersion": 0,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "topology": "top-for-ds-req",
+      "type": "HTTP",
+      "xmlId": "ds-top-req-cap",
+      "anonymousBlockingEnabled": false
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds-top-req-cap2",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": null,
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "",
+      "longDesc1": "",
+      "longDesc2": "",
+      "matchList": [
+        {
+          "pattern": ".*\\.ds-top-req-cap2\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": null,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://example.org",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 0,
+      "qstringIgnore": 0,
+      "rangeRequestHandling": 0,
+      "regexRemap": null,
+      "regionalGeoBlocking": false,
+      "remapText": null,
+      "routingName": "cdn",
+      "signed": false,
+      "signingAlgorithm": null,
+      "sslKeyVersion": 0,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "topology": "top-for-ds-req2",
+      "type": "HTTP",
+      "xmlId": "ds-top-req-cap2",
+      "anonymousBlockingEnabled": false
+    },
+    {
+      "active": true,
+      "cdnName": "cdn1",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds-client-steering",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": null,
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s client-steering",
+      "longDesc1": "ds client-steering",
+      "longDesc2": "ds-client-steering",
+      "matchList": [
+        {
+          "pattern": ".*\\.ds-client-steering\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": null,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": null,
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 0,
+      "rangeRequestHandling": 0,
+      "regexRemap": null,
+      "regionalGeoBlocking": false,
+      "remapText": null,
+      "routingName": "cdn",
+      "signed": false,
+      "signingAlgorithm": null,
+      "sslKeyVersion": 0,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "CLIENT_STEERING",
+      "xmlId": "ds-client-steering",
+      "anonymousBlockingEnabled": false
+    }
+  ],
+  "deliveryServicesRegexes": [
+    {
+      "dsName": "ds1",
+      "typeName": "HOST_REGEXP",
+      "setNumber": 1,
+      "pattern": ".*"
+    },
+    {
+      "dsName": "ds1",
+      "typeName": "HOST_REGEXP",
+      "setNumber": 2,
+      "pattern": "\\d+"
+    },
+    {
+      "dsName": "ds2",
+      "typeName": "HOST_REGEXP",
+      "setNumber": 1,
+      "pattern": ".*"
+    },
+    {
+      "dsName": "ds1",
+      "typeName": "HOST_REGEXP",
+      "setNumber": 3,
+      "pattern": ""
+    }
+  ],
+  "deliveryservicesRequiredCapabilities": [
+    {
+      "xmlID": "ds1",
+      "RequiredCapability": "foo"
+    },
+    {
+      "xmlID": "ds2",
+      "RequiredCapability": "bar"
+    },
+    {
+      "xmlID": "msods1",
+      "RequiredCapability": "bar"
+    }
+  ],
+  "topologyBasedDeliveryServicesRequiredCapabilities": [
+    {
+      "xmlID": "ds-top-req-cap",
+      "RequiredCapability": "ram"
+    },
+    {
+      "xmlID": "ds-top-req-cap",
+      "RequiredCapability": "disk"
+    },
+    {
+      "xmlID": "ds-top-req-cap2",
+      "RequiredCapability": "ram"
+    }
+  ],
+  "divisions": [
+    {
+      "name": "division1"
+    },
+    {
+      "name": "cdn-div2"
+    }
+  ],
+  "federations": [
+    {
+      "cname": "the.cname.com.",
+      "ttl": 48,
+      "description": "the description"
+    },
+    {
+      "cname": "booya.com.",
+      "ttl": 34,
+      "description": "fooya"
+    }
+  ],
+  "federation_resolvers": [
+    {
+      "ipAddress": "1.2.3.4",
+      "type": "RESOLVE4",
+      "id": 1
+    },
+    {
+      "ipAddress": "0.0.0.0/12",
+      "type": "RESOLVE4",
+      "id": 2
+    },
+    {
+      "ipAddress": "dead::babe",
+      "type": "RESOLVE6",
+      "id": 3
+    },
+    {
+      "ipAddress": "::f1d0:f00d/123",
+      "type": "RESOLVE6",
+      "id": 4
+    }
+  ],
+  "coordinates": [
+    {
+      "latitude": 1.1,
+      "longitude": 2.2,
+      "name": "coordinate1"
+    },
+    {
+      "latitude": 3.3,
+      "longitude": 4.4,
+      "name": "coordinate2"
+    },
+    {
+      "latitude": 5.5,
+      "longitude": 6.6,
+      "name": "abc-coordinate"
+    }
+  ],
+  "origins": [
+    {
+      "name": "origin1",
+      "cachegroup": "originCachegroup",
+      "deliveryService": "ds1",
+      "fqdn": "origin1.example.com",
+      "ipAddress": "1.2.3.4",
+      "ip6Address": "dead:beef:cafe::42",
+      "port": 1234,
+      "protocol": "http",
+      "tenant": "tenant1"
+    },
+    {
+      "name": "origin2",
+      "cachegroup": "originCachegroup",
+      "deliveryService": "ds2",
+      "fqdn": "origin2.example.com",
+      "ipAddress": "5.6.7.8",
+      "ip6Address": "cafe::42",
+      "port": 5678,
+      "protocol": "https",
+      "tenant": "tenant1"
+    }
+  ],
+  "parameters": [
+    {
+      "configFile": "rascal.properties",
+      "lastUpdated": "2018-01-19T19:01:21.455131+00:00",
+      "name": "health.threshold.loadavg",
+      "secure": false,
+      "value": "25.0"
+    },
+    {
+      "configFile": "rascal.properties",
+      "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+      "name": "health.threshold.availableBandwidthInKbps",
+      "secure": false,
+      "value": ">1750000"
+    },
+    {
+      "configFile": "rascal.properties",
+      "lastUpdated": "2018-01-19T19:01:21.489534+00:00",
+      "name": "history.count",
+      "secure": false,
+      "value": "30"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.434425+00:00",
+      "name": "CONFIG proxy.config.allocator.enable_reclaim",
+      "secure": false,
+      "value": "INT 0"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.435957+00:00",
+      "name": "CONFIG proxy.config.allocator.max_overage",
+      "secure": false,
+      "value": "INT 3"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.437496+00:00",
+      "name": "CONFIG proxy.config.diags.show_location",
+      "secure": false,
+      "value": "INT 0"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.439033+00:00",
+      "name": "CONFIG proxy.config.http.cache.allow_empty_doc",
+      "secure": false,
+      "value": "INT 0"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.440502+00:00",
+      "name": "LOCAL proxy.config.cache.interim.storage",
+      "secure": false,
+      "value": "STRING NULL"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.441933+00:00",
+      "name": "CONFIG proxy.config.http.parent_proxy.file",
+      "secure": false,
+      "value": "STRING parent.config"
+    },
+    {
+      "configFile": "logs_xml.config",
+      "lastUpdated": "2018-01-19T19:01:21.461206+00:00",
+      "name": "LogFormat.Name",
+      "secure": false,
+      "value": "custom_ats_2"
+    },
+    {
+      "configFile": "logs_xml.config",
+      "lastUpdated": "2018-01-19T19:01:21.462772+00:00",
+      "name": "LogObject.Format",
+      "secure": false,
+      "value": "custom_ats_2"
+    },
+    {
+      "configFile": "logs_xml.config",
+      "lastUpdated": "2018-01-19T19:01:21.464259+00:00",
+      "name": "LogObject.Filename",
+      "secure": false,
+      "value": "custom_ats_2"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.467349+00:00",
+      "name": "CONFIG proxy.config.cache.control.filename",
+      "secure": false,
+      "value": "STRING cache.config"
+    },
+    {
+      "configFile": "plugin.config",
+      "lastUpdated": "2018-01-19T19:01:21.469075+00:00",
+      "name": "regex_revalidate.so",
+      "secure": false,
+      "value": "--config regex_revalidate.config"
+    },
+    {
+      "configFile": "records.config",
+      "lastUpdated": "2018-01-19T19:01:21.49285+00:00",
+      "name": "CONFIG proxy.config.hostdb.storage_size",
+      "secure": false,
+      "value": "INT 33554432"
+    },
+    {
+      "configFile": "regex_revalidate.config",
+      "lastUpdated": "2018-01-19T19:01:21.496195+00:00",
+      "name": "maxRevalDurationDays",
+      "secure": false,
+      "value": "90"
+    },
+    {
+      "configFile": "package",
+      "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
+      "name": "trafficserver",
+      "secure": false,
+      "value": "5.3.2-765.f4354b9.el7.centos.x86_64"
+    },
+    {
+      "configFile": "global",
+      "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
+      "name": "use_tenancy",
+      "secure": false,
+      "value": "1"
+    },
+    {
+      "configFile": "global",
+      "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
+      "name": "tm.instance_name",
+      "secure": false,
+      "value": "Traffic Ops ORT Tests"
+    },
+    {
+      "configFile": "global",
+      "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
+      "name": "use_reval_pending",
+      "secure": false,
+      "value": "1"
+    }
+  ],
+  "physLocations": [
+    {
+      "address": "1234 mile high circle",
+      "city": "Denver",
+      "comments": null,
+      "email": null,
+      "lastUpdated": "2018-01-19T21:19:32.081465+00:00",
+      "name": "Denver",
+      "phone": "303-111-1111",
+      "poc": null,
+      "region": "region1",
+      "shortName": "denver",
+      "state": "CO",
+      "zip": "80202"
+    },
+    {
+      "address": "1234 green way",
+      "city": "Boulder",
+      "comments": null,
+      "email": null,
+      "lastUpdated": "2018-01-19T21:19:32.086195+00:00",
+      "name": "Boulder",
+      "phone": "303-222-2222",
+      "poc": null,
+      "region": "region1",
+      "shortName": "boulder",
+      "state": "CO",
+      "zip": "80301"
+    },
+    {
+      "address": "1234 southern way",
+      "city": "Atlanta",
+      "comments": null,
+      "email": null,
+      "lastUpdated": "2018-01-19T21:19:32.089538+00:00",
+      "name": "HotAtlanta",
+      "phone": "404-222-2222",
+      "poc": null,
+      "region": "region1",
+      "shortName": "atlanta",
+      "state": "GA",
+      "zip": "30301"
+    }
+  ],
+  "profiles": [
+    {
+      "cdnName": "cdn1",
+      "description": "Edge Cache - Apache Traffic Server",
+      "name": "ATS_EDGE_TIER_CACHE",
+      "routingDisabled": false,
+      "type": "ATS_PROFILE",
+      "params": [
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.proxy_name",
+          "secure": false,
+          "value": "STRING __HOSTNAME__"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.config_dir",
+          "secure": false,
+          "value": "STRING /opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.admin.user_id",
+          "secure": false,
+          "value": "STRING ats"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.server_ports",
+          "secure": false,
+          "value": "STRING 80 80:ipv6"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.insert_response_via_str",
+          "secure": false,
+          "value": "INT 3"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.parent_proxy_routing_enable",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.parent_proxy.retry_time",
+          "secure": false,
+          "value": "INT 60"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.connect_attempts_timeout",
+          "secure": false,
+          "value": "INT 10"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.cache.required_headers",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.enable_http_stats",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.dns.round_robin_nameservers",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.max_space_mb_for_logs",
+          "secure": false,
+          "value": "INT 512"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.max_space_mb_headroom",
+          "secure": false,
+          "value": "INT 50"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.logfile_dir",
+          "secure": false,
+          "value": "STRING /var/log/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.reverse_proxy.enabled",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.diags.debug.enabled",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.slow.log.threshold",
+          "secure": false,
+          "value": "INT 10000"
+        },
+        {
+          "configFile": "cache.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "hosting.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "parent.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "plugin.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "records.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "volume.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.url_remap.remap_required",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.threshold.queryTime",
+          "secure": false,
+          "value": "1000"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.polling.url",
+          "secure": false,
+          "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Disk_Volume",
+          "secure": false,
+          "value": "1"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.connection.timeout",
+          "secure": false,
+          "value": "2000"
+        },
+        {
+          "configFile": "chkconfig",
+          "name": "trafficserver",
+          "secure": false,
+          "value": "0:off\t1:off\t2:on\t3:on\t4:on\t5:on\t6:off"
+        },
+        {
+          "configFile": "regex_revalidate.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.exec_thread.autoconfig",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "allow_ip",
+          "secure": false,
+          "value": "127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "allow_ip6",
+          "secure": false,
+          "value": "::1/128,fc01:9400:1000:8::/64"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "path",
+          "secure": false,
+          "value": "_astats"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "record_types",
+          "secure": false,
+          "value": "122"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.transaction_active_timeout_in",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.body_factory.template_sets_dir",
+          "secure": false,
+          "value": "STRING /opt/trafficserver/etc/trafficserver/body_factory"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Drive_Letters",
+          "secure": false,
+          "value": "cache"
+        },
+        {
+          "configFile": "ip_allow.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Drive_Prefix",
+          "secure": false,
+          "value": "/var/trafficserver/"
+        },
+        {
+          "configFile": "set_dscp_0.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_10.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_12.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_14.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_18.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_20.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_22.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_26.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_28.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_30.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_34.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_36.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_38.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_8.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_16.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_24.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_32.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_40.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_48.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_56.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_37.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "package",
+          "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
+          "name": "trafficserver",
+          "secure": true,
+          "value": "CHANGEME"
+        },
+        {
+          "configFile": "empty-file.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "non-empty-file.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "non-empty-file.config",
+          "name": "foo",
+          "secure": false,
+          "value": "bar"
+        },
+        {
+          "configFile": "remap.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        }
+      ]
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "edge1 description",
+      "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
+      "name": "EDGE1",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn2",
+      "description": "edge2 description",
+      "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
+      "name": "EDGEInCDN2",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn4",
+      "description": "edge2 description",
+      "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
+      "name": "EDGE2",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn2",
+      "description": "cdn2 edge description",
+      "name": "CDN2_EDGE",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "mid description",
+      "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
+      "name": "MID1",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn2",
+      "description": "mid description",
+      "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
+      "name": "MID2",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "origin description",
+      "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
+      "name": "ORIGIN1",
+      "routing_disabled": false,
+      "type": "ORG_PROFILE"
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "cdn1 description",
+      "lastUpdated": "2018-03-02T17:27:11.80452+00:00",
+      "name": "CCR1",
+      "routing_disabled": false,
+      "type": "TR_PROFILE"
+    },
+    {
+      "cdnName": "cdn2",
+      "description": "cdn2 description",
+      "lastUpdated": "2018-03-02T17:27:11.807948+00:00",
+      "name": "CCR2",
+      "routing_disabled": false,
+      "type": "TR_PROFILE"
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "rascal description",
+      "lastUpdated": "2018-03-02T17:27:11.813052+00:00",
+      "name": "RASCAL1",
+      "routing_disabled": false,
+      "type": "TM_PROFILE",
+      "params": [
+        {
+          "configFile": "rascal.properties",
+          "name": "health.threshold.queryTime",
+          "secure": false,
+          "value": "1000"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.polling.url",
+          "secure": false,
+          "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+        },
+        {
+          "configFile": "rascal-config.txt",
+          "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+          "name": "peers.polling.interval",
+          "secure": false,
+          "value": "60"
+        },
+        {
+          "configFile": "rascal-config.txt",
+          "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
+          "name": "health.polling.interval",
+          "secure": false,
+          "value": "30"
+        }
+      ]
+    },
+    {
+      "cdnName": "cdn1",
+      "description": "mso origin description",
+      "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
+      "name": "MSO",
+      "routing_disabled": false,
+      "type": "ORG_PROFILE"
+    },
+    {
+      "cdnName": "cdn2",
+      "description": "cdn2 mid description",
+      "name": "CDN2_MID",
+      "routing_disabled": false,
+      "type": "ATS_PROFILE"
+    }
+  ],
+  "regions": [
+    {
+      "divisionName": "division1",
+      "name": "region1"
+    },
+    {
+      "divisionName": "cdn-div2",
+      "name": "cdn-region2"
+    }
+  ],
+  "roles": [
+    {
+      "name": "new_admin",
+      "description": "super-user 2",
+      "privLevel": 30,
+      "capabilities": [
+        "all-read",
+        "all-write",
+        "cdn-read"
+      ]
+    },
+    {
+      "name": "bad_admin",
+      "description": "super-user 3",
+      "privLevel": 30,
+      "capabilities": [
+        "all-read",
+        "all-write",
+        "invalid-capability"
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-01",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "127.0.0.21/30",
+              "gateway": "127.0.0.21",
+              "serviceAddress": true
             },
-            "status": "draft"
-        },
+            {
+              "address": "2345:1234:12:8::1/64",
+              "gateway": "2345:1234:12:8::1",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-01\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn2",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "cdn2-test-edge",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "changeType": "create",
-            "deliveryService": {
-                "active": true,
-                "cdnName": "cdn1",
-                "ccrDnsTtl": 30,
-                "deepCachingType": "NEVER",
-                "displayName": "Bad Tenant",
-                "dscp": 0,
-                "geoLimit": 0,
-                "geoProvider": 0,
-                "initialDispersion": 3,
-                "logsEnabled": false,
-                "longDesc": "long desc",
-                "regionalGeoBlocking": false,
-                "tenant": "root",
-                "type": "HTTP",
-                "xmlId": "test-ds2"
+          "ipAddresses": [
+            {
+              "address": "0.0.0.0/0",
+              "gateway": "0.0.0.0",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 1500,
+          "name": "eth0"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGEInCDN2",
+      "rack": "",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": ""
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "guid": null,
+      "hostName": "influxdb02",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "127.0.0.11/22",
+              "gateway": "127.0.0.11",
+              "serviceAddress": true
             },
-            "status": "draft"
-        },
+            {
+              "address": "2345:1234:12:8::2/64",
+              "gateway": "2345:1234:12:8::2",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 1500,
+          "name": "eth1"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 8086,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": ""
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-router-01",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "changeType": "create",
-            "deliveryService": {
-                "ccrDnsTtl": 30,
-                "deepCachingType": "NEVER",
-                "displayName": "Bad Test Case CDN",
-                "dscp": 0,
-                "geoLimit": 0,
-                "geoProvider": 1,
-                "infoUrl": "xxx",
-                "initialDispersion": 1,
-                "logsEnabled": true,
-                "longDesc": "long desc",
-                "orgServerFqdn": "xxx",
-                "regionalGeoBlocking": true,
-                "routingName": "x routing",
-                "tenant": "tenant1",
-                "type": "HTTP",
-                "xmlId": "test-ds3"
+          "ipAddresses": [
+            {
+              "address": "127.0.0.12/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
             },
-            "status": "draft"
-        },
+            {
+              "address": "2345:1234:12:8::3/64",
+              "gateway": "2345:1234:12:8::3",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-router-01\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup2",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-03",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "changeType": "update",
-            "deliveryService": {
-                "active": false,
-                "cdnName": "cdn1",
-                "ccrDnsTtl": 30,
-                "deepCachingType": "NEVER",
-                "displayName": "Testing transitions",
-                "dscp": 3,
-                "geoLimit": 1,
-                "geoProvider": 1,
-                "initialDispersion": 1,
-                "logsEnabled": true,
-                "longDesc": "long desc",
-                "regionalGeoBlocking": true,
-                "routingName": "goodroute",
-                "tenant": "tenant1",
-                "type": "HTTP",
-                "xmlId": "test-transitions"
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:2::4/64",
+              "gateway": "2345:1234:12:2::4",
+              "serviceAddress": false
             },
-            "status": "draft"
+            {
+              "address": "127.0.0.13/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "deliveryServices": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "ATS_EDGE_TIER_CACHE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-03\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-14",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl1",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds1DisplayName",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeHeader1\nedgeHeader2",
-            "exampleURLs": [
-                "http://ccr.ds1.example.net",
-                "https://ccr.ds1.example.net"
-            ],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s 1",
-            "longDesc1": "ds1",
-            "longDesc2": "ds1",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds1\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
-            "routingName": "ccr-ds1",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "type": "HTTP",
-            "xmlId": "ds1",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl2",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": ["fmt", "limit", "somethingelse"],
-            "deepCachingType": "NEVER",
-            "displayName": "d s 1",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "exampleURLs": [
-                "http://ccr.ds2.example.net",
-                "https://ccr.ds2x.example.net"
-            ],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s 1",
-            "longDesc1": "ds2",
-            "longDesc2": "ds2",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds2\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "maxOriginConnections": -1,
-            "midHeaderRewrite": "midHeader1\nmidHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin.ds2.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/ds2plugin.lua",
-            "routingName": "ccr-ds2",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant2",
-            "tenantName": "tenant2",
-            "type": "HTTP_LIVE",
-            "xmlId": "ds2",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl3",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": null,
-            "deepCachingType": "NEVER",
-            "displayName": "d s 1",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "exampleURLs": [
-                "http://ccr.ds3.example.net",
-                "https://ccr.ds3x.example.net"
-            ],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s 3",
-            "longDesc1": "ds3",
-            "longDesc2": "ds3",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds3\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "maxOriginConnections": 0,
-            "midHeaderRewrite": "midHeader1\nmidHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin.ds3.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/ds3plugin.lua",
-            "routingName": "ccr-ds3",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant3",
-            "tenantName": "tenant3",
-            "type": "HTTP_LIVE",
-            "xmlId": "ds3",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "deepCachingType": "NEVER",
-            "displayName": "anymap-ds",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "",
-            "exampleURLs": [],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "",
-            "longDesc1": "",
-            "longDesc2": "",
-            "matchList": [],
-            "maxDnsAnswers": 0,
-            "maxOriginConnections": 1,
-            "midHeaderRewrite": "",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://example.com",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "",
-            "regionalGeoBlocking": false,
-            "remapText": "map some raw remap text",
-            "routingName": "",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant3",
-            "tenantName": "tenant3",
-            "type": "ANY_MAP",
-            "xmlId": "anymap-ds",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl1",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": ["a", "b", "c"],
-            "consistentHashRegex": "foo",
-            "deepCachingType": "ALWAYS",
-            "displayName": "ds-test-minor-versions",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "fqPacingRate": 42,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "logsEnabled": false,
-            "longDesc": "d s 1",
-            "longDesc1": "ds1",
-            "longDesc2": "ds1",
-            "maxDnsAnswers": 0,
-            "maxOriginConnections": 1000,
-            "midHeaderRewrite": "midHeader1\nmidHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin-test-minor-version.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
-            "routingName": "cdn",
-            "signed": true,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenantId": 1,
-            "tenant": "root",
-            "trRequestHeaders": "X-Foo\nX-Bar",
-            "trResponseHeaders": "Access-Control-Allow-Origin: *\nContent-Type: text/html; charset=utf-8",
-            "type": "HTTP_LIVE",
-            "xmlId": "ds-test-minor-versions",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl1",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds1DisplayName",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "exampleURLs": [
-                "http://ccr.msods1.example.net",
-                "https://ccr.msods1.example.net"
-            ],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "mso DS 1",
-            "longDesc1": "msods1",
-            "longDesc2": "msods1",
-            "matchList": [
-                {
-                    "pattern": ".*\\.msods1\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": "midHeader1\nmidHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": true,
-            "orgServerFqdn": "http://origin.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
-            "routingName": "ccr-msods1",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "type": "HTTP_LIVE",
-            "xmlId": "msods1",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "cacheUrl1",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds1natDisplayName",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": "edgeRewrite1\nedgeHeader2",
-            "exampleURLs": [
-                "http://ccr.ds1nat.example.net",
-                "https://ccr.ds1nat.example.net"
-            ],
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s 1",
-            "longDesc1": "ds1nat",
-            "longDesc2": "ds1nat",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds1nat\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": "midHeader1\nmidHeader2",
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": "rr1\nrr2",
-            "regionalGeoBlocking": false,
-            "remapText": "@plugin=tslua.so @pparam=/opt/trafficserver/etc/trafficserver/remapPlugin1.lua",
-            "routingName": "ccr-ds1nat",
-            "signed": false,
-            "signingAlgorithm": "url_sig",
-            "sslKeyVersion": 2,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "type": "HTTP_LIVE_NATNL",
-            "xmlId": "ds1nat",
-            "anonymousBlockingEnabled": true
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds-with-topology",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": null,
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s top",
-            "longDesc1": "ds top",
-            "longDesc2": "ds-top",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds-top\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": null,
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://origin.topology.example.net",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 1,
-            "rangeRequestHandling": 0,
-            "regexRemap": null,
-            "regionalGeoBlocking": false,
-            "remapText": null,
-            "routingName": "cdn",
-            "signed": false,
-            "signingAlgorithm": null,
-            "sslKeyVersion": 0,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "type": "HTTP_LIVE_NATNL",
-            "xmlId": "ds-top",
-            "anonymousBlockingEnabled": false,
-            "topology": "mso-topology",
-            "firstHeaderRewrite": "first header rewrite",
-            "innerHeaderRewrite": "inner header rewrite",
-            "lastHeaderRewrite": "last header rewrite"
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds-top-req-cap",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": null,
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "",
-            "longDesc1": "",
-            "longDesc2": "",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds-top-req-cap\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": null,
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://example.org",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 0,
-            "qstringIgnore": 0,
-            "rangeRequestHandling": 0,
-            "regexRemap": null,
-            "regionalGeoBlocking": false,
-            "remapText": null,
-            "routingName": "cdn",
-            "signed": false,
-            "signingAlgorithm": null,
-            "sslKeyVersion": 0,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "topology": "top-for-ds-req",
-            "type": "HTTP",
-            "xmlId": "ds-top-req-cap",
-            "anonymousBlockingEnabled": false
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds-top-req-cap2",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": null,
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "",
-            "longDesc1": "",
-            "longDesc2": "",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds-top-req-cap2\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": null,
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": "http://example.org",
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 0,
-            "qstringIgnore": 0,
-            "rangeRequestHandling": 0,
-            "regexRemap": null,
-            "regionalGeoBlocking": false,
-            "remapText": null,
-            "routingName": "cdn",
-            "signed": false,
-            "signingAlgorithm": null,
-            "sslKeyVersion": 0,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "topology": "top-for-ds-req2",
-            "type": "HTTP",
-            "xmlId": "ds-top-req-cap2",
-            "anonymousBlockingEnabled": false
-        },
-        {
-            "active": true,
-            "cdnName": "cdn1",
-            "cacheurl": "",
-            "ccrDnsTtl": 3600,
-            "checkPath": "",
-            "consistentHashQueryParams": [],
-            "deepCachingType": "NEVER",
-            "displayName": "ds-client-steering",
-            "dnsBypassCname": null,
-            "dnsBypassIp": "",
-            "dnsBypassIp6": "",
-            "dnsBypassTtl": 30,
-            "dscp": 40,
-            "edgeHeaderRewrite": null,
-            "fqPacingRate": 0,
-            "geoLimit": 0,
-            "geoLimitCountries": "",
-            "geoLimitRedirectURL": null,
-            "geoProvider": 0,
-            "globalMaxMbps": 0,
-            "globalMaxTps": 0,
-            "httpBypassFqdn": "",
-            "infoUrl": "TBD",
-            "initialDispersion": 1,
-            "ipv6RoutingEnabled": true,
-            "lastUpdated": "2018-04-06 16:48:51+00",
-            "logsEnabled": false,
-            "longDesc": "d s client-steering",
-            "longDesc1": "ds client-steering",
-            "longDesc2": "ds-client-steering",
-            "matchList": [
-                {
-                    "pattern": ".*\\.ds-client-steering\\..*",
-                    "setNumber": 0,
-                    "type": "HOST_REGEXP"
-                }
-            ],
-            "maxDnsAnswers": 0,
-            "midHeaderRewrite": null,
-            "missLat": 41.881944,
-            "missLong": -87.627778,
-            "multiSiteOrigin": false,
-            "orgServerFqdn": null,
-            "originShield": null,
-            "profileDescription": null,
-            "profileName": null,
-            "protocol": 2,
-            "qstringIgnore": 0,
-            "rangeRequestHandling": 0,
-            "regexRemap": null,
-            "regionalGeoBlocking": false,
-            "remapText": null,
-            "routingName": "cdn",
-            "signed": false,
-            "signingAlgorithm": null,
-            "sslKeyVersion": 0,
-            "tenant": "tenant1",
-            "tenantName": "tenant1",
-            "type": "CLIENT_STEERING",
-            "xmlId": "ds-client-steering",
-            "anonymousBlockingEnabled": false
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:8::5/64",
+              "gateway": "2345:1234:12:8::5",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.14/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "deliveryServicesRegexes": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-14\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-15",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "dsName": "ds1",
-            "typeName": "HOST_REGEXP",
-            "setNumber": 1,
-            "pattern" : ".*"
-        },
-        {
-            "dsName": "ds1",
-            "typeName": "HOST_REGEXP",
-            "setNumber": 2,
-            "pattern" : "\\d+"
-        },
-        {
-            "dsName": "ds2",
-            "typeName": "HOST_REGEXP",
-            "setNumber": 1,
-            "pattern" : ".*"
-        },
-        {
-            "dsName": "ds1",
-            "typeName": "HOST_REGEXP",
-            "setNumber": 3,
-            "pattern" : ""
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:d::6/64",
+              "gateway": "2345:1234:12:d::6",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.15/30",
+              "gateway": "127.0.0.7",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "deliveryservicesRequiredCapabilities": [
+      ],
+      "ipNetmask": "255.255.255.252",
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-15\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "parentCachegroup",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-mid-16",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "xmlID": "ds1",
-            "RequiredCapability": "foo"
-        },
-        {
-            "xmlID": "ds2",
-            "RequiredCapability": "bar"
-        },
-        {
-            "xmlID": "msods1",
-            "RequiredCapability": "bar"
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:d::7/64",
+              "gateway": "2345:1234:12:d::7",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.16/30",
+              "gateway": "127.0.0.7",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "topologyBasedDeliveryServicesRequiredCapabilities": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "MID1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false,
+      "xmppId": "atlanta-mid-16\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "parentCachegroup",
+      "cdnName": "cdn2",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-mid-17",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "xmlID": "ds-top-req-cap",
-            "RequiredCapability": "ram"
-        },
-        {
-            "xmlID": "ds-top-req-cap",
-            "RequiredCapability": "disk"
-        },
-        {
-            "xmlID": "ds-top-req-cap2",
-            "RequiredCapability": "ram"
+          "ipAddresses": [
+            {
+              "address": "2345:1234:17:d::7/64",
+              "gateway": "2345:1234:17:d::7",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.17/30",
+              "gateway": "127.0.0.17",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "divisions": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "MID2",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false,
+      "xmppId": "atlanta-mid-17\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-org-1",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "name": "division1"
-        },
-        {
-            "name": "cdn-div2"
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:d::8/64",
+              "gateway": "2345:1234:12:d::8",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.17/30",
+              "gateway": "127.0.0.17",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "federations": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-org-1\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-org-2",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "cname": "the.cname.com.",
-            "ttl": 48,
-            "description": "the description"
-        },
-        {
-            "cname": "booya.com.",
-            "ttl": 34,
-            "description": "fooya"
+          "ipAddresses": [
+            {
+              "address": "127.0.0.18/30",
+              "gateway": "127.0.0.18",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:d::9/64",
+              "gateway": "2345:1234:12:d::9",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "federation_resolvers": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-org-1\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-mid-01",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "ipAddress": "1.2.3.4",
-            "type": "RESOLVE4",
-            "id": 1
-        },
-        {
-            "ipAddress": "0.0.0.0/12",
-            "type": "RESOLVE4",
-            "id": 2
-        },
-        {
-            "ipAddress": "dead::babe",
-            "type": "RESOLVE6",
-            "id": 3
-        },
-        {
-            "ipAddress": "::f1d0:f00d/123",
-            "type": "RESOLVE6",
-            "id": 4
+          "ipAddresses": [
+            {
+              "address": "127.0.0.2/30",
+              "gateway": "127.0.0.2",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:9::10/64",
+              "gateway": "2345:1234:12:9::10",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "coordinates": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false,
+      "xmppId": "atlanta-mid-01\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "guid": null,
+      "hostName": "rascal01",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "latitude": 1.1,
-            "longitude": 2.2,
-            "name": "coordinate1"
-        },
-        {
-            "latitude": 3.3,
-            "longitude": 4.4,
-            "name": "coordinate2"
-        },
-        {
-            "latitude": 5.5,
-            "longitude": 6.6,
-            "name": "abc-coordinate"
+          "ipAddresses": [
+            {
+              "address": "127.0.0.4/30",
+              "gateway": "127.0.0.4",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:b::11/64",
+              "gateway": "2345:1234:12:b::11",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "origins": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "RASCAL1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 81,
+      "type": "RASCAL",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup2",
+      "cdnName": "cdn2",
+      "domainName": "kabletown2.net",
+      "guid": null,
+      "hostName": "edge1-cdn2",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "name": "origin1",
-            "cachegroup": "originCachegroup",
-            "deliveryService": "ds1",
-            "fqdn": "origin1.example.com",
-            "ipAddress": "1.2.3.4",
-            "ip6Address": "dead:beef:cafe::42",
-            "port": 1234,
-            "protocol": "http",
-            "tenant": "tenant1"
-        },
-        {
-            "name": "origin2",
-            "cachegroup": "originCachegroup",
-            "deliveryService": "ds2",
-            "fqdn": "origin2.example.com",
-            "ipAddress": "5.6.7.8",
-            "ip6Address": "cafe::42",
-            "port": 5678,
-            "protocol": "https",
-            "tenant": "tenant1"
+          "ipAddresses": [
+            {
+              "address": "127.0.0.31/24",
+              "gateway": "127.0.0.4",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:b::13/64",
+              "gateway": "2345:1234:12:b::13",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "parameters": [
+      ],
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 81,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup1",
+      "cdnName": "cdn1",
+      "domainName": "docker_default",
+      "guid": null,
+      "hostName": "traffic_vault",
+      "httpsPort": 8088,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "configFile": "rascal.properties",
-            "lastUpdated": "2018-01-19T19:01:21.455131+00:00",
-            "name": "health.threshold.loadavg",
-            "secure": false,
-            "value": "25.0"
-        },
-        {
-            "configFile": "rascal.properties",
-            "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
-            "name": "health.threshold.availableBandwidthInKbps",
-            "secure": false,
-            "value": ">1750000"
-        },
-        {
-            "configFile": "rascal.properties",
-            "lastUpdated": "2018-01-19T19:01:21.489534+00:00",
-            "name": "history.count",
-            "secure": false,
-            "value": "30"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.434425+00:00",
-            "name": "CONFIG proxy.config.allocator.enable_reclaim",
-            "secure": false,
-            "value": "INT 0"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.435957+00:00",
-            "name": "CONFIG proxy.config.allocator.max_overage",
-            "secure": false,
-            "value": "INT 3"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.437496+00:00",
-            "name": "CONFIG proxy.config.diags.show_location",
-            "secure": false,
-            "value": "INT 0"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.439033+00:00",
-            "name": "CONFIG proxy.config.http.cache.allow_empty_doc",
-            "secure": false,
-            "value": "INT 0"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.440502+00:00",
-            "name": "LOCAL proxy.config.cache.interim.storage",
-            "secure": false,
-            "value": "STRING NULL"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.441933+00:00",
-            "name": "CONFIG proxy.config.http.parent_proxy.file",
-            "secure": false,
-            "value": "STRING parent.config"
-        },
-        {
-            "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.461206+00:00",
-            "name": "LogFormat.Name",
-            "secure": false,
-            "value": "custom_ats_2"
-        },
-        {
-            "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.462772+00:00",
-            "name": "LogObject.Format",
-            "secure": false,
-            "value": "custom_ats_2"
-        },
-        {
-            "configFile": "logs_xml.config",
-            "lastUpdated": "2018-01-19T19:01:21.464259+00:00",
-            "name": "LogObject.Filename",
-            "secure": false,
-            "value": "custom_ats_2"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.467349+00:00",
-            "name": "CONFIG proxy.config.cache.control.filename",
-            "secure": false,
-            "value": "STRING cache.config"
-        },
-        {
-            "configFile": "plugin.config",
-            "lastUpdated": "2018-01-19T19:01:21.469075+00:00",
-            "name": "regex_revalidate.so",
-            "secure": false,
-            "value": "--config regex_revalidate.config"
-        },
-        {
-            "configFile": "records.config",
-            "lastUpdated": "2018-01-19T19:01:21.49285+00:00",
-            "name": "CONFIG proxy.config.hostdb.storage_size",
-            "secure": false,
-            "value": "INT 33554432"
-        },
-        {
-            "configFile": "regex_revalidate.config",
-            "lastUpdated": "2018-01-19T19:01:21.496195+00:00",
-            "name": "maxRevalDurationDays",
-            "secure": false,
-            "value": "90"
-        },
-        {
-            "configFile": "package",
-            "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
-            "name": "trafficserver",
-            "secure": false,
-            "value": "5.3.2-765.f4354b9.el7.centos.x86_64"
-        },
-        {
-            "configFile": "global",
-            "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
-            "name": "use_tenancy",
-            "secure": false,
-            "value": "1"
-        },
-        {
-            "configFile": "global",
-            "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
-            "name": "tm.instance_name",
-            "secure": false,
-            "value": "Traffic Ops ORT Tests"
-        },
-        {
-            "configFile": "global",
-            "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
-            "name": "use_reval_pending",
-            "secure": false,
-            "value": "1"
+          "ipAddresses": [
+            {
+              "address": "172.26.0.6/16",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:b::12/64",
+              "gateway": "2345:1234:12:b::12",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 1500,
+          "name": "eth1"
         }
-    ],
-    "physLocations": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "ONLINE",
+      "tcpPort": 8088,
+      "type": "RIAK",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": ""
+    },
+    {
+      "cachegroup": "multiOriginCachegroup",
+      "cdnName": "cdn1",
+      "domainName": "ga.denver.kabletown.net",
+      "guid": null,
+      "hostName": "denver-mso-org-01",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "address": "1234 mile high circle",
-            "city": "Denver",
-            "comments": null,
-            "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.081465+00:00",
-            "name": "Denver",
-            "phone": "303-111-1111",
-            "poc": null,
-            "region": "region1",
-            "shortName": "denver",
-            "state": "CO",
-            "zip": "80202"
-        },
-        {
-            "address": "1234 green way",
-            "city": "Boulder",
-            "comments": null,
-            "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.086195+00:00",
-            "name": "Boulder",
-            "phone": "303-222-2222",
-            "poc": null,
-            "region": "region1",
-            "shortName": "boulder",
-            "state": "CO",
-            "zip": "80301"
-        },
-        {
-            "address": "1234 southern way",
-            "city": "Atlanta",
-            "comments": null,
-            "email": null,
-            "lastUpdated": "2018-01-19T21:19:32.089538+00:00",
-            "name": "HotAtlanta",
-            "phone": "404-222-2222",
-            "poc": null,
-            "region": "region1",
-            "shortName": "atlanta",
-            "state": "GA",
-            "zip": "30301"
+          "ipAddresses": [
+            {
+              "address": "127.0.0.1/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:8::20/64",
+              "gateway": "2345:1234:12:8::20",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "profiles": [
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "MSO",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "ORG",
+      "updPending": false,
+      "xmppId": "denver-mso-org-01\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown2.net",
+      "guid": null,
+      "hostName": "edge1-cdn1-cg3",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "cdnName": "cdn1",
-            "description": "Edge Cache - Apache Traffic Server",
-            "name": "ATS_EDGE_TIER_CACHE",
-            "routingDisabled": false,
-            "type": "ATS_PROFILE",
-            "params": [
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.proxy_name",
-                    "secure": false,
-                    "value": "STRING __HOSTNAME__"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.config_dir",
-                    "secure": false,
-                    "value": "STRING /opt/trafficserver/etc/trafficserver"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.admin.user_id",
-                    "secure": false,
-                    "value": "STRING ats"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.server_ports",
-                    "secure": false,
-                    "value": "STRING 80 80:ipv6"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.insert_response_via_str",
-                    "secure": false,
-                    "value": "INT 3"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.parent_proxy_routing_enable",
-                    "secure": false,
-                    "value": "INT 1"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.parent_proxy.retry_time",
-                    "secure": false,
-                    "value": "INT 60"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.connect_attempts_timeout",
-                    "secure": false,
-                    "value": "INT 10"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.cache.required_headers",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.enable_http_stats",
-                    "secure": false,
-                    "value": "INT 1"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.dns.round_robin_nameservers",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.log.max_space_mb_for_logs",
-                    "secure": false,
-                    "value": "INT 512"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.log.max_space_mb_headroom",
-                    "secure": false,
-                    "value": "INT 50"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.log.logfile_dir",
-                    "secure": false,
-                    "value": "STRING /var/log/trafficserver"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.reverse_proxy.enabled",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.diags.debug.enabled",
-                    "secure": false,
-                    "value": "INT 1"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.slow.log.threshold",
-                    "secure": false,
-                    "value": "INT 10000"
-                },
-                {
-                    "configFile": "cache.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "hosting.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "parent.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "plugin.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "storage.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "volume.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.url_remap.remap_required",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.threshold.queryTime",
-                    "secure": false,
-                    "value": "1000"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.polling.url",
-                    "secure": false,
-                    "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
-                },
-                {
-                    "configFile": "storage.config",
-                    "name": "Disk_Volume",
-                    "secure": false,
-                    "value": "1"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.connection.timeout",
-                    "secure": false,
-                    "value": "2000"
-                },
-                {
-                    "configFile": "chkconfig",
-                    "name": "trafficserver",
-                    "secure": false,
-                    "value": "0:off\t1:off\t2:on\t3:on\t4:on\t5:on\t6:off"
-                },
-                {
-                    "configFile": "regex_revalidate.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.exec_thread.autoconfig",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "astats.config",
-                    "name": "allow_ip",
-                    "secure": false,
-                    "value": "127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
-                },
-                {
-                    "configFile": "astats.config",
-                    "name": "allow_ip6",
-                    "secure": false,
-                    "value": "::1/128,fc01:9400:1000:8::/64"
-                },
-                {
-                    "configFile": "astats.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver"
-                },
-                {
-                    "configFile": "astats.config",
-                    "name": "path",
-                    "secure": false,
-                    "value": "_astats"
-                },
-                {
-                    "configFile": "astats.config",
-                    "name": "record_types",
-                    "secure": false,
-                    "value": "122"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.http.transaction_active_timeout_in",
-                    "secure": false,
-                    "value": "INT 0"
-                },
-                {
-                    "configFile": "records.config",
-                    "name": "CONFIG proxy.config.body_factory.template_sets_dir",
-                    "secure": false,
-                    "value": "STRING /opt/trafficserver/etc/trafficserver/body_factory"
-                },
-                {
-                    "configFile": "storage.config",
-                    "name": "Drive_Letters",
-                    "secure": false,
-                    "value": "cache"
-                },
-                {
-                    "configFile": "ip_allow.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver"
-                },
-                {
-                    "configFile": "storage.config",
-                    "name": "Drive_Prefix",
-                    "secure": false,
-                    "value": "/var/trafficserver/"
-                },
-                {
-                    "configFile": "set_dscp_0.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_10.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_12.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_14.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_18.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_20.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_22.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_26.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_28.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_30.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_34.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_36.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_38.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_8.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_16.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_24.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_32.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_40.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_48.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_56.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-                {
-                    "configFile": "set_dscp_37.config",
-                    "name": "location",
-                    "value": "/opt/trafficserver/etc/trafficserver/dscp"
-                },
-        	      {
-            	      "configFile": "package",
-            	      "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
-            	      "name": "trafficserver",
-            	      "secure": true,
-                     "value": "CHANGEME"
-        	      },
-                {
-                    "configFile": "empty-file.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "non-empty-file.config",
-                    "name": "location",
-                    "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver/"
-                },
-                {
-                    "configFile": "non-empty-file.config",
-                    "name": "foo",
-                    "secure": false,
-                    "value": "bar"
-                },
-                {
-                    "configFile": "remap.config",
-                    "name": "location",
-            	      "secure": false,
-                    "value": "/opt/trafficserver/etc/trafficserver"
-                }
-            ]
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "edge1 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
-            "name": "EDGE1",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn2",
-            "description": "edge2 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
-            "name": "EDGEInCDN2",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn4",
-            "description": "edge2 description",
-            "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
-            "name": "EDGE2",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn2",
-            "description": "cdn2 edge description",
-            "name": "CDN2_EDGE",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "mid description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
-            "name": "MID1",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn2",
-            "description": "mid description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
-            "name": "MID2",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "origin description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
-            "name": "ORIGIN1",
-            "routing_disabled": false,
-            "type": "ORG_PROFILE"
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "cdn1 description",
-            "lastUpdated": "2018-03-02T17:27:11.80452+00:00",
-            "name": "CCR1",
-            "routing_disabled": false,
-            "type": "TR_PROFILE"
-        },
-        {
-            "cdnName": "cdn2",
-            "description": "cdn2 description",
-            "lastUpdated": "2018-03-02T17:27:11.807948+00:00",
-            "name": "CCR2",
-            "routing_disabled": false,
-            "type": "TR_PROFILE"
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "rascal description",
-            "lastUpdated": "2018-03-02T17:27:11.813052+00:00",
-            "name": "RASCAL1",
-            "routing_disabled": false,
-            "type": "TM_PROFILE",
-            "params": [
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.threshold.queryTime",
-                    "secure": false,
-                    "value": "1000"
-                },
-                {
-                    "configFile": "rascal.properties",
-                    "name": "health.polling.url",
-                    "secure": false,
-                    "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
-                },
-                {
-                    "configFile": "rascal-config.txt",
-                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
-                    "name": "peers.polling.interval",
-                    "secure": false,
-                    "value": "60"
-                },
-                {
-                    "configFile": "rascal-config.txt",
-                    "lastUpdated": "2018-01-19T19:01:21.472279+00:00",
-                    "name": "health.polling.interval",
-                    "secure": false,
-                    "value": "30"
-                }
-            ]
-        },
-        {
-            "cdnName": "cdn1",
-            "description": "mso origin description",
-            "lastUpdated": "2018-03-02T17:27:11.80173+00:00",
-            "name": "MSO",
-            "routing_disabled": false,
-            "type": "ORG_PROFILE"
-        },
-        {
-            "cdnName": "cdn2",
-            "description": "cdn2 mid description",
-            "name": "CDN2_MID",
-            "routing_disabled": false,
-            "type": "ATS_PROFILE"
+          "ipAddresses": [
+            {
+              "address": "::13/64",
+              "gateway": "2345:1234:12:b::13",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.100/24",
+              "gateway": "127.0.0.4",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "regions": [
+      ],
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 81,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown2.net",
+      "guid": null,
+      "hostName": "edge2-cdn1-cg3",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
         {
-            "divisionName": "division1",
-            "name": "region1"
-        },
-        {
-            "divisionName": "cdn-div2",
-            "name": "cdn-region2"
+          "ipAddresses": [
+            {
+              "address": "::14/64",
+              "gateway": "2345:1234:12:b::13",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.101/24",
+              "gateway": "127.0.0.4",
+              "serviceAddress": true
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "roles": [
+      ],
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 81,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "topology-edge-cg-01",
+      "cdnName": "cdn1",
+      "domainName": "edge-01.forked-topology.kabletown.net",
+      "hostName": "topology-edge-01",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "name": "new_admin",
-            "description": "super-user 2",
-            "privLevel": 30,
-            "capabilities": [
-                "all-read",
-                "all-write",
-                "cdn-read"
-            ]
-        },
-        {
-            "name": "bad_admin",
-            "description": "super-user 3",
-            "privLevel": 30,
-            "capabilities": [
-                "all-read",
-                "all-write",
-                "invalid-capability"
-            ]
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:2::4/64",
+              "gateway": "2345:1234:12:2::4",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.19/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "servers": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-edge-cg-02",
+      "cdnName": "cdn1",
+      "domainName": "edge-02.forked-topology.kabletown.net",
+      "hostName": "topology-edge-02",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-edge-01",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.21/30",
-                            "gateway": "127.0.0.21",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:8::1/64",
-                            "gateway": "2345:1234:12:8::1",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-edge-01\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn2",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "cdn2-test-edge",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "0.0.0.0/0",
-                            "gateway": "0.0.0.0",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 1500,
-                    "name": "eth0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGEInCDN2",
-            "rack": "",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": ""
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "guid": null,
-            "hostName": "influxdb02",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.11/22",
-                            "gateway": "127.0.0.11",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:8::2/64",
-                            "gateway": "2345:1234:12:8::2",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 1500,
-                    "name": "eth1"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 8086,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": ""
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-router-01",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.12/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:8::3/64",
-                            "gateway": "2345:1234:12:8::3",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-router-01\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup2",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-edge-03",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:2::4/64",
-                            "gateway": "2345:1234:12:2::4",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.13/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "ATS_EDGE_TIER_CACHE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-edge-03\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-edge-14",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:8::5/64",
-                            "gateway": "2345:1234:12:8::5",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.14/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-edge-14\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-edge-15",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:d::6/64",
-                            "gateway": "2345:1234:12:d::6",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.15/30",
-                            "gateway": "127.0.0.7",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "ipNetmask": "255.255.255.252",
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-edge-15\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "parentCachegroup",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-mid-16",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:d::7/64",
-                            "gateway": "2345:1234:12:d::7",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.16/30",
-                            "gateway": "127.0.0.7",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "MID1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false,
-            "xmppId": "atlanta-mid-16\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "parentCachegroup",
-            "cdnName": "cdn2",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-mid-17",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:17:d::7/64",
-                            "gateway": "2345:1234:17:d::7",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.17/30",
-                            "gateway": "127.0.0.17",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "MID2",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false,
-            "xmppId": "atlanta-mid-17\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-org-1",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:d::8/64",
-                            "gateway": "2345:1234:12:d::8",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.17/30",
-                            "gateway": "127.0.0.17",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-org-1\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-org-2",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.18/30",
-                            "gateway": "127.0.0.18",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:d::9/64",
-                            "gateway": "2345:1234:12:d::9",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "atlanta-org-1\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "ga.atlanta.kabletown.net",
-            "guid": null,
-            "hostName": "atlanta-mid-01",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.2/30",
-                            "gateway": "127.0.0.2",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:9::10/64",
-                            "gateway": "2345:1234:12:9::10",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false,
-            "xmppId": "atlanta-mid-01\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "guid": null,
-            "hostName": "rascal01",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.4/30",
-                            "gateway": "127.0.0.4",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:b::11/64",
-                            "gateway": "2345:1234:12:b::11",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "RASCAL1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 81,
-            "type": "RASCAL",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup2",
-            "cdnName": "cdn2",
-            "domainName": "kabletown2.net",
-            "guid": null,
-            "hostName": "edge1-cdn2",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.31/24",
-                            "gateway": "127.0.0.4",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:b::13/64",
-                            "gateway": "2345:1234:12:b::13",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 81,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup1",
-            "cdnName": "cdn1",
-            "domainName": "docker_default",
-            "guid": null,
-            "hostName": "traffic_vault",
-            "httpsPort": 8088,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "172.26.0.6/16",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:b::12/64",
-                            "gateway": "2345:1234:12:b::12",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 1500,
-                    "name": "eth1"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "ONLINE",
-            "tcpPort": 8088,
-            "type": "RIAK",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": ""
-        },
-        {
-            "cachegroup": "multiOriginCachegroup",
-            "cdnName": "cdn1",
-            "domainName": "ga.denver.kabletown.net",
-            "guid": null,
-            "hostName": "denver-mso-org-01",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "127.0.0.1/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        },
-                        {
-                            "address": "2345:1234:12:8::20/64",
-                            "gateway": "2345:1234:12:8::20",
-                            "serviceAddress": false
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "MSO",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "ORG",
-            "updPending": false,
-            "xmppId": "denver-mso-org-01\\\\@ocdn.kabletown.net",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown2.net",
-            "guid": null,
-            "hostName": "edge1-cdn1-cg3",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "::13/64",
-                            "gateway": "2345:1234:12:b::13",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.100/24",
-                            "gateway": "127.0.0.4",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 81,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "cachegroup3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown2.net",
-            "guid": null,
-            "hostName": "edge2-cdn1-cg3",
-            "httpsPort": 443,
-            "iloIpAddress": "",
-            "iloIpGateway": "",
-            "iloIpNetmask": "",
-            "iloPassword": "",
-            "iloUsername": "",
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "::14/64",
-                            "gateway": "2345:1234:12:b::13",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.101/24",
-                            "gateway": "127.0.0.4",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "maxBandwidth": null,
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "mgmtIpAddress": "",
-            "mgmtIpGateway": "",
-            "mgmtIpNetmask": "",
-            "offlineReason": null,
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "routerHostName": "",
-            "routerPortName": "",
-            "status": "REPORTED",
-            "tcpPort": 81,
-            "type": "EDGE",
-            "updPending": false,
-            "xmppId": "",
-            "xmppPasswd": "X"
-        },
-        {
-            "cachegroup": "topology-edge-cg-01",
-            "cdnName": "cdn1",
-            "domainName": "edge-01.forked-topology.kabletown.net",
-            "hostName": "topology-edge-01",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:2::4/64",
-                            "gateway": "2345:1234:12:2::4",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.19/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-edge-cg-02",
-            "cdnName": "cdn1",
-            "domainName": "edge-02.forked-topology.kabletown.net",
-            "hostName": "topology-edge-02",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:2::4/64",
-                            "gateway": "2345:1234:12:2::4",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.20/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-04",
-            "cdnName": "cdn1",
-            "domainName": "mid-04.forked-topology.kabletown.net",
-            "hostName": "topology-mid-04",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2345:1234:12:2::4/64",
-                            "gateway": "2345:1234:12:2::4",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "127.0.0.13/30",
-                            "gateway": "127.0.0.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "MID1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc1",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-mid-01",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::2/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.2/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "MID1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc1",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-mid-02",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::3/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.3/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "MID1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc1",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-mid-03",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::4/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.4/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "MID1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc2",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-01",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::5/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.5/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc2",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-02",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::6/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.6/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc2",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-03",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::7/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.7/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-04",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::8/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.8/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-05",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::9/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.9/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-06",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::10/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.10/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc2",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-07",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::11/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.11/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc3",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-edge-08",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.12/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "dtrc1",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "dtrc-mid-04",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::13/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.13/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "cachegroup3",
-            "cdnName": "cdn1",
-            "domainName": "kabletown.net",
-            "hostName": "edgeInCachegroup3",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.13/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "EDGE1",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "parentCachegroup",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInParentCachegroup",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.14/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "secondaryCachegroup",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInSecondaryCachegroup",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.15/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "fallback1",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "edgeInFallback1",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.16/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "fallback2",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "edgeInFallback2",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.17/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "parentCachegroup2",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInParentCachegroup2",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.18/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-edge-cg-01",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "edgeInTopologyEdgeCg01",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.19/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-edge-cg-02",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "edgeInTopologyEdgeCg02",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.20/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_EDGE",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "EDGE",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-01",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg01",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.21/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-02",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg02",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.22/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-03",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg03",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.23/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-04",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg04",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.24/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-05",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg05",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.25/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-06",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg06",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.26/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
-        },
-        {
-            "cachegroup": "topology-mid-cg-07",
-            "cdnName": "cdn2",
-            "domainName": "kabletown.net",
-            "hostName": "midInTopologyMidCg07",
-            "httpsPort": 443,
-            "interfaces": [
-                {
-                    "ipAddresses": [
-                        {
-                            "address": "2001:db8:dead:beef::12/64",
-                            "gateway": "2001:db8:dead:beef::1",
-                            "serviceAddress": false
-                        },
-                        {
-                            "address": "192.0.2.27/24",
-                            "gateway": "192.0.2.1",
-                            "serviceAddress": true
-                        }
-                    ],
-                    "monitor": true,
-                    "mtu": 9000,
-                    "name": "bond0"
-                }
-            ],
-            "physLocation": "Denver",
-            "profile": "CDN2_MID",
-            "rack": "RR 119.02",
-            "revalPending": false,
-            "status": "REPORTED",
-            "tcpPort": 80,
-            "type": "MID",
-            "updPending": false
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:2::4/64",
+              "gateway": "2345:1234:12:2::4",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.20/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "serverCapabilities": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-04",
+      "cdnName": "cdn1",
+      "domainName": "mid-04.forked-topology.kabletown.net",
+      "hostName": "topology-mid-04",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "name": "foo"
-        },
-        {
-            "name": "bar"
-        },
-        {
-            "name": "ram"
-        },
-        {
-            "name": "disk"
-        },
-        {
-            "name": "asdf"
+          "ipAddresses": [
+            {
+              "address": "2345:1234:12:2::4/64",
+              "gateway": "2345:1234:12:2::4",
+              "serviceAddress": false
+            },
+            {
+              "address": "127.0.0.13/30",
+              "gateway": "127.0.0.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "serverServerCapabilities": [
+      ],
+      "physLocation": "Denver",
+      "profile": "MID1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc1",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-mid-01",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "serverHostName": "atlanta-edge-03",
-            "serverCapability": "foo"
-        },
-        {
-            "serverHostName": "atlanta-edge-03",
-            "serverCapability": "bar"
-        },
-        {
-            "serverHostName": "dtrc-mid-01",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-mid-01",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-mid-02",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-mid-02",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-edge-01",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-edge-01",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-edge-01",
-            "serverCapability": "asdf"
-        },
-        {
-            "serverHostName": "dtrc-edge-02",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-edge-02",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-edge-04",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-edge-04",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-edge-05",
-            "serverCapability": "ram"
-        },
-        {
-            "serverHostName": "dtrc-edge-05",
-            "serverCapability": "disk"
-        },
-        {
-            "serverHostName": "dtrc-edge-07",
-            "serverCapability": "asdf"
-        },
-        {
-            "serverHostName": "dtrc-edge-08",
-            "serverCapability": "asdf"
-        },
-        {
-            "serverHostName": "dtrc-mid-04",
-            "serverCapability": "asdf"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::2/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.2/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "serviceCategories": [
+      ],
+      "physLocation": "Denver",
+      "profile": "MID1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc1",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-mid-02",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "name": "serviceCategory1"
-        },
-        {
-            "name": "barServiceCategory2"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::3/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.3/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "staticdnsentries": [
+      ],
+      "physLocation": "Denver",
+      "profile": "MID1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc1",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-mid-03",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "address": "192.168.0.1",
-            "cachegroup": "cachegroup2",
-            "deliveryservice": "ds1",
-            "host": "host2",
-            "type": "A_RECORD",
-            "ttl": 10
-        },
-        {
-            "address": "this.is.a.hostname.",
-            "cachegroup": "cachegroup1",
-            "deliveryservice": "ds1",
-            "host": "host1",
-            "type": "CNAME_RECORD",
-            "ttl": 0
-        },
-        {
-            "address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
-            "cachegroup": "cachegroup2",
-            "deliveryservice": "ds1",
-            "host": "host3",
-            "ttl": 10,
-            "type": "AAAA_RECORD"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::4/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.4/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "statuses": [
+      ],
+      "physLocation": "Denver",
+      "profile": "MID1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc2",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-01",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "description": "Edge: Puts server in CCR config file in this state, but CCR will never route traffic to it. Mid: Server will not be included in parent.config files for its edge caches",
-            "name": "OFFLINE"
-        },
-        {
-            "description": "Edge: Puts server in CCR config file in this state, and CCR will always route traffic to it. Mid: Server will be included in parent.config files for its edges",
-            "name": "ONLINE"
-        },
-        {
-            "description": "Edge: Puts server in CCR config file in this state, and CCR will adhere to the health protocol. Mid: N/A for now",
-            "name": "REPORTED"
-        },
-        {
-            "description": "Temporary down. Edge: XMPP client will send status OFFLINE to CCR, otherwise similar to REPORTED. Mid: Server will not be included in parent.config files for its edge caches",
-            "name": "ADMIN_DOWN"
-        },
-        {
-            "description": "Edge: 12M will not include caches in this state in CCR config files. Mid: N/A for now",
-            "name": "CCR_IGNORE"
-        },
-        {
-            "description": "Pre Production. Not active in any configuration.",
-            "name": "PRE_PROD"
-        },
-        {
-            "name": "TEST_NULL_DESCRIPTION"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::5/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.5/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "tenants": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc2",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-02",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "active": true,
-            "name": "tenant1",
-            "parentName": "root"
-        },
-        {
-            "active": false,
-            "name": "tenant2",
-            "parentName": "tenant1"
-        },
-        {
-            "active": true,
-            "name": "tenant3",
-            "parentName": "tenant2"
-        },
-        {
-            "active": true,
-            "name": "tenant4",
-            "parentName": "root"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::6/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.6/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "topologies": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc2",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-03",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "name": "mso-topology",
-            "description": "a multi-site origin topology",
-            "nodes": [
-                {
-                    "cachegroup": "multiOriginCachegroup",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "parentCachegroup",
-                    "parents": [0]
-                },
-                {
-                    "cachegroup": "cachegroup2",
-                    "parents": [1]
-                }
-            ]
-        },
-        {
-            "name": "another-topology",
-            "description": "another topology",
-            "nodes": [
-                {
-                    "cachegroup": "parentCachegroup",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "cachegroup1",
-                    "parents": [
-                        0
-                    ]
-                },
-                {
-                    "cachegroup": "secondaryCachegroup",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "cachegroup2",
-                    "parents": [
-                        2
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "secondary-parents",
-            "description": "A topology with secondary parents",
-            "nodes": [
-                {
-                    "cachegroup": "parentCachegroup",
-                    "parent": "",
-                    "secParent": "",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "cachegroup1",
-                    "parent": "parentCachegroup",
-                    "secParent": "secondaryCachegroup",
-                    "parents": [
-                        0,
-                        2
-                    ]
-                },
-                {
-                    "cachegroup": "secondaryCachegroup",
-                    "parent": "",
-                    "secParent": "",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "fallback1",
-                    "parent": "secondaryCachegroup",
-                    "secParent": "parentCachegroup",
-                    "parents": [
-                        2,
-                        0
-                    ]
-                },
-                {
-                    "cachegroup": "fallback2",
-                    "parent": "secondaryCachegroup",
-                    "secParent": "parentCachegroup",
-                    "parents": [
-                        2,
-                        0
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "4-tiers",
-            "description": "A 4-tier topology",
-            "nodes": [
-                {
-                    "cachegroup": "parentCachegroup",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "parentCachegroup2",
-                    "parents": [
-                        0
-                    ]
-                },
-                {
-                    "cachegroup": "cachegroup1",
-                    "parents": [
-                        1
-                    ]
-                },
-                {
-                    "cachegroup": "secondaryCachegroup",
-                    "parents": [
-                        1,
-                        0
-                    ]
-                },
-                {
-                    "cachegroup": "fallback1",
-                    "parents": [
-                        3
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "forked-topology",
-            "description": "This topology stems from 2 ancestors",
-            "nodes": [
-                {
-                    "cachegroup": "topology-edge-cg-01",
-                    "parents": [
-                        2
-                    ]
-                },
-                {
-                    "cachegroup": "topology-edge-cg-02",
-                    "parents": [
-                        6
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-01",
-                    "parents": [
-                        3
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-02",
-                    "parents": [
-                        4
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-03",
-                    "parents": [
-                        5
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-04",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "topology-mid-cg-05",
-                    "parents": [
-                        7
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-06",
-                    "parents": [
-                        8
-                    ]
-                },
-                {
-                    "cachegroup": "topology-mid-cg-07",
-                    "parents": []
-                }
-            ]
-        },
-        {
-            "name": "top-for-ds-req",
-            "description": "a topology",
-            "nodes": [
-                {
-                    "cachegroup": "dtrc1",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "dtrc2",
-                    "parents": [0]
-                },
-                {
-                    "cachegroup": "dtrc3",
-                    "parents": [0]
-                }
-            ]
-        },
-        {
-            "name": "top-for-ds-req2",
-            "description": "a topology",
-            "nodes": [
-                {
-                    "cachegroup": "dtrc1",
-                    "parents": []
-                },
-                {
-                    "cachegroup": "dtrc2",
-                    "parents": [0]
-                }
-            ]
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::7/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.7/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "types": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-04",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "description": "Host header regular expression",
-            "lastUpdated": "2018-03-02T19:13:46.788583+00:00",
-            "name": "HOST_REGEXP",
-            "useInTable": "regex"
-        },
-        {
-            "description": "DNS Content routing, RAM cache, National",
-            "lastUpdated": "2018-03-02T19:13:46.792319+00:00",
-            "name": "DNS_LIVE_NATNL",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Other CDN (CDS-IS, Akamai, etc)",
-            "lastUpdated": "2018-03-02T19:13:46.793921+00:00",
-            "name": "OTHER_CDN",
-            "useInTable": "server"
-        },
-        {
-            "description": "Client-Controlled Steering Delivery Service",
-            "lastUpdated": "2018-03-02T19:13:46.795291+00:00",
-            "name": "CLIENT_STEERING",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "influxdb type",
-            "lastUpdated": "2018-03-02T19:13:46.796707+00:00",
-            "name": "INFLUXDB",
-            "useInTable": "server"
-        },
-        {
-            "description": "riak type",
-            "lastUpdated": "2018-03-02T19:13:46.798008+00:00",
-            "name": "RIAK",
-            "useInTable": "server"
-        },
-        {
-            "description": "Origin",
-            "lastUpdated": "2018-03-02T19:13:46.799404+00:00",
-            "name": "ORG",
-            "useInTable": "server"
-        },
-        {
-            "description": "HTTP Content routing cache in RAM ",
-            "lastUpdated": "2018-03-02T19:13:46.800738+00:00",
-            "name": "HTTP_LIVE",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Active Directory User",
-            "lastUpdated": "2018-03-02T19:13:46.802044+00:00",
-            "name": "ACTIVE_DIRECTORY",
-            "useInTable": "tm_user"
-        },
-        {
-            "description": "federation type resolve4",
-            "lastUpdated": "2018-03-02T19:13:46.803471+00:00",
-            "name": "RESOLVE4",
-            "useInTable": "federation"
-        },
-        {
-            "description": "Static DNS A entry",
-            "lastUpdated": "2018-03-02T19:13:46.804776+00:00",
-            "name": "A_RECORD",
-            "useInTable": "staticdnsentry"
-        },
-        {
-            "description": "Local User",
-            "lastUpdated": "2018-03-02T19:13:46.806035+00:00",
-            "name": "LOCAL",
-            "useInTable": "tm_user"
-        },
-        {
-            "description": "Weighted steering target",
-            "lastUpdated": "2018-03-02T19:13:46.80748+00:00",
-            "name": "STEERING_WEIGHT",
-            "useInTable": "steering_target"
-        },
-        {
-            "description": "HTTP Content routing, RAM cache, National",
-            "lastUpdated": "2018-03-02T19:13:46.808911+00:00",
-            "name": "HTTP_LIVE_NATNL",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Ops hosts for management",
-            "lastUpdated": "2018-03-02T19:13:46.810576+00:00",
-            "name": "TOOLS_SERVER",
-            "useInTable": "server"
-        },
-        {
-            "description": "Path regular expression",
-            "lastUpdated": "2018-03-02T19:13:46.812049+00:00",
-            "name": "PATH_REGEXP",
-            "useInTable": "regex"
-        },
-        {
-            "description": "Static DNS CNAME entry",
-            "lastUpdated": "2018-03-02T19:13:46.813461+00:00",
-            "name": "CNAME_RECORD",
-            "useInTable": "staticdnsentry"
-        },
-        {
-            "description": "Kabletown Content Router",
-            "lastUpdated": "2018-03-02T19:13:46.814833+00:00",
-            "name": "CCR",
-            "useInTable": "server"
-        },
-        {
-            "description": "Origin Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
-            "name": "ORG_LOC",
-            "useInTable": "cachegroup"
-        },
-        {
-            "description": "Mid Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
-            "name": "MID_LOC",
-            "useInTable": "cachegroup"
-        },
-        {
-            "description": "Edge Cache",
-            "lastUpdated": "2018-03-02T19:13:46.817689+00:00",
-            "name": "EDGE",
-            "useInTable": "server"
-        },
-        {
-            "description": "Ordered steering target",
-            "lastUpdated": "2018-03-02T19:13:46.81913+00:00",
-            "name": "STEERING_ORDER",
-            "useInTable": "steering_target"
-        },
-        {
-            "description": "DNS Content Routing",
-            "lastUpdated": "2018-03-02T19:13:46.820528+00:00",
-            "name": "DNS",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "federation type resolve6",
-            "lastUpdated": "2018-03-02T19:13:46.822161+00:00",
-            "name": "RESOLVE6",
-            "useInTable": "federation"
-        },
-        {
-            "description": "Static DNS AAAA entry",
-            "lastUpdated": "2018-03-02T19:13:46.823506+00:00",
-            "name": "AAAA_RECORD",
-            "useInTable": "staticdnsentry"
-        },
-        {
-            "description": "HTTP Content Routing, no caching",
-            "lastUpdated": "2018-03-02T19:13:46.824798+00:00",
-            "name": "HTTP_NO_CACHE",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "any_map type",
-            "lastUpdated": "2018-03-02T19:13:46.826411+00:00",
-            "name": "ANY_MAP",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Steering Delivery Service",
-            "lastUpdated": "2018-03-02T19:13:46.827779+00:00",
-            "name": "STEERING",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Edge Cachegroup",
-            "lastUpdated": "2018-03-02T19:13:46.829249+00:00",
-            "name": "EDGE_LOC",
-            "useInTable": "cachegroup"
-        },
-        {
-            "description": "HTTP Content routing cache ",
-            "lastUpdated": "2018-03-02T19:13:46.830862+00:00",
-            "name": "HTTP",
-            "useInTable": "deliveryservice"
-        },
-        {
-            "description": "Mid Tier Cache",
-            "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
-            "name": "MID",
-            "useInTable": "server"
-        },
-        {
-            "description": "Traffic Monitor (Rascal)",
-            "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
-            "name": "RASCAL",
-            "useInTable": "server"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::8/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.8/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "users": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-05",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "addressLine1": "address of admin",
-            "addressLine2": "",
-            "city": "Anywhere",
-            "company": "Comcast",
-            "country": "USA",
-            "email": "admin@example.com",
-            "fullName": "Fred the admin",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "810-555-9876",
-            "postalCode": "55443",
-            "publicSshKey": "",
-            "role": 4,
-            "stateOrProvince": "LA",
-            "tenant": "root",
-            "token": "test",
-            "uid": 0,
-            "username": "adminuser"
-        },
-        {
-            "addressLine1": "address of disallowed",
-            "addressLine2": "place",
-            "city": "somewhere",
-            "company": "else",
-            "country": "UK",
-            "email": "disallowed@example.com",
-            "fullName": "Me me",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "",
-            "postalCode": "",
-            "publicSshKey": "",
-            "registrationSent": "",
-            "role": 1,
-            "stateOrProvince": "",
-            "tenant": "tenant1",
-            "token": "quest",
-            "uid": 0,
-            "username": "disalloweduser"
-        },
-        {
-            "addressLine1": "address of readonly",
-            "addressLine2": "place",
-            "city": "somewhere",
-            "company": "else",
-            "country": "UK",
-            "email": "readonly@example.com",
-            "fullName": "Readonly User",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "",
-            "postalCode": "",
-            "publicSshKey": "",
-            "registrationSent": "",
-            "role": 2,
-            "stateOrProvince": "",
-            "tenant": "tenant1",
-            "uid": 0,
-            "username": "readonlyuser"
-        },
-        {
-            "addressLine1": "address of admin",
-            "addressLine2": "",
-            "city": "Anywhere",
-            "company": "Comcast",
-            "country": "USA",
-            "email": "tenant3user@example.com",
-            "fullName": "Fred the admin",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "810-555-9876",
-            "postalCode": "55443",
-            "publicSshKey": "",
-            "role": 4,
-            "stateOrProvince": "LA",
-            "tenant": "tenant3",
-            "uid": 0,
-            "username": "tenant3user"
-        },
-        {
-            "addressLine1": "address of admin",
-            "addressLine2": "",
-            "city": "Anywhere",
-            "company": "Comcast",
-            "country": "USA",
-            "email": "tenant4user@example.com",
-            "fullName": "Fred the admin",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "810-555-9876",
-            "postalCode": "55443",
-            "publicSshKey": "",
-            "role": 4,
-            "stateOrProvince": "LA",
-            "tenant": "tenant4",
-            "uid": 0,
-            "username": "tenant4user"
-        },
-        {
-            "addressLine1": "address of ops",
-            "addressLine2": "place",
-            "city": "somewhere",
-            "company": "else",
-            "country": "UK",
-            "email": "ops@example.com",
-            "fullName": "Operations User",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "",
-            "postalCode": "",
-            "publicSshKey": "",
-            "registrationSent": "",
-            "role": 3,
-            "stateOrProvince": "",
-            "tenant": "root",
-            "uid": 0,
-            "username": "opsuser"
-        },
-        {
-            "addressLine1": "address of steering",
-            "addressLine2": "place",
-            "city": "somewhere",
-            "company": "else",
-            "country": "UK",
-            "email": "steering@example.com",
-            "fullName": "Steering User",
-            "gid": 0,
-            "localPasswd": "pa$$word",
-            "confirmLocalPasswd": "pa$$word",
-            "newUser": false,
-            "phoneNumber": "",
-            "postalCode": "",
-            "publicSshKey": "",
-            "registrationSent": "",
-            "role": 6,
-            "stateOrProvince": "",
-            "tenant": "root",
-            "uid": 0,
-            "username": "steering"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::9/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.9/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "steeringTargets": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-06",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "deliveryService": "ds1",
-            "target": "ds2",
-            "value": 42,
-            "type": "STEERING_WEIGHT"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::10/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.10/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
         }
-    ],
-    "servercheck_extensions": [
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc2",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-07",
+      "httpsPort": 443,
+      "interfaces": [
         {
-            "name": "ILO_PING",
-            "version": "1.0.0",
-            "info_url": "-",
-            "script_file": "ToPingCheck.pl",
-            "isactive": 1,
-            "description": "",
-            "servercheck_short_name": "ILO",
-            "type": "CHECK_EXTENSION_BOOL"
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::11/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.11/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc3",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-edge-08",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.12/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "dtrc1",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "dtrc-mid-04",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::13/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.13/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "cachegroup3",
+      "cdnName": "cdn1",
+      "domainName": "kabletown.net",
+      "hostName": "edgeInCachegroup3",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.13/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "EDGE1",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "parentCachegroup",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInParentCachegroup",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.14/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "secondaryCachegroup",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInSecondaryCachegroup",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.15/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "fallback1",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "edgeInFallback1",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.16/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "fallback2",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "edgeInFallback2",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.17/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "parentCachegroup2",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInParentCachegroup2",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.18/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-edge-cg-01",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "edgeInTopologyEdgeCg01",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.19/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-edge-cg-02",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "edgeInTopologyEdgeCg02",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.20/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_EDGE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-01",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg01",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.21/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-02",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg02",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.22/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-03",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg03",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.23/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-04",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg04",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.24/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-05",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg05",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.25/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-06",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg06",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.26/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    },
+    {
+      "cachegroup": "topology-mid-cg-07",
+      "cdnName": "cdn2",
+      "domainName": "kabletown.net",
+      "hostName": "midInTopologyMidCg07",
+      "httpsPort": 443,
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "2001:db8:dead:beef::12/64",
+              "gateway": "2001:db8:dead:beef::1",
+              "serviceAddress": false
+            },
+            {
+              "address": "192.0.2.27/24",
+              "gateway": "192.0.2.1",
+              "serviceAddress": true
+            }
+          ],
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "physLocation": "Denver",
+      "profile": "CDN2_MID",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "MID",
+      "updPending": false
+    }
+  ],
+  "serverCapabilities": [
+    {
+      "name": "foo"
+    },
+    {
+      "name": "bar"
+    },
+    {
+      "name": "ram"
+    },
+    {
+      "name": "disk"
+    },
+    {
+      "name": "asdf"
+    }
+  ],
+  "serverServerCapabilities": [
+    {
+      "serverHostName": "atlanta-edge-03",
+      "serverCapability": "foo"
+    },
+    {
+      "serverHostName": "atlanta-edge-03",
+      "serverCapability": "bar"
+    },
+    {
+      "serverHostName": "dtrc-mid-01",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-mid-01",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-mid-02",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-mid-02",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-edge-01",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-edge-01",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-edge-01",
+      "serverCapability": "asdf"
+    },
+    {
+      "serverHostName": "dtrc-edge-02",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-edge-02",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-edge-04",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-edge-04",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-edge-05",
+      "serverCapability": "ram"
+    },
+    {
+      "serverHostName": "dtrc-edge-05",
+      "serverCapability": "disk"
+    },
+    {
+      "serverHostName": "dtrc-edge-07",
+      "serverCapability": "asdf"
+    },
+    {
+      "serverHostName": "dtrc-edge-08",
+      "serverCapability": "asdf"
+    },
+    {
+      "serverHostName": "dtrc-mid-04",
+      "serverCapability": "asdf"
+    }
+  ],
+  "serviceCategories": [
+    {
+      "name": "serviceCategory1"
+    },
+    {
+      "name": "barServiceCategory2"
+    }
+  ],
+  "staticdnsentries": [
+    {
+      "address": "192.168.0.1",
+      "cachegroup": "cachegroup2",
+      "deliveryservice": "ds1",
+      "host": "host2",
+      "type": "A_RECORD",
+      "ttl": 10
+    },
+    {
+      "address": "this.is.a.hostname.",
+      "cachegroup": "cachegroup1",
+      "deliveryservice": "ds1",
+      "host": "host1",
+      "type": "CNAME_RECORD",
+      "ttl": 0
+    },
+    {
+      "address": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+      "cachegroup": "cachegroup2",
+      "deliveryservice": "ds1",
+      "host": "host3",
+      "ttl": 10,
+      "type": "AAAA_RECORD"
+    }
+  ],
+  "statuses": [
+    {
+      "description": "Edge: Puts server in CCR config file in this state, but CCR will never route traffic to it. Mid: Server will not be included in parent.config files for its edge caches",
+      "name": "OFFLINE"
+    },
+    {
+      "description": "Edge: Puts server in CCR config file in this state, and CCR will always route traffic to it. Mid: Server will be included in parent.config files for its edges",
+      "name": "ONLINE"
+    },
+    {
+      "description": "Edge: Puts server in CCR config file in this state, and CCR will adhere to the health protocol. Mid: N/A for now",
+      "name": "REPORTED"
+    },
+    {
+      "description": "Temporary down. Edge: XMPP client will send status OFFLINE to CCR, otherwise similar to REPORTED. Mid: Server will not be included in parent.config files for its edge caches",
+      "name": "ADMIN_DOWN"
+    },
+    {
+      "description": "Edge: 12M will not include caches in this state in CCR config files. Mid: N/A for now",
+      "name": "CCR_IGNORE"
+    },
+    {
+      "description": "Pre Production. Not active in any configuration.",
+      "name": "PRE_PROD"
+    },
+    {
+      "name": "TEST_NULL_DESCRIPTION"
+    }
+  ],
+  "tenants": [
+    {
+      "active": true,
+      "name": "tenant1",
+      "parentName": "root"
+    },
+    {
+      "active": false,
+      "name": "tenant2",
+      "parentName": "tenant1"
+    },
+    {
+      "active": true,
+      "name": "tenant3",
+      "parentName": "tenant2"
+    },
+    {
+      "active": true,
+      "name": "tenant4",
+      "parentName": "root"
+    }
+  ],
+  "topologies": [
+    {
+      "name": "mso-topology",
+      "description": "a multi-site origin topology",
+      "nodes": [
+        {
+          "cachegroup": "multiOriginCachegroup",
+          "parents": []
         },
         {
-            "name": "ORT_ERROR_COUNT",
-            "version": "1.0.0",
-            "info_url": "-",
-            "script_file": "ToORTCheck.pl",
-            "isactive": 1,
-            "description": "",
-            "servercheck_short_name": "ORT",
-            "type": "CHECK_EXTENSION_NUM"
-        }
-    ],
-    "serverchecks": [
-        {
-            "servercheck_short_name": "ILO",
-            "host_name": "atlanta-edge-01",
-            "value": 1
+          "cachegroup": "parentCachegroup",
+          "parents": [
+            0
+          ]
         },
         {
-            "servercheck_short_name": "ORT",
-            "host_name": "atlanta-edge-01",
-            "value": 13
+          "cachegroup": "cachegroup2",
+          "parents": [
+            1
+          ]
         }
-    ],
-    "invalidationJobs": [
+      ]
+    },
+    {
+      "name": "another-topology",
+      "description": "another topology",
+      "nodes": [
         {
-            "deliveryService": "ds1",
-            "regex": "/.*",
-            "startTime": 4117118271000,
-            "ttl": "121m"
+          "cachegroup": "parentCachegroup",
+          "parents": []
         },
         {
-            "deliveryService": "ds1",
-            "regex": "/foo",
-            "startTime": 4117118271000,
-            "ttl": 2160
+          "cachegroup": "cachegroup1",
+          "parents": [
+            0
+          ]
         },
         {
-            "deliveryService":  "ds2",
-            "regex": "\\/some-path?.+\\.jpg",
-            "startTime": "2100-06-19T13:57:51-06:00",
-            "ttl": 2.1
-        }
-    ],
-    "statsSummaries": [
-        {
-            "cdnName": "cdn1",
-            "deliveryServiceName": "all",
-            "statName": "daily_maxgbps",
-            "statValue": 5,
-            "summaryTime": "2019-01-01T00:00:00-06:00"
+          "cachegroup": "secondaryCachegroup",
+          "parents": []
         },
         {
-            "cdnName": "cdn1",
-            "deliveryServiceName": "all",
-            "statName": "daily_bytesserved",
-            "statValue": 1000,
-            "summaryTime": "2019-01-01T00:00:00-06:00"
+          "cachegroup": "cachegroup2",
+          "parents": [
+            2
+          ]
         }
-    ],
-    "capabilities": [
+      ]
+    },
+    {
+      "name": "secondary-parents",
+      "description": "A topology with secondary parents",
+      "nodes": [
         {
-            "name": "test",
-            "description": "quest"
+          "cachegroup": "parentCachegroup",
+          "parent": "",
+          "secParent": "",
+          "parents": []
         },
         {
-            "name": "foo",
-            "description": "bar"
+          "cachegroup": "cachegroup1",
+          "parent": "parentCachegroup",
+          "secParent": "secondaryCachegroup",
+          "parents": [
+            0,
+            2
+          ]
+        },
+        {
+          "cachegroup": "secondaryCachegroup",
+          "parent": "",
+          "secParent": "",
+          "parents": []
+        },
+        {
+          "cachegroup": "fallback1",
+          "parent": "secondaryCachegroup",
+          "secParent": "parentCachegroup",
+          "parents": [
+            2,
+            0
+          ]
+        },
+        {
+          "cachegroup": "fallback2",
+          "parent": "secondaryCachegroup",
+          "secParent": "parentCachegroup",
+          "parents": [
+            2,
+            0
+          ]
         }
-    ]
+      ]
+    },
+    {
+      "name": "4-tiers",
+      "description": "A 4-tier topology",
+      "nodes": [
+        {
+          "cachegroup": "parentCachegroup",
+          "parents": []
+        },
+        {
+          "cachegroup": "parentCachegroup2",
+          "parents": [
+            0
+          ]
+        },
+        {
+          "cachegroup": "cachegroup1",
+          "parents": [
+            1
+          ]
+        },
+        {
+          "cachegroup": "secondaryCachegroup",
+          "parents": [
+            1,
+            0
+          ]
+        },
+        {
+          "cachegroup": "fallback1",
+          "parents": [
+            3
+          ]
+        }
+      ]
+    },
+    {
+      "name": "forked-topology",
+      "description": "This topology stems from 2 ancestors",
+      "nodes": [
+        {
+          "cachegroup": "topology-edge-cg-01",
+          "parents": [
+            2
+          ]
+        },
+        {
+          "cachegroup": "topology-edge-cg-02",
+          "parents": [
+            6
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-01",
+          "parents": [
+            3
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-02",
+          "parents": [
+            4
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-03",
+          "parents": [
+            5
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-04",
+          "parents": []
+        },
+        {
+          "cachegroup": "topology-mid-cg-05",
+          "parents": [
+            7
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-06",
+          "parents": [
+            8
+          ]
+        },
+        {
+          "cachegroup": "topology-mid-cg-07",
+          "parents": []
+        }
+      ]
+    },
+    {
+      "name": "top-for-ds-req",
+      "description": "a topology",
+      "nodes": [
+        {
+          "cachegroup": "dtrc1",
+          "parents": []
+        },
+        {
+          "cachegroup": "dtrc2",
+          "parents": [
+            0
+          ]
+        },
+        {
+          "cachegroup": "dtrc3",
+          "parents": [
+            0
+          ]
+        }
+      ]
+    },
+    {
+      "name": "top-for-ds-req2",
+      "description": "a topology",
+      "nodes": [
+        {
+          "cachegroup": "dtrc1",
+          "parents": []
+        },
+        {
+          "cachegroup": "dtrc2",
+          "parents": [
+            0
+          ]
+        }
+      ]
+    }
+  ],
+  "types": [
+    {
+      "description": "Host header regular expression",
+      "lastUpdated": "2018-03-02T19:13:46.788583+00:00",
+      "name": "HOST_REGEXP",
+      "useInTable": "regex"
+    },
+    {
+      "description": "DNS Content routing, RAM cache, National",
+      "lastUpdated": "2018-03-02T19:13:46.792319+00:00",
+      "name": "DNS_LIVE_NATNL",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Other CDN (CDS-IS, Akamai, etc)",
+      "lastUpdated": "2018-03-02T19:13:46.793921+00:00",
+      "name": "OTHER_CDN",
+      "useInTable": "server"
+    },
+    {
+      "description": "Client-Controlled Steering Delivery Service",
+      "lastUpdated": "2018-03-02T19:13:46.795291+00:00",
+      "name": "CLIENT_STEERING",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "influxdb type",
+      "lastUpdated": "2018-03-02T19:13:46.796707+00:00",
+      "name": "INFLUXDB",
+      "useInTable": "server"
+    },
+    {
+      "description": "riak type",
+      "lastUpdated": "2018-03-02T19:13:46.798008+00:00",
+      "name": "RIAK",
+      "useInTable": "server"
+    },
+    {
+      "description": "Origin",
+      "lastUpdated": "2018-03-02T19:13:46.799404+00:00",
+      "name": "ORG",
+      "useInTable": "server"
+    },
+    {
+      "description": "HTTP Content routing cache in RAM ",
+      "lastUpdated": "2018-03-02T19:13:46.800738+00:00",
+      "name": "HTTP_LIVE",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Active Directory User",
+      "lastUpdated": "2018-03-02T19:13:46.802044+00:00",
+      "name": "ACTIVE_DIRECTORY",
+      "useInTable": "tm_user"
+    },
+    {
+      "description": "federation type resolve4",
+      "lastUpdated": "2018-03-02T19:13:46.803471+00:00",
+      "name": "RESOLVE4",
+      "useInTable": "federation"
+    },
+    {
+      "description": "Static DNS A entry",
+      "lastUpdated": "2018-03-02T19:13:46.804776+00:00",
+      "name": "A_RECORD",
+      "useInTable": "staticdnsentry"
+    },
+    {
+      "description": "Local User",
+      "lastUpdated": "2018-03-02T19:13:46.806035+00:00",
+      "name": "LOCAL",
+      "useInTable": "tm_user"
+    },
+    {
+      "description": "Weighted steering target",
+      "lastUpdated": "2018-03-02T19:13:46.80748+00:00",
+      "name": "STEERING_WEIGHT",
+      "useInTable": "steering_target"
+    },
+    {
+      "description": "HTTP Content routing, RAM cache, National",
+      "lastUpdated": "2018-03-02T19:13:46.808911+00:00",
+      "name": "HTTP_LIVE_NATNL",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Ops hosts for management",
+      "lastUpdated": "2018-03-02T19:13:46.810576+00:00",
+      "name": "TOOLS_SERVER",
+      "useInTable": "server"
+    },
+    {
+      "description": "Path regular expression",
+      "lastUpdated": "2018-03-02T19:13:46.812049+00:00",
+      "name": "PATH_REGEXP",
+      "useInTable": "regex"
+    },
+    {
+      "description": "Static DNS CNAME entry",
+      "lastUpdated": "2018-03-02T19:13:46.813461+00:00",
+      "name": "CNAME_RECORD",
+      "useInTable": "staticdnsentry"
+    },
+    {
+      "description": "Kabletown Content Router",
+      "lastUpdated": "2018-03-02T19:13:46.814833+00:00",
+      "name": "CCR",
+      "useInTable": "server"
+    },
+    {
+      "description": "Origin Cachegroup",
+      "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
+      "name": "ORG_LOC",
+      "useInTable": "cachegroup"
+    },
+    {
+      "description": "Mid Cachegroup",
+      "lastUpdated": "2018-03-02T19:13:46.816199+00:00",
+      "name": "MID_LOC",
+      "useInTable": "cachegroup"
+    },
+    {
+      "description": "Edge Cache",
+      "lastUpdated": "2018-03-02T19:13:46.817689+00:00",
+      "name": "EDGE",
+      "useInTable": "server"
+    },
+    {
+      "description": "Ordered steering target",
+      "lastUpdated": "2018-03-02T19:13:46.81913+00:00",
+      "name": "STEERING_ORDER",
+      "useInTable": "steering_target"
+    },
+    {
+      "description": "DNS Content Routing",
+      "lastUpdated": "2018-03-02T19:13:46.820528+00:00",
+      "name": "DNS",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "federation type resolve6",
+      "lastUpdated": "2018-03-02T19:13:46.822161+00:00",
+      "name": "RESOLVE6",
+      "useInTable": "federation"
+    },
+    {
+      "description": "Static DNS AAAA entry",
+      "lastUpdated": "2018-03-02T19:13:46.823506+00:00",
+      "name": "AAAA_RECORD",
+      "useInTable": "staticdnsentry"
+    },
+    {
+      "description": "HTTP Content Routing, no caching",
+      "lastUpdated": "2018-03-02T19:13:46.824798+00:00",
+      "name": "HTTP_NO_CACHE",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "any_map type",
+      "lastUpdated": "2018-03-02T19:13:46.826411+00:00",
+      "name": "ANY_MAP",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Steering Delivery Service",
+      "lastUpdated": "2018-03-02T19:13:46.827779+00:00",
+      "name": "STEERING",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Edge Cachegroup",
+      "lastUpdated": "2018-03-02T19:13:46.829249+00:00",
+      "name": "EDGE_LOC",
+      "useInTable": "cachegroup"
+    },
+    {
+      "description": "HTTP Content routing cache ",
+      "lastUpdated": "2018-03-02T19:13:46.830862+00:00",
+      "name": "HTTP",
+      "useInTable": "deliveryservice"
+    },
+    {
+      "description": "Mid Tier Cache",
+      "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
+      "name": "MID",
+      "useInTable": "server"
+    },
+    {
+      "description": "Traffic Monitor (Rascal)",
+      "lastUpdated": "2018-03-02T19:13:46.832327+00:00",
+      "name": "RASCAL",
+      "useInTable": "server"
+    }
+  ],
+  "users": [
+    {
+      "addressLine1": "address of admin",
+      "addressLine2": "",
+      "city": "Anywhere",
+      "company": "Comcast",
+      "country": "USA",
+      "email": "admin@example.com",
+      "fullName": "Fred the admin",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "810-555-9876",
+      "postalCode": "55443",
+      "publicSshKey": "",
+      "role": 4,
+      "stateOrProvince": "LA",
+      "tenant": "root",
+      "token": "test",
+      "uid": 0,
+      "username": "adminuser"
+    },
+    {
+      "addressLine1": "address of disallowed",
+      "addressLine2": "place",
+      "city": "somewhere",
+      "company": "else",
+      "country": "UK",
+      "email": "disallowed@example.com",
+      "fullName": "Me me",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "",
+      "postalCode": "",
+      "publicSshKey": "",
+      "registrationSent": "",
+      "role": 1,
+      "stateOrProvince": "",
+      "tenant": "tenant1",
+      "token": "quest",
+      "uid": 0,
+      "username": "disalloweduser"
+    },
+    {
+      "addressLine1": "address of readonly",
+      "addressLine2": "place",
+      "city": "somewhere",
+      "company": "else",
+      "country": "UK",
+      "email": "readonly@example.com",
+      "fullName": "Readonly User",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "",
+      "postalCode": "",
+      "publicSshKey": "",
+      "registrationSent": "",
+      "role": 2,
+      "stateOrProvince": "",
+      "tenant": "tenant1",
+      "uid": 0,
+      "username": "readonlyuser"
+    },
+    {
+      "addressLine1": "address of admin",
+      "addressLine2": "",
+      "city": "Anywhere",
+      "company": "Comcast",
+      "country": "USA",
+      "email": "tenant3user@example.com",
+      "fullName": "Fred the admin",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "810-555-9876",
+      "postalCode": "55443",
+      "publicSshKey": "",
+      "role": 4,
+      "stateOrProvince": "LA",
+      "tenant": "tenant3",
+      "uid": 0,
+      "username": "tenant3user"
+    },
+    {
+      "addressLine1": "address of admin",
+      "addressLine2": "",
+      "city": "Anywhere",
+      "company": "Comcast",
+      "country": "USA",
+      "email": "tenant4user@example.com",
+      "fullName": "Fred the admin",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "810-555-9876",
+      "postalCode": "55443",
+      "publicSshKey": "",
+      "role": 4,
+      "stateOrProvince": "LA",
+      "tenant": "tenant4",
+      "uid": 0,
+      "username": "tenant4user"
+    },
+    {
+      "addressLine1": "address of ops",
+      "addressLine2": "place",
+      "city": "somewhere",
+      "company": "else",
+      "country": "UK",
+      "email": "ops@example.com",
+      "fullName": "Operations User",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "",
+      "postalCode": "",
+      "publicSshKey": "",
+      "registrationSent": "",
+      "role": 3,
+      "stateOrProvince": "",
+      "tenant": "root",
+      "uid": 0,
+      "username": "opsuser"
+    },
+    {
+      "addressLine1": "address of steering",
+      "addressLine2": "place",
+      "city": "somewhere",
+      "company": "else",
+      "country": "UK",
+      "email": "steering@example.com",
+      "fullName": "Steering User",
+      "gid": 0,
+      "localPasswd": "pa$$word",
+      "confirmLocalPasswd": "pa$$word",
+      "newUser": false,
+      "phoneNumber": "",
+      "postalCode": "",
+      "publicSshKey": "",
+      "registrationSent": "",
+      "role": 6,
+      "stateOrProvince": "",
+      "tenant": "root",
+      "uid": 0,
+      "username": "steering"
+    }
+  ],
+  "steeringTargets": [
+    {
+      "deliveryService": "ds1",
+      "target": "ds2",
+      "value": 42,
+      "type": "STEERING_WEIGHT"
+    }
+  ],
+  "servercheck_extensions": [
+    {
+      "name": "ILO_PING",
+      "version": "1.0.0",
+      "info_url": "-",
+      "script_file": "ToPingCheck.pl",
+      "isactive": 1,
+      "description": "",
+      "servercheck_short_name": "ILO",
+      "type": "CHECK_EXTENSION_BOOL"
+    },
+    {
+      "name": "ORT_ERROR_COUNT",
+      "version": "1.0.0",
+      "info_url": "-",
+      "script_file": "ToORTCheck.pl",
+      "isactive": 1,
+      "description": "",
+      "servercheck_short_name": "ORT",
+      "type": "CHECK_EXTENSION_NUM"
+    }
+  ],
+  "serverchecks": [
+    {
+      "servercheck_short_name": "ILO",
+      "host_name": "atlanta-edge-01",
+      "value": 1
+    },
+    {
+      "servercheck_short_name": "ORT",
+      "host_name": "atlanta-edge-01",
+      "value": 13
+    }
+  ],
+  "invalidationJobs": [
+    {
+      "deliveryService": "ds1",
+      "regex": "/.*",
+      "startTime": 4117118271000,
+      "ttl": "121m"
+    },
+    {
+      "deliveryService": "ds1",
+      "regex": "/foo",
+      "startTime": 4117118271000,
+      "ttl": 2160
+    },
+    {
+      "deliveryService": "ds2",
+      "regex": "\\/some-path?.+\\.jpg",
+      "startTime": "2100-06-19T13:57:51-06:00",
+      "ttl": 2.1
+    }
+  ],
+  "statsSummaries": [
+    {
+      "cdnName": "cdn1",
+      "deliveryServiceName": "all",
+      "statName": "daily_maxgbps",
+      "statValue": 5,
+      "summaryTime": "2019-01-01T00:00:00-06:00"
+    },
+    {
+      "cdnName": "cdn1",
+      "deliveryServiceName": "all",
+      "statName": "daily_bytesserved",
+      "statValue": 1000,
+      "summaryTime": "2019-01-01T00:00:00-06:00"
+    }
+  ],
+  "capabilities": [
+    {
+      "name": "test",
+      "description": "quest"
+    },
+    {
+      "name": "foo",
+      "description": "bar"
+    }
+  ]
 }

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -207,7 +207,7 @@ func getATSMajorVersionFromATSVersion(atsVersion string) (int, error) {
 
 	majorVer, err := strconv.ParseUint(majorVerStr, 10, 64)
 	if err != nil {
-		return 0, errors.New("unexpected version format, expected e.g. '7.1.2.whatever'")
+		return 0, errors.New("unexpected version format '" + majorVerStr + "', expected e.g. '7.1.2.whatever'")
 	}
 	return int(majorVer), nil
 }


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- This PR uses `jq` to manipulate the JSON of `tc-fixtures.json` to set the ATS version instead of using `sed`

- Added validation to ensure that the ATS RPM version was set in the right place.

- Includes what the unexpected version format was in the error message citing unexpected version format

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

Manipulating the JSON to set the ATS RPM version in this way also has the benefit of not relying on the file containing a specific string in order for replacement to occur.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Control Cache Config integration tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the `t3c` integration tests

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR modifies existing tests
- [x] Intended behavior is unchanged, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->
It would also be nice to use `jq` to reformat `tc-fixtures.json` for easy comparison once `jq` sets the ATS RPM version, but since that would create a huge diff, I would only include the reformatting commit if the other changes in the PR are approved.
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

