### PR TITLE
Fix t3c apply to pass full path to check-reload

### DIFF
--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -289,6 +289,8 @@ func checkRefs(cfg config.Cfg, cfgFile []byte, filesAdding []string) error {
 
 // checkReload is a helper for the sub-command t3c-check-reload.
 func checkReload(mode t3cutil.Mode, pluginPackagesInstalled []string, changedConfigFiles []string) (t3cutil.ServiceNeeds, error) {
+	log.Infof("t3c-check-reload calling with mode '%v' pluginPackagesInstalled '%v' changedConfigFiles '%v'\n", mode, pluginPackagesInstalled, changedConfigFiles)
+
 	stdOut, stdErr, code := t3cutil.Do(`t3c`, `check`, `reload`,
 		"--run-mode="+mode.String(),
 		"--plugin-packages-installed="+strings.Join(pluginPackagesInstalled, ","),

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -488,7 +488,7 @@ func (r *TrafficOpsReq) replaceCfgFile(cfg *ConfigFile) error {
 		return errors.New("Failed to move temp '" + tmpFileName + "' to real '" + cfg.Path + "': " + err.Error())
 	}
 	cfg.ChangeApplied = true
-	r.changedFiles = append(r.changedFiles, cfg.Name)
+	r.changedFiles = append(r.changedFiles, filepath.Join(cfg.Path, cfg.Name))
 
 	r.RemapConfigReload = cfg.RemapPluginConfig ||
 		cfg.Name == "remap.config" ||

--- a/cache-config/testing/ort-tests/t3c-reload_test.go
+++ b/cache-config/testing/ort-tests/t3c-reload_test.go
@@ -32,45 +32,129 @@ func TestT3cReload(t *testing.T) {
 		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
 		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
 		tcdata.DeliveryServices}, func() {
-		t.Logf("------------- Start TestT3cReload Core ---------------")
 
-		cacheHostName := "atlanta-edge-03"
+		doTestT3cReloadHeaderRewrite(t)
+		doTestT3cReloadAnythingInTrafficserverDir(t)
+		doTestT3cReloadNoChange(t)
 
-		t.Logf("DEBUG TestT3cReload calling badass")
-		if stdOut, exitCode := t3cUpdateReload(cacheHostName, "badass"); exitCode != 0 {
-			t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
-		}
-
-		t.Logf("DEBUG TestT3cReload deleting file")
-
-		// delete a file that we know should trigger a reload.
-		fileNameToRemove := filepath.Join(test_config_dir, "hdr_rw_first_ds-top.config")
-		if err := os.Remove(fileNameToRemove); err != nil {
-			t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
-		}
-
-		t.Logf("DEBUG TestT3cReload setting upate flag")
-		// set the update flag, so syncds will run
-		if err := ExecTOUpdater("atlanta-edge-03", false, true); err != nil {
-			t.Fatalf("t3c-update failed: %v\n", err)
-		}
-
-		t.Logf("DEBUG TestT3cReload calling syncds")
-		stdOut, _ := t3cUpdateReload(cacheHostName, "syncds")
-		// Ignore the exit code error for now, because the ORT Integration Test Framework doesn't currently start ATS.
-		// TODO check err, after running ATS is added to the tests.
-		// if err != nil {
-		// 	t.Fatalf("t3c syncds failed: %v\n", err)
-		// }
-
-		t.Logf("DEBUG TestT3cReload looking for reload string")
-		if !strings.Contains(stdOut, `Running 'traffic_ctl config reload' now`) {
-			t.Errorf("expected t3c to do a reload after adding a header rewrite file, actual: '''%v'''\n", stdOut)
-		}
-
-		t.Logf("------------- End TestT3cReload Core ---------------")
 	})
 	t.Logf("------------- End of TestT3cReload ---------------")
+}
+
+func doTestT3cReloadHeaderRewrite(t *testing.T) {
+	t.Logf("------------- Start doTestT3cReloadHeaderRewrite ---------------")
+
+	cacheHostName := "atlanta-edge-03"
+
+	t.Logf("DEBUG TestT3cReload calling badass")
+	if stdOut, exitCode := t3cUpdateReload(cacheHostName, "badass"); exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	t.Logf("DEBUG TestT3cReload deleting file")
+
+	// delete a file that we know should trigger a reload.
+	fileNameToRemove := filepath.Join(test_config_dir, "hdr_rw_first_ds-top.config")
+	if err := os.Remove(fileNameToRemove); err != nil {
+		t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+	}
+
+	t.Logf("DEBUG TestT3cReload setting upate flag")
+	// set the update flag, so syncds will run
+	if err := ExecTOUpdater("atlanta-edge-03", false, true); err != nil {
+		t.Fatalf("t3c-update failed: %v\n", err)
+	}
+
+	t.Logf("DEBUG TestT3cReload calling syncds")
+	stdOut, _ := t3cUpdateReload(cacheHostName, "syncds")
+	// Ignore the exit code error for now, because the ORT Integration Test Framework doesn't currently start ATS.
+	// TODO check err, after running ATS is added to the tests.
+	// if err != nil {
+	// 	t.Fatalf("t3c syncds failed: %v\n", err)
+	// }
+
+	t.Logf("DEBUG TestT3cReload looking for reload string")
+	if !strings.Contains(stdOut, `Running 'traffic_ctl config reload' now`) {
+		t.Errorf("expected t3c to do a reload after adding a header rewrite file, actual: '''%v'''\n", stdOut)
+	}
+
+	t.Logf("------------- End TestT3cReload doTestT3cReloadHeaderRewrite ---------------")
+}
+
+func doTestT3cReloadAnythingInTrafficserverDir(t *testing.T) {
+	t.Logf("------------- Start doTestT3cReloadAnythingInTrafficserverDir ---------------")
+
+	cacheHostName := "atlanta-edge-03"
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite calling badass")
+	if stdOut, exitCode := t3cUpdateReload(cacheHostName, "badass"); exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite deleting file")
+
+	// delete a random file in etc/trafficserver which should trigger a reload
+	fileNameToRemove := filepath.Join(test_config_dir, "non-empty-file.config")
+	if err := os.Remove(fileNameToRemove); err != nil {
+		t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+	}
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite setting update flag")
+	// set the update flag, so syncds will run
+	if err := ExecTOUpdater("atlanta-edge-03", false, true); err != nil {
+		t.Fatalf("t3c-update failed: %v\n", err)
+	}
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite calling syncds")
+	stdOut, _ := t3cUpdateReload(cacheHostName, "syncds")
+	// Ignore the exit code error for now, because the ORT Integration Test Framework doesn't currently start ATS.
+	// TODO check err, after running ATS is added to the tests.
+	// if err != nil {
+	// 	t.Fatalf("t3c syncds failed: %v\n", err)
+	// }
+
+	t.Logf("DEBUG TestT3cReload looking for reload string")
+	if !strings.Contains(stdOut, `Running 'traffic_ctl config reload' now`) {
+		t.Errorf("expected t3c to do a reload after adding a etc/trafficserver file, actual: '''%v'''\n", stdOut)
+	}
+
+	t.Logf("------------- End TestT3cReload doTestT3cReloadAnythingInTrafficserverDir ---------------")
+}
+
+func doTestT3cReloadNoChange(t *testing.T) {
+	t.Logf("------------- Start doTestT3cReloadNoChange ---------------")
+
+	cacheHostName := "atlanta-edge-03"
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite calling badass")
+	if stdOut, exitCode := t3cUpdateReload(cacheHostName, "badass"); exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite deleting file")
+
+	// no change, should not trigger a reload
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite setting update flag")
+	// set the update flag, so syncds will run
+	if err := ExecTOUpdater("atlanta-edge-03", false, true); err != nil {
+		t.Fatalf("t3c-update failed: %v\n", err)
+	}
+
+	t.Logf("DEBUG doTestT3cReloadHeaderRewrite calling syncds")
+	stdOut, _ := t3cUpdateReload(cacheHostName, "syncds")
+	// Ignore the exit code error for now, because the ORT Integration Test Framework doesn't currently start ATS.
+	// TODO check err, after running ATS is added to the tests.
+	// if err != nil {
+	// 	t.Fatalf("t3c syncds failed: %v\n", err)
+	// }
+
+	t.Logf("DEBUG TestT3cReload looking for reload string")
+	if strings.Contains(stdOut, `Running 'traffic_ctl config reload' now`) {
+		t.Errorf("expected t3c to not reload after no change, actual: '''%v'''\n", stdOut)
+	}
+
+	t.Logf("------------- End TestT3cReload doTestT3cReloadNoChange ---------------")
 }
 
 func t3cUpdateReload(host string, runMode string) (string, int) {

--- a/cache-config/testing/ort-tests/t3c_mode_test.go
+++ b/cache-config/testing/ort-tests/t3c_mode_test.go
@@ -53,9 +53,32 @@ func TestT3cBadassAndSyncDs(t *testing.T) {
 		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
 		tcdata.DeliveryServices}, func() {
 
-		// run badass and check config files.
-		err := runApply("atlanta-edge-03", "badass")
+		// traffic_ctl doesn't work because the test framework doesn't currently run ATS.
+		// So, temporarily replace it with a no-op
+		// TODO: remove this when running ATS is added to the test framework
+
+		if err := os.Rename(`/opt/trafficserver/bin/traffic_ctl`, `/opt/trafficserver/bin/traffic_ctl.real`); err != nil {
+			t.Fatal("temporarily moving traffic_ctl: " + err.Error())
+		}
+
+		fi, err := os.OpenFile(`/opt/trafficserver/bin/traffic_ctl`, os.O_RDWR|os.O_CREATE, 755)
 		if err != nil {
+			t.Fatal("creating temp no-op traffic_ctl file: " + err.Error())
+		}
+		if _, err := fi.WriteString(`#!/usr/bin/env bash` + "\n"); err != nil {
+			fi.Close()
+			t.Fatal("writing temp no-op traffic_ctl file: " + err.Error())
+		}
+		fi.Close()
+
+		defer func() {
+			if err := os.Rename(`/opt/trafficserver/bin/traffic_ctl.real`, `/opt/trafficserver/bin/traffic_ctl`); err != nil {
+				t.Fatal("moving real traffic_ctl back: " + err.Error())
+			}
+		}()
+
+		// run badass and check config files.
+		if err := runApply("atlanta-edge-03", "badass"); err != nil {
 			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
 		}
 

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -1770,6 +1770,18 @@
                     "value": "/opt/trafficserver/etc/trafficserver/"
                 },
                 {
+                    "configFile": "non-empty-file.config",
+                    "name": "location",
+                    "secure": false,
+                    "value": "/opt/trafficserver/etc/trafficserver/"
+                },
+                {
+                    "configFile": "non-empty-file.config",
+                    "name": "foo",
+                    "secure": false,
+                    "value": "bar"
+                },
+                {
                     "configFile": "remap.config",
                     "name": "location",
             	      "secure": false,


### PR DESCRIPTION
Fixes t3c-apply not reloading for any file in etc/trafficserver, like
remap.config or parent.config.

Includes tests.
No docs, no changelog, no interface change and but isn't in a release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Change something that only changes remap.config and no other files, run t3c, verify ATS is reloaded.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information