### PR TITLE
Fix Traffic Vault postgres backend to match Riak backend for empty URI signing keys

### DIFF
--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -2035,6 +2035,29 @@ func DeleteTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Errorf("Unexpected error deleting URI Signing keys for Delivery Service '%s': %v - alerts: %+v", *firstDS.XMLID, err, resp.Alerts)
 	}
 
+	emptyBytes, _, err := TOSession.GetDeliveryServiceURISigningKeys(*firstDS.XMLID, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error getting URI signing keys for Delivery Service '%s': %v", *firstDS.XMLID, err)
+	}
+	emptyMap := make(map[string]interface{})
+	err = json.Unmarshal(emptyBytes, &emptyMap)
+	if err != nil {
+		t.Errorf("unexpected error unmarshalling empty URI signing keys response: %v", err)
+	}
+	renewalKid, hasRenewalKid := emptyMap["renewal_kid"]
+	keys, hasKeys := emptyMap["keys"]
+	if !hasRenewalKid {
+		t.Error("getting empty URI signing keys - expected: 'renewal_kid' key, actual: not present")
+	}
+	if !hasKeys {
+		t.Error("getting empty URI signing keys - expected: 'keys' key, actual: not present")
+	}
+	if renewalKid != nil {
+		t.Errorf("getting empty URI signing keys - expected: 'renewal_kid' value to be nil, actual: %+v", renewalKid)
+	}
+	if keys != nil {
+		t.Errorf("getting empty URI signing keys - expected: 'keys' value to be nil, actual: %+v", keys)
+	}
 }
 
 func GetDeliveryServiceByLogsEnabled(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/dsutil.go
+++ b/traffic_ops/traffic_ops_golang/trafficvault/backends/riaksvc/dsutil.go
@@ -238,11 +238,7 @@ func getURISigningKeys(tx *sql.Tx, authOpts *riak.AuthOptions, riakPort *uint, x
 		return nil, false, errors.New("fetching riak objects: " + err.Error())
 	}
 	if len(ro) == 0 {
-		bts, err := json.Marshal(tc.URISignerKeyset{})
-		if err != nil {
-			return nil, false, errors.New("marshalling empty URISignerKeyset: " + err.Error())
-		}
-		return bts, false, nil
+		return []byte{}, false, nil
 	}
 	if ro[0].Value == nil {
 		return ro[0].Value, false, nil

--- a/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
+++ b/traffic_ops/traffic_ops_golang/urisigning/urisigning.go
@@ -60,6 +60,13 @@ func GetURIsignkeysHandler(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting URI signing keys: "+err.Error()))
 		return
 	}
+	if len(ro) == 0 {
+		ro, err = json.Marshal(tc.URISignerKeyset{})
+		if err != nil {
+			api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("marshalling empty URISignerKeyset: "+err.Error()))
+			return
+		}
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(ro)
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

Make the Traffic Vault Postgres backend return the same JSON response as the Riak
backend when the delivery service has no URI signing keys.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Vault

## What is the best way to verify this PR?
Run the added TO API test with the Postgres Traffic Vault backend configured, followed by the Riak Traffic Vault backend, and verify both pass.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Bugfix, no docs necessary
- [x] No changelog necessary, unreleased bug
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
I'm not 100% sure if this disparity between the responses provided by the Postgres and Riak Traffic Vault backends in this case even causes any real world problems, but I'd rather be safe than sorry, especially since it is a simple fix.
