### PR TITLE
Add t3c manpages

### DIFF
--- a/cache-config/build/build_rpm.sh
+++ b/cache-config/build/build_rpm.sh
@@ -61,35 +61,65 @@ initBuildArea() {
 	fi;
 	set -o nounset; }
 
-	(cd t3c;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c';
+	)
 
-	(cd t3c-apply;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-apply;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-apply';
+	)
 
-	(cd t3c-generate;
-	 go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-generate;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-generate';
+	)
 
-	(cd t3c-request;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-request;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-request';
+	)
 
-	(cd t3c-update;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-update;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-update';
+	)
 
-	(cd t3c-check;
-	 go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-check;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags"
+		buildManpage 't3c-check';
+	)
 
-	(cd t3c-check-refs;
-	 go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-check-refs;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-check-refs';
+	)
 
-	(cd t3c-check-reload;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-check-reload;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags"
+		buildManpage 't3c-check-reload';
+	)
 
-	(cd t3c-diff;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-diff;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-diff';
+	)
 
-	(cd t3c-preprocess;
-	go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags")
+	(
+		cd t3c-preprocess;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 't3c-preprocess';
+	)
 
 	cp -p traffic_ops_ort.pl "$dest";
 	cp -p supermicro_udev_mapper.pl "$dest";
@@ -109,6 +139,17 @@ initBuildArea() {
 	cp build/atstccfg.logrotate "$RPMBUILD"/.;
 
 	echo "The build area has been initialized.";
+}
+
+# buildManpage builds an app's manpage using pandoc.
+# It takes 1 argument: the app name.
+# The working directory must be of the app, and must contain a README.md formatted like a manpage.
+buildManpage() {
+	app="$1";
+	desc="ATC t3c Manual";
+	# prepend the pandoc header to the readme
+  printf "%s\n%s\n%s\n%s" "% ${app}(1) ${app} ${TC_VERSION} | ${desc}" "%" "% $(date '+%Y-%m-%d')" "$(cat ./README.md)" > README.md
+	pandoc --standalone --to man README.md -o "${app}.1";
 }
 
 #----------------------------------------

--- a/cache-config/build/build_rpm.sh
+++ b/cache-config/build/build_rpm.sh
@@ -148,7 +148,7 @@ buildManpage() {
 	app="$1";
 	desc="ATC t3c Manual";
 	# prepend the pandoc header to the readme
-  printf "%s\n%s\n%s\n%s" "% ${app}(1) ${app} ${TC_VERSION} | ${desc}" "%" "% $(date '+%Y-%m-%d')" "$(cat ./README.md)" > README.md
+	printf "%s\n%s\n%s\n%s" "% ${app}(1) ${app} ${TC_VERSION} | ${desc}" "%" "% $(date '+%Y-%m-%d')" "$(cat ./README.md)" > README.md
 	pandoc --standalone --to man README.md -o "${app}.1";
 }
 

--- a/cache-config/build/trafficcontrol-cache-config.spec
+++ b/cache-config/build/trafficcontrol-cache-config.spec
@@ -51,6 +51,7 @@ got3cdir="$ccpath"/t3c
 ( mkdir -p "$got3cdir" && \
 	cd "$got3cdir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c/t3c .
+	cp "$TC_DIR"/"$ccdir"/t3c/t3c.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-apply binary
@@ -58,6 +59,7 @@ go_t3c_apply_dir="$ccpath"/t3c-apply
 ( mkdir -p "$go_t3c_apply_dir" && \
 	cd "$go_t3c_apply_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-apply/t3c-apply .
+	cp "$TC_DIR"/"$ccdir"/t3c-apply/t3c-apply.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-generate binary
@@ -65,6 +67,7 @@ godir="$ccpath"/t3c-generate
 ( mkdir -p "$godir" && \
 	cd "$godir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-generate/t3c-generate .
+	cp "$TC_DIR"/"$ccdir"/t3c-generate/t3c-generate.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-request binary
@@ -72,6 +75,7 @@ go_toreq_dir="$ccpath"/t3c-request
 ( mkdir -p "$go_toreq_dir" && \
 	cd "$go_toreq_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-request/t3c-request .
+	cp "$TC_DIR"/"$ccdir"/t3c-request/t3c-request.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-update binary
@@ -79,6 +83,7 @@ go_toupd_dir="$ccpath"/t3c-update
 ( mkdir -p "$go_toupd_dir" && \
 	cd "$go_toupd_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-update/t3c-update .
+	cp "$TC_DIR"/"$ccdir"/t3c-update/t3c-update.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-check binary
@@ -86,6 +91,7 @@ go_t3c_check_dir="$ccpath"/t3c-check
 ( mkdir -p "$go_t3c_check_dir" && \
 	cd "$go_t3c_check_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-check/t3c-check .
+	cp "$TC_DIR"/"$ccdir"/t3c-check/t3c-check.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-check-refs binary
@@ -93,6 +99,7 @@ go_t3c_check_refs_dir="$ccpath"/t3c-check-refs
 ( mkdir -p "$go_t3c_check_refs_dir" && \
 	cd "$go_t3c_check_refs_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-check-refs/t3c-check-refs .
+	cp "$TC_DIR"/"$ccdir"/t3c-check-refs/t3c-check-refs.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-diff binary
@@ -100,6 +107,7 @@ go_t3c_diff_dir="$ccpath"/t3c-diff
 ( mkdir -p "$go_t3c_diff_dir" && \
 	cd "$go_t3c_diff_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-diff/t3c-diff .
+	cp "$TC_DIR"/"$ccdir"/t3c-diff/t3c-diff.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-diff binary
@@ -107,6 +115,7 @@ go_t3c_check_reload_dir="$ccpath"/t3c-check-reload
 ( mkdir -p "$go_t3c_check_reload_dir" && \
 	cd "$go_t3c_check_reload_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-check-reload/t3c-check-reload .
+	cp "$TC_DIR"/"$ccdir"/t3c-check-reload/t3c-check-reload.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 # copy t3c-preprocess binary
@@ -114,6 +123,7 @@ go_t3c_preprocess_dir="$ccpath"/t3c-preprocess
 ( mkdir -p "$go_t3c_preprocess_dir" && \
 	cd "$go_t3c_preprocess_dir" && \
 	cp "$TC_DIR"/"$ccdir"/t3c-preprocess/t3c-preprocess .
+	cp "$TC_DIR"/"$ccdir"/t3c-preprocess/t3c-preprocess.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 
@@ -121,10 +131,13 @@ go_t3c_preprocess_dir="$ccpath"/t3c-preprocess
 %install
 ccdir="cache-config/"
 installdir="/usr/bin"
+mandir="/usr/share/man"
+man1dir="man1"
 
 mkdir -p ${RPM_BUILD_ROOT}/"$installdir"
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/trafficcontrol-cache-config
+mkdir -p ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"
 
 cp -p ${RPM_SOURCE_DIR}/trafficcontrol-cache-config-%{version}/traffic_ops_ort.pl ${RPM_BUILD_ROOT}/"$installdir"
 cp -p ${RPM_SOURCE_DIR}/trafficcontrol-cache-config-%{version}/supermicro_udev_mapper.pl ${RPM_BUILD_ROOT}/"$installdir"
@@ -134,38 +147,70 @@ cp -p ${RPM_SOURCE_DIR}/trafficcontrol-cache-config-%{version}/build/atstccfg.lo
 touch ${RPM_BUILD_ROOT}/var/log/trafficcontrol-cache-config/atstccfg.log
 
 cp -p "$src"/t3c-generate/t3c-generate ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-generate/t3c-generate.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-generate.1.gz
 
 t3csrc=src/github.com/apache/trafficcontrol/"$ccdir"/t3c
 cp -p "$t3csrc"/t3c ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c/t3c.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c.1.gz
 
 t3c_apply_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-apply
 cp -p "$t3c_apply_src"/t3c-apply ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-apply/t3c-apply.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-apply.1.gz
 
 to_req_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-request
 cp -p "$to_req_src"/t3c-request ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-request/t3c-request.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-request.1.gz
 
 to_upd_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-update
 cp -p "$to_upd_src"/t3c-update ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-update/t3c-update.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-update.1.gz
 
 t3c_diff_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-diff
 cp -p "$t3c_diff_src"/t3c-diff ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-diff/t3c-diff.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-diff.1.gz
 
 t3c_check_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-check
 cp -p "$t3c_check_src"/t3c-check ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-check/t3c-check.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-check.1.gz
 
 t3c_check_refs_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-check-refs
 cp -p "$t3c_check_refs_src"/t3c-check-refs ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-check-refs/t3c-check-refs.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-check-refs.1.gz
 
 t3c_check_reload_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-check-reload
 cp -p "$t3c_check_reload_src"/t3c-check-reload ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-check-reload/t3c-check-reload.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-check-reload.1.gz
 
 t3c_preprocess_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-preprocess
 cp -p "$t3c_preprocess_src"/t3c-preprocess ${RPM_BUILD_ROOT}/"$installdir"
+gzip -c -9 "$src"/t3c-preprocess/t3c-preprocess.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-preprocess.1.gz
+
+ls ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/
 
 %clean
 rm -rf ${RPM_BUILD_ROOT}
 
 %post
+
+# update mandb to put man pages in the whatis database, so apps like 'whatis' and 'apropos' get the new pages
+mandb_out="$(mandb 2>&1)"
+mandb_ret=$?
+if [ $mandb_ret -eq 0 ]; then
+	printf "%s\n" "Updated mandb"
+else
+	printf "Failed to update mandb: code %s\n%s\n" "${mandb_ret}" "${mandb_out}"
+fi
+
+%postun
+
+# update whatis database, to remove t3c data
+mandb_out="$(mandb 2>&1)"
+mandb_ret=$?
+if [ $mandb_ret -eq 0 ]; then
+	printf "%s\n" "Updated mandb"
+else
+	printf "Failed to update mandb: code %s\n%s\n" "${mandb_ret}" "${mandb_out}"
+fi
 
 %files
 %license LICENSE
@@ -182,6 +227,16 @@ rm -rf ${RPM_BUILD_ROOT}
 /usr/bin/t3c-preprocess
 /usr/bin/t3c-request
 /usr/bin/t3c-update
+/usr/share/man/man1/t3c.1.gz
+/usr/share/man/man1/t3c-apply.1.gz
+/usr/share/man/man1/t3c-check.1.gz
+/usr/share/man/man1/t3c-check-refs.1.gz
+/usr/share/man/man1/t3c-check-reload.1.gz
+/usr/share/man/man1/t3c-diff.1.gz
+/usr/share/man/man1/t3c-generate.1.gz
+/usr/share/man/man1/t3c-preprocess.1.gz
+/usr/share/man/man1/t3c-request.1.gz
+/usr/share/man/man1/t3c-update.1.gz
 
 %config(noreplace) /etc/logrotate.d/atstccfg
 %config(noreplace) /var/log/trafficcontrol-cache-config/atstccfg.log

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -1,42 +1,200 @@
-# t3c-apply
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
 
-t3c-apply is a transliteration of traffic_ops_ort.pl script to the go language.
-It is designed to replace the traffic_ops_ort.pl perl script and it is used to apply
-configuration from Traffic Control, stored in Traffic Ops, to the cache.
+      http://www.apache.org/licenses/LICENSE-2.0
 
-Typical usage is to install `t3c` on the cache machine, and then run it periodically via a CRON job.
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
 
-## Options
+<!--
 
-The `t3c-apply` app has the following command-line options:
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
 
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
 
-long option                             | short | default | description
---------------------------------------- | ------| ------- | ------------------------------------------------------------------------------------
---cache-hostname=[hostname]                    | -H    | ""      | override the short hostname of the OS for config generation.
---dispersion=[seconds]                         | -D    | 300     | wait a random number of seconds between 0 and [seconds] before starting.
---login-dispersion=[seconds]                   | -l    | 0       | wait a random number of seconds between 0 and [seconds] before login.
---log-location-debug=[value]                   | -d    | stdout  | Where to log debugs. May be a file path, stdout, stderr, or null
---log-location-error=[value]                   | -e    | stdout  | Where to log errors. May be a file path, stdout, stderr, or null
---log-location-info=[value]                    | -i    | stdout  | Where to log info messages. May be a file path, stdout, stderr, or null
---log-location-warn=[value]                    | -w    | stdout  | Where to log warning messages. May be a file path, stdout, stderr, or null
---num-retries=[number]                         | -r    | 3       | retry connection to Traffic Ops URL [number] times.
---rev-proxy-disable=['true' or 'false']        | -p    | false   | bypass the reverse proxy even if one has been configured.
---reval-wait-time=[seconds]                    | -T    | 60      | wait a random number of seconds between 0 and [seconds] before revlidation
---run-mode=[mode]                              | -m    | report  | The mode of operation, where mode is [badass|report|revalidate|syncds].
---skip-os-check=['true' or 'false']            | -s    | false   | bypass the check for a supported CentOS version.
---traffic-ops-timeout-milliseconds=[ms]        | -t    | 30000   | The Traffic Ops request timeout in milliseconds.
---traffic-ops-password=[password]              | -P    | ""      | TrafficOps password. Required if not set with the environment variable TO_PASS
---traffic-ops-url=[url]                        | -u    | ""      | TrafficOps URL. Required if not set with the environment variable TO_URL
---traffic-ops-user=[username]                  | -U    | ""      | TrafficOps username. Required if not set with the environment variable TO_USER
---trafficserver-home=[directory]               | -R    | ""      | Used to specify an alternate install location for ATS, otherwise its set from the RPM.
---dns-local-bind=['true' or 'false']           | -b    | false   | set the ATS config to bind to the Server's Service Address in Traffic Ops for DNS.
---wait-for-parents=['true' or 'false']         | -W    | true    | do not update if parent_pending = 1 in the update json.
---git=['yes' or 'no' or 'auto']                | -g    | auto    | track changes in git. If yes, create and commit to a repo. If auto, commit if a repo exists.
---default-client-enable-h2=['true' or 'false'] | -2    | false   | Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter.
---default-client-tls-versions=[versions]       | -v    | ""      | Comma-delimited list of default TLS versions for Delivery Services with no Parameter, e.g. '1.1,1.2,1.3'. If omitted, all versions are enabled.
+-->
+# NAME
 
-# Modes
+t3c-apply - Traffic Control Cache Configuration applicator
+
+# SYNOPSIS
+
+t3c-apply [-2bchIpsSvW] [-D seconds] [-d location] [-e location] [-g &lt;yes|no|auto&gt;] [-H hostname] [-i location] [-l seconds] [-M location] [-m &lt;badass|report|revalidate|syncds&gt;] [-P password] [-r retries] [-R path] [-T seconds] [-t milliseconds] [-u url] [-U username] [-V versions] [-w &lt;true|false&gt;]
+
+[&#45;&#45;help]
+
+# DESCRIPTION
+
+The t3c-apply command is a transliteration of traffic_ops_ort.pl script to the go language. It is designed to replace the traffic_ops_ort.pl perl script and it is used to apply configuration from Traffic Control, stored in Traffic Ops, to the cache.
+
+Typical usage is to install t3c on the cache machine, and then run it periodically via a CRON job.
+
+# OPTIONS
+
+-2, --default-client-enable-h2
+
+    Whether to enable HTTP/2 on Delivery Services by default, if
+    they have no explicit Parameter. This is irrelevant if ATS
+    records.config is not serving H2. If omitted, H2 is
+    disabled.
+
+-b, --dns-local-bind
+
+    [true | false] whether to use the server's Service Addresses
+    to set the ATS DNS local bind address
+
+-c, --disable-parent-config-comments
+
+    Whether to disable verbose parent.config comments. Default
+    false.
+
+-D, --dispersion=value
+
+    [seconds] wait a random number of seconds between 0 and
+    [seconds] before starting, default 300 [300]
+
+-d, --log-location-debug=value
+
+    Where to log debugs. May be a file path, stdout, stderr, or
+    null, default ''
+
+-e, --log-location-error=value
+
+    Where to log errors. May be a file path, stdout, stderr, or
+    null, default stderr [stderr]
+
+-g, --git=value
+
+    Create and use a git repo in the config directory. Options
+    are yes, no, and auto. If yes, create and use. If auto, use
+    if it exist. Default is auto. [auto]
+
+-H, --cache-host-name=value
+
+    Host name of the cache to generate config for. Must be the
+    server host name in Traffic Ops, not a URL, and not the FQDN
+
+-h, --help
+
+    Print usage information and exit
+
+-i, --log-location-info=value
+
+    Where to log info. May be a file path, stdout, stderr, or
+    null, default stderr [stderr]
+
+-I, --traffic-ops-insecure
+
+    [true | false] ignore certificate errors from Traffic Ops
+
+-l, --login-dispersion=value
+
+    [seconds] wait a random number of seconds between 0 and
+    [seconds] before login to traffic ops, default 0
+
+-M, --maxmind-location=value
+
+    URL of a maxmind gzipped database file, to be installed into
+    the trafficserver etc directory.
+
+-m, --run-mode=value
+
+    [badass | report | revalidate | syncds] run mode, default is
+    'report' [report]
+
+-p, --reverse-proxy-disable
+
+    [false | true] bypass the reverse proxy even if one has been
+    configured default is false
+
+-P, --traffic-ops-password=value
+
+    Traffic Ops password. Required. May also be set with the
+    environment variable TO_PASS
+
+-r, --num-retries=value
+
+    [number] retry connection to Traffic Ops URL [number] times,
+    default is 3 [3]
+
+-R, --trafficserver-home=value
+
+    Trafficserver Package directory. May also be set with the
+    environment variable TS_HOME
+
+-s, --skip-os-check
+
+    [false | true] skip os check, default is false
+
+-S, --syncds-updates-ipallow
+
+    Whether syncds mode will update ipallow. This exists because
+    ATS had a bug where reloading after changing ipallow would
+    block everything. Default is false.
+
+-T, --reval-wait-time=value
+
+    [seconds] wait a random number of seconds between 0 and
+    [seconds] before revlidation, default is 60 [60]
+
+-t, --traffic-ops-timeout-milliseconds=value
+
+    Timeout in milli-seconds for Traffic Ops requests, default
+    is 30000 [30000]
+
+-u, --traffic-ops-url=value
+
+    Traffic Ops URL. Must be the full URL, including the scheme.
+    Required. May also be set with the environment variable
+    TO_URL
+
+-U, --traffic-ops-user=value
+
+    Traffic Ops username. Required. May also be set with the
+    environment variable TO_USER
+
+-V, --default-client-tls-versions=value
+
+    Comma-delimited list of default TLS versions for Delivery
+    Services with no Parameter, e.g.
+    --default-tls-versions='1.1,1.2,1.3'. If omitted, all
+    versions are enabled.
+
+-v, --omit-via-string-release
+
+    Whether to set the records.config via header to the ATS
+    release from the RPM. Default true.
+
+-w, --log-location-warning=value
+
+    Where to log warnings. May be a file path, stdout, stderr,
+    or null, default stderr [stderr]
+
+-W, --wait-for-parents
+
+    [true | false] do not update if parent_pending = 1 in the
+    update json. default is false, wait for parents
+
+# MODES
 
 The `t3c-apply` app can be run in a number of modes.
 
@@ -47,13 +205,13 @@ The badass mode is typically an emergency-fix mode, which will override and repl
 The revalidate mode will apply Revalidations from Traffic Ops (regex_revalidate.config) but no other configuration. This mode was intended to quickly apply revalidations when `t3c-apply` took a long time to run. It is less relevant with the current speed of `t3c-apply` but may still be useful on slow networks or very large deployments.
 
 mode        | description
-------------| ---
+----------- | ----------------------------------------------------------------
 report      | prints config differences and exits (default)
 badass      | attempts to fix all config differences that it can
 syncds      | syncs delivery services with what is configured in Traffic Ops
 revalidate  | checks for updated revalidations in Traffic Ops and applies them
 
-# Behavior
+# BEHAVIOR
 
 When `t3c-apply` is run, it will:
 
@@ -82,34 +240,38 @@ When `t3c-apply` is run, it will:
 1. If a ntpd.conf config file was changed, and `t3c-apply` is in badass mode, perform a service restart of ntpd.
 1. Update Traffic Ops to unset the Update Pending or Revalidate Pending flag of this Server.
 
-# Special Processing
+# SPECIAL PROCESSING
 
 Certain config files perform extra processing.
 
-## Global replacements
+Global replacements
 
-All config files have certain text directives replaced. This is done by the t3c-generate config generator before the file is returned to `t3c-apply`.
+    All config files have certain text directives replaced. This is done by the t3c-generate config generator before the file is returned to `t3c-apply`.
 
-* `__SERVER_TCP_PORT__` is replaced with the Server's Port from Traffic Ops; unless the server's port is 80, 0, or null, in which case any occurrences preceded by a colon are removed.
-* `__CACHE_IPV4__` is replaced with the Server's IP address from Traffic Ops.
-* `__HOSTNAME__` is replaced with the Server's (short) HostName from Traffic Ops.
-* `__FULL_HOSTNAME__` is replaced with the Server's HostName, a dot, and the Server's DomainName from Traffic Ops (i.e. the Server's Fully Qualified Domain Name).
-* `__RETURN__` is replaced with a newline character, and any whitespace before or after it is removed.
+    __SERVER_TCP_PORT__ is replaced with the Server's Port from Traffic Ops; unless the server's port is 80, 0, or null, in which case any occurrences preceded by a colon are removed.
+    __CACHE_IPV4__      is replaced with the Server's IP address from Traffic Ops.
+    __HOSTNAME__        is replaced with the Server's (short) HostName from Traffic Ops.
+    __FULL_HOSTNAME__   is replaced with the Server's HostName, a dot, and the Server's DomainName from Traffic Ops (i.e. the Server's Fully Qualified Domain Name).
+    __RETURN__          is replaced with a newline character, and any whitespace before or after it is removed.
 
-## remap.config
+remap.config
 
-The `t3c-apply` app processes `##OVERRIDE##` directives in the remap.config file.
+    The `t3c-apply` app processes `##OVERRIDE##` directives in the remap.config file.
 
-The ##OVERRIDE## template string allows the Delivery Service Raw Remap Text field to override to fully override the Delivery Service’s line in the remap.config ATS configuration file, generated by Traffic Ops. The end result is the original, generated line commented out, prepended with ##OVERRIDDEN## and the ##OVERRIDE## rule is activated in its place. This behavior is used to incrementally deploy plugins used in this configuration file. Normally, this entails cloning the Delivery Service that will have the plugin, ensuring it is assigned to a subset of the cache servers that serve the Delivery Service content, then using this ##OVERRIDE## rule to create a remap.config rule that will use the plugin, overriding the normal rule. Simply grow the subset over time at the desired rate to slowly deploy the plugin. When it encompasses all cache servers that serve the original Delivery Service’s content, the “override Delivery Service” can be deleted and the original can use a non-##OVERRIDE## Raw Remap Text to add the plugin.
+    The ##OVERRIDE## template string allows the Delivery Service Raw Remap Text field to override to fully override the Delivery Service’s line in the remap.config ATS configuration file, generated by Traffic Ops. The end result is the original, generated line commented out, prepended with ##OVERRIDDEN## and the ##OVERRIDE## rule is activated in its place. This behavior is used to incrementally deploy plugins used in this configuration file. Normally, this entails cloning the Delivery Service that will have the plugin, ensuring it is assigned to a subset of the cache servers that serve the Delivery Service content, then using this ##OVERRIDE## rule to create a remap.config rule that will use the plugin, overriding the normal rule. Simply grow the subset over time at the desired rate to slowly deploy the plugin. When it encompasses all cache servers that serve the original Delivery Service’s content, the “override Delivery Service” can be deleted and the original can use a non-##OVERRIDE## Raw Remap Text to add the plugin.
 
-## 50-ats.rules
+50-ats.rules
 
-This is presumed to be a udev file for devices which are block devices to be used as disk storage by ATS.
+    This is presumed to be a udev file for devices which are block devices to be used as disk storage by ATS.
 
-The `t3c-apply` app verifies all devices in the file are owned by the owner listed in the file, and logs errors otherwise.
+    The `t3c-apply` app verifies all devices in the file are owned by the owner listed in the file, and logs errors otherwise.
 
-The `t3c-apply` app verifies all devices in the file do not have filesystems. If any device has a filesystem, `t3c-apply` assumes it was a mistake to assign as an ATS storage device, and logs a fatal error.
+    The `t3c-apply` app verifies all devices in the file do not have filesystems. If any device has a filesystem, `t3c-apply` assumes it was a mistake to assign as an ATS storage device, and logs a fatal error.
 
-# Trivia
+# AUTHORS
 
-The "t3c" stands for "Traffic Control Cache Config."
+The t3c application is maintained by Apache Traffic Control project. For help, bug reports, contributing, or anything else, see:
+
+https://trafficcontrol.apache.org/
+
+https://github.com/apache/trafficcontrol

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -38,9 +38,9 @@ t3c-apply - Traffic Control Cache Configuration applicator
 
 # SYNOPSIS
 
-t3c-apply [-2bchIpsSvW] [-D seconds] [-d location] [-e location] [-g &lt;yes|no|auto&gt;] [-H hostname] [-i location] [-l seconds] [-M location] [-m &lt;badass|report|revalidate|syncds&gt;] [-P password] [-r retries] [-R path] [-T seconds] [-t milliseconds] [-u url] [-U username] [-V versions] [-w &lt;true|false&gt;]
+t3c-apply [-2bchIpsSvW] [-D seconds] [-d location] [-e location] [-g \<yes|no|auto\>] [-H hostname] [-i location] [-l seconds] [-M location] [-m \<badass|report|revalidate|syncds\>] [-P password] [-r retries] [-R path] [-T seconds] [-t milliseconds] [-u url] [-U username] [-V versions] [-w \<true|false\>]
 
-[&#45;&#45;help]
+[\-\-help]
 
 # DESCRIPTION
 

--- a/cache-config/t3c-check-refs/README.md
+++ b/cache-config/t3c-check-refs/README.md
@@ -17,38 +17,91 @@
     under the License.
 -->
 
-# t3c-check-refs
+<!--
 
-This implements the ATS plugin readiness verifier as defined in the
-blueprint #4628, see https://github.com/apache/trafficcontrol/pull/4628
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
 
-## Synopsis
-  t3c-check-refs [options] [optional_config_file]
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
 
-## Description
-  The t3c-check-refs app will read an ATS formatted plugin.config or remap.config
-  file line by line and verify that the plugin '.so' files are available in the
-  filesystem or relative to the ATS plugin installation directory by the
-  absolute or relative plugin filename.
+-->
 
-  In addition, any plugin parameters that end in '.config', '.cfg', or '.txt'
-  are considered to be plugin configuration files and there existence in the
-  filesystem or relative to the ATS configuration files directory is verified.
+# NAME
 
-  The configuration file argument is optional.  If no config file argument is
-  supplied, t3c-check-refs reads its config file input from 'stdin'
+t3c-check-refs - Traffic Control Cache Configuration generated file reference check tool
 
-## Options
-  --log-location-debug=[value] | -d [value], where to log debugs, default is empty
-  --log-location-error=[value], | -e [value], where to log errors, default is 'stderr'
-  --log-location-info=[value] | -i [value], where to log infos, default is 'stderr'
-  --trafficserver-config-dir=[value] | -c [value], where to find ATS config files, default is '/opt/trafficserver/etc/trafficserver'
-  --trafficserver-plugin-dir=[value] | -p [value], where to find ATS plugins, default is '/opt/trafficserver/libexec/trafficserver'
-  --help | -h, this help message
+## SYNOPSIS
 
-## Exit Status
-  Returns 0 if no missing plugin DSO or config files are found.
-  Otherwise the total number of missing plugin DSO and config files
-  are returned.
-  
-  
+t3c-check-refs [-c directory] [-d location] [-e location] [-f files] [-i location] [-p directory] [file]
+
+[&#45;&#45;help]
+
+## DESCRIPTION
+
+The t3c-check-refs app will read an ATS formatted plugin.config or remap.config
+file line by line and verify that the plugin '.so' files are available in the
+filesystem or relative to the ATS plugin installation directory by the
+absolute or relative plugin filename.
+
+In addition, any plugin parameters that end in '.config', '.cfg', or '.txt'
+are considered to be plugin configuration files and there existence in the
+filesystem or relative to the ATS configuration files directory is verified.
+
+The configuration file argument is optional.  If no config file argument is
+supplied, t3c-check-refs reads its config file input from stdin.
+
+## OPTIONS
+
+-c, --trafficserver-config-dir=value
+
+    directory where ATS config files are stored.
+    [/opt/trafficserver/etc/trafficserver]
+
+-d, --log-location-debug=value
+
+     Where to log debugs. May be a file path, stdout, stderr
+
+-e, --log-location-error=value
+
+     Where to log errors. May be a file path, stdout, stderr
+     [stderr]
+
+-f, --files-adding=value
+
+    comma-delimited list of file names being added, to not fail
+    to verify if they don't already exist.
+
+-h, --help
+
+    Print usage information and exit
+
+-i, --log-location-info=value
+
+     Where to log infos. May be a file path, stdout, stderr
+     [stderr]
+
+-p, --trafficserver-plugin-dir=value
+
+    directory where ATS plugins are stored.
+    [/opt/trafficserver/libexec/trafficserver]
+
+## EXIT CODES
+
+Returns 0 if no missing plugin DSO or config files are found.
+Otherwise the total number of missing plugin DSO and config files
+are returned.
+
+# AUTHORS
+
+The t3c application is maintained by Apache Traffic Control project. For help, bug reports, contributing, or anything else, see:
+
+https://trafficcontrol.apache.org/
+
+https://github.com/apache/trafficcontrol

--- a/cache-config/t3c-check-refs/README.md
+++ b/cache-config/t3c-check-refs/README.md
@@ -41,7 +41,7 @@ t3c-check-refs - Traffic Control Cache Configuration generated file reference ch
 
 t3c-check-refs [-c directory] [-d location] [-e location] [-f files] [-i location] [-p directory] [file]
 
-[&#45;&#45;help]
+[\-\-help]
 
 ## DESCRIPTION
 

--- a/cache-config/t3c-check-reload/README.md
+++ b/cache-config/t3c-check-reload/README.md
@@ -41,7 +41,7 @@ t3c-check-reload - Traffic Control Cache Configuration reload check tool
 
 t3c-check-reload [-c paths] [-m mode] [-p packages]
 
-[&#45;&#45;help]
+[\-\-help]
 
 # DESCRIPTION
 

--- a/cache-config/t3c-check-reload/README.md
+++ b/cache-config/t3c-check-reload/README.md
@@ -32,55 +32,51 @@
   !!!
 
 -->
+
 # NAME
 
-t3c - Traffic Control Cache Configuration tools
+t3c-check-reload - Traffic Control Cache Configuration reload check tool
 
 # SYNOPSIS
 
-t3c [&#45;&#45;help]
-    &lt;command&gt; [&lt;args&gt;]
+t3c-check-reload [-c paths] [-m mode] [-p packages]
+
+[&#45;&#45;help]
 
 # DESCRIPTION
 
-The `t3c` app generates and applies cache configuration for Apache Traffic Control.
+The t3c-check-reload app takes a comma-delimited list of config file paths
+being changed, and a comma-delimited a list of plugin packages being installed,
+and returns whether a reload or restart of the caching proxy service is
+necessary.
 
-This includes requesting Traffic Ops, generating configuration files for caching proxies such as Apache Traffic Server, verifying Traffic Ops data is valid and produces valid config files, creating a git repo for backups and history, determining whether config changes require a reload or restart of the caching proxy service, performing that restart, and more.
+Possible return values are:
 
-The latest version and documentation can be found at https://github.com/apache/trafficcontrol/cache-config.
+  'restart' - a service restart is necessary
+
+  'reload' - a service reload is necessary
+
+  '' - no reload or restart is necessary.
 
 # OPTIONS
 
---help
-    Prints the synopsis and usage information.
+-c, --changed-config-paths=value
 
-# COMMANDS
+    comma-delimited list of the full paths of all files changed
+    by t3c
+-h, --help
 
-We divide t3c into commands for each independent operation. Each command is its own application and can be called directly or via the t3c app. For example, 't3c apply' or 't3c-apply'.
+    Print usage information and exit
 
-t3c-apply
+-m, --run-mode=value
 
-    Generate and apply cache configuration.
+     [badass | report | revalidate | syncds] run mode, default is
+     'report' [report]
 
-t3c-check
+-p, --plugin-packages-installed=value
 
-    Check that new config can be applied.
-
-t3c-diff
-
-    Diff config files, like diff or git-diff but with config-specific logic.
-
-t3c-request
-
-    Request data from Traffic Ops.
-
-t3c-update
-
-    Update a server's queue and reval status in Traffic Ops.
-
-# NOMENCLATURE
-
-The "t3c" stands for "Traffic Control Cache Config."
+    comma-delimited list of ATS plugin packages which were
+    installed by t3c
 
 # AUTHORS
 

--- a/cache-config/t3c-check/README.md
+++ b/cache-config/t3c-check/README.md
@@ -38,16 +38,16 @@ t3c-check - Traffic Control Cache Configuration generated file check tool
 
 # SYNOPSIS
 
-t3c-check &lt;command&gt; [&lt;args&gt;]
+t3c-check \<command\> [\<args\>]
 
-[&#45;&#45;help]
+[\-\-help]
 
 # DESCRIPTION
 
 The t3c-check application has commands for checking things about new config files, such as
 whether they can be safely applied or if a service reload or restart will be required.
 
-For the arguments of a command, see 't3c-check &lt;command&gt; &#45;&#45;help'.
+For the arguments of a command, see 't3c-check \<command\> \-\-help'.
 
 # COMMANDS
 

--- a/cache-config/t3c-check/README.md
+++ b/cache-config/t3c-check/README.md
@@ -34,53 +34,32 @@
 -->
 # NAME
 
-t3c - Traffic Control Cache Configuration tools
+t3c-check - Traffic Control Cache Configuration generated file check tool
 
 # SYNOPSIS
 
-t3c [&#45;&#45;help]
-    &lt;command&gt; [&lt;args&gt;]
+t3c-check &lt;command&gt; [&lt;args&gt;]
+
+[&#45;&#45;help]
 
 # DESCRIPTION
 
-The `t3c` app generates and applies cache configuration for Apache Traffic Control.
+The t3c-check application has commands for checking things about new config files, such as
+whether they can be safely applied or if a service reload or restart will be required.
 
-This includes requesting Traffic Ops, generating configuration files for caching proxies such as Apache Traffic Server, verifying Traffic Ops data is valid and produces valid config files, creating a git repo for backups and history, determining whether config changes require a reload or restart of the caching proxy service, performing that restart, and more.
-
-The latest version and documentation can be found at https://github.com/apache/trafficcontrol/cache-config.
-
-# OPTIONS
-
---help
-    Prints the synopsis and usage information.
+For the arguments of a command, see 't3c-check &lt;command&gt; &#45;&#45;help'.
 
 # COMMANDS
 
-We divide t3c into commands for each independent operation. Each command is its own application and can be called directly or via the t3c app. For example, 't3c apply' or 't3c-apply'.
+We divide t3c-check into commands for each independent operation. Each command is its own application and can be called directly or via the t3c app. For example, 't3c check refs' or 't3c-check refs' or 't3c-check-refs'.
 
-t3c-apply
+t3c-check-reload
 
-    Generate and apply cache configuration.
+    Check if a reload or restart is needed
 
-t3c-check
+t3c-check-refs
 
-    Check that new config can be applied.
-
-t3c-diff
-
-    Diff config files, like diff or git-diff but with config-specific logic.
-
-t3c-request
-
-    Request data from Traffic Ops.
-
-t3c-update
-
-    Update a server's queue and reval status in Traffic Ops.
-
-# NOMENCLATURE
-
-The "t3c" stands for "Traffic Control Cache Config."
+    Check if a config file's referenced plugins and files are valid
 
 # AUTHORS
 

--- a/cache-config/t3c-diff/README.md
+++ b/cache-config/t3c-diff/README.md
@@ -38,9 +38,9 @@ t3c-diff - Traffic Control Cache Configuration contextual diff tool
 
 # SYNOPSIS
 
-t3c-diff &lt;file-a&gt; &lt;file-a&gt;
+t3c-diff \<file-a\> \<file-a\>
 
-[&#45;&#45;help]
+[\-\-help]
 
 # DESCRIPTION
 

--- a/cache-config/t3c-diff/README.md
+++ b/cache-config/t3c-diff/README.md
@@ -34,53 +34,33 @@
 -->
 # NAME
 
-t3c - Traffic Control Cache Configuration tools
+t3c-diff - Traffic Control Cache Configuration contextual diff tool
 
 # SYNOPSIS
 
-t3c [&#45;&#45;help]
-    &lt;command&gt; [&lt;args&gt;]
+t3c-diff &lt;file-a&gt; &lt;file-a&gt;
+
+[&#45;&#45;help]
 
 # DESCRIPTION
 
-The `t3c` app generates and applies cache configuration for Apache Traffic Control.
+The t3c-diff application compares configuration files with semantic context, omitting comments and other semantically irrelevant text.
 
-This includes requesting Traffic Ops, generating configuration files for caching proxies such as Apache Traffic Server, verifying Traffic Ops data is valid and produces valid config files, creating a git repo for backups and history, determining whether config changes require a reload or restart of the caching proxy service, performing that restart, and more.
+This is useful over standard diff tools without context, for example, when the grammar of a generated comment changes, or a comment contains a date. This allows operators to avoid updating sematically identical files, undesirably updating file timestamps, effecting unnecessary reloads, and other unnecessary and undesirable results.
 
-The latest version and documentation can be found at https://github.com/apache/trafficcontrol/cache-config.
+The input files may be file paths, or 'stdin' in which case that file is read from stdin.
+
+Prints the diff to stdout, and returns the exit code 0 if there was no diff, 1 if there was a diff.
+If one file exists but the other doesn't, it will always be a diff.
+
+Note this means there may be no diff text printed to stdout but still exit 1 indicating a diff
+if the file being created or deleted is semantically empty.
 
 # OPTIONS
 
---help
-    Prints the synopsis and usage information.
+-h, --help
 
-# COMMANDS
-
-We divide t3c into commands for each independent operation. Each command is its own application and can be called directly or via the t3c app. For example, 't3c apply' or 't3c-apply'.
-
-t3c-apply
-
-    Generate and apply cache configuration.
-
-t3c-check
-
-    Check that new config can be applied.
-
-t3c-diff
-
-    Diff config files, like diff or git-diff but with config-specific logic.
-
-t3c-request
-
-    Request data from Traffic Ops.
-
-t3c-update
-
-    Update a server's queue and reval status in Traffic Ops.
-
-# NOMENCLATURE
-
-The "t3c" stands for "Traffic Control Cache Config."
+    Print usage info and exit.
 
 # AUTHORS
 

--- a/cache-config/t3c-generate/README.md
+++ b/cache-config/t3c-generate/README.md
@@ -40,9 +40,9 @@ t3c-generate - Traffic Control Cache Configuration generation tool
 
 t3c-generate [-2bchlvVy] [-D directory] [-e location] [-i location] [-T versions] [-w location]
 
-[&#45;h|&#45;&#45;help]
+[\-\-help]
 
-[&#45;v|&#45;&#45;version]
+[\-\-version]
 
 # DESCRIPTION
 

--- a/cache-config/t3c-generate/README.md
+++ b/cache-config/t3c-generate/README.md
@@ -16,112 +16,115 @@
     specific language governing permissions and limitations
     under the License.
 -->
-# t3c-generate
-The `t3c-generate` app generates configuration files server-side on ATC cache servers.
 
-!!! Warning !!!
-    <strong>t3c-generate does not have a stable command-line interface, it can and will change without warning. Scripts should avoid calling it for the time being.</strong>
+<!--
 
-## Usage
-```
-t3c-generate -h
-t3c-generate -v
-t3c-generate -l
-t3c-generate [-e ERROR_LOCATION] [-i INFO_LOCATION] [-p] [-P TO_PASSWORD] [-r N] [-s] [-t TIMEOUT] [-u TO_URL] [-U TO_USER] [-w WARNING_LOCATION] [-y] [--dir TSROOT] -n CACHE_NAME
-t3c-generate [-e ERROR_LOCATION] [-i INFO_LOCATION] [-p] [-P TO_PASSWORD] [-r N] [-s] [-t TIMEOUT] [-u TO_URL] [-U TO_USER] [-w WARNING_LOCATION] [--dir TSROOT] -n CACHE_NAME -d DATA
-t3c-generate [-e ERROR_LOCATION] [-i INFO_LOCATION] [-p] [-P TO_PASSWORD] [-r N] [-s] [-t TIMEOUT] [-u TO_URL] [-U TO_USER] [-w WARNING_LOCATION] [--dir TSROOT] -n CACHE_NAME -a REVAL_STATUS -q QUEUE_STATUS
-```
-The available options are:
-```
--a, --set-reval-status string
-    Sets the reval_pending property of the server in Traffic Ops. Must be 'true'
-    or 'false'. Requires --set-queue-status also be set. This disables normal
-    output.
--e, --log-location-error string
-    A location for error-level logging. Passing "stderr" causes it to log to
-    STDERR, "stdout" causes logging to STDOUT, "null" disables error-level
-    logging, and anything else is treated as a path to a file which will contain
-    the logs. (Default: stderr)
--d, --get-data string
-    Specifies non-configuration-file data to retrieve from Traffic Ops. This
-    disables normal output. Valid values are update-status, packages, chkconfig,
-    system-info, and statuses. Output is in JSON-encoded format. For specifics,
-    refer to the official documentation.
---dir string
-    Specifies a directory path in which to place Trafficserver configuration
-    files in the event that "location" Parameters aren't found for them. If this
-    is not given and location Parameters aren't found for required files,
-    t3c-generate will exit with an error.
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
+
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
+
+-->
+# NAME
+
+t3c-generate - Traffic Control Cache Configuration generation tool
+
+# SYNOPSIS
+
+t3c-generate [-2bchlvVy] [-D directory] [-e location] [-i location] [-T versions] [-w location]
+
+[&#45;h|&#45;&#45;help]
+
+[&#45;v|&#45;&#45;version]
+
+# DESCRIPTION
+
+The `t3c-generate` app generates Apache Traffic Server configuration files from Traffic Ops data.
+
+The stdin must be JSON text as output by 't3c-request --get-data=config', which contains all the data from Traffic Ops necessary to generate configuration. For the exact format, see t3c-request(1).
+
+The output is a JSON array of objects containing the file and its metadata.
+
+# OPTIONS
+
+-2, --default-client-enable-h2
+
+    Whether to enable HTTP/2 on Delivery Services by default, if
+    they have no explicit Parameter. This is irrelevant if ATS
+    records.config is not serving H2. If omitted, H2 is
+    disabled.
+
+-b, --dns-local-bind
+
+    Whether to use the server's Service Addresses to set the ATS
+    DNS local bind address.
+
+-c, --disable-parent-config-comments
+
+    Disable adding a comments to parent.config individual lines.
+
+-D, --dir=value
+
+    ATS config directory, used for config files without location
+    parameters or with relative paths. May be blank. If blank
+    and any required config file location parameter is missing
+    or relative, will error.
+
+ -e, --log-location-error=value
+
+    Where to log errors. May be a file path, stdout, stderr, or
+    null. [stderr]
+
 -h, --help
-    Print usage information and exit.
--i, --log-location-info string
-    A location for informative-level logging. Passing "stderr" causes it to log
-    to STDERR, "stdout" causes logging to STDOUT, "null" disables
-    informative-level logging, and anything else is treated as a path to a file
-    which will contain the logs. (Default: stderr)
+
+    Print usage information and exit
+
+-i, --log-location-info=value
+
+    Where to log information messages. May be a file path,
+    stdout, stderr, or null. [stderr]
+
 -l, --list-plugins
-    Print the list of plug-ins and exit.
--n, --cache-host-name string
-    Required. Specifies the (short) hostname of the cache server for which
-    output will be generated. Must be the server host name in Traffic Ops, not a
-    URL, or Fully Qualified Domain Name. Behavior when more than one server
-    exists with the passed hostname is undefined.
--p, --traffic-ops-disable-proxy
-    Bypass the Traffic Ops caching proxy and make requests directly to Traffic
-    Ops. Has no effect if no such proxy exists.
--P, --traffic-ops-password string
-    The password to use when authenticating with Traffic Ops password. If not
-    given, the value of the TO_PASSWORD environment variable is used. If that
-    environment variable is not set, this option-argument is required.
--q, --set-queue-status string
-    Sets the upd_pending property of the server in Traffic Ops. Must be 'true'
-    or 'false'. Requires --set-reval-status also be set. This disables normal
-    output.
--r, --num-retries int
-    The number of times to retry getting a file if it fails. (Default 5)
--s, --traffic-ops-insecure
-    Ignore HTTPS certificate errors from Traffic Ops. It is HIGHLY RECOMMENDED
-    to never use this in a production environment, but only for debugging.
--t, --traffic-ops-timeout-milliseconds int
-    Timeout in milliseconds for Traffic Ops requests. (Default 30000)
--u, --traffic-ops-url string
-    The full URL, including scheme and optionally port number, of the Traffic
-    Ops server. If not given, the value of the TO_URL environment variable will
-    be used. If that environment variable is not properly set, this
-    option-argument is required.
--U, --traffic-ops-user string
-    The username to use when authenticating with Traffic Ops. If not given, the
-    value of the TO_USER environment variable will be used. If that environment
-    variable is not set, this option-argument is required.
+
+    Print the list of plugins.
+
+-T, --default-client-tls-versions=value
+
+    Comma-delimited list of default TLS versions for Delivery
+    Services with no Parameter, e.g.
+    '--default-tls-versions=1.1,1.2,1.3'. If omitted, all
+    versions are enabled.
+
 -v, --version
+
     Print version information and exit.
--w, --log-location-warning string
-    A location for warning-level logging. Passing "stderr" causes it to log to
-    STDERR, "stdout" causes logging to STDOUT, "null" disables warning-level
-    logging, and anything else is treated as a path to a file which will contain
-    the logs. (Default: stderr)
+
+-V, --via-string-release
+
+    Whether to use the Release value from the RPM package as a
+    replacement for the ATS version specified in the build that
+    is returned in the Via and Server headers from ATS.
+
+-w, --log-location-warning=value
+
+    Where to log warnings. May be a file path, stdout, stderr,
+    or null. [stderr]
+
 -y, --revalidate-only
-    When given, t3c-generate will only emit files relevant for updating content
-    invalidation jobs. For Apache Traffic Server implementations, this limits
-    the output to be only files named 'regex_revalidate.config'. Has no effect
-    if --get-data or --set-queue-status/--set-reval-status is/are used.
---via_string_release
-    Using this option will set the via string records.config options for Apache
-    Traffic Server so that it will have the rpm file release information in the via
-    string instead of the actual ATS version
---disable-parent-config-comments
-    Disables having per-line parent.config comments. The file header will still be
-    generated.
-```
 
-# Development
+    Whether to exclude files not named 'regex_revalidate.config'
 
-## Updating for new Traffic Control Versions
+# AUTHORS
 
-After a new Traffic Control release, the Traffic Ops client from the new release
-branch should be vendored at `toreq/vendor`, and all usages of
-`config.TOClientNew` should be changed to `config.TOClient`.
+The t3c application is maintained by Apache Traffic Control project. For help, bug reports, contributing, or anything else, see:
 
-There's a script to do this at
-[`./update-to-client/update-to-client.go`](./update-to-client). Run the "script"
-with no arguments for usage information.
+https://trafficcontrol.apache.org/
+
+https://github.com/apache/trafficcontrol

--- a/cache-config/t3c-preprocess/README.md
+++ b/cache-config/t3c-preprocess/README.md
@@ -34,53 +34,35 @@
 -->
 # NAME
 
-t3c - Traffic Control Cache Configuration tools
+t3c-preprocess - Traffic Control Cache Configuration preprocessor
 
 # SYNOPSIS
 
-t3c [&#45;&#45;help]
-    &lt;command&gt; [&lt;args&gt;]
+t3c-preprocess
 
 # DESCRIPTION
 
-The `t3c` app generates and applies cache configuration for Apache Traffic Control.
+The 't3c-preprocess' app preprocesses generated config files, replacing directives with relevant data.
 
-This includes requesting Traffic Ops, generating configuration files for caching proxies such as Apache Traffic Server, verifying Traffic Ops data is valid and produces valid config files, creating a git repo for backups and history, determining whether config changes require a reload or restart of the caching proxy service, performing that restart, and more.
+The stdin must be the JSON '{"data": &lt;data&gt;, "files": &lt;files&gt;}' where &lt;data&gt; is the output of 't3c-request --get-data=config' and &lt;files&gt; is the output of 't3c-generate'.
 
-The latest version and documentation can be found at https://github.com/apache/trafficcontrol/cache-config.
+# DIRECTIVES
 
-# OPTIONS
+The following directives will be replaced. These directives may be placed anywhere in any file, by either t3c-generate(1) or Traffic Ops Parameters.
 
---help
-    Prints the synopsis and usage information.
+    __SERVER_TCP_PORT__ is replaced with the Server's Port from Traffic Ops; unless the server's
+                        port is 80, 0, or null, in which case any occurrences preceded by a colon
+                        are removed.
 
-# COMMANDS
+    __CACHE_IPV4__      is replaced with the Server's IP address from Traffic Ops.
 
-We divide t3c into commands for each independent operation. Each command is its own application and can be called directly or via the t3c app. For example, 't3c apply' or 't3c-apply'.
+    __HOSTNAME__        is replaced with the Server's (short) HostName from Traffic Ops.
 
-t3c-apply
+    __FULL_HOSTNAME__   is replaced with the Server's HostName, a dot, and the Server's DomainName
+                        from Traffic Ops (i.e. the Server's Fully Qualified Domain Name).
 
-    Generate and apply cache configuration.
-
-t3c-check
-
-    Check that new config can be applied.
-
-t3c-diff
-
-    Diff config files, like diff or git-diff but with config-specific logic.
-
-t3c-request
-
-    Request data from Traffic Ops.
-
-t3c-update
-
-    Update a server's queue and reval status in Traffic Ops.
-
-# NOMENCLATURE
-
-The "t3c" stands for "Traffic Control Cache Config."
+    __RETURN__          is replaced with a newline character, and any whitespace before or after
+                        it is removed.
 
 # AUTHORS
 

--- a/cache-config/t3c-preprocess/README.md
+++ b/cache-config/t3c-preprocess/README.md
@@ -44,7 +44,7 @@ t3c-preprocess
 
 The 't3c-preprocess' app preprocesses generated config files, replacing directives with relevant data.
 
-The stdin must be the JSON '{"data": &lt;data&gt;, "files": &lt;files&gt;}' where &lt;data&gt; is the output of 't3c-request --get-data=config' and &lt;files&gt; is the output of 't3c-generate'.
+The stdin must be the JSON '{"data": \<data\>, "files": \<files\>}' where \<data\> is the output of 't3c-request --get-data=config' and \<files\> is the output of 't3c-generate'.
 
 # DIRECTIVES
 

--- a/cache-config/t3c-preprocess/t3c-preprocess.go
+++ b/cache-config/t3c-preprocess/t3c-preprocess.go
@@ -87,6 +87,7 @@ func PreprocessConfigFile(server *atscfg.Server, cfgFile string) string {
 }
 
 func main() {
+	// TODO read log location arguments
 	dataFiles := &DataAndFiles{}
 	if err := json.NewDecoder(os.Stdin).Decode(dataFiles); err != nil {
 		log.Errorln("Error reading json input")

--- a/cache-config/t3c-request/README.md
+++ b/cache-config/t3c-request/README.md
@@ -38,9 +38,9 @@ t3c-request - Traffic Control Cache Configuration data requestor
 
 # SYNOPSIS
 
-t3c-request [-hIprv] [-D &lt;config|update-status|packages|chkconfig|system-info|statuses&gt;] [-d location] [-e location] [-H hostname] [-i location] [-l seconds] [-P password] [-t milliseconds] [-u url] [-U username]
+t3c-request [-hIprv] [-D \<config|update-status|packages|chkconfig|system-info|statuses\>] [-d location] [-e location] [-H hostname] [-i location] [-l seconds] [-P password] [-t milliseconds] [-u url] [-U username]
 
-[&#45;&#45;help]
+[\-\-help]
 
 # DESCRIPTION
 

--- a/cache-config/t3c-request/README.md
+++ b/cache-config/t3c-request/README.md
@@ -17,59 +17,117 @@
     under the License.
 -->
 
-# t3c-request
+<!--
 
-## Synopsis
-	t3c-request [-hI] [-D value] [-d value] [-e value] [-H value] [-i value] \
-		[-l value] [-P value] [-t value] [-u value] [-U value]
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
 
-## Description
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
+
+-->
+# NAME
+
+t3c-request - Traffic Control Cache Configuration data requestor
+
+# SYNOPSIS
+
+t3c-request [-hIprv] [-D &lt;config|update-status|packages|chkconfig|system-info|statuses&gt;] [-d location] [-e location] [-H hostname] [-i location] [-l seconds] [-P password] [-t milliseconds] [-u url] [-U username]
+
+[&#45;&#45;help]
+
+# DESCRIPTION
+
   The t3c-request app is used get update status, package information, linux
   chkconfig status, system info and status from Traffic Ops, see the
-  --get-data option.  If no --get-data option is specified, the servers
+  --get-data option.  If no --get-data option is specified, the server's
   system-info is fetched and returned.
 
-## Options
-	-D, --get-data=value
-      	non-config-file Traffic Ops Data to get. Valid values are
-        update-status, packages, chkconfig, system-info, and
-        statuses [system-info]
-	-d, --log-location-debug=value
-        Where to log debugs. May be a file path, stdout or stderr.
-        Default is no debug logging.
-	-e, --log-location-error=value
-        Where to log errors. May be a file path, stdout, or stderr.
-        Default is stderr.
-	-i, --log-location-info=value
-        Where to log infos. May be a file path, stdout or stderr.
-        Default is stderr.
-	-H, --cache-host-name=value
-     		Host name of the cache to generate config for. Must be the
-        server host name in Traffic Ops, not a URL, and not the FQDN.
-        Defaults to the OS configured hostname.
-	-h, --help  Print usage information and exit
- 	-I, --traffic-ops-insecure
-				[true | false] ignore certificate errors from Traffic Ops
-	-l, --login-dispersion=value
-        [seconds] wait a random number of seconds between 0 and
-        [seconds] before login to traffic ops, default 0
-	-P, --traffic-ops-password=value
-        Traffic Ops password. Required. May also be set with the
-        environment variable TO_PASS
-	-t, --traffic-ops-timeout-milliseconds=value
-        Timeout in milli-seconds for Traffic Ops requests, default
-        is 30000 [30000]
-	-u, --traffic-ops-url=value
-        Traffic Ops URL. Must be the full URL, including the scheme.
-        Required. May also be set with     the environment variable
-        TO_URL
-	-U, --traffic-ops-user=value
-        Traffic Ops username. Required. May also be set with the
-        environment variable TO_USER
-	-p, --traffic-ops-disable-proxy=value
-        [true | false] Whether to not use any configured Traffic Ops
-        proxy Parameter. Only used if get-data is config.
-	-r, --reval-only=value
-        [true | false] Whether to only fetch data needed to revalidate
-        and not all data needed to generate config. Only used if
-        get-data is config.
+# OPTIONS
+
+-D,--get-data=value
+
+    non-config-file Traffic Ops Data to get. Valid values are
+    update-status, packages, chkconfig, system-info, and
+    statuses [system-info]
+
+-d,--log-location-debug=value
+
+    Where to log debugs. May be a file path, stdout, stderr
+
+-e,--log-location-error=value
+
+    Where to log errors. May be a file path, stdout, stderr
+    [stderr]
+
+-H,--cache-host-name=value
+
+    Host name of the cache to generate config for. Must be the
+    server host name in Traffic Ops, not a URL, and not the FQDN
+
+-h,--help
+
+    Print usage information and exit
+
+-i,--log-location-info=value
+
+    Where to log infos. May be a file path, stdout, stderr
+    [stderr]
+
+-I,--traffic-ops-insecure
+
+    [true | false] ignore certificate errors from Traffic Ops
+
+-l,--login-dispersion=value
+
+    [seconds] wait a random number of seconds between 0
+    and [seconds] before login to traffic ops, default 0
+
+-p,--traffic-ops-disable-proxy
+
+    [true | false] whether to not use any configure Traffic Ops
+    proxy parameter. Only used if get-data is config
+	
+-P,--traffic-ops-password=value
+
+    Traffic Ops password. Required. May also be set with the
+    environment variable TO_PASS
+
+-r,--reval-only
+
+    [true | false] whether to only fetch data needed to
+    revalidate, versus all config data. Only used if get-data is
+    config
+-t,--traffic-ops-timeout-milliseconds=value
+
+    Timeout in milli-seconds for Traffic Ops requests, default
+    is 30000 [30000]
+
+-u,--traffic-ops-url=value
+
+    Traffic Ops URL. Must be the full URL, including the scheme.
+    Required. May also be set with     the environment variable
+    TO_URL
+
+-U,--traffic-ops-user=value
+
+    Traffic Ops username. Required. May also be set with the
+    environment variable TO_USER
+
+-v,--version
+
+    Print the app version and exit
+
+# AUTHORS
+
+The t3c application is maintained by Apache Traffic Control project. For help, bug reports, contributing, or anything else, see:
+
+https://trafficcontrol.apache.org/
+
+https://github.com/apache/trafficcontrol

--- a/cache-config/t3c-update/README.md
+++ b/cache-config/t3c-update/README.md
@@ -17,50 +17,111 @@
     under the License.
 -->
 
-# t3c-update
+<!--
 
-## Synopsis
-	t3c-update [-h] [-a value] [-d value] [-e value] [-H value] [-i value] \
-		[-l value] [-P value] [-q value] [-t value] [-u value] [-U value]
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
 
-## Description
-  The t3c-update app is used to set the update and reval status,
-  on Traffic Ops.
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
 
-## Options
-  -a  --set-reval-status [true | false] set the servers revalidate status (required)
-  -q  --set-update-status [true | false] set the servers update queue status (required)
+-->
+# NAME
 
-	-d, --log-location-debug=value
-        Where to log debugs. May be a file path, stdout or stderr.
-        Default is no debug logging.
-	-e, --log-location-error=value
-        Where to log errors. May be a file path, stdout, or stderr.
-        Default is stderr.
-	-i, --log-location-info=value
-        Where to log infos. May be a file path, stdout or stderr.
-        Default is stderr.
-	-H, --cache-host-name=value
-     		Host name of the cache to update the statuses of on TrafficOps.
-        Server host name in Traffic Ops, not a URL, and not the FQDN.
-        Defaults to the OS configured hostname.
-	-h, --help  Print usage information and exit
- 	-I, --traffic-ops-insecure
-				[true | false] ignore certificate errors from Traffic Ops
-	-l, --login-dispersion=value
-        [seconds] wait a random number of seconds between 0 and
-        [seconds] before login to traffic ops, default 0
-	-P, --traffic-ops-password=value
-        Traffic Ops password. Required. May also be set with the
-        environment variable TO_PASS
-	-t, --traffic-ops-timeout-milliseconds=value
-        Timeout in milli-seconds for Traffic Ops requests, default
-        is 30000 [30000]
-	-u, --traffic-ops-url=value
-        Traffic Ops URL. Must be the full URL, including the scheme.
-        Required. May also be set with     the environment variable
-        TO_URL
-	-U, --traffic-ops-user=value
-        Traffic Ops username. Required. May also be set with the
-        environment variable TO_USER
+t3c-update - Traffic Control Cache Configuration cache status updater
 
+# SYNOPSIS
+
+t3c-update [-ahIqv] [-d value] [-e value] [-H value] [-i value] [-l value] [-P value] [-t value] [-u value] [-U
+ value]
+ 
+[&#45;h|&#45;&#45;help]
+
+[&#45;v|&#45;&#45;version]
+
+# DESCRIPTION
+
+  The t3c-update app is used to set the update and reval status in Traffic Ops.
+
+  This is typically used after applying configuration, to set the server's "queue" or "reval" status in Traffic Ops to false.
+
+# OPTIONS
+
+-a, --set-reval-status
+
+    [true | false] sets the servers revalidate status (required)
+
+-d, --log-location-debug=value
+
+    Where to log debugs. May be a file path, stdout, stderr
+
+-e, --log-location-error=value
+
+    Where to log errors. May be a file path, stdout, stderr
+    [stderr]
+
+-H, --cache-host-name=value
+
+    Host name of the cache to generate config for. Must be the
+    server host name in Traffic Ops, not a URL, and not the FQDN
+
+-h, --help
+
+    Print usage information and exit
+
+-i, --log-location-info=value
+
+    Where to log infos. May be a file path, stdout, stderr
+    [stderr]
+
+-I, --traffic-ops-insecure
+
+    [true | false] ignore certificate errors from Traffic Ops
+
+-l, --login-dispersion=value
+
+    [seconds] wait a random number of seconds between 0 and
+    [seconds] before login to traffic ops, default 0
+
+-P, --traffic-ops-password=value
+
+    Traffic Ops password. Required. May also be set with the
+    environment variable TO_PASS
+
+-q, --set-update-status
+
+    [true | false] sets the servers update status (required)
+
+-t, --traffic-ops-timeout-milliseconds=value
+
+    Timeout in milli-seconds for Traffic Ops requests, default
+    is 30000 [30000]
+
+-u, --traffic-ops-url=value
+
+    Traffic Ops URL. Must be the full URL, including the scheme.
+    Required. May also be set with     the environment variable
+    TO_URL
+
+-U, --traffic-ops-user=value
+
+    Traffic Ops username. Required. May also be set with the
+    environment variable TO_USER
+
+-v, --version
+
+    Print the version and exit
+
+# AUTHORS
+
+The t3c application is maintained by Apache Traffic Control project. For help, bug reports, contributing, or anything else, see:
+
+https://trafficcontrol.apache.org/
+
+https://github.com/apache/trafficcontrol

--- a/cache-config/t3c-update/README.md
+++ b/cache-config/t3c-update/README.md
@@ -41,9 +41,9 @@ t3c-update - Traffic Control Cache Configuration cache status updater
 t3c-update [-ahIqv] [-d value] [-e value] [-H value] [-i value] [-l value] [-P value] [-t value] [-u value] [-U
  value]
  
-[&#45;h|&#45;&#45;help]
+[\-\-help]
 
-[&#45;v|&#45;&#45;version]
+[\-\-version]
 
 # DESCRIPTION
 

--- a/cache-config/t3c/README.md
+++ b/cache-config/t3c/README.md
@@ -38,8 +38,8 @@ t3c - Traffic Control Cache Configuration tools
 
 # SYNOPSIS
 
-t3c [&#45;&#45;help]
-    &lt;command&gt; [&lt;args&gt;]
+t3c [\-\-help]
+    \<command\> [\<args\>]
 
 # DESCRIPTION
 

--- a/infrastructure/docker/build/Dockerfile-cache-config
+++ b/infrastructure/docker/build/Dockerfile-cache-config
@@ -41,8 +41,11 @@ RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 		epel-release && \
 	yum -y clean all
 
-RUN yum -y install dnf-plugins-core && \
-	(yum -y config-manager --set-enabled PowerTools || yum -y config-manager --set-enabled powertools) && \
+# CentOS 7 has pandoc in epel (which we installed above), 8 has it in [pP]ower[tT]ools
+RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
+		yum -y install dnf-plugins-core && \
+		(yum -y config-manager --set-enabled PowerTools || yum -y config-manager --set-enabled powertools) \
+	fi && \
 	yum -y install pandoc
 
 ### cache-config specific requirements

--- a/infrastructure/docker/build/Dockerfile-cache-config
+++ b/infrastructure/docker/build/Dockerfile-cache-config
@@ -41,9 +41,9 @@ RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 		epel-release && \
 	yum -y clean all
 
-RUN yum -y install dnf-plugins-core
-RUN yum -y config-manager --set-enabled PowerTools || yum -y config-manager --set-enabled powertools
-RUN yum -y install pandoc
+RUN yum -y install dnf-plugins-core && \
+	(yum -y config-manager --set-enabled PowerTools || yum -y config-manager --set-enabled powertools) && \
+	yum -y install pandoc
 
 ### cache-config specific requirements
 FROM common-dependencies AS cache-config

--- a/infrastructure/docker/build/Dockerfile-cache-config
+++ b/infrastructure/docker/build/Dockerfile-cache-config
@@ -37,8 +37,13 @@ RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 		git \
 		rpm-build \
 		rsync \
+		gzip \
 		epel-release && \
 	yum -y clean all
+
+RUN yum -y install dnf-plugins-core
+RUN yum -y config-manager --set-enabled PowerTools || yum -y config-manager --set-enabled powertools
+RUN yum -y install pandoc
 
 ### cache-config specific requirements
 FROM common-dependencies AS cache-config


### PR DESCRIPTION
Adds t3c manpages.

Is docs. 
No tests, no code change.
No changelog, no interface change.

- [x] This PR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Build RPM, install RPM, verify man, man -K, apropos, etc work for t3c apps.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information