### PR TITLE
Api info reorganization

### DIFF
--- a/lib/go-rfc/http.go
+++ b/lib/go-rfc/http.go
@@ -39,6 +39,7 @@ const (
 	PermissionsPolicy  = "Permissions-Policy"  // W3C "Permissions Policy"
 	Server             = "Server"              // RFC7231§7.4.2
 	UserAgent          = "User-Agent"          // RFC7231§5.5.3
+	Location           = "Location"            // RFC7231§6.3.2
 	Vary               = "Vary"                // RFC7231§7.1.4
 )
 

--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -39,6 +39,15 @@ type Alert struct {
 	Level string `json:"level"`
 }
 
+// NewAlert constructs and returns an Alert of the given level with the given
+// text.
+func NewAlert(level AlertLevel, text string) Alert {
+	return Alert{
+		Level: level.String(),
+		Text:  text,
+	}
+}
+
 // Alerts is merely a collection of arbitrary "Alert"s for ease of use in other structures, most
 // notably those used in Traffic Ops API responses.
 type Alerts struct {
@@ -51,7 +60,7 @@ func CreateErrorAlerts(errs ...error) Alerts {
 	alerts := []Alert{}
 	for _, err := range errs {
 		if err != nil {
-			alerts = append(alerts, Alert{err.Error(), ErrorLevel.String()})
+			alerts = append(alerts, NewAlert(ErrorLevel, err.Error()))
 		}
 	}
 	return Alerts{alerts}
@@ -62,7 +71,7 @@ func CreateErrorAlerts(errs ...error) Alerts {
 func CreateAlerts(level AlertLevel, messages ...string) Alerts {
 	alerts := []Alert{}
 	for _, message := range messages {
-		alerts = append(alerts, Alert{message, level.String()})
+		alerts = append(alerts, NewAlert(level, message))
 	}
 	return Alerts{alerts}
 }

--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -42,7 +42,7 @@ type Alert struct {
 // Alerts is merely a collection of arbitrary "Alert"s for ease of use in other structures, most
 // notably those used in Traffic Ops API responses.
 type Alerts struct {
-	Alerts []Alert `json:"alerts"`
+	Alerts []Alert `json:"alerts,omitempty"`
 }
 
 // CreateErrorAlerts creates and returns an Alerts structure filled with ErrorLevel-level "Alert"s

--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -20,14 +20,7 @@ package tc
  */
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"strings"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
 // Alert represents an informational message, typically returned through the Traffic Ops API.
@@ -74,32 +67,6 @@ func CreateAlerts(level AlertLevel, messages ...string) Alerts {
 		alerts = append(alerts, NewAlert(level, message))
 	}
 	return Alerts{alerts}
-}
-
-// GetHandleErrorsFunc is used to provide an error-handling function. The error handler provides a
-// response to an HTTP request made to the Traffic Ops API and accepts a response code and a set of
-// errors to display as alerts.
-//
-// Deprecated: Traffic Ops API handlers should use
-// github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.HandleErr instead.
-func GetHandleErrorsFunc(w http.ResponseWriter, r *http.Request) func(status int, errs ...error) {
-	return func(status int, errs ...error) {
-		log.Errorf("%v %v\n", r.RemoteAddr, errs)
-		errBytes, jsonErr := json.Marshal(CreateErrorAlerts(errs...))
-		if jsonErr != nil {
-			log.Errorf("failed to marshal error: %s\n", jsonErr)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, http.StatusText(http.StatusInternalServerError))
-			return
-		}
-		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
-
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, StatusKey, status)
-		*r = *r.WithContext(ctx)
-
-		fmt.Fprintf(w, "%s", errBytes)
-	}
 }
 
 // ToStrings converts Alerts to a slice of strings that are their messages. Note that this return

--- a/lib/go-tc/alerts_test.go
+++ b/lib/go-tc/alerts_test.go
@@ -22,8 +22,6 @@ package tc
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 )
@@ -120,30 +118,6 @@ func ExampleAlerts_ErrorString() {
 
 	// Output: foo; bar
 	//
-}
-
-func TestGetHandleErrorFunc(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("", ".", nil)
-	if err != nil {
-		t.Error("Error creating new request")
-	}
-	body := `{"alerts":[{"text":"this is an error","level":"error"}]}`
-
-	errHandler := GetHandleErrorsFunc(w, r)
-	errHandler(http.StatusBadRequest, fmt.Errorf("this is an error"))
-	if w.Body.String() != body {
-		t.Error("Expected body", body, "got", w.Body.String())
-	}
-
-	w = httptest.NewRecorder()
-	body = `{"alerts":[]}`
-
-	errHandler = GetHandleErrorsFunc(w, r)
-	errHandler(http.StatusBadRequest, nil)
-	if w.Body.String() != body {
-		t.Error("Expected body", body, "got", w.Body.String())
-	}
 }
 
 func TestCreateAlerts(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/README.md
+++ b/traffic_ops/traffic_ops_golang/README.md
@@ -135,7 +135,7 @@ func CreateV15(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Deliveryservice creation was successful.", []tc.DeliveryServiceNullableV15{*res})
 }
 
-func createV15(w http.ResponseWriter, r *http.Request, inf *api.APIInfo, reqDS tc.DeliveryServiceNullableV15) *tc.DeliveryServiceNullableV15 {
+func createV15(w http.ResponseWriter, r *http.Request, inf *api.Info, reqDS tc.DeliveryServiceNullableV15) *tc.DeliveryServiceNullableV15 {
   ...
 }
 ```

--- a/traffic_ops/traffic_ops_golang/acme/acme_account.go
+++ b/traffic_ops/traffic_ops_golang/acme/acme_account.go
@@ -139,7 +139,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 	tx := inf.Tx.Tx
 
 	var acmeAccount tc.AcmeAccount
-	if userErr = inf.ParseBody(&acmeAccount); userErr != nil {
+	if userErr = inf.ParseAndValidateBody(&acmeAccount); userErr != nil {
 		inf.HandleErr(http.StatusBadRequest, userErr, nil)
 		return
 	}
@@ -179,7 +179,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	tx := inf.Tx.Tx
 
 	var acmeAccount tc.AcmeAccount
-	if userErr = inf.ParseBody(&acmeAccount); userErr != nil {
+	if userErr = inf.ParseAndValidateBody(&acmeAccount); userErr != nil {
 		inf.HandleErr(http.StatusBadRequest, userErr, nil)
 		return
 	}

--- a/traffic_ops/traffic_ops_golang/acme/acme_account.go
+++ b/traffic_ops/traffic_ops_golang/acme/acme_account.go
@@ -39,7 +39,7 @@ const selectLimitedQuery = `SELECT email, provider from acme_account where email
 
 // Read handles GET requests for all information about the ACME accounts.
 func Read(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -69,7 +69,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 
 // ReadProviders returns a list of unique ACME provider both from the database and cdn.conf
 func ReadProviders(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -111,7 +111,7 @@ func ReadProviders(w http.ResponseWriter, r *http.Request) {
 
 // Create handles POST requests to add a new ACME provider.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -164,7 +164,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -216,7 +216,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 // Delete removes the information about an ACME account.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"provider", "email"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"provider", "email"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -518,31 +518,6 @@ func SendMail(to rfc.EmailAddress, msg []byte, cfg *config.Config) (int, error, 
 	return http.StatusOK, nil, nil
 }
 
-// Version represents an API version.
-type Version struct {
-	// API major version - '3' in '3.1'.
-	Major uint64
-	// API minor version - '1' in '3.1'.
-	Minor uint64
-}
-
-func (v Version) Equals(other Version) bool {
-	return v.Major == other.Major && v.Minor == other.Minor
-}
-
-func (v Version) LessThan(other Version) bool {
-	return v.Major < other.Major || (v.Major == other.Major && v.Minor < other.Minor)
-}
-
-func (v Version) GreaterThan(other Version) bool {
-	return v.Major > other.Major || (v.Major == other.Major && v.Minor > other.Minor)
-}
-
-// String returns a string representation of the Version.
-func (v Version) String() string {
-	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
-}
-
 // getRequestedAPIVersion returns the requested API Version from the request if it exists, or returns "0.0" otherwise.
 func getRequestedAPIVersion(path string) Version {
 	v := Version{

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -53,6 +53,7 @@ import (
 
 type errorConstant string
 
+// Error implements the error interface for errorConstants.
 func (e errorConstant) Error() string {
 	return string(e)
 }

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -526,6 +526,18 @@ type Version struct {
 	Minor uint64
 }
 
+func (v Version) Equals(other Version) bool {
+	return v.Major == other.Major && v.Minor == other.Minor
+}
+
+func (v Version) LessThan(other Version) bool {
+	return v.Major < other.Major || (v.Major == other.Major && v.Minor < other.Minor)
+}
+
+func (v Version) GreaterThan(other Version) bool {
+	return v.Major > other.Major || (v.Major == other.Major && v.Minor > other.Minor)
+}
+
 // String returns a string representation of the Version.
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d", v.Major, v.Minor)
@@ -1000,6 +1012,9 @@ func AddLastModifiedHdr(w http.ResponseWriter, t time.Time) {
 
 // DefaultSort sorts alphabetically for a given readerType (eg: TOCDN, TODeliveryService, TOOrigin etc).
 func DefaultSort(readerType *Info, param string) {
+	if readerType == nil {
+		return
+	}
 	if _, ok := readerType.Params["orderby"]; !ok {
 		readerType.Params["orderby"] = param
 	}

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -69,6 +69,10 @@ const NilTransactionError = errorConstant("method called on Info with nil transa
 // failure.
 const ResourceModifiedError = errorConstant("resource was modified since the time specified by the request headers")
 
+// GoneErr is the error returned in Alerts when an endpoint has been removed,
+// but the API version to which it belonged is still (partially) supported.
+const GoneErr = errorConstant("this endpoint is no longer available; please consult documentation")
+
 // Common context.Context value keys.
 const (
 	DBContextKey           = "db"
@@ -113,8 +117,7 @@ type ResponseWithSummary struct {
 // back to the client, along with an error-level alert stating that the endpoint
 // is no longer available.
 func GoneHandler(w http.ResponseWriter, r *http.Request) {
-	err := errors.New("This endpoint is no longer available; please consult documentation")
-	HandleErr(w, r, nil, http.StatusGone, err, nil)
+	HandleErr(w, r, nil, http.StatusGone, GoneErr, nil)
 }
 
 // WriteAndLogErr writes the response and logs a warning if an error occurs. This should be used in favor of simply
@@ -126,8 +129,9 @@ func WriteAndLogErr(w http.ResponseWriter, r *http.Request, bts []byte) {
 	}
 }
 
-// WriteResp takes any object, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
-// This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
+// WriteResp takes any object, serializes it as JSON, and writes that to w.
+// This is a helper for the common case; not using this in unusual cases is
+// perfectly acceptable.
 func WriteResp(w http.ResponseWriter, r *http.Request, v interface{}) {
 	resp := Response{Response: v}
 	WriteRespRaw(w, r, resp)

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -147,8 +147,8 @@ func WriteRespRaw(w http.ResponseWriter, r *http.Request, v interface{}) {
 
 	respBts, err := json.Marshal(v)
 	if err != nil {
-		log.Errorf("marshalling JSON (raw) for %T: %v", v, err)
-		tc.GetHandleErrorsFunc(w, r)(http.StatusInternalServerError, errors.New(http.StatusText(http.StatusInternalServerError)))
+		err = fmt.Errorf("marshalling JSON (raw) for %T: %w", v, err)
+		handleSimpleErr(w, r, http.StatusInternalServerError, nil, err)
 		return
 	}
 	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
@@ -180,8 +180,8 @@ func WriteRespVals(w http.ResponseWriter, r *http.Request, v interface{}, vals m
 	vals["response"] = v
 	respBts, err := json.Marshal(vals)
 	if err != nil {
-		log.Errorf("marshalling JSON for %T: %v", v, err)
-		tc.GetHandleErrorsFunc(w, r)(http.StatusInternalServerError, errors.New(http.StatusText(http.StatusInternalServerError)))
+		err = fmt.Errorf("marshalling JSON for %T: %w", v, err)
+		handleSimpleErr(w, r, http.StatusInternalServerError, nil, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -310,8 +310,9 @@ func RespWriterVals(w http.ResponseWriter, r *http.Request, tx *sql.Tx, vals map
 	}
 }
 
-// WriteRespAlert creates an alert, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
-// This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
+// WriteRespAlert creates an alert, serializes it as JSON, and writes that to w.
+// This is a helper for the common case; not using this in unusual cases is
+// perfectly acceptable.
 func WriteRespAlert(w http.ResponseWriter, r *http.Request, level tc.AlertLevel, msg string) {
 	if respWritten(r) {
 		log.Errorf("WriteRespAlert called after a write already occurred! Not double-writing! Path %s", r.URL.Path)

--- a/traffic_ops/traffic_ops_golang/api/async_status.go
+++ b/traffic_ops/traffic_ops_golang/api/async_status.go
@@ -44,7 +44,7 @@ const updateAsyncStatusQuery = `UPDATE async_status SET status = $1, message = $
 
 // GetAsyncStatus returns the status of an asynchronous job.
 func GetAsyncStatus(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/api/info.go
+++ b/traffic_ops/traffic_ops_golang/api/info.go
@@ -69,6 +69,7 @@ type Info struct {
 	// Vault implements the interaction interface for Traffic Vault.
 	Vault     trafficvault.TrafficVault
 	request   *http.Request
+	writer    http.ResponseWriter
 	ctxCancel context.CancelFunc
 }
 
@@ -90,7 +91,7 @@ type Info struct {
 //
 // Example:
 //  func handler(w http.ResponseWriter, r *http.Request) {
-//    inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+//    inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 //    if userErr != nil || sysErr != nil {
 //      api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 //      return
@@ -109,7 +110,7 @@ type Info struct {
 //    api.WriteResp(w, r, respObj)
 //  }
 //
-func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (*Info, error, error, int) {
+func NewInfo(w http.ResponseWriter, r *http.Request, requiredParams, intParamNames []string) (*Info, error, error, int) {
 	db, err := GetDB(r.Context())
 	if err != nil {
 		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting db: " + err.Error()), nil, http.StatusInternalServerError
@@ -147,6 +148,7 @@ func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (
 		User:      user,
 		Tx:        tx,
 		request:   r,
+		writer:    w,
 		ctxCancel: ctxCancel,
 	}, nil, nil, http.StatusOK
 }

--- a/traffic_ops/traffic_ops_golang/api/info.go
+++ b/traffic_ops/traffic_ops_golang/api/info.go
@@ -386,18 +386,31 @@ func (inf Info) HandleErrOptionalDeprecation(statusCode int, userErr, sysErr err
 	}
 }
 
-// ParseBody decodes a JSON object from the client request into v, and validates
-// it. Use this function instead of the json package when writing API
-// endpoints to safely decode and validate PUT and POST requests.
+// ParseAndValidateBody decodes a JSON object from the client request into v,
+// and validates it. Use this function instead of the json package when writing
+// API endpoints to safely decode and validate PUT and POST requests.
 //
 // Errors  returned by this method are safe for the user to see, and should be
 // included in Alerts in responses.
-func (inf Info) ParseBody(v ParseValidator) error {
-	if err := json.NewDecoder(inf.request.Body).Decode(&v); err != nil {
-		return fmt.Errorf("decoding: %w", err)
+func (inf Info) ParseAndValidateBody(v ParseValidator) error {
+	if err := inf.ParseBody(&v); err != nil {
+		return err
 	}
 	if err := v.Validate(inf.Tx.Tx); err != nil {
 		return fmt.Errorf("validating: %w", err)
+	}
+	return nil
+}
+
+// ParseBody decodes a JSON object from the client request into v. Use this
+// function instead of the json package when writing API endpoints to safely
+// decode PUT and POST requests.
+//
+// Errors  returned by this method are safe for the user to see, and should be
+// included in Alerts in responses.
+func (inf Info) ParseBody(v interface{}) error {
+	if err := json.NewDecoder(inf.request.Body).Decode(v); err != nil {
+		return fmt.Errorf("decoding: %w", err)
 	}
 	return nil
 }

--- a/traffic_ops/traffic_ops_golang/api/info.go
+++ b/traffic_ops/traffic_ops_golang/api/info.go
@@ -1,0 +1,310 @@
+package api
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
+
+	influx "github.com/influxdata/influxdb/client/v2"
+	"github.com/jmoiron/sqlx"
+)
+
+// Info is a structure produced from a client's request that provides (nearly)
+// all of the information and functionality needed to service that request.
+type Info struct {
+	// Params is a map of request "parameters" to their values. Request
+	// parameters are those found either in the query string - such as 'foo'
+	// with a value of 'bar' in /api/4.0/servers?foo=bar - or as required route
+	// parameters - such as 'test' with a value of 'quest' in
+	// /api/4.0/servers/quest (assuming the route definition was
+	// /api/4.0/servers/{test}).
+	Params map[string]string
+	// IntParams is a map of request "parameters" to their values - but ONLY if
+	// those values are integers. Which parameters should be integers is
+	// typically determined by the arguments to 'NewInfo'.
+	IntParams map[string]int
+	// The currently authenticated user, if and when the client is
+	// authenticated. For routes that require authentication, this *should* be
+	// non-nil, assuming the Info was properly generated.
+	User *auth.CurrentUser
+	// ReqID is a unique ID for the request to which this Info belongs.
+	ReqID uint64
+	// Version specifies the API version requested by the client.
+	Version Version
+	// Tx is a reference to an open database transaction built to service the
+	// request. It will be closed with the Info itself.
+	Tx *sqlx.Tx
+	// Config is a reference to the Traffic Ops server's configuration.
+	Config    *config.Config
+	request   *http.Request
+	ctxCancel context.CancelFunc
+}
+
+// NewInfo constructs Info needed by handlers from a client request. It also
+// returns any user error, any system error, and the status code which should
+// be returned to the client if an error occurred. The Info pointer returned is
+// guaranteed to not be 'nil'.
+//
+// It is encouraged to call Info.Tx.Tx.Commit() manually when all queries are
+// finished, to release database resources early, and also to return an error
+// to the user if the commit failed.
+//
+// NewInfo guarantees the returned Info.Tx is non-nil and Info.Tx.Tx is nil or
+// valid, even if a returned error is not nil. Hence, it is safe to pass the
+// Tx.Tx to HandleErr when this returns errors.
+//
+// Close() must be called to free resources, and should be called in a defer
+// immediately after NewInfo(), to finish the transaction.
+//
+// Example:
+//  func handler(w http.ResponseWriter, r *http.Request) {
+//    inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+//    if userErr != nil || sysErr != nil {
+//      api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+//      return
+//    }
+//    defer inf.Close()
+//
+//    respObj, err := finalDatabaseOperation(inf.Tx)
+//    if err != nil {
+//      api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("final db op: " + err.Error()))
+//      return
+//    }
+//    if err := inf.Tx.Tx.Commit(); err != nil {
+//      api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("committing transaction: " + err.Error()))
+//      return
+//    }
+//    api.WriteResp(w, r, respObj)
+//  }
+//
+func NewInfo(r *http.Request, requiredParams []string, intParamNames []string) (*Info, error, error, int) {
+	db, err := GetDB(r.Context())
+	if err != nil {
+		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting db: " + err.Error()), nil, http.StatusInternalServerError
+	}
+	cfg, err := GetConfig(r.Context())
+	if err != nil {
+		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting config: " + err.Error()), nil, http.StatusInternalServerError
+	}
+	reqID, err := getReqID(r.Context())
+	if err != nil {
+		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting reqID: " + err.Error()), nil, http.StatusInternalServerError
+	}
+	version := getRequestedAPIVersion(r.URL.Path)
+
+	user, err := auth.GetCurrentUser(r.Context())
+	if err != nil {
+		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting user: " + err.Error()), nil, http.StatusInternalServerError
+	}
+	params, intParams, userErr, sysErr, errCode := AllParams(r, requiredParams, intParamNames)
+	if userErr != nil || sysErr != nil {
+		return &Info{Tx: &sqlx.Tx{}}, userErr, sysErr, errCode
+	}
+	dbCtx, ctxCancel := context.WithTimeout(r.Context(), time.Duration(cfg.DBQueryTimeoutSeconds)*time.Second) //only place we could call cancel here is in Info.Close(), which already will rollback the transaction (which is all cancel will do.)
+	tx, err := db.BeginTxx(dbCtx, nil)                                                                         // must be last, MUST not return an error if this succeeds, without closing the tx
+	if err != nil {
+		ctxCancel()
+		return &Info{Tx: &sqlx.Tx{}}, userErr, errors.New("could not begin transaction: " + err.Error()), http.StatusInternalServerError
+	}
+	return &Info{
+		Config:    cfg,
+		ReqID:     reqID,
+		Version:   version,
+		Params:    params,
+		IntParams: intParams,
+		User:      user,
+		Tx:        tx,
+		request:   r,
+		ctxCancel: ctxCancel,
+	}, nil, nil, http.StatusOK
+}
+
+const createChangeLogQuery = `
+INSERT INTO log (
+	level,
+	message,
+	tm_user
+) VALUES (
+	$1,
+	$2,
+	$3
+)
+`
+
+// CreateChangeLog creates a new changelog message at the APICHANGE level for
+// the current user.
+func (inf Info) CreateChangeLog(msg string) {
+	_, err := inf.Tx.Tx.Exec(createChangeLogQuery, ApiChange, msg, inf.User.ID)
+	if err != nil {
+		log.Errorf("Inserting chage log level '%s' message '%s' for user '%s': %v", ApiChange, msg, inf.User.UserName, err)
+	}
+}
+
+// UseIMS returns whether or not If-Modified-Since constraints should be used to
+// service the given request.
+func (inf Info) UseIMS() bool {
+	if inf.request == nil || inf.Config == nil {
+		return false
+	}
+	return inf.Config.UseIMS && inf.request.Header.Get(rfc.IfModifiedSince) != ""
+}
+
+// CheckPrecondition checks a request's "preconditions" - its If-Match and
+// If-Unmodified-Since headers versus the last updated time of the requested
+// object(s), and returns (in order), an HTTP response code appropriate for the
+// precondition check results, a user-safe error that should be returned to
+// clients, and a server-side error that should be logged.
+// Callers must pass in a query that will return one row containing one column
+// that is the representative date/time of the last update of the requested
+// object(s), and optionally any values for placeholder arguments in the query.
+func (inf Info) CheckPrecondition(query string, args ...interface{}) (int, error, error) {
+	if inf.request == nil {
+		return http.StatusInternalServerError, nil, NilRequestError
+	}
+
+	ius := inf.request.Header.Get(rfc.IfUnmodifiedSince)
+	etag := inf.request.Header.Get(rfc.IfMatch)
+	if ius == "" && etag == "" {
+		return http.StatusOK, nil, nil
+	}
+
+	if inf.Tx == nil || inf.Tx.Tx == nil {
+		return http.StatusInternalServerError, nil, NilTransactionError
+	}
+
+	var lastUpdated time.Time
+	if err := inf.Tx.Tx.QueryRow(query, args...).Scan(&lastUpdated); err != nil {
+		return http.StatusInternalServerError, nil, fmt.Errorf("scanning for lastUpdated: %v", err)
+	}
+
+	if etag != "" {
+		if et, ok := rfc.ParseETags(strings.Split(etag, ",")); ok {
+			if lastUpdated.After(et) {
+				return http.StatusPreconditionFailed, ResourceModifiedError, nil
+			}
+		}
+	}
+
+	if ius == "" {
+		return http.StatusOK, nil, nil
+	}
+
+	if tm, ok := rfc.ParseHTTPDate(ius); ok {
+		if lastUpdated.After(tm) {
+			return http.StatusPreconditionFailed, ResourceModifiedError, nil
+		}
+	}
+
+	return http.StatusOK, nil, nil
+}
+
+// Close implements the io.Closer interface. It should be called in a defer immediately after NewInfo().
+//
+// Close will commit the transaction, if it hasn't been rolled back.
+func (inf *Info) Close() {
+	if err := inf.Tx.Tx.Commit(); err != nil && err != sql.ErrTxDone {
+		log.Errorln("committing transaction: " + err.Error())
+	}
+	inf.ctxCancel()
+}
+
+// SendMail is a convenience method used to call SendMail using an Info structure's configuration.
+func (inf *Info) SendMail(to rfc.EmailAddress, msg []byte) (int, error, error) {
+	return SendMail(to, msg, inf.Config)
+}
+
+// IsResourceAuthorizedToCurrentUser is a convenience method used to call
+// github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant.IsResourceAuthorizedToUserTx
+// using an Info structure to provide the current user and database transaction.
+func (inf *Info) IsResourceAuthorizedToCurrentUser(resourceTenantID int) (bool, error) {
+	return tenant.IsResourceAuthorizedToUserTx(resourceTenantID, inf.User, inf.Tx.Tx)
+}
+
+// CreateInfluxClient constructs and returns an InfluxDB HTTP client, if enabled and when possible.
+// The error this returns should not be exposed to the user; it's for logging purposes only.
+//
+// If Influx connections are not enabled, this will return `nil` - but also no error. It is expected
+// that the caller will handle this situation appropriately.
+func (inf *Info) CreateInfluxClient() (*influx.Client, error) {
+	if !inf.Config.InfluxEnabled {
+		return nil, nil
+	}
+
+	var fqdn string
+	var tcpPort uint
+	var httpsPort sql.NullInt64 // this is the only one that's optional
+
+	row := inf.Tx.Tx.QueryRow(influxServersQuery)
+	if e := row.Scan(&fqdn, &tcpPort, &httpsPort); e != nil {
+		return nil, fmt.Errorf("Failed to create influx client: %v", e)
+	}
+
+	host := "http%s://%s:%d"
+	if inf.Config.ConfigInflux != nil && *inf.Config.ConfigInflux.Secure {
+		if !httpsPort.Valid {
+			log.Warnf("INFLUXDB Server %s has no secure ports, assuming default of 8086!", fqdn)
+			httpsPort = sql.NullInt64{Int64: 8086, Valid: true}
+		}
+		port, err := httpsPort.Value()
+		if err != nil {
+			return nil, fmt.Errorf("Failed to create influx client: %v", err)
+		}
+
+		p := port.(int64)
+		if p <= 0 || p > 65535 {
+			log.Warnf("INFLUXDB Server %s has invalid port, assuming default of 8086!", fqdn)
+			p = 8086
+		}
+
+		host = fmt.Sprintf(host, "s", fqdn, p)
+	} else if tcpPort > 0 && tcpPort <= 65535 {
+		host = fmt.Sprintf(host, "", fqdn, tcpPort)
+	} else {
+		log.Warnf("INFLUXDB Server %s has invalid port, assuming default of 8086!", fqdn)
+		host = fmt.Sprintf(host, "", fqdn, 8086)
+	}
+
+	config := influx.HTTPConfig{
+		Addr:      host,
+		Username:  inf.Config.ConfigInflux.User,
+		Password:  inf.Config.ConfigInflux.Password,
+		UserAgent: fmt.Sprintf("TrafficOps/%s (Go)", inf.Config.Version),
+		Timeout:   time.Duration(float64(inf.Config.ReadTimeout)/2.1) * time.Second,
+	}
+
+	var client influx.Client
+	client, e := influx.NewHTTPClient(config)
+	if client == nil {
+		return nil, fmt.Errorf("Failed to create influx client (client was nil): %v", e)
+	}
+	return &client, e
+}

--- a/traffic_ops/traffic_ops_golang/api/info.go
+++ b/traffic_ops/traffic_ops_golang/api/info.go
@@ -124,6 +124,10 @@ func NewInfo(w http.ResponseWriter, r *http.Request, requiredParams, intParamNam
 	if err != nil {
 		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting config: " + err.Error()), nil, http.StatusInternalServerError
 	}
+	tv, err := GetTrafficVault(r.Context())
+	if err != nil {
+		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting TrafficVault: " + err.Error()), nil, http.StatusInternalServerError
+	}
 	reqID, err := getReqID(r.Context())
 	if err != nil {
 		return &Info{Tx: &sqlx.Tx{}}, errors.New("getting reqID: " + err.Error()), nil, http.StatusInternalServerError
@@ -152,6 +156,7 @@ func NewInfo(w http.ResponseWriter, r *http.Request, requiredParams, intParamNam
 		IntParams: intParams,
 		User:      user,
 		Tx:        tx,
+		Vault:     tv,
 		request:   r,
 		writer:    w,
 		ctxCancel: ctxCancel,

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -578,7 +578,7 @@ func CreateHandler(creator Creator) http.HandlerFunc {
 	}
 }
 
-func parseMultipleCreates(data []byte, desiredType reflect.Type, inf *APIInfo) ([]Creator, error) {
+func parseMultipleCreates(data []byte, desiredType reflect.Type, inf *Info) ([]Creator, error) {
 	buf := ioutil.NopCloser(bytes.NewReader(data))
 
 	var genericInt interface{}

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -118,7 +118,7 @@ func checkIfOptionsDeleter(obj interface{}, params map[string]string) (bool, err
 		return false, nil, nil, http.StatusOK
 	}
 	options := optionsDeleter.DeleteKeyOptions()
-	for key, _ := range options {
+	for key := range options {
 		if params[key] != "" {
 			return true, nil, nil, http.StatusOK
 		}

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers.go
@@ -181,7 +181,7 @@ func DeprecatedReadHandler(reader Reader, alternative *string) http.HandlerFunc 
 func readHandlerHelper(reader Reader, errHandler errWriterFunc, successHandler readSuccessWriterFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		useIMS := false
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
+		inf, userErr, sysErr, errCode := NewInfo(w, r, nil, nil)
 		if userErr != nil || sysErr != nil {
 			errHandler(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return
@@ -226,7 +226,7 @@ func readHandlerHelper(reader Reader, errHandler errWriterFunc, successHandler r
 //   *forming and writing the body over the wire
 func UpdateHandler(updater Updater) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
+		inf, userErr, sysErr, errCode := NewInfo(w, r, nil, nil)
 		if userErr != nil || sysErr != nil {
 			HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return
@@ -351,7 +351,7 @@ func DeprecatedDeleteHandler(deleter Deleter, alternative *string) http.HandlerF
 // DeprecatedDeleteHandler always returns a deprecation alert in its response, whereas DeleteHandler does not.
 func deleteHandlerHelper(deleter Deleter, errHandler errWriterFunc, successHandler deleteSuccessWriterFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
+		inf, userErr, sysErr, errCode := NewInfo(w, r, nil, nil)
 		if userErr != nil || sysErr != nil {
 			errHandler(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return
@@ -457,7 +457,7 @@ func deleteHandlerHelper(deleter Deleter, errHandler errWriterFunc, successHandl
 //   *forming and writing the body over the wire
 func CreateHandler(creator Creator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := NewInfo(r, nil, nil)
+		inf, userErr, sysErr, errCode := NewInfo(w, r, nil, nil)
 		if userErr != nil || sysErr != nil {
 			HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -40,11 +40,11 @@ import (
 )
 
 type tester struct {
-	ID          int
-	APIInfoImpl `json:"-"`
-	userErr     error //only for testing
-	sysErr      error //only for testing
-	errCode     int   //only for testing
+	ID       int
+	InfoImpl `json:"-"`
+	userErr  error //only for testing
+	sysErr   error //only for testing
+	errCode  int   //only for testing
 }
 
 var cfg = config.Config{ConfigTrafficOpsGolang: config.ConfigTrafficOpsGolang{DBQueryTimeoutSeconds: 20}, UseIMS: true}

--- a/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_handlers_test.go
@@ -40,11 +40,11 @@ import (
 )
 
 type tester struct {
-	ID       int
-	InfoImpl `json:"-"`
-	userErr  error //only for testing
-	sysErr   error //only for testing
-	errCode  int   //only for testing
+	ID         int
+	InfoerImpl `json:"-"`
+	userErr    error //only for testing
+	sysErr     error //only for testing
+	errCode    int   //only for testing
 }
 
 var cfg = config.Config{ConfigTrafficOpsGolang: config.ConfigTrafficOpsGolang{DBQueryTimeoutSeconds: 20}, UseIMS: true}

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -118,3 +118,19 @@ type Infoer interface {
 	SetInfo(*Info)
 	Info() *Info
 }
+
+// InfoerImpl is an implementation of the Infoer interface.
+type InfoerImpl struct {
+	// ReqInfo is the stored API Info.
+	ReqInfo *Info `json:"-"`
+}
+
+// Info returns the InfoerImpl's stored API Info.
+func (i InfoerImpl) Info() *Info {
+	return i.ReqInfo
+}
+
+// SetInfo sets the InfoerImpl's stored API Info.
+func (i *InfoerImpl) SetInfo(inf *Info) {
+	i.ReqInfo = inf
+}

--- a/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
+++ b/traffic_ops/traffic_ops_golang/api/shared_interfaces.go
@@ -20,11 +20,12 @@ package api
  */
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
-	"net/http"
-	"time"
 )
 
 type CRUDer interface {
@@ -32,7 +33,7 @@ type CRUDer interface {
 	Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time)
 	Update(http.Header) (error, error, int)
 	Delete() (error, error, int)
-	APIInfoer
+	Infoer
 	Identifier
 	Validator
 }
@@ -62,7 +63,7 @@ type Identifier interface {
 type Creator interface {
 	// Create returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Create() (error, error, int)
-	APIInfoer
+	Infoer
 	Identifier
 	Validator
 }
@@ -75,13 +76,13 @@ type MultipleCreator interface {
 type Reader interface {
 	// Read returns the object to write to the user, any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time)
-	APIInfoer
+	Infoer
 }
 
 type Updater interface {
 	// Update returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Update(h http.Header) (error, error, int)
-	APIInfoer
+	Infoer
 	Identifier
 	Validator
 }
@@ -89,7 +90,7 @@ type Updater interface {
 type Deleter interface {
 	// Delete returns any user error, any system error, and the HTTP error code to be returned if there was an error.
 	Delete() (error, error, int)
-	APIInfoer
+	Infoer
 	Identifier
 }
 
@@ -98,7 +99,7 @@ type OptionsDeleter interface {
 	// OptionsDelete returns any user error, any system error, and the HTTP error code to be returned if there was an
 	// error.
 	OptionsDelete() (error, error, int)
-	APIInfoer
+	Infoer
 	Identifier
 	DeleteKeyOptions() map[string]dbhelpers.WhereColumnInfo
 }
@@ -111,9 +112,9 @@ type Tenantable interface {
 	IsTenantAuthorized(user *auth.CurrentUser) (bool, error)
 }
 
-// APIInfoer is an interface that guarantees the existance of a variable through its setters and getters.
+// Infoer is an interface that guarantees the existance of a variable through its setters and getters.
 // Every CRUD operation uses this login session context
-type APIInfoer interface {
-	SetInfo(*APIInfo)
-	APIInfo() *APIInfo
+type Infoer interface {
+	SetInfo(*Info)
+	Info() *Info
 }

--- a/traffic_ops/traffic_ops_golang/api/version.go
+++ b/traffic_ops/traffic_ops_golang/api/version.go
@@ -31,8 +31,8 @@ type Version struct {
 	Minor uint64
 }
 
-// Equals determines if an API Version is exactly equal to some other Version.
-func (v Version) Equals(other Version) bool {
+// Equal determines if an API Version is exactly equal to some other Version.
+func (v Version) Equal(other Version) bool {
 	return v.Major == other.Major && v.Minor == other.Minor
 }
 

--- a/traffic_ops/traffic_ops_golang/api/version.go
+++ b/traffic_ops/traffic_ops_golang/api/version.go
@@ -1,0 +1,52 @@
+package api
+
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+import (
+	"strconv"
+)
+
+// Version represents an API version.
+type Version struct {
+	// API major version - '3' in '3.1'.
+	Major uint64
+	// API minor version - '1' in '3.1'.
+	Minor uint64
+}
+
+// Equals determines if an API Version is exactly equal to some other Version.
+func (v Version) Equals(other Version) bool {
+	return v.Major == other.Major && v.Minor == other.Minor
+}
+
+// LessThan determines if an API Version is a lower version than some other Version.
+func (v Version) LessThan(other Version) bool {
+	return v.Major < other.Major || (v.Major == other.Major && v.Minor < other.Minor)
+}
+
+// GreaterThan determines if an API Version is a higher version than some other Version.
+func (v Version) GreaterThan(other Version) bool {
+	return v.Major > other.Major || (v.Major == other.Major && v.Minor > other.Minor)
+}
+
+// String returns a string representation of the Version.
+func (v Version) String() string {
+	return strconv.FormatUint(v.Major, 10) + "." + strconv.FormatUint(v.Minor, 10)
+}

--- a/traffic_ops/traffic_ops_golang/api/version_test.go
+++ b/traffic_ops/traffic_ops_golang/api/version_test.go
@@ -1,0 +1,121 @@
+package api
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import "fmt"
+
+func ExampleVersion_String() {
+	v := Version{
+		Major: 1,
+		Minor: 2,
+	}
+	fmt.Println(v)
+
+	// Output: 1.2
+}
+
+func ExampleVersion_Equal() {
+	v := Version{
+		Major: 1,
+		Minor: 2,
+	}
+	o := Version{
+		Major: 1,
+		Minor: 2,
+	}
+	fmt.Println(v.Equals(o))
+	fmt.Println(o.Equals(v))
+
+	o.Major++
+	fmt.Println(v.Equals(o))
+	fmt.Println(o.Equals(v))
+
+	o.Major--
+	o.Minor--
+	fmt.Println(v.Equals(o))
+	fmt.Println(o.Equals(v))
+
+	// Output: true
+	// true
+	// false
+	// false
+	// false
+	// false
+}
+
+func ExampleVersion_GreaterThan() {
+	v := Version{
+		Major: 1,
+		Minor: 2,
+	}
+	o := Version{
+		Major: 1,
+		Minor: 2,
+	}
+
+	fmt.Println(v.GreaterThan(o))
+	fmt.Println(o.GreaterThan(v))
+
+	o.Major--
+	fmt.Println(v.GreaterThan(o))
+	fmt.Println(o.GreaterThan(v))
+
+	o.Major++
+	o.Minor--
+	fmt.Println(v.GreaterThan(o))
+	fmt.Println(o.GreaterThan(v))
+
+	// Output: false
+	// false
+	// true
+	// false
+	// true
+	// false
+}
+
+func ExampleVersion_LessThan() {
+	v := Version{
+		Major: 1,
+		Minor: 2,
+	}
+	o := Version{
+		Major: 1,
+		Minor: 2,
+	}
+
+	fmt.Println(v.LessThan(o))
+	fmt.Println(o.LessThan(v))
+
+	o.Major--
+	fmt.Println(v.LessThan(o))
+	fmt.Println(o.LessThan(v))
+
+	o.Major++
+	o.Minor--
+	fmt.Println(v.LessThan(o))
+	fmt.Println(o.LessThan(v))
+
+	// Output: false
+	// false
+	// false
+	// true
+	// false
+	// true
+}

--- a/traffic_ops/traffic_ops_golang/api/version_test.go
+++ b/traffic_ops/traffic_ops_golang/api/version_test.go
@@ -40,17 +40,17 @@ func ExampleVersion_Equal() {
 		Major: 1,
 		Minor: 2,
 	}
-	fmt.Println(v.Equals(o))
-	fmt.Println(o.Equals(v))
+	fmt.Println(v.Equal(o))
+	fmt.Println(o.Equal(v))
 
 	o.Major++
-	fmt.Println(v.Equals(o))
-	fmt.Println(o.Equals(v))
+	fmt.Println(v.Equal(o))
+	fmt.Println(o.Equal(v))
 
 	o.Major--
 	o.Minor--
-	fmt.Println(v.Equals(o))
-	fmt.Println(o.Equals(v))
+	fmt.Println(v.Equal(o))
+	fmt.Println(o.Equal(v))
 
 	// Output: true
 	// true

--- a/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
@@ -40,7 +40,7 @@ import (
 // API Capabilities. In the event a capability parameter is supplied,
 // it will return only those with an exact match.
 func GetAPICapabilitiesHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant.go
@@ -44,7 +44,7 @@ const rootName = `root`
 
 // TOTenant provides a local type against which to define methods
 type TOTenant struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.TenantNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
+++ b/traffic_ops/traffic_ops_golang/apitenant/tenant_test.go
@@ -83,7 +83,7 @@ func TestIsUpdateable(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT")
 
-	child.ReqInfo = &api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*child.ID)}}
+	child.ReqInfo = &api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*child.ID)}}
 	userErr, _, statusCode = child.isUpdatable()
 	if userErr != nil && statusCode != http.StatusOK {
 		t.Errorf("Should be able to update child to new parent (from Parent to Root). userErr = %s, statuscode = %d", userErr, statusCode)
@@ -106,7 +106,7 @@ func TestIsUpdateable(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 
-	parent.ReqInfo = &api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*parent.ID)}}
+	parent.ReqInfo = &api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": strconv.Itoa(*parent.ID)}}
 	userErr, _, statusCode = parent.isUpdatable()
 	if userErr == nil && statusCode != http.StatusBadRequest {
 		t.Errorf("Should NOT be able to update parent to own child (from Parent to Child). userErr = %s, statuscode = %d", userErr, statusCode)
@@ -129,7 +129,7 @@ func getValidChildTenant() *TOTenant {
 		ParentID:    &tenpid,
 		ParentName:  &tenpaname,
 	}
-	ten.ReqInfo = &api.APIInfo{}
+	ten.ReqInfo = &api.Info{}
 	return ten
 }
 
@@ -148,7 +148,7 @@ func getValidParentTenant() *TOTenant {
 		ParentID:    &tenpid,
 		ParentName:  &tenpaname,
 	}
-	ten.ReqInfo = &api.APIInfo{}
+	ten.ReqInfo = &api.Info{}
 	return ten
 }
 
@@ -165,6 +165,6 @@ func getRootTestTenant() *TOTenant {
 		ParentID:    nil,
 		ParentName:  nil,
 	}
-	ten.ReqInfo = &api.APIInfo{}
+	ten.ReqInfo = &api.Info{}
 	return ten
 }

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -39,7 +39,7 @@ const ASNsPrivLevel = 10
 
 //we need a type alias to define functions on
 type TOASNV11 struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.ASNNullable
 }
 
@@ -133,7 +133,7 @@ func (as *TOASNV11) Update(h http.Header) (error, error, int) {
 func (as *TOASNV11) Delete() (error, error, int) { return api.GenericDelete(as) }
 
 func (asn TOASNV11) ASNExists(create bool) error {
-	if asn.Info() == nil || asn.Info().Tx == nil {
+	if asn.Info().Tx == nil {
 		return errors.New("couldn't perform check to see if asn number exists already")
 	}
 	if asn.ASN == nil || asn.CachegroupID == nil {

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -39,12 +39,12 @@ const ASNsPrivLevel = 10
 
 //we need a type alias to define functions on
 type TOASNV11 struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.ASNNullable
 }
 
 func (v *TOASNV11) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "asn")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "asn")
 }
 
 func (v *TOASNV11) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -111,7 +111,7 @@ func (as *TOASNV11) Create() (error, error, int) {
 	return api.GenericCreate(as)
 }
 func (as *TOASNV11) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(as.APIInfo(), "asn")
+	api.DefaultSort(as.Info(), "asn")
 	return api.GenericRead(h, as, useIMS)
 }
 func (v *TOASNV11) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
@@ -133,14 +133,14 @@ func (as *TOASNV11) Update(h http.Header) (error, error, int) {
 func (as *TOASNV11) Delete() (error, error, int) { return api.GenericDelete(as) }
 
 func (asn TOASNV11) ASNExists(create bool) error {
-	if asn.APIInfo() == nil || asn.APIInfo().Tx == nil {
+	if asn.Info() == nil || asn.Info().Tx == nil {
 		return errors.New("couldn't perform check to see if asn number exists already")
 	}
 	if asn.ASN == nil || asn.CachegroupID == nil {
 		return errors.New("no asn or cachegroup ID specified")
 	}
 	query := `SELECT id from asn where asn=$1`
-	rows, err := asn.APIInfo().Tx.Query(query, *asn.ASN)
+	rows, err := asn.Info().Tx.Query(query, *asn.ASN)
 	if err != nil {
 		return errors.New("selecting asns: " + err.Error())
 	}

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -84,7 +84,7 @@ func TestGetASNs(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOASNV11{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{},
 	}
 	asns, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -160,7 +160,7 @@ func TestCheckNumberForUpdate(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -198,7 +198,7 @@ func TestASNExistsForUpdateFailure(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -234,7 +234,7 @@ func TestASNExistsForUpdateSuccess(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -267,7 +267,7 @@ func TestASNExists(t *testing.T) {
 	asnNum := 2
 	cachegroupID := 10
 	asn := TOASNV11{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID},
 	}
 	err = asn.ASNExists(true)

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -84,7 +84,7 @@ func TestGetASNs(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOASNV11{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ASNNullable{},
 	}
 	asns, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -122,7 +122,7 @@ func TestInterfaces(t *testing.T) {
 func TestValidate(t *testing.T) {
 	i := -99
 	asn := TOASNV11{
-		api.InfoImpl{nil},
+		api.InfoerImpl{},
 		tc.ASNNullable{ASN: &i, CachegroupID: &i},
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(asn.Validate())))
@@ -160,7 +160,7 @@ func TestCheckNumberForUpdate(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -198,7 +198,7 @@ func TestASNExistsForUpdateFailure(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -234,7 +234,7 @@ func TestASNExistsForUpdateSuccess(t *testing.T) {
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -267,7 +267,7 @@ func TestASNExists(t *testing.T) {
 	asnNum := 2
 	cachegroupID := 10
 	asn := TOASNV11{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID},
 	}
 	err = asn.ASNExists(true)

--- a/traffic_ops/traffic_ops_golang/asn/asns_test.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns_test.go
@@ -81,10 +81,10 @@ func TestGetASNs(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOASNV11{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ASNNullable{},
 	}
 	asns, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -122,7 +122,7 @@ func TestInterfaces(t *testing.T) {
 func TestValidate(t *testing.T) {
 	i := -99
 	asn := TOASNV11{
-		api.APIInfoImpl{},
+		api.InfoImpl{nil},
 		tc.ASNNullable{ASN: &i, CachegroupID: &i},
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(asn.Validate())))
@@ -155,12 +155,12 @@ func TestCheckNumberForUpdate(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin()}
+	reqInfo := api.Info{Tx: db.MustBegin()}
 	asnNum := 2
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -193,12 +193,12 @@ func TestASNExistsForUpdateFailure(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin()}
+	reqInfo := api.Info{Tx: db.MustBegin()}
 	asnNum := 2
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -229,12 +229,12 @@ func TestASNExistsForUpdateSuccess(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin()}
+	reqInfo := api.Info{Tx: db.MustBegin()}
 	asnNum := 2
 	cachegroupID := 10
 	id := 1
 	asn := TOASNV11{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID, ID: &id},
 	}
 	err = asn.ASNExists(false)
@@ -263,11 +263,11 @@ func TestASNExists(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin()}
+	reqInfo := api.Info{Tx: db.MustBegin()}
 	asnNum := 2
 	cachegroupID := 10
 	asn := TOASNV11{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ASNNullable{ASN: &asnNum, CachegroupID: &cachegroupID},
 	}
 	err = asn.ASNExists(true)

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -43,7 +43,7 @@ import (
 )
 
 type TOCacheGroup struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.CacheGroupNullable
 }
 
@@ -371,10 +371,10 @@ func (cg *TOCacheGroup) createCacheGroupFallbacks() error {
 func (cg *TOCacheGroup) isValidCacheGroupFallback(fallbackName string) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT cachegroup.id 
-FROM cachegroup 
-JOIN type on type.id = cachegroup.type 
-WHERE cachegroup.name = $1 
+SELECT cachegroup.id
+FROM cachegroup
+JOIN type on type.id = cachegroup.type
+WHERE cachegroup.name = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -389,9 +389,9 @@ AND (type.name = 'EDGE_LOC')
 func (cg *TOCacheGroup) isAllowedToFallback(cacheGroupType int) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT type.name 
-FROM type 
-WHERE type.id = $1 
+SELECT type.name
+FROM type
+WHERE type.id = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -546,7 +546,7 @@ func (cg *TOCacheGroup) Read(h http.Header, useIMS bool) ([]interface{}, error, 
 	}
 
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(cg.APIInfo().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(cg.Info().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return cacheGroups, nil, nil, http.StatusNotModified, &maxTime

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -43,7 +43,7 @@ import (
 )
 
 type TOCacheGroup struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.CacheGroupNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -137,9 +137,9 @@ func TestReadCacheGroups(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCacheGroup{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
 	cachegroups, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -205,7 +205,7 @@ func TestValidate(t *testing.T) {
 	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT\\s+name,\\s+use_in_table").WillReturnRows(rows)
 	tx := db.MustBegin()
-	reqInfo := api.APIInfo{Tx: tx}
+	reqInfo := api.Info{Tx: tx}
 
 	// invalid name, shortname, loattude, and longitude
 	id := 1
@@ -218,7 +218,7 @@ func TestValidate(t *testing.T) {
 	ti := 6
 	lu := tc.TimeNoMod{Time: time.Now()}
 	c := TOCacheGroup{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,
@@ -259,7 +259,7 @@ func TestValidate(t *testing.T) {
 	lo = 90.0
 	lm = []tc.LocalizationMethod{tc.LocalizationMethodGeo, tc.LocalizationMethodCZ, tc.LocalizationMethodDeepCZ}
 	c = TOCacheGroup{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,
@@ -331,9 +331,9 @@ func TestBadTypeParamCacheGroups(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"type": "wrong"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"type": "wrong"}}
 	obj := TOCacheGroup{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
 	_, userErr, _, sc, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups_test.go
@@ -139,7 +139,7 @@ func TestReadCacheGroups(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCacheGroup{
-		api.InfoImpl{ReqInfo: &reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
 	cachegroups, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -218,7 +218,7 @@ func TestValidate(t *testing.T) {
 	ti := 6
 	lu := tc.TimeNoMod{Time: time.Now()}
 	c := TOCacheGroup{
-		api.InfoImpl{ReqInfo: &reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,
@@ -259,7 +259,7 @@ func TestValidate(t *testing.T) {
 	lo = 90.0
 	lm = []tc.LocalizationMethod{tc.LocalizationMethodGeo, tc.LocalizationMethodCZ, tc.LocalizationMethodDeepCZ}
 	c = TOCacheGroup{
-		api.InfoImpl{ReqInfo: &reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{
 			ID:                  &id,
 			Name:                &nm,
@@ -333,7 +333,7 @@ func TestBadTypeParamCacheGroups(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"type": "wrong"}}
 	obj := TOCacheGroup{
-		api.InfoImpl{ReqInfo: &reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CacheGroupNullable{},
 	}
 	_, userErr, _, sc, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/dspost.go
@@ -38,7 +38,7 @@ import (
 )
 
 func DSPostHandlerV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -71,7 +71,7 @@ func DSPostHandlerV31(w http.ResponseWriter, r *http.Request) {
 }
 
 func DSPostHandlerV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -33,7 +33,7 @@ import (
 )
 
 func QueueUpdates(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -51,7 +51,7 @@ const (
 
 // TOCacheGroupParameter is a type alias that is used to define CRUD functions on.
 type TOCacheGroupParameter struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.CacheGroupParameterNullable
 	CacheGroupID int `json:"-" db:"cachegroup_id"`
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -218,7 +218,7 @@ func (cgparam *TOCacheGroupParameter) Delete() (error, error, int) {
 
 // ReadAllCacheGroupParameters reads all cachegroup parameter associations.
 func ReadAllCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleDeprecatedErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr, nil)
 		return
@@ -273,7 +273,7 @@ func GetAllCacheGroupParameters(tx *sqlx.Tx, parameters map[string]string) (tc.C
 // AddCacheGroupParameters performs a Create for cachegroup parameter associations.
 // AddCacheGroupParameters accepts data as a single association or an array of multiple.
 func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleDeprecatedErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr, nil)
 		return

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -51,7 +51,7 @@ const (
 
 // TOCacheGroupParameter is a type alias that is used to define CRUD functions on.
 type TOCacheGroupParameter struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.CacheGroupParameterNullable
 	CacheGroupID int `json:"-" db:"cachegroup_id"`
 }
@@ -71,7 +71,7 @@ func (cgparam *TOCacheGroupParameter) Read(h http.Header, useIMS bool) ([]interf
 	var maxTime time.Time
 	var runSecond bool
 	queryParamsToQueryCols := cgparam.ParamColumns()
-	parameters := cgparam.APIInfo().Params
+	parameters := cgparam.Info().Params
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
@@ -352,14 +352,14 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 }
 
 func selectAllQuery() string {
-	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name 
-				FROM cachegroup_parameter AS cgp 
+	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name
+				FROM cachegroup_parameter AS cgp
 				JOIN cachegroup AS cg ON cg.id = cachegroup`
 }
 
 func insertQuery() string {
-	return `INSERT INTO cachegroup_parameter 
-		(cachegroup, 
-		parameter) 
+	return `INSERT INTO cachegroup_parameter
+		(cachegroup,
+		parameter)
 		VALUES `
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters_test.go
@@ -194,7 +194,7 @@ func TestReadCacheGroupParameters(t *testing.T) {
 				}
 				mock.ExpectCommit()
 
-				reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: testCase.params}
+				reqInfo := api.Info{Tx: db.MustBegin(), Params: testCase.params}
 				toParameterReader.SetInfo(&reqInfo)
 
 				parameters, userErr, sysErr, returnCode, _ := toParameterReader.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cachesstats/cachesstats.go
+++ b/traffic_ops/traffic_ops_golang/cachesstats/cachesstats.go
@@ -35,7 +35,7 @@ import (
 const ATSCurrentConnectionsStat = "ats.proxy.process.http.current_client_connections"
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/capabilities/capabilities.go
+++ b/traffic_ops/traffic_ops_golang/capabilities/capabilities.go
@@ -38,7 +38,7 @@ FROM capability
 `
 
 func Read(w http.ResponseWriter, r *http.Request) {
-	inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/cdn/capacity.go
+++ b/traffic_ops/traffic_ops_golang/cdn/capacity.go
@@ -39,7 +39,7 @@ import (
 )
 
 func GetCapacity(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -37,7 +37,7 @@ import (
 
 //we need a type alias to define functions on
 type TOCDN struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.CDNNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/cdn/cdns.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns.go
@@ -37,12 +37,12 @@ import (
 
 //we need a type alias to define functions on
 type TOCDN struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.CDNNullable
 }
 
 func (v *TOCDN) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "cdn")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "cdn")
 }
 
 func (v *TOCDN) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
@@ -137,13 +137,13 @@ func (cdn *TOCDN) Create() (error, error, int) {
 }
 
 func (cdn *TOCDN) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(cdn.APIInfo(), "name")
+	api.DefaultSort(cdn.Info(), "name")
 	return api.GenericRead(h, cdn, useIMS)
 }
 
 func (cdn *TOCDN) Update(h http.Header) (error, error, int) {
 	if cdn.ID != nil {
-		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
+		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.Info().Tx.Tx, int64(*cdn.ID), cdn.Info().User.UserName)
 		if userErr != nil || sysErr != nil {
 			return userErr, sysErr, errCode
 		}
@@ -154,7 +154,7 @@ func (cdn *TOCDN) Update(h http.Header) (error, error, int) {
 
 func (cdn *TOCDN) Delete() (error, error, int) {
 	if cdn.ID != nil {
-		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.APIInfo().Tx.Tx, int64(*cdn.ID), cdn.APIInfo().User.UserName)
+		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDNWithID(cdn.Info().Tx.Tx, int64(*cdn.ID), cdn.Info().User.UserName)
 		if userErr != nil || sysErr != nil {
 			return userErr, sysErr, errCode
 		}

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -83,7 +83,7 @@ func TestReadCDNs(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOCDN{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CDNNullable{},
 	}
 	cdns, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -81,9 +81,9 @@ func TestReadCDNs(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOCDN{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.CDNNullable{},
 	}
 	cdns, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
+++ b/traffic_ops/traffic_ops_golang/cdn/cdns_test.go
@@ -83,7 +83,7 @@ func TestReadCDNs(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOCDN{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.CDNNullable{},
 	}
 	cdns, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/cdn/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssec.go
@@ -48,7 +48,7 @@ const (
 )
 
 func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -130,7 +130,7 @@ func CreateDNSSECKeys(w http.ResponseWriter, r *http.Request) {
 const DefaultDSTTL = 60 * time.Second
 
 func GetDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -392,7 +392,7 @@ WHERE cdn.name = $1
 }
 
 func DeleteDNSSECKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/domains.go
+++ b/traffic_ops/traffic_ops_golang/cdn/domains.go
@@ -21,10 +21,11 @@ package cdn
 
 import (
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"net/http"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
@@ -82,7 +83,7 @@ func getDomainsList(useIMS bool, header http.Header, tx *sqlx.Tx) ([]tc.Domain, 
 
 func DomainsHandler(w http.ResponseWriter, r *http.Request) {
 	useIMS := false
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/genksk.go
+++ b/traffic_ops/traffic_ops_golang/cdn/genksk.go
@@ -39,7 +39,7 @@ const DefaultKSKExpiration = 365 * 24 * time.Hour
 const DefaultZSKExpiration = 30 * 24 * time.Hour
 
 func GenerateKSK(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/health.go
+++ b/traffic_ops/traffic_ops_golang/cdn/health.go
@@ -31,7 +31,7 @@ import (
 )
 
 func GetHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -48,7 +48,7 @@ func GetHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func GetNameHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/namedelete.go
+++ b/traffic_ops/traffic_ops_golang/cdn/namedelete.go
@@ -31,7 +31,7 @@ import (
 )
 
 func DeleteName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/queue.go
+++ b/traffic_ops/traffic_ops_golang/cdn/queue.go
@@ -42,7 +42,7 @@ func Queue(w http.ResponseWriter, r *http.Request) {
 	var str string
 	params := make(map[string]string, 0)
 
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/cdn/sslkeys.go
@@ -27,7 +27,7 @@ import (
 )
 
 func GetSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
+++ b/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
@@ -41,7 +41,7 @@ const deleteAdminQuery = `DELETE FROM cdn_lock WHERE cdn=$1 RETURNING username, 
 
 // Read is the handler for GET requests to /cdn_locks.
 func Read(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -86,7 +86,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 // Create is the handler for POST requests to /cdn_locks.
 func Create(w http.ResponseWriter, r *http.Request) {
 	soft := "soft"
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -139,7 +139,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 // Delete is the handler for DELETE requests to /cdn_locks.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"cdn"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
+++ b/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
@@ -39,7 +39,7 @@ import (
 
 // we need a type alias to define functions on
 type TOCDNFederation struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.CDNFederation
 	TenantID *int `json:"-" db:"tenant_id"`
 }

--- a/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
+++ b/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
@@ -64,7 +64,7 @@ cdn_notification.notification
 
 // Read is the handler for GET requests to /cdn_notifications.
 func Read(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -115,7 +115,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 
 // Create is the handler for POST requests to /cdn_notifications.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -147,7 +147,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 // Delete is the handler for DELETE requests to /cdn_notifications.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
+++ b/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
@@ -33,10 +33,10 @@ import (
 
 const readQuery = `
 SELECT cn.id,
-	cn.cdn, 
+	cn.cdn,
 	cn.last_updated,
-	cn.user, 
-	cn.notification 
+	cn.user,
+	cn.notification
 FROM cdn_notification as cn
 INNER JOIN cdn ON cdn.name = cn.cdn
 INNER JOIN tm_user ON tm_user.username = cn.user
@@ -164,7 +164,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, alert.Text, respObj)
 }
 
-func deleteCDNNotification(inf *api.APIInfo) (tc.Alert, tc.CDNNotification, error, error, int) {
+func deleteCDNNotification(inf *api.Info) (tc.Alert, tc.CDNNotification, error, error, int) {
 	var userErr error
 	var sysErr error
 	var statusCode = http.StatusOK

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -36,7 +36,7 @@ import (
 
 //we need a type alias to define functions on
 type TOCoordinate struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.CoordinateNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates.go
@@ -36,7 +36,7 @@ import (
 
 //we need a type alias to define functions on
 type TOCoordinate struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.CoordinateNullable
 }
 
@@ -52,7 +52,7 @@ func (v *TOCoordinate) ParamColumns() map[string]dbhelpers.WhereColumnInfo {
 }
 
 func (v *TOCoordinate) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "coordinate")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "coordinate")
 }
 
 func (v *TOCoordinate) UpdateQuery() string { return updateQuery() }
@@ -125,7 +125,7 @@ func (coordinate TOCoordinate) Validate() error {
 
 func (coord *TOCoordinate) Create() (error, error, int) { return api.GenericCreate(coord) }
 func (coord *TOCoordinate) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(coord.APIInfo(), "name")
+	api.DefaultSort(coord.Info(), "name")
 	return api.GenericRead(h, coord, useIMS)
 }
 func (v *TOCoordinate) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -85,9 +85,9 @@ func TestReadCoordinates(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCoordinate{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.CoordinateNullable{},
 	}
 	coordinates, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -87,7 +87,7 @@ func TestReadCoordinates(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCoordinate{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.CoordinateNullable{},
 	}
 	coordinates, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
+++ b/traffic_ops/traffic_ops_golang/coordinate/coordinates_test.go
@@ -87,7 +87,7 @@ func TestReadCoordinates(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TOCoordinate{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.CoordinateNullable{},
 	}
 	coordinates, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -39,7 +39,7 @@ import (
 // Handler creates and serves the CRConfig from the raw SQL data.
 // This MUST only be used for debugging or previewing, the raw un-snapshotted data MUST NOT be used by any component of the CDN.
 func Handler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"cdn"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -59,7 +59,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 // SnapshotGetHandler gets and serves the CRConfig from the snapshot table.
 func SnapshotGetHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"cdn"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -89,7 +89,7 @@ func SnapshotGetHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func SnapshotGetMonitoringLegacyHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"cdn"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -116,7 +116,7 @@ func SnapshotGetMonitoringLegacyHandler(w http.ResponseWriter, r *http.Request) 
 
 // SnapshotGetMonitoringHandler gets and serves the CRConfig from the snapshot table.
 func SnapshotGetMonitoringHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"cdn"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"cdn"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -138,7 +138,7 @@ func SnapshotGetMonitoringHandler(w http.ResponseWriter, r *http.Request) {
 
 // SnapshotHandler creates the CRConfig JSON and writes it to the snapshot table in the database.
 func SnapshotHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id", "cdnID"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"id", "cdnID"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/crstats/cdnrouting.go
+++ b/traffic_ops/traffic_ops_golang/crstats/cdnrouting.go
@@ -30,7 +30,7 @@ import (
 
 // GetCDNRouting is the handler for getting aggregated routing percentages across CDNs.
 func GetCDNRouting(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/crstats/dsrouting.go
+++ b/traffic_ops/traffic_ops_golang/crstats/dsrouting.go
@@ -36,7 +36,7 @@ import (
 
 // GetDSRouting is the handler for getting aggregated routing percentages for a DS.
 func GetDSRouting(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 
 	if userErr != nil || sysErr != nil {

--- a/traffic_ops/traffic_ops_golang/dbdump/dbdump.go
+++ b/traffic_ops/traffic_ops_golang/dbdump/dbdump.go
@@ -43,7 +43,7 @@ func filename() string {
 }
 
 func DBDump(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/acme.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/acme.go
@@ -150,7 +150,7 @@ func (d *DNSProviderTrafficRouter) CleanUp(domain, token, keyAuth string) error 
 
 // GenerateAcmeCertificates gets and saves certificates using ACME protocol from a give ACME provider.
 func GenerateAcmeCertificates(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -234,7 +234,7 @@ func GenerateAcmeCertificates(w http.ResponseWriter, r *http.Request) {
 
 // GenerateLetsEncryptCertificates gets and saves new certificates from Let's Encrypt.
 func GenerateLetsEncryptCertificates(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/acme_renew.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/acme_renew.go
@@ -40,7 +40,7 @@ import (
 
 // RenewAcmeCertificate renews the SSL certificate for a delivery service if possible through ACME protocol.
 func RenewAcmeCertificate(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xmlid"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"xmlid"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -74,7 +74,7 @@ func RenewCertificates(w http.ResponseWriter, r *http.Request) {
 
 func renewCertificates(w http.ResponseWriter, r *http.Request, deprecated bool) {
 	deprecation := util.StrPtr(API_ACME_AUTORENEW)
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, errCode, userErr, sysErr, deprecated, deprecation)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/capacity.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/capacity.go
@@ -36,7 +36,7 @@ import (
 )
 
 func GetCapacity(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash/consistenthash.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/consistenthash/consistenthash.go
@@ -23,12 +23,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
 	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 )
 
 // struct for the response object from Traffic Router
@@ -47,7 +48,7 @@ type TRConsistentHashRequest struct {
 
 // Post is the handler for POST requests to /consistenthash.
 func Post(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -136,7 +136,7 @@ func GetDSTLSVersions(dsID int, tx *sql.Tx) ([]string, error) {
 // But it'd be much more convenient for users. Alternatively, remove IDs from
 // the database entirely and use real candidate keys.
 func CreateV15(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -157,7 +157,7 @@ func CreateV15(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceNullableV15{*res})
 }
 func CreateV30(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -178,7 +178,7 @@ func CreateV30(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceV30{*res})
 }
 func CreateV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -199,7 +199,7 @@ func CreateV31(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service creation was successful", []tc.DeliveryServiceV31{*res})
 }
 func CreateV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -623,7 +623,7 @@ func (ds *TODeliveryService) Read(h http.Header, useIMS bool) ([]interface{}, er
 }
 
 func UpdateV15(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -647,7 +647,7 @@ func UpdateV15(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceNullableV15{*res})
 }
 func UpdateV30(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -671,7 +671,7 @@ func UpdateV30(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceV30{*res})
 }
 func UpdateV31(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -694,7 +694,7 @@ func UpdateV31(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, "Delivery Service update was successful", []tc.DeliveryServiceV31{*res})
 }
 func UpdateV40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -49,7 +49,7 @@ const (
 
 // RequiredCapability provides a type to define methods on.
 type RequiredCapability struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.DeliveryServicesRequiredCapability
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -63,8 +63,8 @@ func TestCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
 			},
@@ -127,8 +127,8 @@ func TestUnauthorizedCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 1},
 			},
@@ -179,8 +179,8 @@ func TestReadDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
 			},
@@ -251,8 +251,8 @@ func TestDeleteDeliveryServicesRequiredCapability(t *testing.T) {
 	mock.ExpectExec("DELETE").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
 			},
@@ -292,8 +292,8 @@ func TestUnauthorizedDeleteDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 1},
 			},
@@ -353,8 +353,8 @@ func TestCreateDeliveryServicesRequiredCapabilityInvalidDSType(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		api.InfoImpl{
+			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
 			},

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities_test.go
@@ -63,7 +63,7 @@ func TestCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
@@ -127,7 +127,7 @@ func TestUnauthorizedCreateDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 1},
@@ -179,7 +179,7 @@ func TestReadDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
@@ -251,7 +251,7 @@ func TestDeleteDeliveryServicesRequiredCapability(t *testing.T) {
 	mock.ExpectExec("DELETE").WillReturnResult(sqlmock.NewResult(1, 1))
 
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},
@@ -292,7 +292,7 @@ func TestUnauthorizedDeleteDeliveryServicesRequiredCapability(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 1},
@@ -353,7 +353,7 @@ func TestCreateDeliveryServicesRequiredCapabilityInvalidDSType(t *testing.T) {
 
 	mock.ExpectBegin()
 	rc := RequiredCapability{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Tx:   db.MustBegin(),
 				User: &auth.CurrentUser{PrivLevel: 30},

--- a/traffic_ops/traffic_ops_golang/deliveryservice/eligible.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/eligible.go
@@ -35,7 +35,7 @@ import (
 )
 
 func GetServersEligible(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -137,7 +137,7 @@ JOIN type t ON s.type = t.id
 WHERE s.cdn_id = (SELECT cdn_id from deliveryservice where id = (select v from ds_id))
 	AND (t.name LIKE 'EDGE%' OR t.name LIKE 'ORG%')
 `
-	dataFetchQuery := `, 
+	dataFetchQuery := `,
 cg.name as cachegroup,
 s.cachegroup as cachegroup_id,
 s.cdn_id,

--- a/traffic_ops/traffic_ops_golang/deliveryservice/health.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/health.go
@@ -33,7 +33,7 @@ import (
 )
 
 func GetHealth(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -47,7 +47,7 @@ const (
 
 // AddSSLKeys adds the given ssl keys to the given delivery service.
 func AddSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -137,7 +137,7 @@ func AddSSLKeys(w http.ResponseWriter, r *http.Request) {
 
 // GetSSLKeysByXMLIDV15 fetches the deliveryservice ssl keys by the specified xmlID. V15 includes expiration date.
 func GetSSLKeysByXMLIDV15(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xmlid"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"xmlid"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -239,7 +239,7 @@ func base64EncodeCertificate(cert *tc.DeliveryServiceSSLKeysCertificate) {
 
 // DeleteSSLKeys deletes a Delivery Service's sslkeys via a DELETE method
 func DeleteSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xmlid"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"xmlid"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
@@ -37,7 +37,7 @@ type DnsRecord struct {
 }
 
 func GetDnsChallengeRecords(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
@@ -28,7 +28,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
 )
 
 // GetAssignment is the handler for GET requests to
@@ -42,15 +41,8 @@ func GetAssignment(w http.ResponseWriter, r *http.Request) {
 	}
 	defer inf.Close()
 
-	// Middleware should've already handled this, so idk why this is a pointer at all tbh
-	version := inf.Version
-	if version == nil {
-		middleware.NotImplementedHandler().ServeHTTP(w, r)
-		return
-	}
-
 	// This should never happen because a route doesn't exist for it
-	if version.Major < 4 {
+	if inf.Version.Major < 4 {
 		w.Header().Set("Allow", http.MethodPut)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		api.WriteRespAlert(w, r, tc.ErrorLevel, http.StatusText(http.StatusMethodNotAllowed))
@@ -150,15 +142,8 @@ func PutAssignment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Middleware should've already handled this, so idk why this is a pointer at all tbh
-	version := inf.Version
-	if version == nil {
-		middleware.NotImplementedHandler().ServeHTTP(w, r)
-		return
-	}
-
 	// Don't accept "assignee" in lieu of "assigneeId" in API version < 4.0
-	if version.Major < 4 {
+	if inf.Version.Major < 4 {
 		req.Assignee = nil
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/assign.go
@@ -33,7 +33,7 @@ import (
 // GetAssignment is the handler for GET requests to
 // /deliveryservice_requests/{{ID}}/assign.
 func GetAssignment(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -128,7 +128,7 @@ func getAssignee(r *assignmentRequest, xmlID string, tx *sql.Tx) (string, int, e
 // PutAssignment is the handler for PUT requsets to
 // /deliveryservice_requests/{{ID}}/assign.
 func PutAssignment(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -31,17 +31,17 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 )
 
 //we need a type alias to define functions on
 type TODeliveryServiceRequestComment struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.DeliveryServiceRequestCommentNullable
 }
 
 func (v *TODeliveryServiceRequestComment) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "deliveryservice_request_comment")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "deliveryservice_request_comment")
 }
 
 func (v *TODeliveryServiceRequestComment) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -113,7 +113,7 @@ func (comment *TODeliveryServiceRequestComment) Create() (error, error, int) {
 }
 
 func (comment *TODeliveryServiceRequestComment) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(comment.APIInfo(), "xmlId")
+	api.DefaultSort(comment.Info(), "xmlId")
 	return api.GenericRead(h, comment, useIMS)
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/comment/comments.go
@@ -36,7 +36,7 @@ import (
 
 //we need a type alias to define functions on
 type TODeliveryServiceRequestComment struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.DeliveryServiceRequestCommentNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -163,7 +163,7 @@ func getOriginals(ids []int, tx *sqlx.Tx, needOriginals map[int][]*tc.DeliverySe
 
 // Get is the GET handler for /deliveryservice_requests.
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -562,7 +562,7 @@ func createLegacy(w http.ResponseWriter, r *http.Request, inf *api.Info) (result
 
 // Post is the handler for POST requests to /deliveryservice_requests.
 func Post(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -590,7 +590,7 @@ func Post(w http.ResponseWriter, r *http.Request) {
 // Delete is the handler for DELETE requests to /deliveryservice_requests.
 func Delete(w http.ResponseWriter, r *http.Request) {
 	var omitExtraLongDescFields bool
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -865,7 +865,7 @@ func putLegacy(w http.ResponseWriter, r *http.Request, inf *api.Info) (result ds
 
 // Put is the handler for PUT requests to /deliveryservice_requests.
 func Put(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -307,7 +307,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 // isTenantAuthorized ensures the user is authorized on the DSR's
 // DeliveryService's Tenant, as appropriate to the change type.
-func isTenantAuthorized(dsr tc.DeliveryServiceRequestV40, inf *api.APIInfo) (bool, error) {
+func isTenantAuthorized(dsr tc.DeliveryServiceRequestV40, inf *api.Info) (bool, error) {
 	if dsr.Requested != nil && (dsr.ChangeType == tc.DSRChangeTypeUpdate || dsr.ChangeType == tc.DSRChangeTypeCreate) {
 		if dsr.Requested.TenantID == nil {
 			log.Debugf("requested.tenantID is nil")
@@ -340,7 +340,7 @@ func isTenantAuthorized(dsr tc.DeliveryServiceRequestV40, inf *api.APIInfo) (boo
 }
 
 // Warning: this assumes inf isn't nil, and neither is dsr, inf.Tx or inf.User or inf.Tx.Tx.
-func insert(dsr *tc.DeliveryServiceRequestV40, inf *api.APIInfo) (int, error, error) {
+func insert(dsr *tc.DeliveryServiceRequestV40, inf *api.Info) (int, error, error) {
 	dsr.Author = inf.User.UserName
 	dsr.LastEditedBy = inf.User.UserName
 	if dsr.ChangeType != tc.DSRChangeTypeDelete {
@@ -420,7 +420,7 @@ func (d dsrManipulationResult) String() string {
 	return builder.String()
 }
 
-func createV4(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result dsrManipulationResult) {
+func createV4(w http.ResponseWriter, r *http.Request, inf *api.Info) (result dsrManipulationResult) {
 	tx := inf.Tx.Tx
 	var dsr tc.DeliveryServiceRequestV40
 	if err := json.NewDecoder(r.Body).Decode(&dsr); err != nil {
@@ -494,7 +494,7 @@ func createV4(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result 
 	return
 }
 
-func createLegacy(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result dsrManipulationResult) {
+func createLegacy(w http.ResponseWriter, r *http.Request, inf *api.Info) (result dsrManipulationResult) {
 	tx := inf.Tx.Tx
 	var dsr tc.DeliveryServiceRequestNullable
 	if err := json.NewDecoder(r.Body).Decode(&dsr); err != nil {
@@ -699,7 +699,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	inf.CreateChangeLog(res.String())
 }
 
-func putV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result dsrManipulationResult) {
+func putV40(w http.ResponseWriter, r *http.Request, inf *api.Info) (result dsrManipulationResult) {
 	tx := inf.Tx.Tx
 	var dsr tc.DeliveryServiceRequestV40
 	if err := json.NewDecoder(r.Body).Decode(&dsr); err != nil {
@@ -814,7 +814,7 @@ func putV40(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result ds
 	return
 }
 
-func putLegacy(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result dsrManipulationResult) {
+func putLegacy(w http.ResponseWriter, r *http.Request, inf *api.Info) (result dsrManipulationResult) {
 	tx := inf.Tx.Tx
 	var dsr tc.DeliveryServiceRequestNullable
 	if err := json.NewDecoder(r.Body).Decode(&dsr); err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
@@ -28,7 +28,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/routing/middleware"
 )
 
 // GetStatus is the handler for GET requests to
@@ -42,15 +41,8 @@ func GetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	defer inf.Close()
 
-	// Middleware should've already handled this, so idk why this is a pointer at all tbh
-	version := inf.Version
-	if version == nil {
-		middleware.NotImplementedHandler().ServeHTTP(w, r)
-		return
-	}
-
 	// This should never happen because a route doesn't exist for it
-	if version.Major < 4 {
+	if inf.Version.Major < 4 {
 		w.Header().Set("Allow", http.MethodPut)
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		api.WriteRespAlert(w, r, tc.ErrorLevel, http.StatusText(http.StatusMethodNotAllowed))
@@ -110,13 +102,6 @@ func PutStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer inf.Close()
-
-	// Middleware should've already handled this, so idk why this is a pointer at all tbh
-	version := inf.Version
-	if version == nil {
-		middleware.NotImplementedHandler().ServeHTTP(w, r)
-		return
-	}
 
 	if inf.User == nil {
 		sysErr = errors.New("got api info with no user")

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/status.go
@@ -33,7 +33,7 @@ import (
 // GetStatus is the handler for GET requests to
 // /deliveryservice_requests/{{ID}}/status.
 func GetStatus(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -95,7 +95,7 @@ RETURNING last_updated
 // /deliveryservice_requests/{{ID}}/status.
 func PutStatus(w http.ResponseWriter, r *http.Request) {
 	var omitExtraLongDescFields bool
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/safe.go
@@ -57,7 +57,7 @@ RETURNING id
 func UpdateSafe(w http.ResponseWriter, r *http.Request) {
 	var ok bool
 	var err error
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -97,7 +97,7 @@ func checkLastAvailableEdgeOrOrigin(dsID, serverID int, usesMSO bool, tx *sql.Tx
 }
 
 func deleteDSS(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"serverid", "dsid"}, []string{"serverid", "dsid"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"serverid", "dsid"}, []string{"serverid", "dsid"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -48,7 +48,7 @@ import (
 
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceServer struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.DeliveryServiceServer
 	TenantIDs          pq.Int64Array `json:"-" db:"accessibleTenants"`
 	DeliveryServiceIDs pq.Int64Array `json:"-" db:"dsids"`
@@ -875,7 +875,7 @@ WHERE s.id in (select server from deliveryservice_server where deliveryservice =
 }
 
 type TODSSDeliveryService struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.DeliveryServiceNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -109,7 +109,7 @@ func (dss *TODeliveryServiceServer) Validate(tx *sql.Tx) error {
 
 // ReadDSSHandler is the handler for GET requests to /deliveryserviceserver.
 func ReadDSSHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"limit", "page"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"limit", "page"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -346,7 +346,7 @@ func hasAvailableEdgesCurrentlyAssigned(tx *sql.Tx, dsID int) (bool, error) {
 
 // GetReplaceHandler is the handler for POST requests to the /deliveryserviceserver API endpoint.
 func GetReplaceHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"limit", "page"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"limit", "page"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -450,7 +450,7 @@ type TODeliveryServiceServers tc.DeliveryServiceServers
 
 // GetCreateHandler is the handler for POST requests to /deliveryservices/{{XMLID}}/servers.
 func GetCreateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"xml_id"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"xml_id"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -676,7 +676,7 @@ VALUES (:id, :server )`
 
 // GetReadAssigned is the handler for GET requests to /deliveryservices/{id}/servers.
 func GetReadAssigned(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -881,10 +881,7 @@ type TODSSDeliveryService struct {
 
 // Read shows all of the delivery services associated with the specified server.
 func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	version := dss.APIInfo().Version
-	if version == nil {
-		return nil, nil, errors.New("TODSSDeliveryService.Read called with nil API version"), http.StatusInternalServerError, nil
-	}
+	version := dss.Info().Version
 	if version.Major == 1 && version.Minor < 1 {
 		return nil, nil, fmt.Errorf("TODSSDeliveryService.Read called with invalid API version: %d.%d", version.Major, version.Minor), http.StatusInternalServerError, nil
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -48,7 +48,7 @@ import (
 
 // TODeliveryServiceRequest provides a type alias to define functions on
 type TODeliveryServiceServer struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.DeliveryServiceServer
 	TenantIDs          pq.Int64Array `json:"-" db:"accessibleTenants"`
 	DeliveryServiceIDs pq.Int64Array `json:"-" db:"dsids"`
@@ -875,7 +875,7 @@ WHERE s.id in (select server from deliveryservice_server where deliveryservice =
 }
 
 type TODSSDeliveryService struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.DeliveryServiceNullable
 }
 
@@ -891,9 +891,9 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 	var maxTime time.Time
 	var runSecond bool
 	returnable := []interface{}{}
-	params := dss.APIInfo().Params
-	tx := dss.APIInfo().Tx.Tx
-	user := dss.APIInfo().User
+	params := dss.Info().Params
+	tx := dss.Info().Tx.Tx
+	user := dss.Info().User
 
 	if err := api.IsInt(params["id"]); err != nil {
 		return nil, err, nil, http.StatusBadRequest, nil
@@ -928,10 +928,10 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 	}
 	where, queryValues = dbhelpers.AddTenancyCheck(where, queryValues, "ds.tenant_id", tenantIDs)
 	query := deliveryservice.SelectDeliveryServicesQuery + where + orderBy + pagination
-	queryValues["server"] = dss.APIInfo().Params["id"]
+	queryValues["server"] = dss.Info().Params["id"]
 
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(dss.APIInfo().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(dss.Info().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return returnable, nil, nil, http.StatusNotModified, &maxTime
@@ -943,7 +943,7 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 	log.Debugln("generated deliveryServices query: " + query)
 	log.Debugf("executing with values: %++v\n", queryValues)
 
-	dses, userErr, sysErr, _ := deliveryservice.GetDeliveryServices(query, queryValues, dss.APIInfo().Tx)
+	dses, userErr, sysErr, _ := deliveryservice.GetDeliveryServices(query, queryValues, dss.Info().Tx)
 	if sysErr != nil {
 		sysErr = fmt.Errorf("reading server dses: %v ", sysErr)
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/sslkeys.go
@@ -40,7 +40,7 @@ import (
 // certificate based on the values submitted. It then stores these values in
 // TrafficVault and updates the SSL key version.
 func GenerateSSLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/urlkey.go
@@ -35,7 +35,7 @@ import (
 
 // GetURLKeysByID returns the URL sig keys for a delivery service identified by the id in the path parameter.
 func GetURLKeysByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -88,7 +88,7 @@ func GetURLKeysByID(w http.ResponseWriter, r *http.Request) {
 
 // GetURLKeysByName returns the URL sig keys for a delivery service identified by the xmlId in the path parameter.
 func GetURLKeysByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -134,7 +134,7 @@ func GetURLKeysByName(w http.ResponseWriter, r *http.Request) {
 // CopyURLKeys copies the URL sig keys from a delivery service in the 'copy-name' path parameter
 // to the delivery service in the 'name' path parameter.
 func CopyURLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name", "copy-name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name", "copy-name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -228,7 +228,7 @@ func CopyURLKeys(w http.ResponseWriter, r *http.Request) {
 
 // GenerateURLKeys generates new URL sig keys for the delivery service identified by the xmlId in the path parameter.
 func GenerateURLKeys(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -317,7 +317,7 @@ func GenerateURLSigKeys() (tc.URLSigKeys, error) {
 
 // DeleteURLKeysByID deletes the URL sig keys for the delivery service identified by the id in the path parameter.
 func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -379,7 +379,7 @@ func DeleteURLKeysByID(w http.ResponseWriter, r *http.Request) {
 
 // DeleteURLKeysByName deletes the URL sig keys for the delivery service identified by the xmlId in the path parameter.
 func DeleteURLKeysByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservicerequests/deliveryservicerequests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicerequests/deliveryservicerequests.go
@@ -43,7 +43,7 @@ const msg = "From: %s\r\nTo:%s\r\nContent-Type: text/html\r\nSubject: Delivery S
 // /deliveryservices/request - not to be confused with a Delivery Service
 // Request as created using the /deliveryservice_requests.
 func Request(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
@@ -38,7 +38,7 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -88,7 +88,7 @@ WHERE ds.tenant_id = ANY($1)
 }
 
 func DSGet(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"dsid"}, []string{"dsid"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"dsid"}, []string{"dsid"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -145,7 +145,7 @@ JOIN type as rt ON r.type = rt.id
 }
 
 func Post(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"dsid"}, []string{"dsid"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"dsid"}, []string{"dsid"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -230,10 +230,10 @@ func getCurrentDetails(tx *sql.Tx, dsID int, regexID int) error {
 	var setNumber int
 	var typeName string
 	err := tx.QueryRow(`
-select dsr.set_number, t.name 
-from deliveryservice_regex as dsr 
-join regex as r on dsr.regex = r.id 
-join type as t on t.id = r.type 
+select dsr.set_number, t.name
+from deliveryservice_regex as dsr
+join regex as r on dsr.regex = r.id
+join type as t on t.id = r.type
 where dsr.deliveryservice=$1 and r.id=$2`,
 		dsID, regexID).Scan(&setNumber, &typeName)
 	if err != nil {
@@ -246,7 +246,7 @@ where dsr.deliveryservice=$1 and r.id=$2`,
 }
 
 func Put(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"dsid", "regexid"}, []string{"dsid", "regexid"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"dsid", "regexid"}, []string{"dsid", "regexid"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -329,7 +329,7 @@ func Put(w http.ResponseWriter, r *http.Request) {
 func canUpdate(tx *sql.Tx, dsr tc.DeliveryServiceRegexPost) error {
 	var name string
 	err := tx.QueryRow(`
-select name from type as t 
+select name from type as t
 where t.id=$1`,
 		dsr.Type).Scan(&name)
 	if err != nil {
@@ -380,7 +380,7 @@ where deliveryservice = $1 and set_number = $2`,
 }
 
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"dsid", "regexid"}, []string{"dsid", "regexid"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"dsid", "regexid"}, []string{"dsid", "regexid"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -36,12 +36,12 @@ import (
 
 //we need a type alias to define functions on
 type TODivision struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.DivisionNullable
 }
 
 func (v *TODivision) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "division")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "division")
 }
 
 func (v *TODivision) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -104,12 +104,12 @@ func (division TODivision) Validate() error {
 
 func (dv *TODivision) Create() (error, error, int) { return api.GenericCreate(dv) }
 func (dv *TODivision) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	params := dv.APIInfo().Params
+	params := dv.Info().Params
 	// TODO move to router, and do for all endpoints
 	if strings.HasSuffix(params["name"], ".json") {
 		params["name"] = params["name"][:len(params["name"])-len(".json")]
 	}
-	api.DefaultSort(dv.APIInfo(), "name")
+	api.DefaultSort(dv.Info(), "name")
 	return api.GenericRead(h, dv, useIMS)
 }
 func (dv *TODivision) Update(h http.Header) (error, error, int) { return api.GenericUpdate(h, dv) }

--- a/traffic_ops/traffic_ops_golang/division/divisions.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions.go
@@ -36,7 +36,7 @@ import (
 
 //we need a type alias to define functions on
 type TODivision struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.DivisionNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -73,9 +73,9 @@ func TestGetDivisions(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TODivision{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.DivisionNullable{},
 	}
 	vals, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -75,7 +75,7 @@ func TestGetDivisions(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TODivision{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.DivisionNullable{},
 	}
 	vals, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/division/divisions_test.go
+++ b/traffic_ops/traffic_ops_golang/division/divisions_test.go
@@ -75,7 +75,7 @@ func TestGetDivisions(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TODivision{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.DivisionNullable{},
 	}
 	vals, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
@@ -74,7 +74,7 @@ RETURNING federation_resolver.id,
 
 // Create is the handler for POST requests to /federation_resolvers.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -106,7 +106,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 func Read(w http.ResponseWriter, r *http.Request) {
 	var maxTime time.Time
 	var runSecond bool
-	inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -240,7 +240,7 @@ func SelectMaxLastUpdatedQuery(where string, tableName string) string {
 
 // Delete is the handler for DELETE requests to /federation_resolvers.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, sysErr, userErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
@@ -271,7 +271,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, alert.Text, respObj)
 }
 
-func deleteFederationResolver(inf *api.APIInfo) (tc.Alert, tc.FederationResolver, error, error, int) {
+func deleteFederationResolver(inf *api.Info) (tc.Alert, tc.FederationResolver, error, error, int) {
 	var userErr error
 	var sysErr error
 	var statusCode = http.StatusOK

--- a/traffic_ops/traffic_ops_golang/federations/allfederations.go
+++ b/traffic_ops/traffic_ops_golang/federations/allfederations.go
@@ -33,7 +33,7 @@ import (
 
 func GetAll(w http.ResponseWriter, r *http.Request) {
 	var maxTime *time.Time
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -128,8 +128,8 @@ func getFedNameByID(tx *sql.Tx, id int) (string, bool, error) {
 
 // TOFedDSes data structure to use on read/delete of federation deliveryservices
 type TOFedDSes struct {
-	api.APIInfoImpl `json:"-"`
-	fedID           *int
+	api.InfoImpl `json:"-"`
+	fedID        *int
 	tc.FederationDeliveryServiceNullable
 }
 
@@ -180,12 +180,12 @@ func (v *TOFedDSes) GetKeyFieldsInfo() []api.KeyFieldInfo {
 }
 
 func (v *TOFedDSes) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(v.APIInfo(), "xmlId")
+	api.DefaultSort(v.Info(), "xmlId")
 	return api.GenericRead(h, v, useIMS)
 }
 
 func (v *TOFedDSes) Delete() (error, error, int) {
-	dsIDStr, ok := v.APIInfo().Params["dsID"]
+	dsIDStr, ok := v.Info().Params["dsID"]
 	if !ok {
 		return errors.New("dsID must be specified for deletion"), nil, http.StatusBadRequest
 	}
@@ -204,7 +204,7 @@ func (v *TOFedDSes) Delete() (error, error, int) {
 		return userErr, sysErr, errCode
 	}
 	// Check that we can delete it
-	if respCode, usrErr, sysErr := checkFedDSDeletion(v.APIInfo().Tx.Tx, *v.fedID, dsID); usrErr != nil || sysErr != nil {
+	if respCode, usrErr, sysErr := checkFedDSDeletion(v.Info().Tx.Tx, *v.fedID, dsID); usrErr != nil || sysErr != nil {
 		if usrErr != nil {
 			return usrErr, sysErr, respCode
 		}
@@ -212,7 +212,7 @@ func (v *TOFedDSes) Delete() (error, error, int) {
 	}
 
 	// Actually delete the DS from the Federation
-	if err := deleteFedDS(v.APIInfo().Tx.Tx, *v.fedID, dsID); err != nil {
+	if err := deleteFedDS(v.Info().Tx.Tx, *v.fedID, dsID); err != nil {
 		return api.ParseDBError(err)
 	}
 

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -128,8 +128,8 @@ func getFedNameByID(tx *sql.Tx, id int) (string, bool, error) {
 
 // TOFedDSes data structure to use on read/delete of federation deliveryservices
 type TOFedDSes struct {
-	api.InfoImpl `json:"-"`
-	fedID        *int
+	api.InfoerImpl `json:"-"`
+	fedID          *int
 	tc.FederationDeliveryServiceNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/federations/ds.go
+++ b/traffic_ops/traffic_ops_golang/federations/ds.go
@@ -35,7 +35,7 @@ import (
 )
 
 func PostDSes(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federations/federation_resolvers.go
@@ -36,7 +36,7 @@ WHERE ffr.federation = $1
 
 // GetFederationFederationResolversHandler returns a subset of federation_resolvers belonging to the federation ID supplied.
 func GetFederationFederationResolversHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -56,7 +56,7 @@ func GetFederationFederationResolversHandler(w http.ResponseWriter, r *http.Requ
 
 // AssignFederationResolversToFederationHandler associates one or more federation_resolver to the federation ID supplied.
 func AssignFederationResolversToFederationHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/federations/federations.go
+++ b/traffic_ops/traffic_ops_golang/federations/federations.go
@@ -74,7 +74,7 @@ RETURNING federation_resolver.ip_address
 `
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -309,7 +309,7 @@ ORDER BY
 // Confusingly, it does not create a federation, but is instead used to manipulate the resolvers
 // used by one or more particular Delivery Services for one or more particular Federations.
 func AddFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -424,7 +424,7 @@ func addFederationResolver(res []string, t tc.FederationResolverType, fedID uint
 // Confusingly, it does not delete a federation, but is instead used to remove an association
 // between all federation resolvers and all federations assigned to the authenticated user.
 func RemoveFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -478,7 +478,7 @@ func removeFederationResolverMappingsForCurrentUser(tx *sql.Tx, u *auth.CurrentU
 }
 
 func ReplaceFederationResolverMappingsForCurrentUser(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -144,7 +144,7 @@ func (v *TOUsers) Read(h http.Header, useIMS bool) ([]interface{}, error, error,
 func (v *TOUsers) Delete() (error, error, int) { return api.GenericDelete(v) }
 
 func PostUsers(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -42,8 +42,8 @@ const (
 
 // TOUsers data structure to use on read/delete of federation users
 type TOUsers struct {
-	api.InfoImpl `json:"-"`
-	Federation   *int `json:"-" db:"federation"`
+	api.InfoerImpl `json:"-"`
+	Federation     *int `json:"-" db:"federation"`
 	tc.FederationUser
 }
 

--- a/traffic_ops/traffic_ops_golang/federations/user.go
+++ b/traffic_ops/traffic_ops_golang/federations/user.go
@@ -42,8 +42,8 @@ const (
 
 // TOUsers data structure to use on read/delete of federation users
 type TOUsers struct {
-	api.APIInfoImpl `json:"-"`
-	Federation      *int `json:"-" db:"federation"`
+	api.InfoImpl `json:"-"`
+	Federation   *int `json:"-" db:"federation"`
 	tc.FederationUser
 }
 
@@ -127,12 +127,12 @@ func (v *TOUsers) GetType() string {
 }
 
 func (v *TOUsers) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	fedIDStr := v.APIInfo().Params["id"]
+	fedIDStr := v.Info().Params["id"]
 	fedID, err := strconv.Atoi(fedIDStr)
 	if err != nil {
 		return nil, errors.New("federation id must be an integer"), nil, http.StatusBadRequest, nil
 	}
-	_, exists, err := getFedNameByID(v.APIInfo().Tx.Tx, fedID)
+	_, exists, err := getFedNameByID(v.Info().Tx.Tx, fedID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting federation cname from ID %v: %v", fedID, err), http.StatusInternalServerError, nil
 	} else if !exists {

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -301,7 +301,7 @@ func (job *InvalidationJob) Read(h http.Header, useIMS bool) ([]interface{}, err
 // Used by POST requests to `/jobs`, creates a new content invalidation job
 // from the provided request body.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -443,7 +443,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 // Used by PUT requests to `/jobs`, replaces an existing content invalidation job
 // with the provided request body.
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -620,7 +620,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 
 // Used by DELETE requests to `/jobs`, deletes an existing content invalidation job
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -43,7 +43,7 @@ import (
 )
 
 type InvalidationJob struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.InvalidationJob
 }
 
@@ -219,12 +219,12 @@ func (job *InvalidationJob) Read(h http.Header, useIMS bool) ([]interface{}, err
 		"dsId":            dbhelpers.WhereColumnInfo{Column: "job.job_deliveryservice", Checker: api.IsInt},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.APIInfo().Params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.Info().Params, queryParamsToSQLCols)
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}
 
-	accessibleTenants, err := tenant.GetUserTenantIDListTx(job.APIInfo().Tx.Tx, job.APIInfo().User.TenantID)
+	accessibleTenants, err := tenant.GetUserTenantIDListTx(job.Info().Tx.Tx, job.Info().User.TenantID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting accessible tenants for user - %v", err), http.StatusInternalServerError, nil
 	}
@@ -254,7 +254,7 @@ func (job *InvalidationJob) Read(h http.Header, useIMS bool) ([]interface{}, err
 	queryValues["tenants"] = pq.Array(accessibleTenants)
 
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(job.APIInfo().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(job.Info().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return []interface{}{}, nil, nil, http.StatusNotModified, &maxTime
@@ -269,7 +269,7 @@ func (job *InvalidationJob) Read(h http.Header, useIMS bool) ([]interface{}, err
 	log.Debugf("executing with values: %++v\n", queryValues)
 
 	returnable := []interface{}{}
-	rows, err := job.APIInfo().Tx.NamedQuery(query, queryValues)
+	rows, err := job.Info().Tx.NamedQuery(query, queryValues)
 	if err != nil {
 		return nil, nil, fmt.Errorf("querying: %v", err), http.StatusInternalServerError, nil
 	}
@@ -752,7 +752,7 @@ func setRevalFlags(d interface{}, tx *sql.Tx) error {
 	return nil
 }
 
-// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// Checks if the current user's (identified in the Info) tenant has permissions to
 // edit a Delivery Service. `ds` is expected to be the integral, unique identifer of the
 // Delivery Service in question.
 //
@@ -763,7 +763,7 @@ func setRevalFlags(d interface{}, tx *sql.Tx) error {
 //
 // Note: If no such delivery service exists, the return values shall indicate that the
 // user isn't authorized.
-func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (bool, error) {
+func IsUserAuthorizedToModifyDSID(inf *api.Info, ds uint) (bool, error) {
 	var t uint
 	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM deliveryservice where id=$1`, ds)
 	if err := row.Scan(&t); err != nil {
@@ -776,7 +776,7 @@ func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (bool, error) {
 	return tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
 }
 
-// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// Checks if the current user's (identified in the Info) tenant has permissions to
 // edit a Delivery Service. `ds` is expected to be the "xml_id" of the
 // Delivery Service in question.
 //
@@ -787,7 +787,7 @@ func IsUserAuthorizedToModifyDSID(inf *api.APIInfo, ds uint) (bool, error) {
 //
 // Note: If no such delivery service exists, the return values shall indicate that the
 // user isn't authorized.
-func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (bool, error) {
+func IsUserAuthorizedToModifyDSXMLID(inf *api.Info, ds string) (bool, error) {
 	var t uint
 	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM deliveryservice where xml_id=$1`, ds)
 	if err := row.Scan(&t); err != nil {
@@ -800,7 +800,7 @@ func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (bool, error) 
 	return tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
 }
 
-// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// Checks if the current user's (identified in the Info) tenant has permissions to
 // edit on par with the user identified by `u`. `u` is expected to be the integral,
 // unique identifer of the user in question (not the current, requesting user).
 //
@@ -811,7 +811,7 @@ func IsUserAuthorizedToModifyDSXMLID(inf *api.APIInfo, ds string) (bool, error) 
 //
 // Note: If no such delivery service exists, the return values shall indicate that the
 // user isn't authorized.
-func IsUserAuthorizedToModifyJobsMadeByUserID(inf *api.APIInfo, u uint) (bool, error) {
+func IsUserAuthorizedToModifyJobsMadeByUserID(inf *api.Info, u uint) (bool, error) {
 	var t uint
 	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM tm_user where id=$1`, u)
 	if err := row.Scan(&t); err != nil {
@@ -824,7 +824,7 @@ func IsUserAuthorizedToModifyJobsMadeByUserID(inf *api.APIInfo, u uint) (bool, e
 	return tenant.IsResourceAuthorizedToUserTx(int(t), inf.User, inf.Tx.Tx)
 }
 
-// Checks if the current user's (identified in the APIInfo) tenant has permissions to
+// Checks if the current user's (identified in the Info) tenant has permissions to
 // edit on par with the user identified by `u`. `u` is expected to be the username of
 // the user in question (not the current, requesting user).
 //
@@ -835,7 +835,7 @@ func IsUserAuthorizedToModifyJobsMadeByUserID(inf *api.APIInfo, u uint) (bool, e
 //
 // Note: If no such delivery service exists, the return values shall indicate that the
 // user isn't authorized.
-func IsUserAuthorizedToModifyJobsMadeByUsername(inf *api.APIInfo, u string) (bool, error) {
+func IsUserAuthorizedToModifyJobsMadeByUsername(inf *api.Info, u string) (bool, error) {
 	var t uint
 	row := inf.Tx.Tx.QueryRow(`SELECT tenant_id FROM tm_user where username=$1`, u)
 	if err := row.Scan(&t); err != nil {

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -43,7 +43,7 @@ import (
 )
 
 type InvalidationJob struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.InvalidationJob
 }
 
@@ -424,11 +424,6 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("Marshaling JSON: %v", err))
-		return
-	}
-
-	if inf.Version == nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("nil API version"))
 		return
 	}
 

--- a/traffic_ops/traffic_ops_golang/iso/iso.go
+++ b/traffic_ops/traffic_ops_golang/iso/iso.go
@@ -85,7 +85,7 @@ const (
 //   Content-Type: application/download
 //
 func ISOs(w http.ResponseWriter, req *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(req, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, req, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, req, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/iso/osversions.go
+++ b/traffic_ops/traffic_ops_golang/iso/osversions.go
@@ -43,7 +43,7 @@ import (
 // endpoint returned a single JSON object, whereas the CRUDer interface returns an array of JSON
 // objects per the Read method.
 func GetOSVersions(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/login/logout.go
+++ b/traffic_ops/traffic_ops_golang/login/logout.go
@@ -32,7 +32,7 @@ import (
 
 func LogoutHandler(secret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+		inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 		tx := inf.Tx.Tx
 		if userErr != nil || sysErr != nil {
 			api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/login/register.go
+++ b/traffic_ops/traffic_ops_golang/login/register.go
@@ -21,21 +21,20 @@ package login
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 )
-import "database/sql"
-import "errors"
-import "fmt"
-import "html/template"
-import "net/http"
-
-import "github.com/apache/trafficcontrol/lib/go-log"
-import "github.com/apache/trafficcontrol/lib/go-rfc"
-import "github.com/apache/trafficcontrol/lib/go-tc"
-
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/config"
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
 type registrationEmailFormatter struct {
 	From         rfc.EmailAddress
@@ -158,7 +157,7 @@ func RegisterUser(w http.ResponseWriter, r *http.Request) {
 	var reqV4 tc.UserRegistrationRequestV4
 	var email rfc.EmailAddress
 
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	var tx = inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -47,7 +47,7 @@ const (
 
 // Get is the handler for GET requests to /logs.
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"days", "limit"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -74,7 +74,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 // Get is the handler for GET requests to /logs V4.0.
 func Getv40(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"days", "limit"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -103,7 +103,7 @@ func Getv40(w http.ResponseWriter, r *http.Request) {
 
 // GetNewCount is the handler for GET requests to /logs/newcount.
 func GetNewCount(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, []string{"days", "limit"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -157,7 +157,7 @@ FROM "log" as l JOIN tm_user as u ON l.tm_user = u.id`
 
 const countQuery = `SELECT count(l.tm_user) FROM log as l`
 
-func getLogV40(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
+func getLogV40(inf *api.Info, days int) ([]tc.Log, uint64, error) {
 	var count = uint64(0)
 	var whereCount string
 
@@ -208,7 +208,7 @@ func getLogV40(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
 	return ls, count, nil
 }
 
-func getLog(inf *api.APIInfo, days int, limit int) ([]tc.Log, uint64, error) {
+func getLog(inf *api.Info, days int, limit int) ([]tc.Log, uint64, error) {
 	var count = uint64(0)
 	var whereCount string
 	if _, ok := inf.Params["limit"]; !ok {

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -803,7 +803,7 @@ func ExpectedGetParams() []parameter.TOParameter {
 	value := "3000"
 	return []parameter.TOParameter{
 		{
-			InfoImpl: api.InfoImpl{ReqInfo: nil},
+			InfoerImpl: api.InfoerImpl{ReqInfo: nil},
 			ParameterNullable: tc.ParameterNullable{
 				ConfigFile:  nil,
 				ID:          nil,

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring_test.go
@@ -803,7 +803,7 @@ func ExpectedGetParams() []parameter.TOParameter {
 	value := "3000"
 	return []parameter.TOParameter{
 		{
-			APIInfoImpl: api.APIInfoImpl{ReqInfo: nil},
+			InfoImpl: api.InfoImpl{ReqInfo: nil},
 			ParameterNullable: tc.ParameterNullable{
 				ConfigFile:  nil,
 				ID:          nil,

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -45,7 +45,7 @@ import (
 
 //we need a type alias to define functions on
 type TOOrigin struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.Origin
 }
 

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -45,7 +45,7 @@ import (
 
 //we need a type alias to define functions on
 type TOOrigin struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.Origin
 }
 

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -52,7 +52,7 @@ var (
 
 //we need a type alias to define functions on
 type TOParameter struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.ParameterNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -52,12 +52,12 @@ var (
 
 //we need a type alias to define functions on
 type TOParameter struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.ParameterNullable
 }
 
 func (v *TOParameter) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "parameter")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "parameter")
 }
 
 // AllowMultipleCreates indicates whether an array can be POSTed using the shared Create handler
@@ -148,12 +148,12 @@ func (param *TOParameter) Read(h http.Header, useIMS bool) ([]interface{}, error
 	var runSecond bool
 	code := http.StatusOK
 	queryParamsToQueryCols := param.ParamColumns()
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(param.APIInfo().Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(param.Info().Params, queryParamsToQueryCols)
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(param.APIInfo().Tx, h, queryValues, param.SelectMaxLastUpdatedQuery(where, orderBy, pagination, "parameter"))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(param.Info().Tx, h, queryValues, param.SelectMaxLastUpdatedQuery(where, orderBy, pagination, "parameter"))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return []interface{}{}, nil, nil, http.StatusNotModified, &maxTime

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -100,7 +100,7 @@ func TestGetParameters(t *testing.T) {
 		Params: map[string]string{"name": "1"},
 	}
 	obj := TOParameter{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -94,13 +94,13 @@ func TestGetParameters(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{
+	reqInfo := api.Info{
 		Tx:     db.MustBegin(),
 		User:   &auth.CurrentUser{PrivLevel: 30},
 		Params: map[string]string{"name": "1"},
 	}
 	obj := TOParameter{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters_test.go
@@ -100,7 +100,7 @@ func TestGetParameters(t *testing.T) {
 		Params: map[string]string{"name": "1"},
 	}
 	obj := TOParameter{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -35,12 +35,12 @@ import (
 
 //we need a type alias to define functions on
 type TOPhysLocation struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.PhysLocationNullable
 }
 
 func (v *TOPhysLocation) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "phys_location")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "phys_location")
 }
 
 func (v *TOPhysLocation) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -105,7 +105,7 @@ func (pl *TOPhysLocation) Validate() error {
 }
 
 func (pl *TOPhysLocation) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(pl.APIInfo(), "name")
+	api.DefaultSort(pl.Info(), "name")
 	return api.GenericRead(h, pl, useIMS)
 }
 func (v *TOPhysLocation) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -35,7 +35,7 @@ import (
 
 //we need a type alias to define functions on
 type TOPhysLocation struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.PhysLocationNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -96,9 +96,9 @@ func TestGetPhysLocations(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOPhysLocation{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.PhysLocationNullable{},
 	}
 	physLocations, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -98,7 +98,7 @@ func TestGetPhysLocations(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOPhysLocation{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.PhysLocationNullable{},
 	}
 	physLocations, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations_test.go
@@ -98,7 +98,7 @@ func TestGetPhysLocations(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 	obj := TOPhysLocation{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.PhysLocationNullable{},
 	}
 	physLocations, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/ping/vault.go
+++ b/traffic_ops/traffic_ops_golang/ping/vault.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Vault(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/plugins/plugins.go
+++ b/traffic_ops/traffic_ops_golang/plugins/plugins.go
@@ -32,7 +32,7 @@ import (
 // Get handler for getting enabled TO Plugins.
 func Get(p plugin.Plugins) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		inf, sysErr, userErr, errCode := api.NewInfo(r, nil, nil)
+		inf, sysErr, userErr, errCode := api.NewInfo(w, r, nil, nil)
 		if sysErr != nil || userErr != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/profile/copy.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy.go
@@ -71,10 +71,10 @@ func CopyProfileHandler(w http.ResponseWriter, r *http.Request) {
 	api.WriteRespAlertObj(w, r, tc.SuccessLevel, successMsg, p.Response)
 }
 
-func copyProfile(inf *api.APIInfo, p *tc.ProfileCopy) errorDetails {
+func copyProfile(inf *api.Info, p *tc.ProfileCopy) errorDetails {
 	if inf == nil || p == nil {
 		return errorDetails{
-			sysErr:  errors.New("copyProfile received nil APIInfo or ProfileCopy reference"),
+			sysErr:  errors.New("copyProfile received nil api.Info or ProfileCopy reference"),
 			errCode: http.StatusInternalServerError,
 		}
 	}
@@ -104,7 +104,7 @@ func copyProfile(inf *api.APIInfo, p *tc.ProfileCopy) errorDetails {
 		"name": p.ExistingName,
 	}
 	toProfile := &TOProfile{
-		api.APIInfoImpl{
+		api.InfoImpl{
 			ReqInfo: inf,
 		},
 		tc.ProfileNullable{},
@@ -173,14 +173,14 @@ func copyProfile(inf *api.APIInfo, p *tc.ProfileCopy) errorDetails {
 	return errorDetails{}
 }
 
-func copyParameters(inf *api.APIInfo, p *tc.ProfileCopy) errorDetails {
+func copyParameters(inf *api.Info, p *tc.ProfileCopy) errorDetails {
 	// use existing ProfileParameter CRUD helpers to find parameters for the existing profile
 	inf.Params = map[string]string{
 		"profileId": fmt.Sprintf("%d", p.ExistingID),
 	}
 
 	toParam := &profileparameter.TOProfileParameter{
-		APIInfoImpl: api.APIInfoImpl{
+		InfoImpl: api.InfoImpl{
 			ReqInfo: inf,
 		},
 	}

--- a/traffic_ops/traffic_ops_golang/profile/copy.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy.go
@@ -104,7 +104,7 @@ func copyProfile(inf *api.Info, p *tc.ProfileCopy) errorDetails {
 		"name": p.ExistingName,
 	}
 	toProfile := &TOProfile{
-		api.InfoImpl{
+		api.InfoerImpl{
 			ReqInfo: inf,
 		},
 		tc.ProfileNullable{},
@@ -180,7 +180,7 @@ func copyParameters(inf *api.Info, p *tc.ProfileCopy) errorDetails {
 	}
 
 	toParam := &profileparameter.TOProfileParameter{
-		InfoImpl: api.InfoImpl{
+		InfoerImpl: api.InfoerImpl{
 			ReqInfo: inf,
 		},
 	}

--- a/traffic_ops/traffic_ops_golang/profile/copy.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy.go
@@ -41,7 +41,7 @@ type errorDetails struct {
 
 // CopyProfileHandler creates a new profile and parameters from an existing profile.
 func CopyProfileHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profile/copy_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/copy_test.go
@@ -100,7 +100,7 @@ func TestCopyProfileInvalidExistingProfile(t *testing.T) {
 			mockFindProfile(t, mock, c.profile.Response.Name, c.mockProfileExists)
 			mockReadProfile(t, mock, c.existingProfile, c.mockReadProfile)
 
-			inf := api.APIInfo{
+			inf := api.Info{
 				Tx: db.MustBegin(),
 				Params: map[string]string{
 					"existing_profile": c.profile.Response.ExistingName,
@@ -155,7 +155,7 @@ func TestCopyNewProfileExists(t *testing.T) {
 
 	mockFindProfile(t, mock, profile.Response.Name, 1)
 
-	inf := api.APIInfo{
+	inf := api.Info{
 		Tx: db.MustBegin(),
 		Params: map[string]string{
 			"existing_profile": profile.Response.ExistingName,

--- a/traffic_ops/traffic_ops_golang/profile/profile_export.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_export.go
@@ -34,7 +34,7 @@ import (
 
 // ExportProfileHandler exports a profile per ID
 func ExportProfileHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{IDQueryParam}, []string{IDQueryParam})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{IDQueryParam}, []string{IDQueryParam})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profile/profile_import.go
+++ b/traffic_ops/traffic_ops_golang/profile/profile_import.go
@@ -34,7 +34,7 @@ import (
 
 // ImportProfileHandler handles importing profile
 func ImportProfileHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -58,7 +58,7 @@ const (
 
 //we need a type alias to define functions on
 type TOProfile struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.ProfileNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -98,10 +98,10 @@ func TestGetProfiles(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
 
 	obj := TOProfile{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ProfileNullable{},
 	}
 	profiles, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -101,7 +101,7 @@ func TestGetProfiles(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
 
 	obj := TOProfile{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ProfileNullable{},
 	}
 	profiles, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -101,7 +101,7 @@ func TestGetProfiles(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"name": "1"}}
 
 	obj := TOProfile{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ProfileNullable{},
 	}
 	profiles, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyid.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyid.go
@@ -29,7 +29,7 @@ import (
 )
 
 func GetProfileID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyname.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/parameterprofilebyname.go
@@ -29,7 +29,7 @@ import (
 )
 
 func GetProfileName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postparameterprofile.go
@@ -34,7 +34,7 @@ import (
 )
 
 func PostParamProfile(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparameter.go
@@ -34,7 +34,7 @@ import (
 )
 
 func PostProfileParam(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyid.go
@@ -31,7 +31,7 @@ import (
 )
 
 func PostProfileParamsByID(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/postprofileparametersbyname.go
@@ -33,7 +33,7 @@ import (
 )
 
 func PostProfileParamsByName(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -41,7 +41,7 @@ const (
 
 //we need a type alias to define functions on
 type TOProfileParameter struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.ProfileParameterNullable
 }
 
@@ -118,18 +118,18 @@ func (pp *TOProfileParameter) Validate() error {
 //to be added to the struct
 func (pp *TOProfileParameter) Create() (error, error, int) {
 	if pp.ProfileID != nil {
-		cdnName, err := dbhelpers.GetCDNNameFromProfileID(pp.ReqInfo.Tx.Tx, *pp.ProfileID)
+		cdnName, err := dbhelpers.GetCDNNameFromProfileID(pp.Info().Tx.Tx, *pp.ProfileID)
 		if err != nil {
 			return nil, err, http.StatusInternalServerError
 		}
-		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(pp.ReqInfo.Tx.Tx, string(cdnName), pp.ReqInfo.User.UserName)
+		userErr, sysErr, errCode := dbhelpers.CheckIfCurrentUserCanModifyCDN(pp.Info().Tx.Tx, string(cdnName), pp.Info().User.UserName)
 		if userErr != nil || sysErr != nil {
 			return userErr, sysErr, errCode
 		}
 	} else {
 		return errors.New("no profile ID in request"), nil, http.StatusBadRequest
 	}
-	resultRows, err := pp.APIInfo().Tx.NamedQuery(insertQuery(), pp)
+	resultRows, err := pp.Info().Tx.NamedQuery(insertQuery(), pp)
 	if err != nil {
 		return api.ParseDBError(err)
 	}
@@ -168,7 +168,7 @@ func (pp *TOProfileParameter) Update(h http.Header) (error, error, int) {
 	return nil, nil, http.StatusNotImplemented
 }
 func (pp *TOProfileParameter) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(pp.APIInfo(), "parameter")
+	api.DefaultSort(pp.Info(), "parameter")
 	return api.GenericRead(h, pp, useIMS)
 }
 func (pp *TOProfileParameter) Delete() (error, error, int) {

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -41,7 +41,7 @@ const (
 
 //we need a type alias to define functions on
 type TOProfileParameter struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.ProfileParameterNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -81,7 +81,7 @@ func TestGetProfileParameters(t *testing.T) {
 	txx := db.MustBegin()
 	reqInfo := api.Info{Tx: txx, Params: map[string]string{"profile": "1"}}
 	obj := TOProfileParameter{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.ProfileParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -79,9 +79,9 @@ func TestGetProfileParameters(t *testing.T) {
 	mock.ExpectCommit()
 
 	txx := db.MustBegin()
-	reqInfo := api.APIInfo{Tx: txx, Params: map[string]string{"profile": "1"}}
+	reqInfo := api.Info{Tx: txx, Params: map[string]string{"profile": "1"}}
 	obj := TOProfileParameter{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.ProfileParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters_test.go
@@ -81,7 +81,7 @@ func TestGetProfileParameters(t *testing.T) {
 	txx := db.MustBegin()
 	reqInfo := api.Info{Tx: txx, Params: map[string]string{"profile": "1"}}
 	obj := TOProfileParameter{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.ProfileParameterNullable{},
 	}
 	pps, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -32,7 +32,7 @@ import (
 
 //we need a type alias to define functions on
 type TORegion struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.Region
 }
 

--- a/traffic_ops/traffic_ops_golang/region/regions.go
+++ b/traffic_ops/traffic_ops_golang/region/regions.go
@@ -32,12 +32,12 @@ import (
 
 //we need a type alias to define functions on
 type TORegion struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.Region
 }
 
 func (v *TORegion) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, v.ID, "region")
+	return api.GetLastUpdated(v.Info().Tx, v.ID, "region")
 }
 
 func (v *TORegion) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = t }
@@ -105,7 +105,7 @@ func (region *TORegion) Validate() error {
 }
 
 func (rg *TORegion) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(rg.APIInfo(), "name")
+	api.DefaultSort(rg.Info(), "name")
 	return api.GenericRead(h, rg, useIMS)
 }
 func (v *TORegion) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -76,7 +76,7 @@ func TestReadRegions(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TORegion{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.Region{},
 	}
 	regions, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -74,9 +74,9 @@ func TestReadRegions(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TORegion{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.Region{},
 	}
 	regions, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/region/regions_test.go
+++ b/traffic_ops/traffic_ops_golang/region/regions_test.go
@@ -76,7 +76,7 @@ func TestReadRegions(t *testing.T) {
 
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"id": "1"}}
 	obj := TORegion{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.Region{},
 	}
 	regions, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -42,7 +42,7 @@ import (
 )
 
 type TORole struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.Role
 	LastUpdated    *tc.TimeNoMod   `json:"-"`
 	PQCapabilities *pq.StringArray `json:"-" db:"capabilities"`

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -42,7 +42,7 @@ import (
 )
 
 type TORole struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.Role
 	LastUpdated    *tc.TimeNoMod   `json:"-"`
 	PQCapabilities *pq.StringArray `json:"-" db:"capabilities"`
@@ -64,7 +64,7 @@ WHERE name=$2 RETURNING last_updated`
 }
 
 func (v *TORole) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "role")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "role")
 }
 
 func (v *TORole) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
@@ -193,7 +193,7 @@ func (role *TORole) deleteRoleCapabilityAssociations(tx *sqlx.Tx) (error, error,
 }
 
 func (role *TORole) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(role.APIInfo(), "name")
+	api.DefaultSort(role.Info(), "name")
 	vals, userErr, sysErr, errCode, maxTime := api.GenericRead(h, role, useIMS)
 	if errCode == http.StatusNotModified {
 		return []interface{}{}, nil, nil, errCode, maxTime

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -83,7 +83,7 @@ func TestValidate(t *testing.T) {
 	role := tc.Role{}
 	role.Name = &n
 	r := TORole{
-		InfoerImpl: api.InfoerImpl{&reqInfo},
+		InfoerImpl: api.InfoerImpl{ReqInfo: &reqInfo},
 		Role:       role,
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
@@ -103,7 +103,7 @@ func TestValidate(t *testing.T) {
 	role.Description = stringAddr("this is a description")
 	role.PrivLevel = intAddr(30)
 	r = TORole{
-		InfoerImpl: api.InfoerImpl{&reqInfo},
+		InfoerImpl: api.InfoerImpl{ReqInfo: &reqInfo},
 		Role:       role,
 	}
 	err := r.Validate()

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -83,8 +83,8 @@ func TestValidate(t *testing.T) {
 	role := tc.Role{}
 	role.Name = &n
 	r := TORole{
-		InfoImpl: api.InfoImpl{&reqInfo},
-		Role:     role,
+		InfoerImpl: api.InfoerImpl{&reqInfo},
+		Role:       role,
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
 
@@ -103,8 +103,8 @@ func TestValidate(t *testing.T) {
 	role.Description = stringAddr("this is a description")
 	role.PrivLevel = intAddr(30)
 	r = TORole{
-		InfoImpl: api.InfoImpl{&reqInfo},
-		Role:     role,
+		InfoerImpl: api.InfoerImpl{&reqInfo},
+		Role:       role,
 	}
 	err := r.Validate()
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -79,12 +79,12 @@ func TestInterfaces(t *testing.T) {
 func TestValidate(t *testing.T) {
 	// invalid name, empty domainname
 	n := "not_a_valid_role"
-	reqInfo := api.APIInfo{}
+	reqInfo := api.Info{}
 	role := tc.Role{}
 	role.Name = &n
 	r := TORole{
-		APIInfoImpl: api.APIInfoImpl{ReqInfo: &reqInfo},
-		Role:        role,
+		InfoImpl: api.InfoImpl{&reqInfo},
+		Role:     role,
 	}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(r.Validate())))
 
@@ -103,8 +103,8 @@ func TestValidate(t *testing.T) {
 	role.Description = stringAddr("this is a description")
 	role.PrivLevel = intAddr(30)
 	r = TORole{
-		APIInfoImpl: api.APIInfoImpl{ReqInfo: &reqInfo},
-		Role:        role,
+		InfoImpl: api.InfoImpl{&reqInfo},
+		Role:     role,
 	}
 	err := r.Validate()
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -135,14 +135,14 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdn_locks/?$`, cdn_lock.Create, auth.PrivLevelOperations, nil, Authenticated, nil, 4134390562},
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdn_locks/?$`, cdn_lock.Delete, auth.PrivLevelOperations, nil, Authenticated, nil, 4134390564},
 
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `acme_accounts/providers?$`, acme.ReadProviders, auth.PrivLevelOperations, nil, Authenticated, nil, 4034390565},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `acme_accounts/providers/?$`, acme.ReadProviders, auth.PrivLevelOperations, nil, Authenticated, nil, 4034390565},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/sslkeys/generate/acme/?$`, deliveryservice.GenerateAcmeCertificates, auth.PrivLevelOperations, nil, Authenticated, nil, 2534390576},
 
 		// ACME account information
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `acme_accounts/?$`, acme.Read, auth.PrivLevelAdmin, nil, Authenticated, nil, 4034390561},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `acme_accounts/?$`, acme.Create, auth.PrivLevelAdmin, nil, Authenticated, nil, 4034390562},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `acme_accounts/?$`, acme.Update, auth.PrivLevelAdmin, nil, Authenticated, nil, 4034390563},
-		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `acme_accounts/{provider}/{email}?$`, acme.Delete, auth.PrivLevelAdmin, nil, Authenticated, nil, 4034390564},
+		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `acme_accounts/{provider}/{email}/?$`, acme.Delete, auth.PrivLevelAdmin, nil, Authenticated, nil, 4034390564},
 
 		//Delivery service ACME
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `deliveryservices/xmlId/{xmlid}/sslkeys/renew$`, deliveryservice.RenewAcmeCertificate, auth.PrivLevelOperations, nil, Authenticated, nil, 2534390573},

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -1310,14 +1310,13 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 func MemoryStatsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := runtime.MemStats{}
 		runtime.ReadMemStats(&stats)
 
 		bytes, err := json.Marshal(stats)
 		if err != nil {
-			log.Errorln("unable to marshal stats: " + err.Error())
-			handleErrs(http.StatusInternalServerError, errors.New("marshalling error"))
+			err = fmt.Errorf("unable to marshal stats: %w", err)
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, errors.New("marshalling error"), err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1327,13 +1326,12 @@ func MemoryStatsHandler() http.HandlerFunc {
 
 func DBStatsHandler(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := db.DB.Stats()
 
 		bytes, err := json.Marshal(stats)
 		if err != nil {
-			log.Errorln("unable to marshal stats: " + err.Error())
-			handleErrs(http.StatusInternalServerError, errors.New("marshalling error"))
+			err = fmt.Errorf("unable to marshal stats: %v", err)
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, errors.New("marshalling error"), err)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/traffic_ops/traffic_ops_golang/server/detail.go
+++ b/traffic_ops/traffic_ops_golang/server/detail.go
@@ -72,7 +72,7 @@ func GetDetailParamHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	servers, err := getDetailServers(inf.Tx.Tx, inf.User, hostName, physLocationID, util.CamelToSnakeCase(orderBy), limit, *inf.Version)
+	servers, err := getDetailServers(inf.Tx.Tx, inf.User, hostName, physLocationID, util.CamelToSnakeCase(orderBy), limit, inf.Version)
 	respVals := map[string]interface{}{
 		"orderby": orderBy,
 		"limit":   limit,

--- a/traffic_ops/traffic_ops_golang/server/detail.go
+++ b/traffic_ops/traffic_ops_golang/server/detail.go
@@ -37,7 +37,7 @@ import (
 )
 
 func GetDetailParamHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/server/put_status.go
+++ b/traffic_ops/traffic_ops_golang/server/put_status.go
@@ -66,7 +66,7 @@ func InvalidStatusForDeliveryServicesAlertText(prefix, serverType string, dsIDs 
 
 // UpdateStatusHandler is the handler for PUT requests to the /servers/{{ID}}/status API endpoint.
 func UpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/server/queue_update.go
+++ b/traffic_ops/traffic_ops_golang/server/queue_update.go
@@ -35,7 +35,7 @@ import (
 // QueueUpdateHandler implements an http handler that updates a server's
 // upd_pending value.
 func QueueUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -1634,7 +1634,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	api.CreateChangeLogRawTx(api.ApiChange, changeLogMsg, inf.User, tx)
 }
 
-func createV2(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
+func createV2(inf *api.Info, w http.ResponseWriter, r *http.Request) {
 	var server tc.ServerNullableV2
 
 	tx := inf.Tx.Tx
@@ -1716,7 +1716,7 @@ func createV2(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 	api.CreateChangeLogRawTx(api.ApiChange, changeLogMsg, inf.User, tx)
 }
 
-func createV3(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
+func createV3(inf *api.Info, w http.ResponseWriter, r *http.Request) {
 	var server tc.ServerV30
 
 	tx := inf.Tx.Tx
@@ -1804,7 +1804,7 @@ func createV3(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 	api.CreateChangeLogRawTx(api.ApiChange, changeLogMsg, inf.User, tx)
 }
 
-func createV4(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
+func createV4(inf *api.Info, w http.ResponseWriter, r *http.Request) {
 	var server tc.ServerV40
 
 	tx := inf.Tx.Tx

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -822,7 +822,7 @@ and p.id = $1
 // Read is the handler for GET requests to /servers.
 func Read(w http.ResponseWriter, r *http.Request) {
 	var maxTime *time.Time
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)
@@ -1353,7 +1353,7 @@ func deleteInterfaces(id int, tx *sql.Tx) (error, error, int) {
 
 // Update is the handler for PUT requests to /servers.
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
@@ -1877,7 +1877,7 @@ func createV4(inf *api.Info, w http.ResponseWriter, r *http.Request) {
 
 // Create is the handler for POST requests to /servers.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -1947,7 +1947,7 @@ func getActiveDeliveryServicesThatOnlyHaveThisServerAssigned(id int, serverType 
 
 // Delete is the handler for DELETE requests to the /servers API endpoint.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/server/servers_assignment.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_assignment.go
@@ -118,7 +118,7 @@ func checkForLastServerInActiveDeliveryServices(serverID int, serverType string,
 
 // AssignDeliveryServicesToServerHandler is the handler for POST requests to /servers/{{ID}}/deliveryservices.
 func AssignDeliveryServicesToServerHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_server_capability.go
@@ -48,7 +48,7 @@ const (
 
 type (
 	TOServerServerCapability struct {
-		api.InfoImpl `json:"-"`
+		api.InfoerImpl `json:"-"`
 		tc.ServerServerCapability
 	}
 

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -32,7 +32,7 @@ import (
 )
 
 func GetServerUpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"host_name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"host_name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/server/servers_update_status.go
+++ b/traffic_ops/traffic_ops_golang/server/servers_update_status.go
@@ -44,7 +44,7 @@ func GetServerUpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
 		return
 	}
-	if inf.Version == nil || inf.Version.Major < 4 {
+	if inf.Version.Major < 4 {
 		api.WriteRespRaw(w, r, serverUpdateStatus)
 	} else {
 		api.WriteResp(w, r, serverUpdateStatus)

--- a/traffic_ops/traffic_ops_golang/server/update.go
+++ b/traffic_ops/traffic_ops_golang/server/update.go
@@ -33,7 +33,7 @@ import (
 
 // UpdateHandler implements an http handler that updates a server's upd_pending and reval_pending values.
 func UpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"id-or-name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"id-or-name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -35,8 +35,8 @@ import (
 )
 
 type TOServerCapability struct {
-	api.APIInfoImpl `json:"-"`
-	RequestedName   string
+	api.InfoImpl  `json:"-"`
+	RequestedName string
 	tc.ServerCapability
 }
 
@@ -116,7 +116,7 @@ func (v *TOServerCapability) Validate() error {
 }
 
 func (v *TOServerCapability) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(v.APIInfo(), "name")
+	api.DefaultSort(v.Info(), "name")
 	return api.GenericRead(h, v, useIMS)
 }
 

--- a/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
+++ b/traffic_ops/traffic_ops_golang/servercapability/servercapability.go
@@ -35,8 +35,8 @@ import (
 )
 
 type TOServerCapability struct {
-	api.InfoImpl  `json:"-"`
-	RequestedName string
+	api.InfoerImpl `json:"-"`
+	RequestedName  string
 	tc.ServerCapability
 }
 

--- a/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
@@ -35,7 +35,7 @@ import (
 
 // Create handler for creating a new servercheck extension.
 func Create(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -177,7 +177,7 @@ func selectQuery() string {
 
 // Get handler for getting servercheck extensions.
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -231,7 +231,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 // Delete is the handler for deleting servercheck extensions.
 func Delete(w http.ResponseWriter, r *http.Request) {
-	inf, sysErr, userErr, errCode := api.NewInfo(r, []string{"id"}, []string{"id"})
+	inf, sysErr, userErr, errCode := api.NewInfo(w, r, []string{"id"}, []string{"id"})
 	tx := inf.Tx.Tx
 	if sysErr != nil || userErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -213,7 +213,7 @@ func ReadServerCheck(w http.ResponseWriter, r *http.Request) {
 	api.WriteResp(w, r, data)
 }
 
-func handleReadServerCheck(inf *api.APIInfo, tx *sql.Tx) ([]tc.GenericServerCheck, error, error, int) {
+func handleReadServerCheck(inf *api.Info, tx *sql.Tx) ([]tc.GenericServerCheck, error, error, int) {
 	extensions := make(map[string]string)
 
 	// Query Parameters to Database Query column mappings

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -101,7 +101,7 @@ WHERE (type.name = 'CHECK_EXTENSION_BOOL' OR
 
 // CreateUpdateServercheck handles creating or updating an existing servercheck
 func CreateUpdateServercheck(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -196,7 +196,7 @@ DO UPDATE SET %[1]s = EXCLUDED.%[1]s`, colName)
 
 // ReadServerCheck is the handler for GET requests for /servercheck
 func ReadServerCheck(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -31,16 +31,16 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 )
 
 type TOServiceCategory struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.ServiceCategory
 }
 
 func (v *TOServiceCategory) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdatedByName(v.APIInfo().Tx, v.Name, "service_category")
+	return api.GetLastUpdatedByName(v.Info().Tx, v.Name, "service_category")
 }
 
 func (v *TOServiceCategory) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = t }
@@ -104,7 +104,7 @@ func (serviceCategory *TOServiceCategory) Create() (error, error, int) {
 }
 
 func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(serviceCategory.APIInfo(), "name")
+	api.DefaultSort(serviceCategory.Info(), "name")
 	serviceCategories, userErr, sysErr, errCode, maxTime := api.GenericRead(h, serviceCategory, useIMS)
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode, nil

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -114,7 +114,7 @@ func (serviceCategory *TOServiceCategory) Read(h http.Header, useIMS bool) ([]in
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
+++ b/traffic_ops/traffic_ops_golang/servicecategory/servicecategories.go
@@ -35,7 +35,7 @@ import (
 )
 
 type TOServiceCategory struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.ServiceCategory
 }
 

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -36,7 +36,7 @@ import (
 )
 
 type TOStaticDNSEntry struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.StaticDNSEntryNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry.go
@@ -36,12 +36,12 @@ import (
 )
 
 type TOStaticDNSEntry struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.StaticDNSEntryNullable
 }
 
 func (v *TOStaticDNSEntry) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "staticdnsentry")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "staticdnsentry")
 }
 
 func (v *TOStaticDNSEntry) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -139,7 +139,7 @@ func (staticDNSEntry TOStaticDNSEntry) Validate() error {
 }
 
 func (en *TOStaticDNSEntry) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(en.APIInfo(), "host")
+	api.DefaultSort(en.Info(), "host")
 	return api.GenericRead(h, en, useIMS)
 }
 func (en *TOStaticDNSEntry) Create() (error, error, int) {

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -86,9 +86,9 @@ func TestValidate(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	tx := db.MustBegin()
 
-	reqInfo := api.APIInfo{Tx: tx}
+	reqInfo := api.Info{Tx: tx}
 	// invalid name, empty domainname
-	ts := TOStaticDNSEntry{APIInfoImpl: api.APIInfoImpl{ReqInfo: &reqInfo}}
+	ts := TOStaticDNSEntry{InfoImpl: api.InfoImpl{&reqInfo}}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(ts.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -88,7 +88,7 @@ func TestValidate(t *testing.T) {
 
 	reqInfo := api.Info{Tx: tx}
 	// invalid name, empty domainname
-	ts := TOStaticDNSEntry{InfoerImpl: api.InfoerImpl{&reqInfo}}
+	ts := TOStaticDNSEntry{InfoerImpl: api.InfoerImpl{ReqInfo: &reqInfo}}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(ts.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{

--- a/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
+++ b/traffic_ops/traffic_ops_golang/staticdnsentry/staticdnsentry_test.go
@@ -88,7 +88,7 @@ func TestValidate(t *testing.T) {
 
 	reqInfo := api.Info{Tx: tx}
 	// invalid name, empty domainname
-	ts := TOStaticDNSEntry{InfoImpl: api.InfoImpl{&reqInfo}}
+	ts := TOStaticDNSEntry{InfoerImpl: api.InfoerImpl{&reqInfo}}
 	errs := util.JoinErrsStr(test.SortErrors(test.SplitErrors(ts.Validate())))
 
 	expectedErrs := util.JoinErrsStr([]error{

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -37,7 +37,7 @@ import (
 
 //we need a type alias to define functions on
 type TOStatus struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.StatusNullable
 	SQLDescription sql.NullString `json:"-" db:"description"`
 }

--- a/traffic_ops/traffic_ops_golang/status/statuses.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses.go
@@ -37,13 +37,13 @@ import (
 
 //we need a type alias to define functions on
 type TOStatus struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.StatusNullable
 	SQLDescription sql.NullString `json:"-" db:"description"`
 }
 
 func (v *TOStatus) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "status")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "status")
 }
 
 func (v *TOStatus) SelectMaxLastUpdatedQuery(where, orderBy, pagination, tableName string) string {
@@ -105,7 +105,7 @@ func (status TOStatus) Validate() error {
 
 func (st *TOStatus) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
 	errCode := http.StatusOK
-	api.DefaultSort(st.APIInfo(), "name")
+	api.DefaultSort(st.Info(), "name")
 	readVals, userErr, sysErr, errCode, maxTime := api.GenericRead(h, st, useIMS)
 	if userErr != nil || sysErr != nil {
 		return nil, userErr, sysErr, errCode, nil

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -79,7 +79,7 @@ func TestReadStatuses(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOStatus{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.StatusNullable{},
 		sql.NullString{},
 	}

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -79,7 +79,7 @@ func TestReadStatuses(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOStatus{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.StatusNullable{},
 		sql.NullString{},
 	}

--- a/traffic_ops/traffic_ops_golang/status/statuses_test.go
+++ b/traffic_ops/traffic_ops_golang/status/statuses_test.go
@@ -76,10 +76,10 @@ func TestReadStatuses(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOStatus{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.StatusNullable{},
 		sql.NullString{},
 	}

--- a/traffic_ops/traffic_ops_golang/steering/steering.go
+++ b/traffic_ops/traffic_ops_golang/steering/steering.go
@@ -33,7 +33,7 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -40,7 +40,7 @@ import (
 )
 
 type TOSteeringTargetV11 struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.SteeringTargetNullable
 	DSTenantID  *int          `json:"-" db:"tenant"`
 	LastUpdated *tc.TimeNoMod `json:"-" db:"last_updated"`

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -40,7 +40,7 @@ import (
 )
 
 type TOSteeringTargetV11 struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.SteeringTargetNullable
 	DSTenantID  *int          `json:"-" db:"tenant"`
 	LastUpdated *tc.TimeNoMod `json:"-" db:"last_updated"`

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets_test.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets_test.go
@@ -67,13 +67,13 @@ func TestInvalidSteeringTargetType(t *testing.T) {
 	m := make(map[string]string)
 	m["deliveryservice"] = "3"
 	stObj := &TOSteeringTargetV11{
-		InfoImpl: api.InfoImpl{
+		InfoerImpl: api.InfoerImpl{
 			ReqInfo: &api.Info{
 				Params:    m,
 				IntParams: nil,
 				User:      nil,
 				ReqID:     0,
-				Version:   nil,
+				Version:   api.Version{},
 				Tx:        tx,
 				Config:    nil,
 			},

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets_test.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets_test.go
@@ -20,12 +20,13 @@ package steeringtargets
  */
 
 import (
+	"testing"
+
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
-	"testing"
 )
 
 func TestInvalidSteeringTargetType(t *testing.T) {
@@ -66,8 +67,8 @@ func TestInvalidSteeringTargetType(t *testing.T) {
 	m := make(map[string]string)
 	m["deliveryservice"] = "3"
 	stObj := &TOSteeringTargetV11{
-		APIInfoImpl: api.APIInfoImpl{
-			ReqInfo: &api.APIInfo{
+		InfoImpl: api.InfoImpl{
+			ReqInfo: &api.Info{
 				Params:    m,
 				IntParams: nil,
 				User:      nil,

--- a/traffic_ops/traffic_ops_golang/systeminfo/system_info.go
+++ b/traffic_ops/traffic_ops_golang/systeminfo/system_info.go
@@ -32,7 +32,7 @@ import (
 )
 
 func Get(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/topology/queue_update.go
+++ b/traffic_ops/traffic_ops_golang/topology/queue_update.go
@@ -61,7 +61,7 @@ func Validate(reqObj tc.TopologiesQueueUpdateRequest, topologyName tc.TopologyNa
 
 // QueueUpdateHandler queues server updates for all servers in all cachegroups included in a given topology.
 func QueueUpdateHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"name"}, []string{})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"name"}, []string{})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -44,9 +44,9 @@ import (
 
 // TOTopology is a type alias on which we can define functions.
 type TOTopology struct {
-	api.APIInfoImpl `json:"-"`
-	Alerts          tc.Alerts `json:"-"`
-	RequestedName   string
+	api.InfoImpl  `json:"-"`
+	Alerts        tc.Alerts `json:"-"`
+	RequestedName string
 	tc.Topology
 }
 
@@ -116,7 +116,7 @@ func (topology *TOTopology) Validate() error {
 		rules[fmt.Sprintf("node %v self parent", index)] = checkForSelfParents(topology.Nodes, index)
 		cacheGroupNames[index] = node.Cachegroup
 	}
-	if cacheGroupMap, userErr, sysErr, _ = cachegroup.GetCacheGroupsByName(cacheGroupNames, topology.APIInfoImpl.ReqInfo.Tx); userErr != nil || sysErr != nil {
+	if cacheGroupMap, userErr, sysErr, _ = cachegroup.GetCacheGroupsByName(cacheGroupNames, topology.InfoImpl.ReqInfo.Tx); userErr != nil || sysErr != nil {
 		var err error
 		message := "could not get cachegroups"
 		if userErr != nil {
@@ -273,7 +273,7 @@ func (topology *TOTopology) nodesInOtherTopologies() ([]tc.TopologyNode, map[str
 
 func (topology TOTopology) validateDSRequiredCapabilities(currentTopoName string) error {
 	baseError := errors.New("unable to verify that delivery service required capabilities are satisfied")
-	tx := topology.APIInfo().Tx.Tx
+	tx := topology.Info().Tx.Tx
 	dsRequiredCapabilities, dsCDNs, err := getDSRequiredCapabilitiesByTopology(currentTopoName, tx)
 	if err != nil {
 		log.Errorf("validating delivery service required capabilities for topology %s: %v", currentTopoName, err)
@@ -409,7 +409,7 @@ func (topology *TOTopology) GetAuditName() string {
 
 // Create is a requirement of the api.Creator interface.
 func (topology *TOTopology) Create() (error, error, int) {
-	tx := topology.APIInfo().Tx.Tx
+	tx := topology.Info().Tx.Tx
 	userErr, sysErr, statusCode := topology.checkIfTopologyCanBeAlteredByCurrentUser()
 	if userErr != nil || sysErr != nil {
 		return userErr, sysErr, statusCode
@@ -606,7 +606,7 @@ func (topology *TOTopology) Update(h http.Header) (error, error, int) {
 	}
 
 	// check if the entity was already updated
-	userErr, sysErr, errCode = api.CheckIfUnModifiedByName(h, topology.ReqInfo.Tx, topology.Name, "topology")
+	userErr, sysErr, errCode = api.CheckIfUnModifiedByName(h, topology.InfoImpl.Tx, topology.Name, "topology")
 	if userErr != nil || sysErr != nil {
 		return userErr, sysErr, errCode
 	}
@@ -614,7 +614,7 @@ func (topology *TOTopology) Update(h http.Header) (error, error, int) {
 	if userErr != nil || sysErr != nil {
 		return userErr, sysErr, statusCode
 	}
-	oldTopology := TOTopology{APIInfoImpl: topology.APIInfoImpl, Topology: topologies[0].(tc.Topology)}
+	oldTopology := TOTopology{InfoImpl: topology.InfoImpl, Topology: topologies[0].(tc.Topology)}
 
 	if err := oldTopology.removeParents(); err != nil {
 		return nil, err, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/trafficstats/cache.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/cache.go
@@ -89,7 +89,7 @@ func cacheConfigFromRequest(r *http.Request, i *api.Info) (tc.TrafficCacheStatsC
 // GetCacheStats handler for getting cache stats
 func GetCacheStats(w http.ResponseWriter, r *http.Request) {
 	// Perl didn't require "interval", but it would only return summary data if it was not given
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"metricType", "startDate", "endDate", "cdnName"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"metricType", "startDate", "endDate", "cdnName"}, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/trafficstats/cache.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/cache.go
@@ -64,7 +64,7 @@ AND time < $end
 GROUP BY time(%s, %s), cdn%s`
 )
 
-func cacheConfigFromRequest(r *http.Request, i *api.APIInfo) (tc.TrafficCacheStatsConfig, int, error) {
+func cacheConfigFromRequest(r *http.Request, i *api.Info) (tc.TrafficCacheStatsConfig, int, error) {
 	c := tc.TrafficCacheStatsConfig{}
 	statsConfig, rc, e := tsConfigFromRequest(r, i)
 	if e != nil {

--- a/traffic_ops/traffic_ops_golang/trafficstats/cdn.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/cdn.go
@@ -43,7 +43,7 @@ SELECT last(value) FROM "%s"."monthly"."%s"
 
 // GetCurrentStats handler for getting current stats for CDNs
 func GetCurrentStats(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 
 	if userErr != nil || sysErr != nil {

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -75,7 +75,7 @@ const (
 		GROUP BY time(%s, %s), cachegroup%s`
 )
 
-func dsConfigFromRequest(r *http.Request, i *api.APIInfo) (tc.TrafficDSStatsConfig, int, error) {
+func dsConfigFromRequest(r *http.Request, i *api.Info) (tc.TrafficDSStatsConfig, int, error) {
 	c := tc.TrafficDSStatsConfig{}
 	statsConfig, rc, e := tsConfigFromRequest(r, i)
 	if e != nil {
@@ -178,7 +178,7 @@ func GetDSStats(w http.ResponseWriter, r *http.Request) {
 	handleRequest(w, r, client, c, inf)
 }
 
-func handleRequest(w http.ResponseWriter, r *http.Request, client *influx.Client, cfg tc.TrafficDSStatsConfig, inf *api.APIInfo) {
+func handleRequest(w http.ResponseWriter, r *http.Request, client *influx.Client, cfg tc.TrafficDSStatsConfig, inf *api.Info) {
 	// TODO: as above, this could be done on TO itself, thus sending only one synchronous request
 	// per hit on this endpoint, rather than the current two. Not sure if that's worth it for large
 	// data sets, though.

--- a/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/deliveryservice.go
@@ -116,7 +116,7 @@ func dsConfigFromRequest(r *http.Request, i *api.Info) (tc.TrafficDSStatsConfig,
 // GetDSStats handler for getting deliveryservice stats
 func GetDSStats(w http.ResponseWriter, r *http.Request) {
 	// Perl didn't require "interval", but it would only return summary data if it was not given
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"metricType", "startDate", "endDate"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"metricType", "startDate", "endDate"}, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -50,7 +50,7 @@ func GetStatsSummary(w http.ResponseWriter, r *http.Request) {
 	return
 }
 
-func getLastSummaryDate(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) {
+func getLastSummaryDate(w http.ResponseWriter, r *http.Request, inf *api.Info) {
 	queryParamsToSQLCols := map[string]dbhelpers.WhereColumnInfo{
 		"statName": dbhelpers.WhereColumnInfo{Column: "stat_name"},
 	}
@@ -72,7 +72,7 @@ func getLastSummaryDate(w http.ResponseWriter, r *http.Request, inf *api.APIInfo
 	api.WriteResp(w, r, resp)
 }
 
-func getStatsSummary(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) {
+func getStatsSummary(w http.ResponseWriter, r *http.Request, inf *api.Info) {
 	queryParamsToSQLCols := map[string]dbhelpers.WhereColumnInfo{
 		"statName":            dbhelpers.WhereColumnInfo{Column: "stat_name"},
 		"cdnName":             dbhelpers.WhereColumnInfo{Column: "cdn_name"},

--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -33,7 +33,7 @@ import (
 
 // GetStatsSummary handler for getting stats summaries
 func GetStatsSummary(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{}, []string{})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{}, []string{})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -113,7 +113,7 @@ func queryStatsSummary(tx *sqlx.Tx, q string, queryValues map[string]interface{}
 
 // CreateStatsSummary handler for creating stats summaries
 func CreateStatsSummary(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{}, []string{})
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{}, []string{})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/trafficstats/util.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/util.go
@@ -50,7 +50,7 @@ const (
 	defaultInterval = "1m"
 )
 
-func tsConfigFromRequest(r *http.Request, i *api.APIInfo) (tc.TrafficStatsConfig, int, error) {
+func tsConfigFromRequest(r *http.Request, i *api.Info) (tc.TrafficStatsConfig, int, error) {
 	c := tc.TrafficStatsConfig{}
 	var e error
 	if accept := r.Header.Get("Accept"); accept != "" {

--- a/traffic_ops/traffic_ops_golang/trafficstats/util_test.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/util_test.go
@@ -41,7 +41,7 @@ func TestTSConfigFromRequest(t *testing.T) {
 		t.Fatalf("Failed to parse test end time: %v", err)
 	}
 
-	inf := api.APIInfo{
+	inf := api.Info{
 		Params: map[string]string{
 			"limit":      "10",
 			"offset":     "0",

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -38,7 +38,7 @@ import (
 
 // TOType is a needed type alias to define functions on.
 type TOType struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.TypeNullable
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types.go
+++ b/traffic_ops/traffic_ops_golang/types/types.go
@@ -38,12 +38,12 @@ import (
 
 // TOType is a needed type alias to define functions on.
 type TOType struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.TypeNullable
 }
 
 func (v *TOType) GetLastUpdated() (*time.Time, bool, error) {
-	return api.GetLastUpdated(v.APIInfo().Tx, *v.ID, "type")
+	return api.GetLastUpdated(v.Info().Tx, *v.ID, "type")
 }
 
 func (v *TOType) SetLastUpdated(t tc.TimeNoMod) { v.LastUpdated = &t }
@@ -107,7 +107,7 @@ func (typ *TOType) Validate() error {
 }
 
 func (tp *TOType) Read(h http.Header, useIMS bool) ([]interface{}, error, error, int, *time.Time) {
-	api.DefaultSort(tp.APIInfo(), "name")
+	api.DefaultSort(tp.Info(), "name")
 	return api.GenericRead(h, tp, useIMS)
 }
 

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -86,10 +86,10 @@ func TestGetType(t *testing.T) {
 	mock.ExpectQuery("SELECT").WillReturnRows(rows)
 	mock.ExpectCommit()
 
-	reqInfo := api.APIInfo{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
+	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOType{
-		api.APIInfoImpl{ReqInfo: &reqInfo},
+		api.InfoImpl{&reqInfo},
 		tc.TypeNullable{},
 	}
 	types, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -129,7 +129,7 @@ func createDummyType(field string) *TOType {
 		Major: 2,
 		Minor: 0,
 	}
-	apiInfo := api.APIInfo{
+	apiInfo := api.Info{
 		Version: &version,
 	}
 	return &TOType{
@@ -138,7 +138,7 @@ func createDummyType(field string) *TOType {
 			Description: &field,
 			UseInTable:  &field,
 		},
-		APIInfoImpl: api.APIInfoImpl{
+		InfoImpl: api.InfoImpl{
 			ReqInfo: &apiInfo,
 		},
 	}

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -89,7 +89,7 @@ func TestGetType(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOType{
-		api.InfoImpl{&reqInfo},
+		api.InfoerImpl{&reqInfo},
 		tc.TypeNullable{},
 	}
 	types, userErr, sysErr, _, _ := obj.Read(nil, false)
@@ -130,7 +130,7 @@ func createDummyType(field string) *TOType {
 		Minor: 0,
 	}
 	apiInfo := api.Info{
-		Version: &version,
+		Version: version,
 	}
 	return &TOType{
 		TypeNullable: tc.TypeNullable{
@@ -138,7 +138,7 @@ func createDummyType(field string) *TOType {
 			Description: &field,
 			UseInTable:  &field,
 		},
-		InfoImpl: api.InfoImpl{
+		InfoerImpl: api.InfoerImpl{
 			ReqInfo: &apiInfo,
 		},
 	}

--- a/traffic_ops/traffic_ops_golang/types/types_test.go
+++ b/traffic_ops/traffic_ops_golang/types/types_test.go
@@ -89,7 +89,7 @@ func TestGetType(t *testing.T) {
 	reqInfo := api.Info{Tx: db.MustBegin(), Params: map[string]string{"dsId": "1"}}
 
 	obj := TOType{
-		api.InfoerImpl{&reqInfo},
+		api.InfoerImpl{ReqInfo: &reqInfo},
 		tc.TypeNullable{},
 	}
 	types, userErr, sysErr, _, _ := obj.Read(nil, false)

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -38,7 +38,7 @@ import (
 
 // endpoint handler for fetching uri signing keys from riak
 func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -74,7 +74,7 @@ func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 
 // removeDeliveryServiceURIKeysHandler is the HTTP DELETE handler used to remove urisigning keys assigned to a delivery service.
 func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -134,7 +134,7 @@ func RemoveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request)
 
 // saveDeliveryServiceURIKeysHandler is the HTTP POST or PUT handler used to store urisigning keys to a delivery service.
 func SaveDeliveryServiceURIKeysHandler(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -112,12 +112,7 @@ func Current(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	version := inf.Version
-	if version == nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, fmt.Errorf("TOUsers.Read called with invalid API version"), nil)
-		return
-	}
-	if version.Major >= 4 {
+	if inf.Version.Major >= 4 {
 		api.WriteResp(w, r, currentUser)
 	} else {
 		legacyUser := currentUser.Downgrade()

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -99,7 +99,7 @@ RETURNING address_line1,
 `
 
 func Current(w http.ResponseWriter, r *http.Request) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return
@@ -163,7 +163,7 @@ WHERE u.id=$1
 func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 	var useV4User bool
 	var userV4 tc.UserV4
-	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, tx, errCode, userErr, sysErr)

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -40,13 +40,13 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
 	"github.com/jmoiron/sqlx"
 )
 
 type TOUser struct {
-	api.APIInfoImpl `json:"-"`
+	api.InfoImpl `json:"-"`
 	tc.User
 }
 
@@ -204,7 +204,7 @@ func (this *TOUser) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	var runSecond bool
 	var query string
 
-	inf := this.APIInfo()
+	inf := this.Info()
 	api.DefaultSort(inf, "username")
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, this.ParamColumns())
 	if len(errs) > 0 {
@@ -218,7 +218,7 @@ func (this *TOUser) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	where, queryValues = dbhelpers.AddTenancyCheck(where, queryValues, "u.tenant_id", tenantIDs)
 
 	if useIMS {
-		runSecond, maxTime = ims.TryIfModifiedSinceQuery(this.APIInfo().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
+		runSecond, maxTime = ims.TryIfModifiedSinceQuery(this.Info().Tx, h, queryValues, selectMaxLastUpdatedQuery(where))
 		if !runSecond {
 			log.Debugln("IMS HIT")
 			return []interface{}{}, nil, nil, http.StatusNotModified, &maxTime

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -46,7 +46,7 @@ import (
 )
 
 type TOUser struct {
-	api.InfoImpl `json:"-"`
+	api.InfoerImpl `json:"-"`
 	tc.User
 }
 
@@ -232,9 +232,6 @@ func (this *TOUser) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	orderBy = groupBy + orderBy
 
 	version := inf.Version
-	if version == nil {
-		return nil, nil, fmt.Errorf("TOUsers.Read called with invalid API version"), http.StatusInternalServerError, nil
-	}
 	if version.Major >= 4 {
 		query = this.SelectQuery40() + where + orderBy + pagination
 	} else {

--- a/traffic_ops/traffic_ops_golang/vault/bucket.go
+++ b/traffic_ops/traffic_ops_golang/vault/bucket.go
@@ -39,7 +39,7 @@ func GetBucketKeyDeprecated(w http.ResponseWriter, r *http.Request) {
 }
 
 func getBucketKey(w http.ResponseWriter, r *http.Request, a tc.Alerts) {
-	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"bucket", "key"}, nil)
+	inf, userErr, sysErr, errCode := api.NewInfo(w, r, []string{"bucket", "key"}, nil)
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 		return


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR restructures the familiar `api.APIInfo` struct a bit. It retains a reference to an http response writer, allowing many `api` package functions to be aliased with a much shorter argument list.

For example,

```go
api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
```

can be called as simply
```go
inf.HandleErr(errCode, userErr, sysErr)
```

... allowing you to pass only the information that has actually changed since the handler function's execution began.

New methods include aliases for response writing, some IMS/IUS/IM niceties, parsing/parse-and-validating, and a handler for parsing and writing db errors in the same step, which converts

```go
if err := dbOperation(); err != nil {
    userErr, sysErr, errCode := api.ParseDBError(err)
    api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
    return
}
```
into
```go
if err := dbOperation(); err != nil {
    inf.HandleDBErr(err)
    return
}
```

This also changes the info struct's name from `api.APIInfo` to `api.Info` (because the former "stutters"), moves it and its methods to its own file, and changes the `Version` member from a reference to an `api.Version` to just an `api.Version` value. Apart from naming, call signature (now requires the response writer to construct) and that one field change, most code is untouched. However, the `/acme_accounts` handlers have been retooled to showcase the new Info methods, and part of the DSRs handler was also done to show off an IMS-related method (because `/acme_accounts` does not support IMS requests).

Also, this PR removed the deprecated `/lib/go-tc.GetHandleErrorsFunc` and the last three places it was used.

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make sure unit and client/TO integration tests still pass.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary, because the changes only affect internal development.
- [x] An update to CHANGELOG.md is not necessary because client-facing behavior is unaltered.
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**