### PR TITLE
Fix Docs spacing/indentation and RFC3339 time

### DIFF
--- a/docs/source/admin/ansible-labs/ansible_labs.rst
+++ b/docs/source/admin/ansible-labs/ansible_labs.rst
@@ -37,9 +37,9 @@ Lab Implementation Concepts
 ===========================
 
 .. figure:: ATC.lab.layers.svg
-	 :scale: 100 %
-	 :align: center
-	 :figclass: align-center
+	:scale: 100 %
+	:align: center
+	:figclass: align-center
 
 The basic idea is to separate responsibilities to allow each implementation to use the tools/technologies that are already in use within their organizations.
 
@@ -150,9 +150,9 @@ It's very useful to still review the Administrator's Guide in the documentation 
 If you're attempting to optimize the wallclock time needed to deploy all the components in parallel, they should be installed like the following:
 
 .. figure:: ATC.Installation.dependencies.svg
-	 :scale: 100 %
-	 :align: center
-	 :figclass: align-center
+	:scale: 100 %
+	:align: center
+	:figclass: align-center
 
 Ansible Bonuses
 ===============

--- a/docs/source/admin/environment_creation.rst
+++ b/docs/source/admin/environment_creation.rst
@@ -51,4 +51,4 @@ Audience for Ansible-based Lab Deployment
 	:caption: Read more
 	:glob:
 
- 	ansible-labs/*
+	ansible-labs/*

--- a/docs/source/admin/quick_howto/anonymous_blocking.rst
+++ b/docs/source/admin/quick_howto/anonymous_blocking.rst
@@ -33,9 +33,9 @@ Configure Anonymous Blocking
 			"name": "Anonymous IP Blocking Policy",
 
 			"anonymousIp": { "blockAnonymousVPN": true,
-			                 "blockHostingProvider": true,
-			                 "blockPublicProxy": true,
-			                 "blockTorExitNode": true},
+				"blockHostingProvider": true,
+				"blockPublicProxy": true,
+				"blockTorExitNode": true},
 
 			"ip4Whitelist": ["192.168.30.0/24", "10.0.2.0/24", "10.1.1.1/32"],
 			"ip6Whitelist": ["2001:550:90a::/48", "::1/128"],

--- a/docs/source/admin/quick_howto/federations.rst
+++ b/docs/source/admin/quick_howto/federations.rst
@@ -77,9 +77,9 @@ Configure Federations
 		curl -ki -H "Cookie: mojolicious=eyJleHBpcmVzIjoxNDQ5MTA1MTI2LCJhdXRoX2RhdGEiOiJmZWRlcmF0aW9uX3VzZXIxIn0---06b4f870d809d82a91433e92eae8320875c3e8b0;" -XPUT 'http://localhost:3000/api/2.0/federations' -d '
 		{"federations": [
 			{ "deliveryService": "images-c1",
-			  "mappings":
+				"mappings":
 				{ "resolve4": [ "8.8.8.8/32", "8.8.4.4/32" ],
-				  "resolve6": ["2001:4860:4860::8888/128", "2001:4860:4860::8844"]
+					"resolve6": ["2001:4860:4860::8888/128", "2001:4860:4860::8844"]
 				}
 			}
 		]}'

--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -449,13 +449,13 @@ This file deals with the configuration parameters of running Traffic Ops itself.
 
 	:traffic_vault_backend:
 
-	    .. versionadded:: 6.0
-		    Optional. The name of which backend to use for Traffic Vault. Currently, the only supported backend is "riak".
+		.. versionadded:: 6.0
+			Optional. The name of which backend to use for Traffic Vault. Currently, the only supported backend is "riak".
 
 	:traffic_vault_config:
 
-	    .. versionadded:: 6.0
-		    Optional. The JSON configuration which is unique to the chosen Traffic Vault backend. See :ref:`traffic_vault_admin` for the configuration options for each supported backend.
+		.. versionadded:: 6.0
+			Optional. The JSON configuration which is unique to the chosen Traffic Vault backend. See :ref:`traffic_vault_admin` for the configuration options for each supported backend.
 
 	.. _admin-routing-blacklist:
 
@@ -475,8 +475,8 @@ This file deals with the configuration parameters of running Traffic Ops itself.
 
 :use_ims:
 
-    .. versionadded:: 5.0
-	    This is an optional boolean value to enable the handling of the "If-Modified-Since" HTTP request header. Default: false
+	.. versionadded:: 5.0
+		This is an optional boolean value to enable the handling of the "If-Modified-Since" HTTP request header. Default: false
 
 Example cdn.conf
 ''''''''''''''''
@@ -661,7 +661,7 @@ You will need to update `cdn.conf`_ with any necessary changes.
 
 	'hypnotoad' => ...
 		'listen' => 'https://[::]:443?cert=/etc/pki/tls/certs/trafficops.crt&key=/etc/pki/tls/private/trafficops.key&ca=/etc/pki/tls/certs/localhost.ca&verify=0x00&ciphers=AES128-GCM-SHA256:HIGH:!RC4:!MD5:!aNULL:!EDH:!ED'
-		 ...
+		...
 
 .. _admin-to-ext-script:
 

--- a/docs/source/admin/traffic_portal/usingtrafficportal.rst
+++ b/docs/source/admin/traffic_portal/usingtrafficportal.rst
@@ -370,7 +370,7 @@ Use the `Quick Search` to search across all table columns or the column filter t
 :Cache Group:       [Visible by default] The :ref:`Name of the Cache Group <cache-group-name>` to which this server belongs
 :CDN:               [Visible by default] The name of the CDN to which the server belongs
 :Domain:            [Visible by default] The domain part of the server's :abbr:`FQDN (Fully Qualified Domain Name)`
-:Hash ID:			The identifier of the server used in Traffic Router's consistent hashing algorithm.
+:Hash ID:           The identifier of the server used in Traffic Router's consistent hashing algorithm.
 :Host:              [Visible by default] The (short) hostname of the server
 :HTTPS Port:        The port on which the server listens for incoming HTTPS connections/requests
 :ID:                An integral, unique identifier for this server

--- a/docs/source/admin/traffic_router.rst
+++ b/docs/source/admin/traffic_router.rst
@@ -369,9 +369,9 @@ Normally, when performing consistent hashing for an HTTP-:ref:`routed <ds-types>
 
 .. caution:: Certain query parameters are reserved by Traffic Router for its own use, and thus cannot be present in any Consistent Hash Query Parameters. These reserved parameters are:
 
-	 - trred
-	 - format
-	 - fakeClientIPAddress
+	- trred
+	- format
+	- fakeClientIPAddress
 
 .. _tr-dnssec:
 
@@ -442,11 +442,11 @@ Example Request Flow
 The following is an example of the request flow when a client requests the routing name for an example delivery service, ``tr.service.cdn.example.com``. The request flow assumes that the resolver is cold and has yet to build a local cache of lookups, meaning it has to walk the domain hierarchy asking for ``NS`` records until it reaches ``service.cdn.example.com``. This example starts after the resolver has determined which name servers are authoritative for ``cdn.example.com``. Note that the same logic is applied for each of the three queries made by the resolver.
 
 .. figure:: traffic_router/images/edge_tr_example.png
-   :scale: 30%
-   :align: center
-   :alt: Example Request Flow for Edge Traffic Routing
+	:scale: 30%
+	:align: center
+	:alt: Example Request Flow for Edge Traffic Routing
 
-   Example Request Flow for Edge Traffic Routing. Note this picks up when the resolver hits the CDN managed domain.
+	Example Request Flow for Edge Traffic Routing. Note this picks up when the resolver hits the CDN managed domain.
 
 .. _tr-logs:
 

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -132,6 +132,11 @@ Traffic Ops will often return responses from its API that include dates. As of t
 
 .. note:: In practice, all Traffic Ops API responses use the UTC timezone (offset ``+00``), but do note that this custom format is not capable of representing all timezones.
 
+.. code-block:: text
+	:caption: Example Date/Timestamp
+
+	2021-06-07 08:01:02+00
+
 Using API Endpoints
 ===================
 #. Authenticate with valid Traffic Control user account credentials (the same used by Traffic Portal).

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -124,6 +124,14 @@ The following, reserved properties of ``summary`` are guaranteed to always have 
 ``count``
 	``count`` contains an unsigned integer that defines the total number of results that could possibly be returned given the non-pagination query parameters supplied by the client.
 
+.. _non-rfc-datetime:
+
+Traffic Ops's Custom Date/Time Format
+-------------------------------------
+Traffic Ops will often return responses from its API that include dates. As of the time of this writing, the vast majority of those dates are written in a non-:rfc:3339 format (this is tracked by :issue:`5911`). This is most commonly the case in the ``last_updated`` properties of objects returned as JSON-encoded documents. The format used is :samp:`{YYYY}-{MM}-{DD} {hh}:{mm}:{ss}±{ZZ}`, where ``YYYY`` is the 4-digit year, ``MM`` is the two-digit (zero padded) month, ``DD`` is the two-digit (zero padded) day of the month, ``hh`` is the two-digit (zero padded) hour of the day, ``mm`` is the two-digit (zero padded) minute of the hour, ``ss`` is the two-digit (zero padded) second of the minute, and ``ZZ`` is the two-digit (zero padded) timezone offset in hours of the date/time's local timezone from UTC (the offset can be positive or negative as indicated by a ``+`` or a ``-`` directly before it, where the sample has a ``±``).
+
+.. note:: In practice, all Traffic Ops API responses use the UTC timezone (offset ``+00``), but do note that this custom format is not capable of representing all timezones.
+
 Using API Endpoints
 ===================
 #. Authenticate with valid Traffic Control user account credentials (the same used by Traffic Portal).

--- a/docs/source/api/v1/api_capabilities.rst
+++ b/docs/source/api/v1/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -150,7 +150,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/api_capabilities.rst
+++ b/docs/source/api/v1/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -150,7 +150,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -182,4 +182,3 @@ Response Structure
 		"id": 273,
 		"capability": "types-write"
 	}}
-

--- a/docs/source/api/v1/api_capabilities_id.rst
+++ b/docs/source/api/v1/api_capabilities_id.rst
@@ -161,7 +161,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/api_capabilities_id.rst
+++ b/docs/source/api/v1/api_capabilities_id.rst
@@ -63,7 +63,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -161,7 +161,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/asns.rst
+++ b/docs/source/api/v1/asns.rst
@@ -73,7 +73,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -140,7 +140,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -171,4 +171,3 @@ Response Structure
 		"id": 1,
 		"lastUpdated": "2019-12-02 21:49:08+00"
 	}}
-

--- a/docs/source/api/v1/asns_id.rst
+++ b/docs/source/api/v1/asns_id.rst
@@ -58,7 +58,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -138,7 +138,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/cachegroupparameters.rst
+++ b/docs/source/api/v1/cachegroupparameters.rst
@@ -55,7 +55,7 @@ Response Structure
 :cachegroupParameters: An array of identifying information for the :ref:`cache-group-parameters` of :term:`Cache Groups`
 
 	:cachegroup:   A string containing the :ref:`cache-group-name` of the :term:`Cache Group`
-	:last_updated: Date and time of last modification in an ISO-like format
+	:last_updated: Date and time of last modification in :ref:`non-rfc-datetime`
 	:parameter:    An integer that is the :term:`Parameter`'s :ref:`parameter-id`
 
 .. code-block:: http

--- a/docs/source/api/v1/cachegroupparameters.rst
+++ b/docs/source/api/v1/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v1/cachegroups.rst
+++ b/docs/source/api/v1/cachegroups.rst
@@ -71,7 +71,7 @@ Response Structure
 
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 
@@ -200,7 +200,7 @@ Response Structure
 
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 

--- a/docs/source/api/v1/cachegroups_id.rst
+++ b/docs/source/api/v1/cachegroups_id.rst
@@ -68,7 +68,7 @@ Response Structure
 
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 
@@ -211,7 +211,7 @@ Response Structure
 
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 

--- a/docs/source/api/v1/cachegroups_id_parameters.rst
+++ b/docs/source/api/v1/cachegroups_id_parameters.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :secure:      A boolean value describing whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`

--- a/docs/source/api/v1/cachegroups_id_unassigned_parameters.rst
+++ b/docs/source/api/v1/cachegroups_id_unassigned_parameters.rst
@@ -65,7 +65,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`

--- a/docs/source/api/v1/capabilities.rst
+++ b/docs/source/api/v1/capabilities.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :name:        Name of the capability
 :description: Describes the permissions covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -123,7 +123,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the permissions covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 :name:        Name of the capability
 
 .. code-block:: http

--- a/docs/source/api/v1/capabilities_name.rst
+++ b/docs/source/api/v1/capabilities_name.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability
-:lastUpdated: Date and time of the last update made to this capability, in ISO format
+:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
 :name:        Name of the capability
 
 .. code-block:: http
@@ -129,7 +129,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in ISO format
+:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
 :name:        The name of the capability
 
 .. code-block:: http

--- a/docs/source/api/v1/capabilities_name.rst
+++ b/docs/source/api/v1/capabilities_name.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 :name:        Name of the capability
 
 .. code-block:: http
@@ -129,7 +129,7 @@ Request Structure
 Response Structure
 ------------------
 :description: Describes the APIs covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 :name:        The name of the capability
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns.rst
+++ b/docs/source/api/v1/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns.rst
+++ b/docs/source/api/v1/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns_id.rst
+++ b/docs/source/api/v1/cdns_id.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns_id.rst
+++ b/docs/source/api/v1/cdns_id.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http
@@ -193,4 +193,3 @@ Response Structure
 			"level": "success"
 		}
 	]}
-

--- a/docs/source/api/v1/cdns_name_federations.rst
+++ b/docs/source/api/v1/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_federations.rst
+++ b/docs/source/api/v1/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_federations_id.rst
+++ b/docs/source/api/v1/cdns_name_federations_id.rst
@@ -82,7 +82,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of the :ref:`to-api-v1-cdns-name-federations` endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -172,7 +172,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_federations_id.rst
+++ b/docs/source/api/v1/cdns_name_federations_id.rst
@@ -82,7 +82,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of the :ref:`to-api-v1-cdns-name-federations` endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -172,7 +172,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v1/cdns_name_name.rst
+++ b/docs/source/api/v1/cdns_name_name.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v1/cdns_name_name.rst
+++ b/docs/source/api/v1/cdns_name_name.rst
@@ -45,7 +45,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http
@@ -120,4 +120,3 @@ Response Structure
 			"level": "success"
 		}
 	]}
-

--- a/docs/source/api/v1/deliveryservices.rst
+++ b/docs/source/api/v1/deliveryservices.rst
@@ -113,7 +113,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -469,7 +469,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices.rst
+++ b/docs/source/api/v1/deliveryservices.rst
@@ -113,7 +113,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -469,7 +469,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id.rst
+++ b/docs/source/api/v1/deliveryservices_id.rst
@@ -121,7 +121,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id.rst
+++ b/docs/source/api/v1/deliveryservices_id.rst
@@ -121,7 +121,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id_safe.rst
+++ b/docs/source/api/v1/deliveryservices_id_safe.rst
@@ -111,7 +111,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id_safe.rst
+++ b/docs/source/api/v1/deliveryservices_id_safe.rst
@@ -111,7 +111,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/deliveryservices_id_servers.rst
+++ b/docs/source/api/v1/deliveryservices_id_servers.rst
@@ -64,7 +64,7 @@ Response Structure
 :ipAddress:      The IPv4 address of the server- applicable for the interface ``interfaceName``
 :ipGateway:      The IPv4 gateway of the server- applicable for the interface ``interfaceName``
 :ipNetmask:      The IPv4 subnet mask of the server- applicable for the interface ``interfaceName``
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v1/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v1/deliveryservices_id_servers_eligible.rst
@@ -69,7 +69,7 @@ Response Structure
 :ipAddress:      The IPv4 address of the server- applicable for the interface ``interfaceName``
 :ipGateway:      The IPv4 gateway of the server- applicable for the interface ``interfaceName``
 :ipNetmask:      The IPv4 subnet mask of the server- applicable for the interface ``interfaceName``
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v1/deliveryservices_id_unassigned_servers.rst
+++ b/docs/source/api/v1/deliveryservices_id_unassigned_servers.rst
@@ -86,7 +86,7 @@ Response Structure
 .. code-block:: json
 	:caption: Response Example
 
-	 {
+	{
 			"alerts": [{
 				"level": "warning",
 				"text": "This endpoint is deprecated, and will be removed in the future"
@@ -138,4 +138,3 @@ Response Structure
 		}
 
 .. [1] Users with the roles "admin" and/or "operations" will be able to see servers not assigned to *any* given :term:`Delivery Service`, whereas any other user will only be able to see the servers not assigned to :term:`Delivery Services` their Tenant is allowed to see.
-

--- a/docs/source/api/v1/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/v1/deliveryservices_required_capabilities.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :deliveryServiceID:   The associated :term:`Delivery Service`'s integral, unique identifier
 :xmlID:               The associated :term:`Delivery Service`'s :ref:`ds-xmlid`
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -138,7 +138,7 @@ Request Structure
 Response Structure
 ------------------
 :deliveryServiceID:   The newly associated :term:`Delivery Service`'s integral, unique identifier
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The newly associated :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v1/divisions.rst
+++ b/docs/source/api/v1/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/divisions.rst
+++ b/docs/source/api/v1/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/divisions_id.rst
+++ b/docs/source/api/v1/divisions_id.rst
@@ -71,7 +71,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -137,7 +137,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/divisions_id.rst
+++ b/docs/source/api/v1/divisions_id.rst
@@ -71,7 +71,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http
@@ -137,7 +137,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v1/federation_resolvers.rst
+++ b/docs/source/api/v1/federation_resolvers.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:lastUpdated: The date and time at which this resolver was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this resolver was last updated, in :ref:`non-rfc-datetime`
 
 	.. versionadded:: 1.4
 
@@ -236,4 +236,3 @@ Response Structure
 		"ipAddress": "1.2.6.4/22",
 		"type": "RESOLVE6"
 	}}
-

--- a/docs/source/api/v1/keys_ping.rst
+++ b/docs/source/api/v1/keys_ping.rst
@@ -43,8 +43,8 @@ No parameters available.
 
 Response Structure
 ------------------
-:server:	The hostname and port of :ref:`tv-overview`.
-:status:	The `reason phrase <https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1>`_ of the response that :ref:`to-overview` received from :ref:`tv-overview`.
+:server: The hostname and port of :ref:`tv-overview`.
+:status: The `reason phrase <https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.1.1>`_ of the response that :ref:`to-overview` received from :ref:`tv-overview`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v1/logs.rst
+++ b/docs/source/api/v1/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in an ISO-like format
+:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/logs.rst
+++ b/docs/source/api/v1/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/logs_days_days.rst
+++ b/docs/source/api/v1/logs_days_days.rst
@@ -60,7 +60,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in an ISO-like format
+:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/logs_days_days.rst
+++ b/docs/source/api/v1/logs_days_days.rst
@@ -60,7 +60,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v1/parameters.rst
+++ b/docs/source/api/v1/parameters.rst
@@ -72,7 +72,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -171,7 +171,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/parameters_id.rst
+++ b/docs/source/api/v1/parameters_id.rst
@@ -70,7 +70,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -157,7 +157,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/parameters_id_profiles.rst
+++ b/docs/source/api/v1/parameters_id_profiles.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v1/parameters_id_unassigned_profiles.rst
+++ b/docs/source/api/v1/parameters_id_unassigned_profiles.rst
@@ -52,7 +52,7 @@ Response Structure
 ------------------
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v1/parameters_profile_name.rst
+++ b/docs/source/api/v1/parameters_profile_name.rst
@@ -53,7 +53,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/phys_locations.rst
+++ b/docs/source/api/v1/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/phys_locations.rst
+++ b/docs/source/api/v1/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/phys_locations_id.rst
+++ b/docs/source/api/v1/phys_locations_id.rst
@@ -75,7 +75,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -190,7 +190,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/phys_locations_id.rst
+++ b/docs/source/api/v1/phys_locations_id.rst
@@ -75,7 +75,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -190,7 +190,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v1/profileparameters.rst
+++ b/docs/source/api/v1/profileparameters.rst
@@ -51,7 +51,7 @@ Request Structure
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :ref:`non-rfc-datetime`
 :parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
 :profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 
@@ -150,7 +150,7 @@ Array Format
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in an ISO-like format
+:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :ref:`non-rfc-datetime`
 :parameter:   :ref:`parameter-name` of the :term:`Parameter` which is assigned to ``profile``
 :parameterId: The :ref:`parameter-id` of the assigned :term:`Parameter`
 :profile:     :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` is assigned

--- a/docs/source/api/v1/profiles.rst
+++ b/docs/source/api/v1/profiles.rst
@@ -56,7 +56,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`
@@ -130,7 +130,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v1/profiles_id.rst
+++ b/docs/source/api/v1/profiles_id.rst
@@ -53,13 +53,13 @@ Response Structure
 :cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description: The :term:`Profile`'s :ref:`profile-description`
 :id:          The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated: The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:        The :term:`Profile`'s :ref:`profile-name`
 :params:      An array of :term:`Parameters` in use by this :term:`Profile`
 
 	:configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 	:id:          The :term:`Parameter`'s :ref:`parameter-id`
-	:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+	:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 	:name:        :ref:`parameter-name` of the :term:`Parameter`
 	:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 	:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -174,7 +174,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v1/profiles_id_parameters.rst
+++ b/docs/source/api/v1/profiles_id_parameters.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/profiles_id_unassigned_parameters.rst
+++ b/docs/source/api/v1/profiles_id_unassigned_parameters.rst
@@ -53,7 +53,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/profiles_id_unassigned_parameters.rst
+++ b/docs/source/api/v1/profiles_id_unassigned_parameters.rst
@@ -74,7 +74,7 @@ Response Structure
 	Date: Wed, 05 Dec 2018 21:37:50 GMT
 	Transfer-Encoding: chunked
 
-	{	"alerts": [{
+	{ "alerts": [{
 			"level": "warning",
 			"text": "This endpoint is deprecated, and will be removed in the future"
 		}],

--- a/docs/source/api/v1/profiles_name_name_parameters.rst
+++ b/docs/source/api/v1/profiles_name_name_parameters.rst
@@ -50,7 +50,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v1/profiles_trimmed.rst
+++ b/docs/source/api/v1/profiles_trimmed.rst
@@ -36,7 +36,7 @@ Response Structure
 :name: The :ref:`profile-name` of the :term:`Profile`
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true

--- a/docs/source/api/v1/regions.rst
+++ b/docs/source/api/v1/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/regions.rst
+++ b/docs/source/api/v1/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/regions_id.rst
+++ b/docs/source/api/v1/regions_id.rst
@@ -143,7 +143,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/regions_id.rst
+++ b/docs/source/api/v1/regions_id.rst
@@ -143,7 +143,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v1/server_server_capabilities.rst
+++ b/docs/source/api/v1/server_server_capabilities.rst
@@ -67,7 +67,7 @@ Response Structure
 ------------------
 :serverHostName:   The server's host name
 :serverId:         The server's integral, unique identifier
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -136,7 +136,7 @@ Request Structure
 Response Structure
 ------------------
 :serverId:         The integral, unique identifier of the newly associated server
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v1/servers_id_deliveryservices.rst
+++ b/docs/source/api/v1/servers_id_deliveryservices.rst
@@ -117,7 +117,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/servers_id_deliveryservices.rst
+++ b/docs/source/api/v1/servers_id_deliveryservices.rst
@@ -117,7 +117,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:  The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled: A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:        The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:        A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:           The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:          The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/servers_totals.rst
+++ b/docs/source/api/v1/servers_totals.rst
@@ -54,7 +54,7 @@ Response Structure
 	Whole-Content-Sha512: J4wy8zf+LX44/qWIbvziWHCcDZpUJ9GOpOVUVqPbVHUCh1V19o8FnE7T+V0639n9Xyw9k10NcaGIqASA+O9Rzg==
 	Content-Length: 305
 
-	{	"alerts": [
+	{ "alerts": [
 		{
 			"level": "warning",
 			"text": "This endpoint is deprecated"

--- a/docs/source/api/v1/stats_summary.rst
+++ b/docs/source/api/v1/stats_summary.rst
@@ -109,7 +109,7 @@ Summary Stats
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in an ISO-like format
+:summaryTime: Timestamp of the last updated summary, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -201,7 +201,7 @@ Request Structure
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.

--- a/docs/source/api/v1/stats_summary.rst
+++ b/docs/source/api/v1/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -202,7 +202,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v1/statuses.rst
+++ b/docs/source/api/v1/statuses.rst
@@ -68,7 +68,7 @@ Response Structure
 ------------------
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
-:lastUpdated: The date and time at which this status was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this status was last modified, in :ref:`non-rfc-datetime`
 :name:        The name of the status
 
 .. code-block:: http

--- a/docs/source/api/v1/statuses_id.rst
+++ b/docs/source/api/v1/statuses_id.rst
@@ -72,7 +72,7 @@ Response Structure
 ------------------
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
-:lastUpdated: The date and time at which this status was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this status was last modified, in :ref:`non-rfc-datetime`
 :name:        The name of the status
 
 .. code-block:: http

--- a/docs/source/api/v1/types.rst
+++ b/docs/source/api/v1/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/types.rst
+++ b/docs/source/api/v1/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -129,7 +129,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/types_id.rst
+++ b/docs/source/api/v1/types_id.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -129,7 +129,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v1/user_current.rst
+++ b/docs/source/api/v1/user_current.rst
@@ -44,7 +44,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -184,7 +184,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users.rst
+++ b/docs/source/api/v1/users.rst
@@ -81,7 +81,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -210,7 +210,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users.rst
+++ b/docs/source/api/v1/users.rst
@@ -81,7 +81,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -210,7 +210,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users_id.rst
+++ b/docs/source/api/v1/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -194,7 +194,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users_id.rst
+++ b/docs/source/api/v1/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -194,7 +194,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v1/users_id_deliveryservices.rst
+++ b/docs/source/api/v1/users_id_deliveryservices.rst
@@ -104,7 +104,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v1/users_id_deliveryservices.rst
+++ b/docs/source/api/v1/users_id_deliveryservices.rst
@@ -104,7 +104,7 @@ Response Structure
 :infoUrl:             An :ref:`ds-info-url`
 :initialDispersion:   The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:  A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:         A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:            The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:           The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/api_capabilities.rst
+++ b/docs/source/api/v2/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/api_capabilities.rst
+++ b/docs/source/api/v2/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/asns.rst
+++ b/docs/source/api/v2/asns.rst
@@ -73,7 +73,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -140,7 +140,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -209,7 +209,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/asns_id.rst
+++ b/docs/source/api/v2/asns_id.rst
@@ -67,7 +67,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/cachegroupparameters.rst
+++ b/docs/source/api/v2/cachegroupparameters.rst
@@ -55,7 +55,7 @@ Response Structure
 :cachegroupParameters: An array of identifying information for the :ref:`cache-group-parameters` of :term:`Cache Groups`
 
 	:cachegroup:   A string containing the :ref:`cache-group-name` of the :term:`Cache Group`
-	:last_updated: Date and time of last modification in an ISO-like format
+	:last_updated: Date and time of last modification in :ref:`non-rfc-datetime`
 	:parameter:    An integer that is the :term:`Parameter`'s :ref:`parameter-id`
 
 .. code-block:: http

--- a/docs/source/api/v2/cachegroupparameters.rst
+++ b/docs/source/api/v2/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v2/cachegroups.rst
+++ b/docs/source/api/v2/cachegroups.rst
@@ -66,7 +66,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`
@@ -176,7 +176,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v2/cachegroups_id.rst
+++ b/docs/source/api/v2/cachegroups_id.rst
@@ -83,7 +83,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v2/cachegroups_id_parameters.rst
+++ b/docs/source/api/v2/cachegroups_id_parameters.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :secure:      A boolean value describing whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`

--- a/docs/source/api/v2/capabilities.rst
+++ b/docs/source/api/v2/capabilities.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :name:        Name of the capability
 :description: Describes the permissions covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/cdns.rst
+++ b/docs/source/api/v2/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v2/cdns.rst
+++ b/docs/source/api/v2/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v2/cdns_name_federations.rst
+++ b/docs/source/api/v2/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/cdns_name_federations.rst
+++ b/docs/source/api/v2/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/cdns_name_federations_id.rst
+++ b/docs/source/api/v2/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/cdns_name_federations_id.rst
+++ b/docs/source/api/v2/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v2/deliveryservice_request_comments.rst
+++ b/docs/source/api/v2/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v2/deliveryservice_request_comments.rst
+++ b/docs/source/api/v2/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v2/deliveryservice_requests.rst
+++ b/docs/source/api/v2/deliveryservice_requests.rst
@@ -84,7 +84,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -122,7 +122,7 @@ Response Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -165,7 +165,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -335,7 +335,7 @@ Request Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -478,7 +478,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -516,7 +516,7 @@ Response Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -559,7 +559,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -730,7 +730,7 @@ Request Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -891,7 +891,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -929,7 +929,7 @@ Response Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -972,7 +972,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservice_requests.rst
+++ b/docs/source/api/v2/deliveryservice_requests.rst
@@ -81,92 +81,92 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -296,84 +296,84 @@ Creates a new :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:changeType:            The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
-:status:                        The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
-:deliveryService:       The :term:`Delivery Service` that you have submitted for review as part of this request.
+:changeType:      The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
+:status:          The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:deliveryService: The :term:`Delivery Service` that you have submitted for review as part of this request.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
 .. code-block:: http
 	:caption: Request Example
@@ -475,92 +475,92 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -690,91 +690,88 @@ Updates an existing :ref:`Delivery Service Request <ds_requests>`.
 
 Request Structure
 -----------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:     The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:status: The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. table:: Request Query Parameters
 
@@ -891,92 +888,92 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_assign.rst
@@ -28,8 +28,8 @@ Assign a :term:`Delivery Service Request` to a user.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:assignee:      The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:id:       The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:assignee: The username of the user to whom the :term:`Delivery Service Request` is assigned.
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,12 +49,12 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                        A boolean that defines :ref:`ds-active`.
 	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
@@ -91,7 +91,7 @@ Response Structure
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -131,11 +131,11 @@ Response Structure
 	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
 	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_assign.rst
@@ -53,7 +53,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                        A boolean that defines :ref:`ds-active`.
@@ -91,7 +91,7 @@ Response Structure
 	:infoUrl:                       An :ref:`ds-info-url`
 	:initialDispersion:             The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -134,7 +134,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_status.rst
@@ -49,94 +49,94 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:assigneeId:            The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:assigneeId:      The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v2/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v2/deliveryservice_requests_id_status.rst
@@ -54,7 +54,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -92,7 +92,7 @@ Response Structure
 	:infoUrl:                   An :ref:`ds-info-url`
 	:initialDispersion:         The :ref:`ds-initial-dispersion`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -135,7 +135,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -100,7 +100,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -100,7 +100,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -390,7 +390,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -368,34 +368,34 @@ Response Structure
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -420,8 +420,8 @@ Response Structure
 :remapText:            :ref:`ds-raw-remap`
 :signed:               ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-:rangeSliceBlockSize: An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	   This integer indicates the :ref:`ds-ssl-key-version`
+:rangeSliceBlockSize:  An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
+:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
 :trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices_id_safe.rst
+++ b/docs/source/api/v2/deliveryservices_id_safe.rst
@@ -96,7 +96,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices_id_safe.rst
+++ b/docs/source/api/v2/deliveryservices_id_safe.rst
@@ -96,7 +96,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/deliveryservices_id_servers.rst
+++ b/docs/source/api/v2/deliveryservices_id_servers.rst
@@ -64,7 +64,7 @@ Response Structure
 :ipAddress:      The IPv4 address of the server- applicable for the interface ``interfaceName``
 :ipGateway:      The IPv4 gateway of the server- applicable for the interface ``interfaceName``
 :ipNetmask:      The IPv4 subnet mask of the server- applicable for the interface ``interfaceName``
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v2/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v2/deliveryservices_id_servers_eligible.rst
@@ -69,7 +69,7 @@ Response Structure
 :ipAddress:      The IPv4 address of the server- applicable for the interface ``interfaceName``
 :ipGateway:      The IPv4 gateway of the server- applicable for the interface ``interfaceName``
 :ipNetmask:      The IPv4 subnet mask of the server- applicable for the interface ``interfaceName``
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v2/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/v2/deliveryservices_required_capabilities.rst
@@ -67,7 +67,7 @@ Response Structure
 ------------------
 :deliveryServiceID:   The associated :term:`Delivery Service`'s integral, unique identifier
 :xmlID:               The associated :term:`Delivery Service`'s :ref:`ds-xmlid`
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -136,7 +136,7 @@ Request Structure
 Response Structure
 ------------------
 :deliveryServiceID:   The newly associated :term:`Delivery Service`'s integral, unique identifier
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The newly associated :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v2/divisions.rst
+++ b/docs/source/api/v2/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/divisions.rst
+++ b/docs/source/api/v2/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/divisions_id.rst
+++ b/docs/source/api/v2/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/divisions_id.rst
+++ b/docs/source/api/v2/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v2/federation_resolvers.rst
+++ b/docs/source/api/v2/federation_resolvers.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:lastUpdated: The date and time at which this resolver was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this resolver was last updated, in :ref:`non-rfc-datetime`
 :type:        The :term:`Type` of the resolver
 
 .. code-block:: http
@@ -228,4 +228,3 @@ Response Structure
 		"ipAddress": "1.2.6.4/22",
 		"type": "RESOLVE6"
 	}}
-

--- a/docs/source/api/v2/logs.rst
+++ b/docs/source/api/v2/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in an ISO-like format
+:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v2/logs.rst
+++ b/docs/source/api/v2/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v2/parameters.rst
+++ b/docs/source/api/v2/parameters.rst
@@ -72,7 +72,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -171,7 +171,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v2/parameters_id.rst
+++ b/docs/source/api/v2/parameters_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v2/phys_locations.rst
+++ b/docs/source/api/v2/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/phys_locations.rst
+++ b/docs/source/api/v2/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/phys_locations_id.rst
+++ b/docs/source/api/v2/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/phys_locations_id.rst
+++ b/docs/source/api/v2/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v2/profileparameters.rst
+++ b/docs/source/api/v2/profileparameters.rst
@@ -51,7 +51,7 @@ Request Structure
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :ref:`non-rfc-datetime`
 :parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
 :profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 
@@ -150,7 +150,7 @@ Array Format
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in an ISO-like format
+:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :ref:`non-rfc-datetime`
 :parameter:   :ref:`parameter-name` of the :term:`Parameter` which is assigned to ``profile``
 :parameterId: The :ref:`parameter-id` of the assigned :term:`Parameter`
 :profile:     :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` is assigned

--- a/docs/source/api/v2/profiles.rst
+++ b/docs/source/api/v2/profiles.rst
@@ -56,7 +56,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`
@@ -130,7 +130,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v2/profiles_id.rst
+++ b/docs/source/api/v2/profiles_id.rst
@@ -70,7 +70,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v2/profiles_id_parameters.rst
+++ b/docs/source/api/v2/profiles_id_parameters.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v2/profiles_name_name_parameters.rst
+++ b/docs/source/api/v2/profiles_name_name_parameters.rst
@@ -50,7 +50,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v2/regions.rst
+++ b/docs/source/api/v2/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/regions.rst
+++ b/docs/source/api/v2/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/regions_id.rst
+++ b/docs/source/api/v2/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/regions_id.rst
+++ b/docs/source/api/v2/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v2/server_server_capabilities.rst
+++ b/docs/source/api/v2/server_server_capabilities.rst
@@ -65,7 +65,7 @@ Response Structure
 ------------------
 :serverHostName:   The server's host name
 :serverId:         The server's integral, unique identifier
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Request Structure
 Response Structure
 ------------------
 :serverId:         The integral, unique identifier of the newly associated server
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v2/servers_id_deliveryservices.rst
+++ b/docs/source/api/v2/servers_id_deliveryservices.rst
@@ -102,7 +102,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/servers_id_deliveryservices.rst
+++ b/docs/source/api/v2/servers_id_deliveryservices.rst
@@ -102,7 +102,7 @@ Response Structure
 :infoUrl:                   An :ref:`ds-info-url`
 :initialDispersion:         The :ref:`ds-initial-dispersion`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v2/stats_summary.rst
+++ b/docs/source/api/v2/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v2/stats_summary.rst
+++ b/docs/source/api/v2/stats_summary.rst
@@ -109,7 +109,7 @@ Summary Stats
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in an ISO-like format
+:summaryTime: Timestamp of the last updated summary, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -199,7 +199,7 @@ Request Structure
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.

--- a/docs/source/api/v2/statuses.rst
+++ b/docs/source/api/v2/statuses.rst
@@ -68,7 +68,7 @@ Response Structure
 ------------------
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
-:lastUpdated: The date and time at which this status was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this status was last modified, in :ref:`non-rfc-datetime`
 :name:        The name of the status
 
 .. code-block:: http

--- a/docs/source/api/v2/types.rst
+++ b/docs/source/api/v2/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v2/types.rst
+++ b/docs/source/api/v2/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v2/types_id.rst
+++ b/docs/source/api/v2/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v2/types_id.rst
+++ b/docs/source/api/v2/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v2/user_current.rst
+++ b/docs/source/api/v2/user_current.rst
@@ -44,7 +44,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -176,7 +176,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v2/users.rst
+++ b/docs/source/api/v2/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v2/users.rst
+++ b/docs/source/api/v2/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v2/users_id.rst
+++ b/docs/source/api/v2/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v2/users_id.rst
+++ b/docs/source/api/v2/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/api_capabilities.rst
+++ b/docs/source/api/v3/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/api_capabilities.rst
+++ b/docs/source/api/v3/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/asns.rst
+++ b/docs/source/api/v3/asns.rst
@@ -73,7 +73,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -142,7 +142,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -211,7 +211,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/asns_id.rst
+++ b/docs/source/api/v3/asns_id.rst
@@ -67,7 +67,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/cachegroupparameters.rst
+++ b/docs/source/api/v3/cachegroupparameters.rst
@@ -55,7 +55,7 @@ Response Structure
 :cachegroupParameters: An array of identifying information for the :ref:`cache-group-parameters` of :term:`Cache Groups`
 
 	:cachegroup:   A string containing the :ref:`cache-group-name` of the :term:`Cache Group`
-	:last_updated: Date and time of last modification in an ISO-like format
+	:last_updated: Date and time of last modification in :ref:`non-rfc-datetime`
 	:parameter:    An integer that is the :term:`Parameter`'s :ref:`parameter-id`
 
 .. code-block:: http

--- a/docs/source/api/v3/cachegroupparameters.rst
+++ b/docs/source/api/v3/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v3/cachegroups.rst
+++ b/docs/source/api/v3/cachegroups.rst
@@ -70,7 +70,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`
@@ -180,7 +180,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v3/cachegroups_id.rst
+++ b/docs/source/api/v3/cachegroups_id.rst
@@ -83,7 +83,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v3/cachegroups_id_parameters.rst
+++ b/docs/source/api/v3/cachegroups_id_parameters.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :secure:      A boolean value describing whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`

--- a/docs/source/api/v3/capabilities.rst
+++ b/docs/source/api/v3/capabilities.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :name:        Name of the capability
 :description: Describes the permissions covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/cdns.rst
+++ b/docs/source/api/v3/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v3/cdns.rst
+++ b/docs/source/api/v3/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v3/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v3/cdns_name_configs_monitoring.rst
@@ -98,15 +98,15 @@ Response Structure
 
 :trafficServers: An array of objects that represent the :term:`cache servers` being monitored within this CDN
 
-	:cacheGroup:    The :term:`Cache Group` to which this :term:`cache server` belongs
-	:fqdn:          An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
-	:hashId:        The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
-	:hostName:      The (short) hostname of the :term:`cache server`
-	:port:          The port on which the :term:`cache server` listens for incoming connections
-	:profile:       A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
-	:status:        The status of the :term:`cache server`
-	:type:          A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
-	:interfaces:		A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
+	:cacheGroup: The :term:`Cache Group` to which this :term:`cache server` belongs
+	:fqdn:       An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
+	:hashId:     The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
+	:hostName:   The (short) hostname of the :term:`cache server`
+	:port:       The port on which the :term:`cache server` listens for incoming connections
+	:profile:    A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
+	:status:     The status of the :term:`cache server`
+	:type:       A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
+	:interfaces: A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
 
 		:ipAddresses: A set of objects representing IP Addresses assigned to this network interface. In most scenarios, only one or two (usually one IPv4 address and one IPv6 address) will be present, but it is illegal for this set to be an empty collection.
 

--- a/docs/source/api/v3/cdns_name_federations.rst
+++ b/docs/source/api/v3/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_federations.rst
+++ b/docs/source/api/v3/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_federations_id.rst
+++ b/docs/source/api/v3/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_federations_id.rst
+++ b/docs/source/api/v3/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v3/cdns_name_snapshot.rst
+++ b/docs/source/api/v3/cdns_name_snapshot.rst
@@ -4,7 +4,7 @@
 .. you may not use this file except in compliance with the License.
 .. You may obtain a copy of the License at
 ..
-..     http://www.apache.org/licenses/LICENSE-2.0
+..   http://www.apache.org/licenses/LICENSE-2.0
 ..
 .. Unless required by applicable law or agreed to in writing, software
 .. distributed under the License is distributed on an "AS IS" BASIS,
@@ -165,9 +165,7 @@ Response Structure
 		.. seealso:: :ref:`anonymous_blocking-qht`
 
 	:consistentHashQueryParameters: A set of query parameters that Traffic Router should consider when determining a consistent hash for a given client request.
-
 	:consistentHashRegex:           An optional regular expression that will ensure clients are consistently routed to a :term:`cache server` based on matches to it.
-
 	:coverageZoneOnly:              A string containing a boolean that tells whether or not this :term:`Delivery Service` routes traffic based only on its :term:`Coverage Zone File`
 
 		.. seealso:: :ref:`ds-geo-limit`
@@ -186,8 +184,8 @@ Response Structure
 			"true"
 				:term:`cache servers` will be chosen at random
 
-	:domains:             An array of domains served by this :term:`Delivery Service`
-	:ecsEnabled:          A string containing a boolean from :ref:`ds-ecs` that tells whether EDNS0 client subnet is enabled on this :term:`Delivery Service`; one of:
+	:domains:    An array of domains served by this :term:`Delivery Service`
+	:ecsEnabled: A string containing a boolean from :ref:`ds-ecs` that tells whether EDNS0 client subnet is enabled on this :term:`Delivery Service`; one of:
 
 		"false"
 			EDNS0 client subnet is not enabled on this :term:`Delivery Service`
@@ -249,8 +247,8 @@ Response Structure
 
 		.. seealso:: :ref:`regionalgeo-qht`
 	:requiredCapabilities: An array of this Delivery Service's :term:`required capabilities <Delivery Service required capabilities>`. If there are no required capabilities, this field is omitted.
-	:routingName: A string that is this :ref:`Delivery Service's Routing Name <ds-routing-name>`
-	:soa:         An object defining the :abbr:`SOA (Start of Authority)` record for the :term:`Delivery Service`'s :abbr:`TLDs (Top-Level Domains)` (defined in ``domains``)
+	:routingName:          A string that is this :ref:`Delivery Service's Routing Name <ds-routing-name>`
+	:soa:                  An object defining the :abbr:`SOA (Start of Authority)` record for the :term:`Delivery Service`'s :abbr:`TLDs (Top-Level Domains)` (defined in ``domains``)
 
 		:admin: The name of the administrator for this zone - i.e. the RNAME
 
@@ -314,9 +312,9 @@ Response Structure
 
 :stats: An object containing metadata information regarding the CDN
 
-	:CDN_name:   The name of this CDN
-	:date:       The UNIX epoch timestamp date in the Traffic Ops server's own timezone
-	:tm_host:    The :abbr:`FQDN (Fully Qualified Domain Name)` of the Traffic Ops server
+	:CDN_name: The name of this CDN
+	:date:     The UNIX epoch timestamp date in the Traffic Ops server's own timezone
+	:tm_host:  The :abbr:`FQDN (Fully Qualified Domain Name)` of the Traffic Ops server
 
 		.. deprecated:: ATCv6
 
@@ -326,7 +324,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 
@@ -365,212 +363,212 @@ Response Structure
 
 	{
 		"response": {
-		    "config": {
-			"api.cache-control.max-age": "10",
-			"certificates.polling.interval": "300000",
-			"consistent.dns.routing": "true",
-			"coveragezone.polling.interval": "3600000",
-			"coveragezone.polling.url": "https://trafficops.infra.ciab.test:443/coverage-zone.json",
-			"dnssec.dynamic.response.expiration": "300s",
-			"dnssec.enabled": "false",
-			"domain_name": "mycdn.ciab.test",
-			"federationmapping.polling.interval": "60000",
-			"federationmapping.polling.url": "https://${toHostname}/api/2.0/federations/all",
-			"geolocation.polling.interval": "86400000",
-			"geolocation.polling.url": "https://trafficops.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
-			"keystore.maintenance.interval": "300",
-			"neustar.polling.interval": "86400000",
-			"neustar.polling.url": "https://trafficops.infra.ciab.test:443/neustar.tar.gz",
-			"soa": {
-			    "admin": "twelve_monkeys",
-			    "expire": "604800",
-			    "minimum": "30",
-			    "refresh": "28800",
-			    "retry": "7200"
+			"config": {
+				"api.cache-control.max-age": "10",
+				"certificates.polling.interval": "300000",
+				"consistent.dns.routing": "true",
+				"coveragezone.polling.interval": "3600000",
+				"coveragezone.polling.url": "https://trafficops.infra.ciab.test:443/coverage-zone.json",
+				"dnssec.dynamic.response.expiration": "300s",
+				"dnssec.enabled": "false",
+				"domain_name": "mycdn.ciab.test",
+				"federationmapping.polling.interval": "60000",
+				"federationmapping.polling.url": "https://${toHostname}/api/2.0/federations/all",
+				"geolocation.polling.interval": "86400000",
+				"geolocation.polling.url": "https://trafficops.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
+				"keystore.maintenance.interval": "300",
+				"neustar.polling.interval": "86400000",
+				"neustar.polling.url": "https://trafficops.infra.ciab.test:443/neustar.tar.gz",
+				"soa": {
+					"admin": "twelve_monkeys",
+					"expire": "604800",
+					"minimum": "30",
+					"refresh": "28800",
+					"retry": "7200"
+				},
+				"steeringmapping.polling.interval": "60000",
+				"ttls": {
+					"A": "3600",
+					"AAAA": "3600",
+					"DNSKEY": "30",
+					"DS": "30",
+					"NS": "3600",
+					"SOA": "86400"
+				},
+				"zonemanager.cache.maintenance.interval": "300",
+				"zonemanager.threadpool.scale": "0.50"
 			},
-			"steeringmapping.polling.interval": "60000",
-			"ttls": {
-			    "A": "3600",
-			    "AAAA": "3600",
-			    "DNSKEY": "30",
-			    "DS": "30",
-			    "NS": "3600",
-			    "SOA": "86400"
-			},
-			"zonemanager.cache.maintenance.interval": "300",
-			"zonemanager.threadpool.scale": "0.50"
-		    },
-		    "contentRouters": {
-			"trafficrouter": {
-			    "api.port": "3333",
-			    "fqdn": "trafficrouter.infra.ciab.test",
-			    "httpsPort": 443,
-			    "ip": "172.26.0.15",
-			    "ip6": "",
-			    "location": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "CCR_CIAB",
-			    "secure.api.port": "3443",
-			    "status": "ONLINE"
-			}
-		    },
-		    "contentServers": {
-			"edge": {
-			    "cacheGroup": "CDN_in_a_Box_Edge",
-			    "capabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "fqdn": "edge.infra.ciab.test",
-			    "hashCount": 999,
-			    "hashId": "edge",
-			    "httpsPort": 443,
-			    "interfaceName": "eth0",
-			    "ip": "172.26.0.3",
-			    "ip6": "",
-			    "locationId": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "ATS_EDGE_TIER_CACHE",
-			    "routingDisabled": 0,
-			    "status": "REPORTED",
-			    "type": "EDGE"
-			},
-			"mid": {
-			    "cacheGroup": "CDN_in_a_Box_Mid",
-			    "capabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "fqdn": "mid.infra.ciab.test",
-			    "hashCount": 999,
-			    "hashId": "mid",
-			    "httpsPort": 443,
-			    "interfaceName": "eth0",
-			    "ip": "172.26.0.4",
-			    "ip6": "",
-			    "locationId": "CDN_in_a_Box_Mid",
-			    "port": 80,
-			    "profile": "ATS_MID_TIER_CACHE",
-			    "routingDisabled": 0,
-			    "status": "REPORTED",
-			    "type": "MID"
-			}
-		    },
-		    "deliveryServices": {
-			"demo1": {
-			    "anonymousBlockingEnabled": "false",
-			    "consistentHashQueryParams": [
-				"abc",
-				"pdq",
-				"xxx",
-				"zyx"
-			    ],
-			    "coverageZoneOnly": "false",
-			    "deepCachingType": "NEVER",
-			    "dispersion": {
-				"limit": 1,
-				"shuffled": "true"
-			    },
-			    "domains": [
-				"demo1.mycdn.ciab.test"
-			    ],
-			    "ecsEnabled": "false",
-			    "geolocationProvider": "maxmindGeolocationService",
-			    "ip6RoutingEnabled": "true",
-			    "matchsets": [
-				{
-				    "matchlist": [
-					{
-					    "match-type": "HOST",
-					    "regex": ".*\\.demo1\\..*"
-					}
-				    ],
-				    "protocol": "HTTP"
+			"contentRouters": {
+				"trafficrouter": {
+					"api.port": "3333",
+					"fqdn": "trafficrouter.infra.ciab.test",
+					"httpsPort": 443,
+					"ip": "172.26.0.15",
+					"ip6": "",
+					"location": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "CCR_CIAB",
+					"secure.api.port": "3443",
+					"status": "ONLINE"
 				}
-			    ],
-			    "missLocation": {
-				"lat": 42,
-				"long": -88
-			    },
-			    "protocol": {
-				"acceptHttps": "true",
-				"redirectToHttps": "false"
-			    },
-			    "regionalGeoBlocking": "false",
-			    "requiredCapabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "routingName": "video",
-			    "soa": {
-				"admin": "traffic_ops",
-				"expire": "604800",
-				"minimum": "30",
-				"refresh": "28800",
-				"retry": "7200"
-			    },
-			    "sslEnabled": "true",
-			    "topology": "my-topology",
-			    "ttls": {
-				"A": "",
-				"AAAA": "",
-				"NS": "3600",
-				"SOA": "86400"
-			    }
+			},
+			"contentServers": {
+				"edge": {
+					"cacheGroup": "CDN_in_a_Box_Edge",
+					"capabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"fqdn": "edge.infra.ciab.test",
+					"hashCount": 999,
+					"hashId": "edge",
+					"httpsPort": 443,
+					"interfaceName": "eth0",
+					"ip": "172.26.0.3",
+					"ip6": "",
+					"locationId": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "ATS_EDGE_TIER_CACHE",
+					"routingDisabled": 0,
+					"status": "REPORTED",
+					"type": "EDGE"
+				},
+				"mid": {
+					"cacheGroup": "CDN_in_a_Box_Mid",
+					"capabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"fqdn": "mid.infra.ciab.test",
+					"hashCount": 999,
+					"hashId": "mid",
+					"httpsPort": 443,
+					"interfaceName": "eth0",
+					"ip": "172.26.0.4",
+					"ip6": "",
+					"locationId": "CDN_in_a_Box_Mid",
+					"port": 80,
+					"profile": "ATS_MID_TIER_CACHE",
+					"routingDisabled": 0,
+					"status": "REPORTED",
+					"type": "MID"
+				}
+			},
+			"deliveryServices": {
+				"demo1": {
+					"anonymousBlockingEnabled": "false",
+					"consistentHashQueryParams": [
+						"abc",
+						"pdq",
+						"xxx",
+						"zyx"
+					],
+					"coverageZoneOnly": "false",
+					"deepCachingType": "NEVER",
+					"dispersion": {
+						"limit": 1,
+						"shuffled": "true"
+					},
+					"domains": [
+						"demo1.mycdn.ciab.test"
+					],
+					"ecsEnabled": "false",
+					"geolocationProvider": "maxmindGeolocationService",
+					"ip6RoutingEnabled": "true",
+					"matchsets": [
+						{
+							"matchlist": [
+								{
+									"match-type": "HOST",
+									"regex": ".*\\.demo1\\..*"
+								}
+							],
+							"protocol": "HTTP"
+						}
+					],
+					"missLocation": {
+						"lat": 42,
+						"long": -88
+					},
+					"protocol": {
+						"acceptHttps": "true",
+						"redirectToHttps": "false"
+					},
+					"regionalGeoBlocking": "false",
+					"requiredCapabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"routingName": "video",
+					"soa": {
+						"admin": "traffic_ops",
+						"expire": "604800",
+						"minimum": "30",
+						"refresh": "28800",
+						"retry": "7200"
+					},
+					"sslEnabled": "true",
+					"topology": "my-topology",
+					"ttls": {
+						"A": "",
+						"AAAA": "",
+						"NS": "3600",
+						"SOA": "86400"
+					}
+				}
+			},
+			"edgeLocations": {
+				"CDN_in_a_Box_Edge": {
+					"backupLocations": {
+						"fallbackToClosest": "true"
+					},
+					"latitude": 38.897663,
+					"localizationMethods": [
+						"GEO",
+						"CZ",
+						"DEEP_CZ"
+					],
+					"longitude": -77.036574
+				}
+			},
+			"monitors": {
+				"trafficmonitor": {
+					"fqdn": "trafficmonitor.infra.ciab.test",
+					"httpsPort": 443,
+					"ip": "172.26.0.14",
+					"ip6": "",
+					"location": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "RASCAL-Traffic_Monitor",
+					"status": "ONLINE"
+				}
+			},
+			"stats": {
+				"CDN_name": "CDN-in-a-Box",
+				"date": 1590600715,
+				"tm_host": "trafficops.infra.ciab.test:443",
+				"tm_path": "/api/3.0/snapshot",
+				"tm_user": "admin",
+				"tm_version": "development"
+			},
+			"topologies": {
+				"my-topology": {
+					"nodes": [
+						"CDN_in_a_Box_Edge"
+					]
+				}
+			},
+			"trafficRouterLocations": {
+				"CDN_in_a_Box_Edge": {
+					"backupLocations": {
+						"fallbackToClosest": "false"
+					},
+					"latitude": 38.897663,
+					"localizationMethods": [
+						"GEO",
+						"CZ",
+						"DEEP_CZ"
+					],
+					"longitude": -77.036574
+				}
 			}
-		    },
-		    "edgeLocations": {
-			"CDN_in_a_Box_Edge": {
-			    "backupLocations": {
-				"fallbackToClosest": "true"
-			    },
-			    "latitude": 38.897663,
-			    "localizationMethods": [
-				"GEO",
-				"CZ",
-				"DEEP_CZ"
-			    ],
-			    "longitude": -77.036574
-			}
-		    },
-		    "monitors": {
-			"trafficmonitor": {
-			    "fqdn": "trafficmonitor.infra.ciab.test",
-			    "httpsPort": 443,
-			    "ip": "172.26.0.14",
-			    "ip6": "",
-			    "location": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "RASCAL-Traffic_Monitor",
-			    "status": "ONLINE"
-			}
-		    },
-		    "stats": {
-			"CDN_name": "CDN-in-a-Box",
-			"date": 1590600715,
-			"tm_host": "trafficops.infra.ciab.test:443",
-			"tm_path": "/api/3.0/snapshot",
-			"tm_user": "admin",
-			"tm_version": "development"
-		    },
-		    "topologies": {
-			"my-topology": {
-			    "nodes": [
-				"CDN_in_a_Box_Edge"
-			    ]
-			}
-		    },
-		    "trafficRouterLocations": {
-			"CDN_in_a_Box_Edge": {
-			    "backupLocations": {
-				"fallbackToClosest": "false"
-			    },
-			    "latitude": 38.897663,
-			    "localizationMethods": [
-				"GEO",
-				"CZ",
-				"DEEP_CZ"
-			    ],
-			    "longitude": -77.036574
-			}
-		    }
 		}
 	}
 

--- a/docs/source/api/v3/cdns_name_snapshot_new.rst
+++ b/docs/source/api/v3/cdns_name_snapshot_new.rst
@@ -326,7 +326,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v3/deliveryservice_request_comments.rst
+++ b/docs/source/api/v3/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v3/deliveryservice_request_comments.rst
+++ b/docs/source/api/v3/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -84,7 +84,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -125,7 +125,7 @@ Response Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -169,7 +169,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -346,7 +346,7 @@ Request Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -494,7 +494,7 @@ Response Structure
 :author:          The username of the user who created the Delivery Service Request.
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -535,7 +535,7 @@ Response Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -579,7 +579,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
@@ -755,7 +755,7 @@ Request Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -959,7 +959,7 @@ Response Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -1003,7 +1003,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -81,96 +81,96 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -304,88 +304,88 @@ Creates a new :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:changeType:            The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
-:status:                        The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
-:deliveryService:       The :term:`Delivery Service` that you have submitted for review as part of this request.
+:changeType:      The action that you want to perform on the delivery service. It can be "create", "update", or "delete".
+:status:          The status of your request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:deliveryService: The :term:`Delivery Service` that you have submitted for review as part of this request.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
 .. code-block:: http
 	:caption: Request Example
@@ -491,96 +491,96 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:author:          The username of the user who created the Delivery Service Request.
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:              A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                              A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example
@@ -714,95 +714,90 @@ Updates an existing :ref:`Delivery Service Request <ds_requests>`.
 
 Request Structure
 -----------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                       A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                     An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                          The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:     The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:status: The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. table:: Request Query Parameters
 
@@ -923,96 +918,93 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                The username of the user who created the Delivery Service Request.
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                             The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                                 The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                               Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                             A :ref:`ds-check-path`
-	:consistentHashQueryParams:             An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:                   A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:                       The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                           The :ref:`ds-display-name`
-	:dnsBypassCname:                        A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                           A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                          A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                          The :ref:`ds-dns-bypass-ttl`
-	:dscp:                                  A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                            A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:                     A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                           An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:                    A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                          The :ref:`ds-fqpr`
-	:geoLimit:                              An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:                     A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:                   A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                           The :ref:`ds-geo-provider`
-	:globalMaxMbps:                         The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                          The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                        A :ref:`ds-http-bypass-fqdn`
-	:id:                                    An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                               An :ref:`ds-info-url`
-	:initialDispersion:                     The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:                    A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:                    A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:                     A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                           The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                           A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                              The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                             An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                             An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                             The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:                               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:                             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                         The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:                  The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:                      A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                               The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                              The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:                       A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                         The :ref:`ds-origin-url`
-	:originShield:                          A :ref:`ds-origin-shield` string
-	:profileDescription:                    The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                             An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                           The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                              An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                         An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:                  An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                            A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:                   A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                             :ref:`ds-raw-remap`
-	:routingName:                           The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                                ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:                      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                         This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                                The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:                      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:                     If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                                  The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                                The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                                 This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                        The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_assign.rst
@@ -53,7 +53,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -94,7 +94,7 @@ Response Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -138,7 +138,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_assign.rst
@@ -28,8 +28,8 @@ Assign a :term:`Delivery Service Request` to a user.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:assignee:      The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:id:       The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:assignee: The username of the user to whom the :term:`Delivery Service Request` is assigned.
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,97 +49,97 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
-		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
-		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
-		:type:                  The type of match performed using ``pattern``.
+		:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
+		:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
+		:type:      The type of match performed using ``pattern``.
 
-	:maxDnsAnswers:                 The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
-	:maxOriginConnections:          The :ref:`ds-max-origin-connections`
-	:midHeaderRewrite:              A set of :ref:`ds-mid-header-rw-rules`
-	:missLat:                       The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
-	:missLong:                      The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
-	:multiSiteOrigin:               A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
-	:orgServerFqdn:                 The :ref:`ds-origin-url`
-	:originShield:                  A :ref:`ds-origin-shield` string
-	:profileDescription:            The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:profileId:                     An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
-	:profileName:                   The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
-	:protocol:                      An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
-	:qstringIgnore:                 An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
-	:rangeRequestHandling:          An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
-	:regexRemap:                    A :ref:`ds-regex-remap`
-	:regionalGeoBlocking:           A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
-	:remapText:                     :ref:`ds-raw-remap`
-	:routingName:                   The :ref:`ds-routing-name` of this :term:`Delivery Service`
-	:signed:                        ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
-	:signingAlgorithm:              Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
-	:sslKeyVersion:                 This integer indicates the :ref:`ds-ssl-key-version`
-	:tenant:                        The name of the :term:`Tenant` who owns this :term:`Origin`
-	:tenantId:                      The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
-	:topology:                      The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
-	:trRequestHeaders:              If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
-	:trResponseHeaders:             If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
-	:type:                          The :ref:`ds-types` of this :term:`Delivery Service`
-	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
-	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
+	:maxDnsAnswers:        The :ref:`ds-max-dns-answers` allowed for this :term:`Delivery Service`
+	:maxOriginConnections: The :ref:`ds-max-origin-connections`
+	:midHeaderRewrite:     A set of :ref:`ds-mid-header-rw-rules`
+	:missLat:              The :ref:`ds-geo-miss-default-latitude` used by this :term:`Delivery Service`
+	:missLong:             The :ref:`ds-geo-miss-default-longitude` used by this :term:`Delivery Service`
+	:multiSiteOrigin:      A boolean that defines the use of :ref:`ds-multi-site-origin` by this :term:`Delivery Service`
+	:orgServerFqdn:        The :ref:`ds-origin-url`
+	:originShield:         A :ref:`ds-origin-shield` string
+	:profileDescription:   The :ref:`profile-description` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:profileId:            An optional :ref:`profile-id` of a :ref:`ds-profile` with which this :term:`Delivery Service` shall be associated
+	:profileName:          The :ref:`profile-name` of the :ref:`ds-profile` with which this :term:`Delivery Service` is associated
+	:protocol:             An integral, unique identifier that corresponds to the :ref:`ds-protocol` used by this :term:`Delivery Service`
+	:qstringIgnore:        An integral, unique identifier that corresponds to the :ref:`ds-qstring-handling` setting on this :term:`Delivery Service`
+	:rangeRequestHandling: An integral, unique identifier that corresponds to the :ref:`ds-range-request-handling` setting on this :term:`Delivery Service`
+	:regexRemap:           A :ref:`ds-regex-remap`
+	:regionalGeoBlocking:  A boolean defining the :ref:`ds-regionalgeo` setting on this :term:`Delivery Service`
+	:remapText:            :ref:`ds-raw-remap`
+	:routingName:          The :ref:`ds-routing-name` of this :term:`Delivery Service`
+	:signed:               ``true`` if     and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
+	:signingAlgorithm:     Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
+	:sslKeyVersion:        This integer indicates the :ref:`ds-ssl-key-version`
+	:tenant:               The name of the :term:`Tenant` who owns this :term:`Origin`
+	:tenantId:             The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
+	:topology:             The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
+	:trRequestHeaders:     If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`
+	:trResponseHeaders:    If defined, this defines the :ref:`ds-tr-resp-headers` used by Traffic Router for this :term:`Delivery Service`
+	:type:                 The :ref:`ds-types` of this :term:`Delivery Service`
+	:typeId:               The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
+	:xmlId:                This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_status.rst
@@ -28,8 +28,8 @@ Sets the status of a :term:`Delivery Service Request`.
 
 Request Structure
 -----------------
-:id:            The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:status:        The status of the `DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:     The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:status: The status of the `DSR <Delivery Service Request>`. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Request Example
@@ -49,58 +49,58 @@ Request Structure
 
 Response Structure
 ------------------
-:assignee:              The username of the user to whom the :term:`Delivery Service Request` is assigned.
-:assigneeId:            The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
-:author:                The author of the :term:`Delivery Service Request`
-:authorId:              The integral, unique identifier assigned to the author
-:changeType:            The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:             The date and time at which the :term:`DSR <Delivery Service Request>` was created, in ISO format.
-:deliveryService:       The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
+:assignee:        The username of the user to whom the :term:`Delivery Service Request` is assigned.
+:assigneeId:      The integral, unique identifier of the user to whom the :term:`Delivery Service Request` is assigned.
+:author:          The author of the :term:`Delivery Service Request`
+:authorId:        The integral, unique identifier assigned to the author
+:changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
-	:active:                        A boolean that defines :ref:`ds-active`.
-	:anonymousBlockingEnabled:      A boolean that defines :ref:`ds-anonymous-blocking`
-	:cacheurl:                      A :ref:`ds-cacheurl`
+	:active:                   A boolean that defines :ref:`ds-active`.
+	:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+	:cacheurl:                 A :ref:`ds-cacheurl`
 
 		.. deprecated:: ATCv3.0
 			This field has been deprecated in Traffic Control 3.x and is subject to removal in Traffic Control 4.x or later
 
-	:ccrDnsTtl:                     The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
-	:cdnId:                         The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:cdnName:                       Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
-	:checkPath:                     A :ref:`ds-check-path`
-	:consistentHashQueryParams:     An array of :ref:`ds-consistent-hashing-qparams`
-	:consistentHashRegex:           A :ref:`ds-consistent-hashing-regex`
-	:deepCachingType:               The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-	:displayName:                   The :ref:`ds-display-name`
-	:dnsBypassCname:                A :ref:`ds-dns-bypass-cname`
-	:dnsBypassIp:                   A :ref:`ds-dns-bypass-ip`
-	:dnsBypassIp6:                  A :ref:`ds-dns-bypass-ipv6`
-	:dnsBypassTtl:                  The :ref:`ds-dns-bypass-ttl`
-	:dscp:                          A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-	:ecsEnabled:                    A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-	:edgeHeaderRewrite:             A set of :ref:`ds-edge-header-rw-rules`
-	:exampleURLs:                   An array of :ref:`ds-example-urls`
-	:firstHeaderRewrite:            A set of :ref:`ds-first-header-rw-rules`
-	:fqPacingRate:                  The :ref:`ds-fqpr`
-	:geoLimit:                      An integer that defines the :ref:`ds-geo-limit`
-	:geoLimitCountries:             A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
-	:geoLimitRedirectUrl:           A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
-	:geoProvider:                   The :ref:`ds-geo-provider`
-	:globalMaxMbps:                 The :ref:`ds-global-max-mbps`
-	:globalMaxTps:                  The :ref:`ds-global-max-tps`
-	:httpBypassFqdn:                A :ref:`ds-http-bypass-fqdn`
-	:id:                            An integral, unique identifier for this :term:`Delivery Service`
-	:infoUrl:                       An :ref:`ds-info-url`
-	:initialDispersion:             The :ref:`ds-initial-dispersion`
-	:innerHeaderRewrite:            A set of :ref:`ds-inner-header-rw-rules`
-	:ipv6RoutingEnabled:            A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
-	:lastHeaderRewrite:             A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:                   The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:logsEnabled:                   A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-	:longDesc:                      The :ref:`ds-longdesc` of this :term:`Delivery Service`
-	:longDesc1:                     An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
-	:longDesc2:                     An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
-	:matchList:                     The :term:`Delivery Service`'s :ref:`ds-matchlist`
+	:ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
+	:cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
+	:checkPath:                 A :ref:`ds-check-path`
+	:consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
+	:consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
+	:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+	:displayName:               The :ref:`ds-display-name`
+	:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+	:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+	:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+	:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+	:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+	:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+	:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+	:exampleURLs:               An array of :ref:`ds-example-urls`
+	:firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
+	:fqPacingRate:              The :ref:`ds-fqpr`
+	:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+	:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`\ [#geolimit]_
+	:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`\ [#geolimit]_
+	:geoProvider:               The :ref:`ds-geo-provider`
+	:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+	:globalMaxTps:              The :ref:`ds-global-max-tps`
+	:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+	:id:                        An integral, unique identifier for this :term:`Delivery Service`
+	:infoUrl:                   An :ref:`ds-info-url`
+	:initialDispersion:         The :ref:`ds-initial-dispersion`
+	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
+	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
+	:longDesc2:                 An optional field containing the :ref:`ds-longdesc3` of this :term:`Delivery Service`
+	:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 		:pattern:               A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 		:setNumber:             An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -136,11 +136,11 @@ Response Structure
 	:typeId:                        The integral, unique identifier of the :ref:`ds-types` of this :term:`Delivery Service`
 	:xmlId:                         This :term:`Delivery Service`'s :ref:`ds-xmlid`
 
-:id:                    The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
-:lastEditedBy:          The username of user who last edited this :term:`DSR <Delivery Service Request>`
-:lastEditedById:        The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:           The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in ISO format.
-:status:                The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
+:id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
+:lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
+:lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v3/deliveryservice_requests_id_status.rst
@@ -54,7 +54,7 @@ Response Structure
 :author:          The author of the :term:`Delivery Service Request`
 :authorId:        The integral, unique identifier assigned to the author
 :changeType:      The change type of the :term:`DSR <Delivery Service Request>`. It can be ``create``, ``update``, or ``delete``....
-:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in an ISO-like format.
+:createdAt:       The date and time at which the :term:`DSR <Delivery Service Request>` was created, in :ref:`non-rfc-datetime`.
 :deliveryService: The delivery service that the :term:`DSR <Delivery Service Request>` is requesting to update.
 
 	:active:                   A boolean that defines :ref:`ds-active`.
@@ -95,7 +95,7 @@ Response Structure
 	:innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 	:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 	:lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+	:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 	:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 	:longDesc1:                 An optional field containing the :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -139,7 +139,7 @@ Response Structure
 :id:             The integral, unique identifier assigned to the :term:`DSR <Delivery Service Request>`
 :lastEditedBy:   The username of user who last edited this :term:`DSR <Delivery Service Request>`
 :lastEditedById: The integral, unique identifier assigned to the user who last edited this :term:`DSR <Delivery Service Request>`
-:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in an ISO-like format.
+:lastUpdated:    The date and time at which the :term:`DSR <Delivery Service Request>` was last updated, in :ref:`non-rfc-datetime`.
 :status:         The status of the request. Can be "draft", "submitted", "rejected", "pending", or "complete".
 
 .. code-block:: http

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -109,7 +109,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -419,7 +419,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -31,7 +31,7 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-    +-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| Name              | Required | Description                                                                                                                             |
 	+===================+==========+=========================================================================================================================================+
 	| cdn               | no       | Show only the :term:`Delivery Services` belonging to the :ref:`ds-cdn` identified by this integral, unique identifier                   |
@@ -44,7 +44,7 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant            | no       | Show only the :term:`Delivery Services` belonging to the :term:`Tenant` identified by this integral, unique identifier                  |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-    | topology          | no       | Show only the :term:`Delivery Services` assigned to the :term:`Topology` identified by this unique name                                 |
+	| topology          | no       | Show only the :term:`Delivery Services` assigned to the :term:`Topology` identified by this unique name                                 |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| type              | no       | Return only :term:`Delivery Services` of the :term:`Delivery Service` :ref:`ds-types` identified by this integral, unique identifier    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -66,7 +66,7 @@ Request Structure
 	| page              | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1.    |
 	|                   |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                       |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-    | active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
+	| active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 
 Response Structure
@@ -394,37 +394,37 @@ Response Structure
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
 :firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -452,7 +452,7 @@ Response Structure
 :signed:                ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
 :rangeSliceBlockSize:   An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	    This integer indicates the :ref:`ds-ssl-key-version`
+:sslKeyVersion:         This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :topology:              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 :trRequestHeaders:      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -109,7 +109,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices_id_safe.rst
+++ b/docs/source/api/v3/deliveryservices_id_safe.rst
@@ -99,7 +99,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices_id_safe.rst
+++ b/docs/source/api/v3/deliveryservices_id_safe.rst
@@ -99,7 +99,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/deliveryservices_id_servers.rst
+++ b/docs/source/api/v3/deliveryservices_id_servers.rst
@@ -70,7 +70,7 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v3/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v3/deliveryservices_id_servers_eligible.rst
@@ -75,7 +75,7 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v3/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/v3/deliveryservices_required_capabilities.rst
@@ -67,7 +67,7 @@ Response Structure
 ------------------
 :deliveryServiceID:   The associated :term:`Delivery Service`'s integral, unique identifier
 :xmlID:               The associated :term:`Delivery Service`'s :ref:`ds-xmlid`
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -136,7 +136,7 @@ Request Structure
 Response Structure
 ------------------
 :deliveryServiceID:   The newly associated :term:`Delivery Service`'s integral, unique identifier
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The newly associated :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v3/divisions.rst
+++ b/docs/source/api/v3/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/divisions.rst
+++ b/docs/source/api/v3/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/divisions_id.rst
+++ b/docs/source/api/v3/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/divisions_id.rst
+++ b/docs/source/api/v3/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v3/federation_resolvers.rst
+++ b/docs/source/api/v3/federation_resolvers.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:lastUpdated: The date and time at which this resolver was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this resolver was last updated, in :ref:`non-rfc-datetime`
 :type:        The :term:`Type` of the resolver
 
 .. code-block:: http
@@ -228,4 +228,3 @@ Response Structure
 		"ipAddress": "1.2.6.4/22",
 		"type": "RESOLVE6"
 	}}
-

--- a/docs/source/api/v3/logs.rst
+++ b/docs/source/api/v3/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in an ISO-like format
+:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v3/logs.rst
+++ b/docs/source/api/v3/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v3/parameters.rst
+++ b/docs/source/api/v3/parameters.rst
@@ -72,7 +72,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -171,7 +171,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v3/parameters_id.rst
+++ b/docs/source/api/v3/parameters_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v3/phys_locations.rst
+++ b/docs/source/api/v3/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/phys_locations.rst
+++ b/docs/source/api/v3/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/phys_locations_id.rst
+++ b/docs/source/api/v3/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/phys_locations_id.rst
+++ b/docs/source/api/v3/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v3/profileparameters.rst
+++ b/docs/source/api/v3/profileparameters.rst
@@ -51,7 +51,7 @@ Request Structure
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :ref:`non-rfc-datetime`
 :parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
 :profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 
@@ -150,7 +150,7 @@ Array Format
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in an ISO-like format
+:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :ref:`non-rfc-datetime`
 :parameter:   :ref:`parameter-name` of the :term:`Parameter` which is assigned to ``profile``
 :parameterId: The :ref:`parameter-id` of the assigned :term:`Parameter`
 :profile:     :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` is assigned

--- a/docs/source/api/v3/profiles.rst
+++ b/docs/source/api/v3/profiles.rst
@@ -56,7 +56,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`
@@ -130,7 +130,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v3/profiles_id.rst
+++ b/docs/source/api/v3/profiles_id.rst
@@ -70,7 +70,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v3/profiles_id_parameters.rst
+++ b/docs/source/api/v3/profiles_id_parameters.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v3/profiles_name_name_parameters.rst
+++ b/docs/source/api/v3/profiles_name_name_parameters.rst
@@ -50,7 +50,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v3/regions.rst
+++ b/docs/source/api/v3/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/regions.rst
+++ b/docs/source/api/v3/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/regions_id.rst
+++ b/docs/source/api/v3/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/regions_id.rst
+++ b/docs/source/api/v3/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v3/server_server_capabilities.rst
+++ b/docs/source/api/v3/server_server_capabilities.rst
@@ -65,7 +65,7 @@ Response Structure
 ------------------
 :serverHostName:   The server's host name
 :serverId:         The server's integral, unique identifier
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Request Structure
 Response Structure
 ------------------
 :serverId:         The integral, unique identifier of the newly associated server
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -105,7 +105,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -105,7 +105,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v3/servicecategories.rst
+++ b/docs/source/api/v3/servicecategories.rst
@@ -32,33 +32,33 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | Name      | Description                                                                                                   |
-    +===========+===============================================================================================================+
-    | name      | Filter for :term:`Service Categories` with this name                                                          |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | orderby   | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
-    |           | array                                                                                                         |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | sortOrder | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | limit     | Choose the maximum number of results to return                                                                |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | offset    | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | page      | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
-    |           | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
-    |           | defined to make use of ``page``.                                                                              |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| Name      | Description                                                                                                   |
+	+===========+===============================================================================================================+
+	| name      | Filter for :term:`Service Categories` with this name                                                          |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| orderby   | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
+	|           | array                                                                                                         |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| sortOrder | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| limit     | Choose the maximum number of results to return                                                                |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| offset    | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| page      | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
+	|           | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
+	|           | defined to make use of ``page``.                                                                              |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
-    :caption: Request Example
+	:caption: Request Example
 
-    GET /api/3.0/service_categories?name=SERVICE_CATEGORY_NAME HTTP/1.1
-    Host: trafficops.infra.ciab.test
-    User-Agent: curl/7.47.0
-    Accept: */*
-    Cookie: mojolicious=...
+	GET /api/3.0/service_categories?name=SERVICE_CATEGORY_NAME HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
 
 Response Structure
 ------------------
@@ -66,28 +66,28 @@ Response Structure
 :lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
 
 .. code-block:: http
-    :caption: Response Example
+	:caption: Response Example
 
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-    Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-    Access-Control-Allow-Origin: *
-    Content-Type: application/json
-    Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-    Whole-Content-Sha512: Yzr6TfhxgpZ3pbbrr4TRG4wC3PlnHDDzgs2igtz/1ppLSy2MzugqaGW4y5yzwzl5T3+7q6HWej7GQZt1XIVeZQ==
-    X-Server-Name: traffic_ops_golang/
-    Date: Wed, 11 Mar 2020 20:02:47 GMT
-    Content-Length: 102
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: Yzr6TfhxgpZ3pbbrr4TRG4wC3PlnHDDzgs2igtz/1ppLSy2MzugqaGW4y5yzwzl5T3+7q6HWej7GQZt1XIVeZQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 11 Mar 2020 20:02:47 GMT
+	Content-Length: 102
 
-    {
-        "response": [
-            {
-                "lastUpdated": "2020-03-04 15:46:20-07",
-                "name": "SERVICE_CATEGORY_NAME"
-            }
-        ]
-    }
+	{
+		"response": [
+			{
+				"lastUpdated": "2020-03-04 15:46:20-07",
+				"name": "SERVICE_CATEGORY_NAME"
+			}
+		]
+	}
 
 ``POST``
 ========
@@ -102,19 +102,19 @@ Request Structure
 :name:        This :term:`Service Category`'s name
 
 .. code-block:: http
-    :caption: Request Example
+	:caption: Request Example
 
-    POST /api/3.0/service_categories HTTP/1.1
-    Host: trafficops.infra.ciab.test
-    User-Agent: curl/7.47.0
-    Accept: */*
-    Cookie: mojolicious=...
-    Content-Length: 48
-    Content-Type: application/json
+	POST /api/3.0/service_categories HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 48
+	Content-Type: application/json
 
-    {
-        "name": "SERVICE_CATEGORY_NAME",
-    }
+	{
+		"name": "SERVICE_CATEGORY_NAME",
+	}
 
 Response Structure
 ------------------
@@ -122,32 +122,32 @@ Response Structure
 :lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
 
 .. code-block:: http
-    :caption: Response Example
+	:caption: Response Example
 
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-    Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-    Access-Control-Allow-Origin: *
-    Content-Type: application/json
-    Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-    Whole-Content-Sha512: +pJm4c3O+JTaSXNt+LP+u240Ba/SsvSSDOQ4rDc6hcyZ0FIL+iY/WWrMHhpLulRGKGY88bM4YPCMaxGn3FZ9yQ==
-    X-Server-Name: traffic_ops_golang/
-    Date: Wed, 11 Mar 2020 20:12:20 GMT
-    Content-Length: 154
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: +pJm4c3O+JTaSXNt+LP+u240Ba/SsvSSDOQ4rDc6hcyZ0FIL+iY/WWrMHhpLulRGKGY88bM4YPCMaxGn3FZ9yQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 11 Mar 2020 20:12:20 GMT
+	Content-Length: 154
 
-    {
-        "alerts": [
-            {
-                "text": "serviceCategory was created.",
-                "level": "success"
-            }
-        ],
-        "response": {
-            "lastUpdated": "2020-03-11 14:12:20-06",
-            "name": "SERVICE_CATEGORY_NAME"
-        }
-    }
+	{
+		"alerts": [
+			{
+				"text": "serviceCategory was created.",
+				"level": "success"
+			}
+		],
+		"response": {
+			"lastUpdated": "2020-03-11 14:12:20-06",
+			"name": "SERVICE_CATEGORY_NAME"
+		}
+	}
 
 ``DELETE``
 ==========

--- a/docs/source/api/v3/servicecategories.rst
+++ b/docs/source/api/v3/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/servicecategories.rst
+++ b/docs/source/api/v3/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v3/stats_summary.rst
+++ b/docs/source/api/v3/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v3/stats_summary.rst
+++ b/docs/source/api/v3/stats_summary.rst
@@ -109,7 +109,7 @@ Summary Stats
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in an ISO-like format
+:summaryTime: Timestamp of the last updated summary, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -199,7 +199,7 @@ Request Structure
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.

--- a/docs/source/api/v3/statuses.rst
+++ b/docs/source/api/v3/statuses.rst
@@ -68,7 +68,7 @@ Response Structure
 ------------------
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
-:lastUpdated: The date and time at which this status was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this status was last modified, in :ref:`non-rfc-datetime`
 :name:        The name of the status
 
 .. code-block:: http

--- a/docs/source/api/v3/types.rst
+++ b/docs/source/api/v3/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v3/types.rst
+++ b/docs/source/api/v3/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v3/types_id.rst
+++ b/docs/source/api/v3/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v3/types_id.rst
+++ b/docs/source/api/v3/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v3/user_current.rst
+++ b/docs/source/api/v3/user_current.rst
@@ -44,7 +44,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -176,7 +176,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/users.rst
+++ b/docs/source/api/v3/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/users.rst
+++ b/docs/source/api/v3/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/users_id.rst
+++ b/docs/source/api/v3/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v3/users_id.rst
+++ b/docs/source/api/v3/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/api_capabilities.rst
+++ b/docs/source/api/v4/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in ISO format
+:lastUpdated: The time at which this capability was last updated, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/api_capabilities.rst
+++ b/docs/source/api/v4/api_capabilities.rst
@@ -60,7 +60,7 @@ Response Structure
 
 :httpRoute:   The request route for which this capability applies - relative to the Traffic Ops server's URL
 :id:          An integer which uniquely identifies this capability
-:lastUpdated: The time at which this capability was last updated, in an ISO-like format
+:lastUpdated: The time at which this capability was last updated, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/asns.rst
+++ b/docs/source/api/v4/asns.rst
@@ -73,7 +73,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -142,7 +142,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -211,7 +211,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/asns_id.rst
+++ b/docs/source/api/v4/asns_id.rst
@@ -67,7 +67,7 @@ Response Structure
 :cachegroup:   A string that is the :ref:`cache-group-name` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cachegroupparameters.rst
+++ b/docs/source/api/v4/cachegroupparameters.rst
@@ -55,7 +55,7 @@ Response Structure
 :cachegroupParameters: An array of identifying information for the :ref:`cache-group-parameters` of :term:`Cache Groups`
 
 	:cachegroup:   A string containing the :ref:`cache-group-name` of the :term:`Cache Group`
-	:last_updated: Date and time of last modification in an ISO-like format
+	:last_updated: Date and time of last modification in :ref:`non-rfc-datetime`
 	:parameter:    An integer that is the :term:`Parameter`'s :ref:`parameter-id`
 
 .. code-block:: http

--- a/docs/source/api/v4/cachegroupparameters.rst
+++ b/docs/source/api/v4/cachegroupparameters.rst
@@ -156,7 +156,7 @@ Response Structure
 :parameterId:  An integer that is the :ref:`parameter-id` of the :term:`Parameter` which has been assigned
 
 .. code-block:: http
- 	:caption: Response Example
+	:caption: Response Example
 
 	HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
@@ -184,4 +184,3 @@ Response Structure
 			"parameterId": 124
 		}
 	]}
-

--- a/docs/source/api/v4/cachegroups.rst
+++ b/docs/source/api/v4/cachegroups.rst
@@ -70,7 +70,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`
@@ -180,7 +180,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v4/cachegroups_id.rst
+++ b/docs/source/api/v4/cachegroups_id.rst
@@ -83,7 +83,7 @@ Response Structure
 :fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
 :fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in an ISO-like format
+:lastUpdated:                   The time and date at which this entry was last updated in :ref:`non-rfc-datetime`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v4/cachegroups_id_parameters.rst
+++ b/docs/source/api/v4/cachegroups_id_parameters.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :secure:      A boolean value describing whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`

--- a/docs/source/api/v4/capabilities.rst
+++ b/docs/source/api/v4/capabilities.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :name:        Name of the capability
 :description: Describes the permissions covered by the capability.
-:lastUpdated: Date and time of the last update made to this capability, in an ISO-like format
+:lastUpdated: Date and time of the last update made to this capability, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -56,7 +56,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -119,7 +119,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -54,11 +54,11 @@ Request Structure
 
 Response Structure
 ------------------
-:id:			The integral, unique identifier of the notification
-:cdn:			The name of the CDN to which the notification belongs to
-:lastUpdated:	The time and date this server entry was last updated in an ISO-like format
-:notification:	The content of the notification
-:user:			The user responsible for creating the notification
+:id:           The integral, unique identifier of the notification
+:cdn:          The name of the CDN to which the notification belongs to
+:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:notification: The content of the notification
+:user:         The user responsible for creating the notification
 
 .. code-block:: http
 	:caption: Response Example
@@ -98,8 +98,8 @@ Creates a notification for a specific CDN.
 
 Request Structure
 -----------------
-:cdn:			The name of the CDN to which the notification shall belong
-:notification:	The content of the notification
+:cdn:          The name of the CDN to which the notification shall belong
+:notification: The content of the notification
 
 .. code-block:: http
 	:caption: Request Example
@@ -117,11 +117,11 @@ Request Structure
 
 Response Structure
 ------------------
-:id:			The integral, unique identifier of the notification
-:cdn:			The name of the CDN to which the notification belongs to
-:lastUpdated:	The time and date this server entry was last updated in an ISO-like format
-:notification:	The content of the notification
-:user:			The user responsible for creating the notification
+:id:           The integral, unique identifier of the notification
+:cdn:          The name of the CDN to which the notification belongs to
+:lastUpdated:  The time and date this server entry was last updated in an ISO-like format
+:notification: The content of the notification
+:user:         The user responsible for creating the notification
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cdns.rst
+++ b/docs/source/api/v4/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
+:lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v4/cdns.rst
+++ b/docs/source/api/v4/cdns.rst
@@ -64,7 +64,7 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in ISO format
+:lastUpdated:   Date and time when the CDN was last modified in an ISO-like format
 :name:          The name of the CDN
 
 .. code-block:: http

--- a/docs/source/api/v4/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v4/cdns_name_configs_monitoring.rst
@@ -98,15 +98,15 @@ Response Structure
 
 :trafficServers: An array of objects that represent the :term:`cache servers` being monitored within this CDN
 
-	:cacheGroup:    The :term:`Cache Group` to which this :term:`cache server` belongs
-	:fqdn:          An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
-	:hashId:        The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
-	:hostName:      The (short) hostname of the :term:`cache server`
-	:port:          The port on which the :term:`cache server` listens for incoming connections
-	:profile:       A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
-	:status:        The status of the :term:`cache server`
-	:type:          A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
-	:interfaces:		A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
+	:cacheGroup: The :term:`Cache Group` to which this :term:`cache server` belongs
+	:fqdn:       An :abbr:`FQDN (Fully Qualified Domain Name)` that resolves to the :term:`cache server`'s IPv4 (or IPv6) address
+	:hashId:     The (short) hostname for the :term:`cache server` - named "hashId" for legacy reasons
+	:hostName:   The (short) hostname of the :term:`cache server`
+	:port:       The port on which the :term:`cache server` listens for incoming connections
+	:profile:    A string that is the :ref:`profile-name` of the :term:`Profile` assigned to this :term:`cache server`
+	:status:     The status of the :term:`cache server`
+	:type:       A string that names the :term:`Type` of the :term:`cache server` - should (ideally) be either ``EDGE`` or ``MID``
+	:interfaces: A set of the network interfaces in use by the server. In most scenarios, only one will be present, but it is illegal for this set to be an empty collection.
 
 		:ipAddresses: A set of objects representing IP Addresses assigned to this network interface. In most scenarios, only one or two (usually one IPv4 address and one IPv6 address) will be present, but it is illegal for this set to be an empty collection.
 

--- a/docs/source/api/v4/cdns_name_federations.rst
+++ b/docs/source/api/v4/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_federations.rst
+++ b/docs/source/api/v4/cdns_name_federations.rst
@@ -79,7 +79,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created. Refer to the ``POST`` method of this endpoint to see how federations can be created.
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 .. code-block:: http
@@ -161,7 +161,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_federations_id.rst
+++ b/docs/source/api/v4/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this federation was last modified, in :ref:`non-rfc-datetime`
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_federations_id.rst
+++ b/docs/source/api/v4/cdns_name_federations_id.rst
@@ -70,7 +70,7 @@ Response Structure
 
 	.. note:: This key will only be present if the description was provided when the federation was created
 
-:lastUpdated: The date and time at which this federation was last modified, in ISO format
+:lastUpdated: The date and time at which this federation was last modified, in an ISO-like format
 :ttl:         Time to Live (TTL) for the ``cname``, in hours
 
 

--- a/docs/source/api/v4/cdns_name_snapshot.rst
+++ b/docs/source/api/v4/cdns_name_snapshot.rst
@@ -320,7 +320,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 
@@ -359,211 +359,211 @@ Response Structure
 
 	{
 		"response": {
-		    "config": {
-			"api.cache-control.max-age": "10",
-			"certificates.polling.interval": "300000",
-			"consistent.dns.routing": "true",
-			"coveragezone.polling.interval": "3600000",
-			"coveragezone.polling.url": "https://static.infra.ciab.test:443/coverage-zone.json",
-			"dnssec.dynamic.response.expiration": "300s",
-			"dnssec.enabled": "false",
-			"domain_name": "mycdn.ciab.test",
-			"federationmapping.polling.interval": "60000",
-			"federationmapping.polling.url": "https://${toHostname}/api/2.0/federations/all",
-			"geolocation.polling.interval": "86400000",
-			"geolocation.polling.url": "https://static.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
-			"keystore.maintenance.interval": "300",
-			"neustar.polling.interval": "86400000",
-			"neustar.polling.url": "https://static.infra.ciab.test:443/neustar.tar.gz",
-			"soa": {
-			    "admin": "twelve_monkeys",
-			    "expire": "604800",
-			    "minimum": "30",
-			    "refresh": "28800",
-			    "retry": "7200"
+			"config": {
+				"api.cache-control.max-age": "10",
+				"certificates.polling.interval": "300000",
+				"consistent.dns.routing": "true",
+				"coveragezone.polling.interval": "3600000",
+				"coveragezone.polling.url": "https://static.infra.ciab.test:443/coverage-zone.json",
+				"dnssec.dynamic.response.expiration": "300s",
+				"dnssec.enabled": "false",
+				"domain_name": "mycdn.ciab.test",
+				"federationmapping.polling.interval": "60000",
+				"federationmapping.polling.url": "https://${toHostname}/api/2.0/federations/all",
+				"geolocation.polling.interval": "86400000",
+				"geolocation.polling.url": "https://static.infra.ciab.test:443/GeoLite2-City.mmdb.gz",
+				"keystore.maintenance.interval": "300",
+				"neustar.polling.interval": "86400000",
+				"neustar.polling.url": "https://static.infra.ciab.test:443/neustar.tar.gz",
+				"soa": {
+					"admin": "twelve_monkeys",
+					"expire": "604800",
+					"minimum": "30",
+					"refresh": "28800",
+					"retry": "7200"
+				},
+				"steeringmapping.polling.interval": "60000",
+				"ttls": {
+					"A": "3600",
+					"AAAA": "3600",
+					"DNSKEY": "30",
+					"DS": "30",
+					"NS": "3600",
+					"SOA": "86400"
+				},
+				"zonemanager.cache.maintenance.interval": "300",
+				"zonemanager.threadpool.scale": "0.50"
 			},
-			"steeringmapping.polling.interval": "60000",
-			"ttls": {
-			    "A": "3600",
-			    "AAAA": "3600",
-			    "DNSKEY": "30",
-			    "DS": "30",
-			    "NS": "3600",
-			    "SOA": "86400"
-			},
-			"zonemanager.cache.maintenance.interval": "300",
-			"zonemanager.threadpool.scale": "0.50"
-		    },
-		    "contentRouters": {
-			"trafficrouter": {
-			    "api.port": "3333",
-			    "fqdn": "trafficrouter.infra.ciab.test",
-			    "httpsPort": 443,
-			    "ip": "172.26.0.15",
-			    "ip6": "",
-			    "location": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "CCR_CIAB",
-			    "secure.api.port": "3443",
-			    "status": "ONLINE"
-			}
-		    },
-		    "contentServers": {
-			"edge": {
-			    "cacheGroup": "CDN_in_a_Box_Edge",
-			    "capabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "fqdn": "edge.infra.ciab.test",
-			    "hashCount": 999,
-			    "hashId": "edge",
-			    "httpsPort": 443,
-			    "interfaceName": "eth0",
-			    "ip": "172.26.0.3",
-			    "ip6": "",
-			    "locationId": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "ATS_EDGE_TIER_CACHE",
-			    "routingDisabled": 0,
-			    "status": "REPORTED",
-			    "type": "EDGE"
-			},
-			"mid": {
-			    "cacheGroup": "CDN_in_a_Box_Mid",
-			    "capabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "fqdn": "mid.infra.ciab.test",
-			    "hashCount": 999,
-			    "hashId": "mid",
-			    "httpsPort": 443,
-			    "interfaceName": "eth0",
-			    "ip": "172.26.0.4",
-			    "ip6": "",
-			    "locationId": "CDN_in_a_Box_Mid",
-			    "port": 80,
-			    "profile": "ATS_MID_TIER_CACHE",
-			    "routingDisabled": 0,
-			    "status": "REPORTED",
-			    "type": "MID"
-			}
-		    },
-		    "deliveryServices": {
-			"demo1": {
-			    "anonymousBlockingEnabled": "false",
-			    "consistentHashQueryParams": [
-				"abc",
-				"pdq",
-				"xxx",
-				"zyx"
-			    ],
-			    "coverageZoneOnly": "false",
-			    "deepCachingType": "NEVER",
-			    "dispersion": {
-				"limit": 1,
-				"shuffled": "true"
-			    },
-			    "domains": [
-				"demo1.mycdn.ciab.test"
-			    ],
-			    "ecsEnabled": "false",
-			    "geolocationProvider": "maxmindGeolocationService",
-			    "ip6RoutingEnabled": "true",
-			    "matchsets": [
-				{
-				    "matchlist": [
-					{
-					    "match-type": "HOST",
-					    "regex": ".*\\.demo1\\..*"
-					}
-				    ],
-				    "protocol": "HTTP"
+			"contentRouters": {
+				"trafficrouter": {
+					"api.port": "3333",
+					"fqdn": "trafficrouter.infra.ciab.test",
+					"httpsPort": 443,
+					"ip": "172.26.0.15",
+					"ip6": "",
+					"location": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "CCR_CIAB",
+					"secure.api.port": "3443",
+					"status": "ONLINE"
 				}
-			    ],
-			    "missLocation": {
-				"lat": 42,
-				"long": -88
-			    },
-			    "protocol": {
-				"acceptHttps": "true",
-				"redirectToHttps": "false"
-			    },
-			    "regionalGeoBlocking": "false",
-			    "requiredCapabilities": [
-				"RAM_DISK_STORAGE"
-			    ],
-			    "routingName": "video",
-			    "soa": {
-				"admin": "traffic_ops",
-				"expire": "604800",
-				"minimum": "30",
-				"refresh": "28800",
-				"retry": "7200"
-			    },
-			    "sslEnabled": "true",
-			    "topology": "my-topology",
-			    "ttls": {
-				"A": "",
-				"AAAA": "",
-				"NS": "3600",
-				"SOA": "86400"
-			    }
+			},
+			"contentServers": {
+				"edge": {
+					"cacheGroup": "CDN_in_a_Box_Edge",
+					"capabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"fqdn": "edge.infra.ciab.test",
+					"hashCount": 999,
+					"hashId": "edge",
+					"httpsPort": 443,
+					"interfaceName": "eth0",
+					"ip": "172.26.0.3",
+					"ip6": "",
+					"locationId": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "ATS_EDGE_TIER_CACHE",
+					"routingDisabled": 0,
+					"status": "REPORTED",
+					"type": "EDGE"
+				},
+				"mid": {
+					"cacheGroup": "CDN_in_a_Box_Mid",
+					"capabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"fqdn": "mid.infra.ciab.test",
+					"hashCount": 999,
+					"hashId": "mid",
+					"httpsPort": 443,
+					"interfaceName": "eth0",
+					"ip": "172.26.0.4",
+					"ip6": "",
+					"locationId": "CDN_in_a_Box_Mid",
+					"port": 80,
+					"profile": "ATS_MID_TIER_CACHE",
+					"routingDisabled": 0,
+					"status": "REPORTED",
+					"type": "MID"
+				}
+			},
+			"deliveryServices": {
+				"demo1": {
+					"anonymousBlockingEnabled": "false",
+					"consistentHashQueryParams": [
+						"abc",
+						"pdq",
+						"xxx",
+						"zyx"
+					],
+					"coverageZoneOnly": "false",
+					"deepCachingType": "NEVER",
+					"dispersion": {
+						"limit": 1,
+						"shuffled": "true"
+					},
+					"domains": [
+						"demo1.mycdn.ciab.test"
+					],
+					"ecsEnabled": "false",
+					"geolocationProvider": "maxmindGeolocationService",
+					"ip6RoutingEnabled": "true",
+					"matchsets": [
+						{
+							"matchlist": [
+								{
+									"match-type": "HOST",
+									"regex": ".*\\.demo1\\..*"
+								}
+							],
+							"protocol": "HTTP"
+						}
+					],
+					"missLocation": {
+						"lat": 42,
+						"long": -88
+					},
+					"protocol": {
+						"acceptHttps": "true",
+						"redirectToHttps": "false"
+					},
+					"regionalGeoBlocking": "false",
+					"requiredCapabilities": [
+						"RAM_DISK_STORAGE"
+					],
+					"routingName": "video",
+					"soa": {
+						"admin": "traffic_ops",
+						"expire": "604800",
+						"minimum": "30",
+						"refresh": "28800",
+						"retry": "7200"
+					},
+					"sslEnabled": "true",
+					"topology": "my-topology",
+					"ttls": {
+						"A": "",
+						"AAAA": "",
+						"NS": "3600",
+						"SOA": "86400"
+					}
+				}
+			},
+			"edgeLocations": {
+				"CDN_in_a_Box_Edge": {
+					"backupLocations": {
+						"fallbackToClosest": "true"
+					},
+					"latitude": 38.897663,
+					"localizationMethods": [
+						"GEO",
+						"CZ",
+						"DEEP_CZ"
+					],
+					"longitude": -77.036574
+				}
+			},
+			"monitors": {
+				"trafficmonitor": {
+					"fqdn": "trafficmonitor.infra.ciab.test",
+					"httpsPort": 443,
+					"ip": "172.26.0.14",
+					"ip6": "",
+					"location": "CDN_in_a_Box_Edge",
+					"port": 80,
+					"profile": "RASCAL-Traffic_Monitor",
+					"status": "ONLINE"
+				}
+			},
+			"stats": {
+				"CDN_name": "CDN-in-a-Box",
+				"date": 1590600715,
+				"tm_host": "trafficops.infra.ciab.test:443",
+				"tm_user": "admin",
+				"tm_version": "development"
+			},
+			"topologies": {
+				"my-topology": {
+					"nodes": [
+						"CDN_in_a_Box_Edge"
+					]
+				}
+			},
+			"trafficRouterLocations": {
+				"CDN_in_a_Box_Edge": {
+					"backupLocations": {
+						"fallbackToClosest": "false"
+					},
+					"latitude": 38.897663,
+					"localizationMethods": [
+						"GEO",
+						"CZ",
+						"DEEP_CZ"
+					],
+					"longitude": -77.036574
+				}
 			}
-		    },
-		    "edgeLocations": {
-			"CDN_in_a_Box_Edge": {
-			    "backupLocations": {
-				"fallbackToClosest": "true"
-			    },
-			    "latitude": 38.897663,
-			    "localizationMethods": [
-				"GEO",
-				"CZ",
-				"DEEP_CZ"
-			    ],
-			    "longitude": -77.036574
-			}
-		    },
-		    "monitors": {
-			"trafficmonitor": {
-			    "fqdn": "trafficmonitor.infra.ciab.test",
-			    "httpsPort": 443,
-			    "ip": "172.26.0.14",
-			    "ip6": "",
-			    "location": "CDN_in_a_Box_Edge",
-			    "port": 80,
-			    "profile": "RASCAL-Traffic_Monitor",
-			    "status": "ONLINE"
-			}
-		    },
-		    "stats": {
-			"CDN_name": "CDN-in-a-Box",
-			"date": 1590600715,
-			"tm_host": "trafficops.infra.ciab.test:443",
-			"tm_user": "admin",
-			"tm_version": "development"
-		    },
-		    "topologies": {
-			"my-topology": {
-			    "nodes": [
-				"CDN_in_a_Box_Edge"
-			    ]
-			}
-		    },
-		    "trafficRouterLocations": {
-			"CDN_in_a_Box_Edge": {
-			    "backupLocations": {
-				"fallbackToClosest": "false"
-			    },
-			    "latitude": 38.897663,
-			    "localizationMethods": [
-				"GEO",
-				"CZ",
-				"DEEP_CZ"
-			    ],
-			    "longitude": -77.036574
-			}
-		    }
 		}
 	}
 

--- a/docs/source/api/v4/cdns_name_snapshot_new.rst
+++ b/docs/source/api/v4/cdns_name_snapshot_new.rst
@@ -320,7 +320,7 @@ Response Structure
 	:tm_user:    The username of the currently logged-in user
 	:tm_version: The full version number of the Traffic Ops server, including release number, git commit hash, and supported Enterprise Linux version
 
-:topologies:	An array of :term:`Topologies` where each key is the name of that Topology.
+:topologies: An array of :term:`Topologies` where each key is the name of that Topology.
 
 	:nodes: An array of the names of the :term:`Edge-Tier` :term:`Cache Groups` in this :term:`Topology`. :term:`Mid-Tier` Cache Groups in the topology are not included.
 

--- a/docs/source/api/v4/deliveryservice_request_comments.rst
+++ b/docs/source/api/v4/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:                   The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v4/deliveryservice_request_comments.rst
+++ b/docs/source/api/v4/deliveryservice_request_comments.rst
@@ -60,7 +60,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -139,7 +139,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 
@@ -223,7 +223,7 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in ISO format
+:lastUpdated:                   The date and time at which the user was last modified, in an ISO-like format
 :value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
 

--- a/docs/source/api/v4/deliveryservices.rst
+++ b/docs/source/api/v4/deliveryservices.rst
@@ -31,7 +31,7 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-    +-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| Name              | Required | Description                                                                                                                             |
 	+===================+==========+=========================================================================================================================================+
 	| cdn               | no       | Show only the :term:`Delivery Services` belonging to the :ref:`ds-cdn` identified by this integral, unique identifier                   |
@@ -44,7 +44,7 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant            | no       | Show only the :term:`Delivery Services` belonging to the :term:`Tenant` identified by this integral, unique identifier                  |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-    | topology          | no       | Show only the :term:`Delivery Services` assigned to the :term:`Topology` identified by this unique name                                 |
+	| topology          | no       | Show only the :term:`Delivery Services` assigned to the :term:`Topology` identified by this unique name                                 |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| type              | no       | Return only :term:`Delivery Services` of the :term:`Delivery Service` :ref:`ds-types` identified by this integral, unique identifier    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -66,7 +66,7 @@ Request Structure
 	| page              | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1.    |
 	|                   |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                       |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-    | active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
+	| active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 
 Response Structure
@@ -379,37 +379,37 @@ Response Structure
 :checkPath:                 A :ref:`ds-check-path`
 :consistentHashRegex:       A :ref:`ds-consistent-hashing-regex`
 :consistentHashQueryParams: An array of :ref:`ds-consistent-hashing-qparams`
-:deepCachingType:     		The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
-:displayName:       		The :ref:`ds-display-name`
-:dnsBypassCname:    		A :ref:`ds-dns-bypass-cname`
-:dnsBypassIp:       		A :ref:`ds-dns-bypass-ip`
-:dnsBypassIp6:      		A :ref:`ds-dns-bypass-ipv6`
-:dnsBypassTtl:      		The :ref:`ds-dns-bypass-ttl`
-:dscp:              		A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
-:ecsEnabled:        		A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
-:edgeHeaderRewrite: 		A set of :ref:`ds-edge-header-rw-rules`
-:exampleURLs:       		An array of :ref:`ds-example-urls`
+:deepCachingType:           The :ref:`ds-deep-caching` setting for this :term:`Delivery Service`
+:displayName:               The :ref:`ds-display-name`
+:dnsBypassCname:            A :ref:`ds-dns-bypass-cname`
+:dnsBypassIp:               A :ref:`ds-dns-bypass-ip`
+:dnsBypassIp6:              A :ref:`ds-dns-bypass-ipv6`
+:dnsBypassTtl:              The :ref:`ds-dns-bypass-ttl`
+:dscp:                      A :ref:`ds-dscp` to be used within the :term:`Delivery Service`
+:ecsEnabled:                A boolean that defines the :ref:`ds-ecs` setting on this :term:`Delivery Service`
+:edgeHeaderRewrite:         A set of :ref:`ds-edge-header-rw-rules`
+:exampleURLs:               An array of :ref:`ds-example-urls`
 :firstHeaderRewrite:        A set of :ref:`ds-first-header-rw-rules`
-:fqPacingRate:      		The :ref:`ds-fqpr`
-:geoLimit:            		An integer that defines the :ref:`ds-geo-limit`
-:geoLimitCountries:  		A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
-:geoLimitRedirectUrl: 		A :ref:`ds-geo-limit-redirect-url`
-:geoProvider:         		The :ref:`ds-geo-provider`
-:globalMaxMbps:       		The :ref:`ds-global-max-mbps`
-:globalMaxTps:        		The :ref:`ds-global-max-tps`
-:httpBypassFqdn:      		A :ref:`ds-http-bypass-fqdn`
-:id:                  		An integral, unique identifier for this :term:`Delivery Service`
-:infoUrl:             		An :ref:`ds-info-url`
-:initialDispersion:   		The :ref:`ds-initial-dispersion`
+:fqPacingRate:              The :ref:`ds-fqpr`
+:geoLimit:                  An integer that defines the :ref:`ds-geo-limit`
+:geoLimitCountries:         A string containing a comma-separated list defining the :ref:`ds-geo-limit-countries`
+:geoLimitRedirectUrl:       A :ref:`ds-geo-limit-redirect-url`
+:geoProvider:               The :ref:`ds-geo-provider`
+:globalMaxMbps:             The :ref:`ds-global-max-mbps`
+:globalMaxTps:              The :ref:`ds-global-max-tps`
+:httpBypassFqdn:            A :ref:`ds-http-bypass-fqdn`
+:id:                        An integral, unique identifier for this :term:`Delivery Service`
+:infoUrl:                   An :ref:`ds-info-url`
+:initialDispersion:         The :ref:`ds-initial-dispersion`
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
-:ipv6RoutingEnabled:  		A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
+:ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:        		The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
-:logsEnabled:         		A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
-:longDesc:            		The :ref:`ds-longdesc` of this :term:`Delivery Service`
-:longDesc1:           		The :ref:`ds-longdesc2` of this :term:`Delivery Service`
-:longDesc2:           		The :ref:`ds-longdesc3` of this :term:`Delivery Service`
-:matchList:          		The :term:`Delivery Service`'s :ref:`ds-matchlist`
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
+:longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
+:longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
+:longDesc2:                 The :ref:`ds-longdesc3` of this :term:`Delivery Service`
+:matchList:                 The :term:`Delivery Service`'s :ref:`ds-matchlist`
 
 	:pattern:   A regular expression - the use of this pattern is dependent on the ``type`` field (backslashes are escaped)
 	:setNumber: An integer that provides explicit ordering of :ref:`ds-matchlist` items - this is used as a priority ranking by Traffic Router, and is not guaranteed to correspond to the ordering of items in the array.
@@ -437,7 +437,7 @@ Response Structure
 :signed:                ``true`` if  and only if ``signingAlgorithm`` is not ``null``, ``false`` otherwise
 :signingAlgorithm:      Either a :ref:`ds-signing-algorithm` or ``null`` to indicate URL/URI signing is not implemented on this :term:`Delivery Service`
 :rangeSliceBlockSize:   An integer that defines the byte block size for the ATS Slice Plugin. It can only and must be set if ``rangeRequestHandling`` is set to 3.
-:sslKeyVersion: 	    This integer indicates the :ref:`ds-ssl-key-version`
+:sslKeyVersion:         This integer indicates the :ref:`ds-ssl-key-version`
 :tenantId:              The integral, unique identifier of the :ref:`ds-tenant` who owns this :term:`Delivery Service`
 :topology:              The unique name of the :term:`Topology` that this :term:`Delivery Service` is assigned to
 :trRequestHeaders:      If defined, this defines the :ref:`ds-tr-req-headers` used by Traffic Router for this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices.rst
+++ b/docs/source/api/v4/deliveryservices.rst
@@ -104,7 +104,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -404,7 +404,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices.rst
+++ b/docs/source/api/v4/deliveryservices.rst
@@ -104,7 +104,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`
@@ -404,7 +404,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices_id_safe.rst
+++ b/docs/source/api/v4/deliveryservices_id_safe.rst
@@ -94,7 +94,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices_id_safe.rst
+++ b/docs/source/api/v4/deliveryservices_id_safe.rst
@@ -94,7 +94,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/deliveryservices_id_servers.rst
+++ b/docs/source/api/v4/deliveryservices_id_servers.rst
@@ -70,7 +70,7 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v4/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v4/deliveryservices_id_servers_eligible.rst
@@ -75,7 +75,7 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in an ISO-like format
+:lastUpdated:    The time and date at which this server was last updated, in :ref:`non-rfc-datetime`
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v4/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/v4/deliveryservices_required_capabilities.rst
@@ -67,7 +67,7 @@ Response Structure
 ------------------
 :deliveryServiceID:   The associated :term:`Delivery Service`'s integral, unique identifier
 :xmlID:               The associated :term:`Delivery Service`'s :ref:`ds-xmlid`
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -136,7 +136,7 @@ Request Structure
 Response Structure
 ------------------
 :deliveryServiceID:   The newly associated :term:`Delivery Service`'s integral, unique identifier
-:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:         The date and time at which this association between the :term:`Delivery Service` and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :requiredCapability:  The newly associated :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v4/divisions.rst
+++ b/docs/source/api/v4/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/divisions.rst
+++ b/docs/source/api/v4/divisions.rst
@@ -55,7 +55,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http
@@ -115,7 +115,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/divisions_id.rst
+++ b/docs/source/api/v4/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this Division was last modified, in :ref:`non-rfc-datetime`
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/divisions_id.rst
+++ b/docs/source/api/v4/divisions_id.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in ISO format
+:lastUpdated: The date and time at which this Division was last modified, in an ISO-like format
 :name:        The Division name
 
 .. code-block:: http

--- a/docs/source/api/v4/federation_resolvers.rst
+++ b/docs/source/api/v4/federation_resolvers.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:lastUpdated: The date and time at which this resolver was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this resolver was last updated, in :ref:`non-rfc-datetime`
 :type:        The :term:`Type` of the resolver
 
 .. code-block:: http
@@ -228,4 +228,3 @@ Response Structure
 		"ipAddress": "1.2.6.4/22",
 		"type": "RESOLVE6"
 	}}
-

--- a/docs/source/api/v4/logs.rst
+++ b/docs/source/api/v4/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in an ISO-like format
+:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v4/logs.rst
+++ b/docs/source/api/v4/logs.rst
@@ -52,7 +52,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in ISO format
+:lastUpdated: Date and time at which the change was made, in an ISO-like format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems

--- a/docs/source/api/v4/parameters.rst
+++ b/docs/source/api/v4/parameters.rst
@@ -69,7 +69,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -168,7 +168,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v4/parameters_id.rst
+++ b/docs/source/api/v4/parameters_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v4/phys_locations.rst
+++ b/docs/source/api/v4/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/phys_locations.rst
+++ b/docs/source/api/v4/phys_locations.rst
@@ -70,7 +70,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -171,7 +171,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/phys_locations_id.rst
+++ b/docs/source/api/v4/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in ISO format
+:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/phys_locations_id.rst
+++ b/docs/source/api/v4/phys_locations_id.rst
@@ -84,7 +84,7 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in an ISO-like format
+:lastUpdated: The date and time at which the physical location was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location

--- a/docs/source/api/v4/profileparameters.rst
+++ b/docs/source/api/v4/profileparameters.rst
@@ -51,7 +51,7 @@ Request Structure
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :ref:`non-rfc-datetime`
 :parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
 :profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 
@@ -150,7 +150,7 @@ Array Format
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in an ISO-like format
+:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :ref:`non-rfc-datetime`
 :parameter:   :ref:`parameter-name` of the :term:`Parameter` which is assigned to ``profile``
 :parameterId: The :ref:`parameter-id` of the assigned :term:`Parameter`
 :profile:     :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` is assigned

--- a/docs/source/api/v4/profiles.rst
+++ b/docs/source/api/v4/profiles.rst
@@ -56,7 +56,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`
@@ -130,7 +130,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v4/profiles_id.rst
+++ b/docs/source/api/v4/profiles_id.rst
@@ -70,7 +70,7 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in an ISO-like format
+:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :ref:`non-rfc-datetime`
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v4/profiles_id_parameters.rst
+++ b/docs/source/api/v4/profiles_id_parameters.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v4/profiles_name_name_parameters.rst
+++ b/docs/source/api/v4/profiles_name_name_parameters.rst
@@ -50,7 +50,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`

--- a/docs/source/api/v4/regions.rst
+++ b/docs/source/api/v4/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/regions.rst
+++ b/docs/source/api/v4/regions.rst
@@ -68,7 +68,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/regions_id.rst
+++ b/docs/source/api/v4/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
+:lastUpdated:  The date and time at which this region was last updated, in :ref:`non-rfc-datetime`
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/regions_id.rst
+++ b/docs/source/api/v4/regions_id.rst
@@ -66,7 +66,7 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :divisionId:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated, in ISO format
+:lastUpdated:  The date and time at which this region was last updated, in an ISO-like format
 :name:         The region name
 
 .. code-block:: http

--- a/docs/source/api/v4/server_server_capabilities.rst
+++ b/docs/source/api/v4/server_server_capabilities.rst
@@ -65,7 +65,7 @@ Response Structure
 ------------------
 :serverHostName:   The server's host name
 :serverId:         The server's integral, unique identifier
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -134,7 +134,7 @@ Request Structure
 Response Structure
 ------------------
 :serverId:         The integral, unique identifier of the newly associated server
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in an ISO-like format
+:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :ref:`non-rfc-datetime`
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v4/servers_id_deliveryservices.rst
+++ b/docs/source/api/v4/servers_id_deliveryservices.rst
@@ -100,7 +100,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :rfc:`3339` format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/servers_id_deliveryservices.rst
+++ b/docs/source/api/v4/servers_id_deliveryservices.rst
@@ -100,7 +100,7 @@ Response Structure
 :innerHeaderRewrite:        A set of :ref:`ds-inner-header-rw-rules`
 :ipv6RoutingEnabled:        A boolean that defines the :ref:`ds-ipv6-routing` setting on this :term:`Delivery Service`
 :lastHeaderRewrite:         A set of :ref:`ds-last-header-rw-rules`
-:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in an ISO-like format
+:lastUpdated:               The date and time at which this :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 :logsEnabled:               A boolean that defines the :ref:`ds-logs-enabled` setting on this :term:`Delivery Service`
 :longDesc:                  The :ref:`ds-longdesc` of this :term:`Delivery Service`
 :longDesc1:                 The :ref:`ds-longdesc2` of this :term:`Delivery Service`

--- a/docs/source/api/v4/servicecategories.rst
+++ b/docs/source/api/v4/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/servicecategories.rst
+++ b/docs/source/api/v4/servicecategories.rst
@@ -32,33 +32,33 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | Name      | Description                                                                                                   |
-    +===========+===============================================================================================================+
-    | name      | Filter for :term:`Service Categories` with this name                                                          |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | orderby   | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
-    |           | array                                                                                                         |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | sortOrder | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | limit     | Choose the maximum number of results to return                                                                |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | offset    | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
-    | page      | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
-    |           | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
-    |           | defined to make use of ``page``.                                                                              |
-    +-----------+---------------------------------------------------------------------------------------------------------------+
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| Name      | Description                                                                                                   |
+	+===========+===============================================================================================================+
+	| name      | Filter for :term:`Service Categories` with this name                                                          |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| orderby   | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` |
+	|           | array                                                                                                         |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| sortOrder | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                      |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| limit     | Choose the maximum number of results to return                                                                |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| offset    | The number of results to skip before beginning to return results. Must use in conjunction with limit          |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
+	| page      | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long   |
+	|           | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
+	|           | defined to make use of ``page``.                                                                              |
+	+-----------+---------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
-    :caption: Request Example
+	:caption: Request Example
 
-    GET /api/4.0/service_categories?name=SERVICE_CATEGORY_NAME HTTP/1.1
-    Host: trafficops.infra.ciab.test
-    User-Agent: curl/7.47.0
-    Accept: */*
-    Cookie: mojolicious=...
+	GET /api/4.0/service_categories?name=SERVICE_CATEGORY_NAME HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
 
 Response Structure
 ------------------
@@ -66,28 +66,28 @@ Response Structure
 :lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
 
 .. code-block:: http
-    :caption: Response Example
+	:caption: Response Example
 
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-    Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-    Access-Control-Allow-Origin: *
-    Content-Type: application/json
-    Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-    Whole-Content-Sha512: Yzr6TfhxgpZ3pbbrr4TRG4wC3PlnHDDzgs2igtz/1ppLSy2MzugqaGW4y5yzwzl5T3+7q6HWej7GQZt1XIVeZQ==
-    X-Server-Name: traffic_ops_golang/
-    Date: Wed, 11 Mar 2020 20:02:47 GMT
-    Content-Length: 102
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: Yzr6TfhxgpZ3pbbrr4TRG4wC3PlnHDDzgs2igtz/1ppLSy2MzugqaGW4y5yzwzl5T3+7q6HWej7GQZt1XIVeZQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 11 Mar 2020 20:02:47 GMT
+	Content-Length: 102
 
-    {
-        "response": [
-            {
-                "lastUpdated": "2020-03-04 15:46:20-07",
-                "name": "SERVICE_CATEGORY_NAME"
-            }
-        ]
-    }
+	{
+		"response": [
+			{
+				"lastUpdated": "2020-03-04 15:46:20-07",
+				"name": "SERVICE_CATEGORY_NAME"
+			}
+		]
+	}
 
 ``POST``
 ========
@@ -102,19 +102,19 @@ Request Structure
 :name:        This :term:`Service Category`'s name
 
 .. code-block:: http
-    :caption: Request Example
+	:caption: Request Example
 
-    POST /api/4.0/service_categories HTTP/1.1
-    Host: trafficops.infra.ciab.test
-    User-Agent: curl/7.47.0
-    Accept: */*
-    Cookie: mojolicious=...
-    Content-Length: 48
-    Content-Type: application/json
+	POST /api/4.0/service_categories HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+	Content-Length: 48
+	Content-Type: application/json
 
-    {
-        "name": "SERVICE_CATEGORY_NAME",
-    }
+	{
+		"name": "SERVICE_CATEGORY_NAME",
+	}
 
 Response Structure
 ------------------
@@ -122,32 +122,32 @@ Response Structure
 :lastUpdated: The date and time at which this :term:`Service Category` was last modified, in ISO format
 
 .. code-block:: http
-    :caption: Response Example
+	:caption: Response Example
 
-    HTTP/1.1 200 OK
-    Access-Control-Allow-Credentials: true
-    Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
-    Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
-    Access-Control-Allow-Origin: *
-    Content-Type: application/json
-    Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
-    Whole-Content-Sha512: +pJm4c3O+JTaSXNt+LP+u240Ba/SsvSSDOQ4rDc6hcyZ0FIL+iY/WWrMHhpLulRGKGY88bM4YPCMaxGn3FZ9yQ==
-    X-Server-Name: traffic_ops_golang/
-    Date: Wed, 11 Mar 2020 20:12:20 GMT
-    Content-Length: 154
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: +pJm4c3O+JTaSXNt+LP+u240Ba/SsvSSDOQ4rDc6hcyZ0FIL+iY/WWrMHhpLulRGKGY88bM4YPCMaxGn3FZ9yQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Wed, 11 Mar 2020 20:12:20 GMT
+	Content-Length: 154
 
-    {
-        "alerts": [
-            {
-                "text": "serviceCategory was created.",
-                "level": "success"
-            }
-        ],
-        "response": {
-            "lastUpdated": "2020-03-11 14:12:20-06",
-            "name": "SERVICE_CATEGORY_NAME"
-        }
-    }
+	{
+		"alerts": [
+			{
+				"text": "serviceCategory was created.",
+				"level": "success"
+			}
+		],
+		"response": {
+			"lastUpdated": "2020-03-11 14:12:20-06",
+			"name": "SERVICE_CATEGORY_NAME"
+		}
+	}
 
 ``DELETE``
 ==========

--- a/docs/source/api/v4/servicecategories.rst
+++ b/docs/source/api/v4/servicecategories.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -119,7 +119,7 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/stats_summary.rst
+++ b/docs/source/api/v4/stats_summary.rst
@@ -110,7 +110,7 @@ Summary Stats
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
+:summaryTime: Timestamp of the last updated summary, in an ISO-like format
 
 .. code-block:: http
 	:caption: Response Example
@@ -200,7 +200,7 @@ Request Structure
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
 :summaryTime:         Timestamp of summary, in an ISO-like format
-:statDate:            Date stat was taken, in :rfc:`3339` format
+:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v4/stats_summary.rst
+++ b/docs/source/api/v4/stats_summary.rst
@@ -109,7 +109,7 @@ Summary Stats
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
@@ -157,7 +157,7 @@ Summary Stats
 Last Updated Summary Stat
 """""""""""""""""""""""""
 
-:summaryTime: Timestamp of the last updated summary, in an ISO-like format
+:summaryTime: Timestamp of the last updated summary, in :ref:`non-rfc-datetime`
 
 .. code-block:: http
 	:caption: Response Example
@@ -199,7 +199,7 @@ Request Structure
 
 :statName:            Stat name summary stat represents
 :statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in an ISO-like format
+:summaryTime:         Timestamp of summary, in :ref:`non-rfc-datetime`
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.

--- a/docs/source/api/v4/statuses.rst
+++ b/docs/source/api/v4/statuses.rst
@@ -68,7 +68,7 @@ Response Structure
 ------------------
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
-:lastUpdated: The date and time at which this status was last modified, in an ISO-like format
+:lastUpdated: The date and time at which this status was last modified, in :ref:`non-rfc-datetime`
 :name:        The name of the status
 
 .. code-block:: http

--- a/docs/source/api/v4/types.rst
+++ b/docs/source/api/v4/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v4/types.rst
+++ b/docs/source/api/v4/types.rst
@@ -54,7 +54,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -122,7 +122,7 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
@@ -156,5 +156,3 @@ Response Structure
 			"useInTable": "server"
 		}]
 	}
-
-

--- a/docs/source/api/v4/types_id.rst
+++ b/docs/source/api/v4/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
+:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v4/types_id.rst
+++ b/docs/source/api/v4/types_id.rst
@@ -64,7 +64,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in ISO format
+:lastUpdated: The date and time at which this type was last updated, in an ISO-like format
 :name:        The name of this type
 :useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 

--- a/docs/source/api/v4/user_current.rst
+++ b/docs/source/api/v4/user_current.rst
@@ -44,7 +44,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -176,7 +176,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A legacy field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/users.rst
+++ b/docs/source/api/v4/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/users.rst
+++ b/docs/source/api/v4/users.rst
@@ -77,7 +77,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -202,7 +202,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/users_id.rst
+++ b/docs/source/api/v4/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in ISO format
+:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/api/v4/users_id.rst
+++ b/docs/source/api/v4/users_id.rst
@@ -57,7 +57,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides
@@ -190,7 +190,7 @@ Response Structure
 :fullName:         The user's full name, e.g. "John Quincy Adams"
 :gid:              A deprecated field only kept for legacy compatibility reasons that used to contain the UNIX group ID of the user - now it is always ``null``
 :id:               An integral, unique identifier for this user
-:lastUpdated:      The date and time at which the user was last modified, in an ISO-like format
+:lastUpdated:      The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
 :newUser:          A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:      The user's phone number
 :postalCode:       The postal code of the area in which the user resides

--- a/docs/source/development/traffic_router.rst
+++ b/docs/source/development/traffic_router.rst
@@ -53,15 +53,15 @@ Using Homebrew, |AdoptOpenJDK instructions|_
 .. code-block:: shell
 	:caption: Install OpenJDK 8 on macOS
 
-        brew tap AdoptOpenJDK/openjdk
-        brew cask install adoptopenjdk8
+	brew tap AdoptOpenJDK/openjdk
+	brew cask install adoptopenjdk8
 
 Next, set the JAVA_HOME environment variable. Add this line to your ``~/.bash_profile``:
 
 .. code-block:: shell
-        :caption: Set JAVA_HOME environment variable
+	:caption: Set JAVA_HOME environment variable
 
-        export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
+	export JAVA_HOME=$(/usr/libexec/java_home -v1.8)
 
 .. |AdoptOpenJDK instructions| replace:: add the AdoptOpenJDK tap and install the ``adoptopenjdk8`` cask
 .. _AdoptOpenJDK instructions: https://github.com/AdoptOpenJDK/homebrew-openjdk#other-versions
@@ -108,16 +108,16 @@ To install the Traffic Router Developer environment:
 #. Set the environment variable TRAFFIC_MONITOR_HOSTS to be a semicolon delimited list of Traffic Monitors that can be accessed during integration tests OR install the :file:`traffic_monitor.properties` file.
 #. Additional configuration is set using the below files:
 
-  * copy :file:`core/src/main/conf/dns.properties` to :file:`core/src/test/conf/`
-  * copy :file:`core/src/main/conf/http.properties` to :file:`core/src/test/conf/`
-  * copy :file:`core/src/main/conf/log4j.properties` to :file:`core/src/test/conf/`
-  * copy :file:`core/src/main/conf/traffic_monitor.properties` to :file:`core/src/test/conf/` and then edit the ``traffic_monitor.bootstrap.hosts`` property
-  * copy :file:`core/src/main/conf/traffic_ops.properties` to :file:`core/src/test/conf/` and then edit the credentials as appropriate for the Traffic Ops instance you will be using.
-  * Default configuration values now reside in :file:`core/src/main/webapp/WEB-INF/applicationContext.xml`
+	* copy :file:`core/src/main/conf/dns.properties` to :file:`core/src/test/conf/`
+	* copy :file:`core/src/main/conf/http.properties` to :file:`core/src/test/conf/`
+	* copy :file:`core/src/main/conf/log4j.properties` to :file:`core/src/test/conf/`
+	* copy :file:`core/src/main/conf/traffic_monitor.properties` to :file:`core/src/test/conf/` and then edit the ``traffic_monitor.bootstrap.hosts`` property
+	* copy :file:`core/src/main/conf/traffic_ops.properties` to :file:`core/src/test/conf/` and then edit the credentials as appropriate for the Traffic Ops instance you will be using.
+	* Default configuration values now reside in :file:`core/src/main/webapp/WEB-INF/applicationContext.xml`
 
-  	.. note:: These values may be overridden by creating and/or modifying the property files listed in :file:`core/src/main/resources/applicationProperties.xml`
+	.. note:: These values may be overridden by creating and/or modifying the property files listed in :file:`core/src/main/resources/applicationProperties.xml`
 
-  	.. note:: Pre-existing properties files are still honored by Traffic Router. For example :file:`traffic_monitor.properties` may contain the :abbr:`FQDN (Fully Qualified Domain Name)` and port of the Traffic Monitor instance(s), separated by semicolons as necessary (do not include scheme e.g. ``http://``)
+	.. note:: Pre-existing properties files are still honored by Traffic Router. For example :file:`traffic_monitor.properties` may contain the :abbr:`FQDN (Fully Qualified Domain Name)` and port of the Traffic Monitor instance(s), separated by semicolons as necessary (do not include scheme e.g. ``http://``)
 
 
 #. Import the existing git repository as projects into your IDE (Eclipse):
@@ -309,7 +309,7 @@ API
 :ref:`tr-api`
 
 .. toctree::
-  :hidden:
-  :maxdepth: 1
+	:hidden:
+	:maxdepth: 1
 
-  traffic_router/traffic_router_api
+	traffic_router/traffic_router_api

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -44,7 +44,7 @@ Glossary
 	Cache Groups
 		A group of caching HTTP proxy servers that together create a combined larger cache using consistent hashing. Traffic Router treats all servers in a :dfn:`Cache Group` as though they are in the  same geographic location, though they are in fact only in the same general area. A :dfn:`Cache Group` has one single set of geographical coordinates even if the :term:`cache servers` that make up the :dfn:`Cache Group` are actually in :term:`Physical Locations`. The :term:`cache servers` in a :dfn:`Cache Group` are not aware of the other :term:`cache servers` in the group - there is no clustering software or communications between :term:`cache servers` in a :dfn:`Cache Group`.
 
-  		There are two basic types of :dfn:`Cache Groups`: EDGE_LOC and MID_LOC ("LOC" being short for "location" - a holdover from when :dfn:`Cache Groups` were called "Cache Locations). Traffic Control is a two-tiered system, where the clients get directed to the Edge-tier (EDGE_LOC) :dfn:`Cache Group`. On cache miss, the :term:`cache server` in the Edge-tier :dfn:`Cache Group` obtains content from a Mid-tier (MID_LOC) :dfn:`Cache Group`, rather than the origin, which is shared with multiple Edge-tier :dfn:`Cache Groups`. Edge-tier :dfn:`Cache Groups` are usually configured to have a single "parent" :dfn:`Cache Group`, but in general Mid-tier :dfn:`Cache Groups` have many "children".
+		There are two basic types of :dfn:`Cache Groups`: EDGE_LOC and MID_LOC ("LOC" being short for "location" - a holdover from when :dfn:`Cache Groups` were called "Cache Locations). Traffic Control is a two-tiered system, where the clients get directed to the Edge-tier (EDGE_LOC) :dfn:`Cache Group`. On cache miss, the :term:`cache server` in the Edge-tier :dfn:`Cache Group` obtains content from a Mid-tier (MID_LOC) :dfn:`Cache Group`, rather than the origin, which is shared with multiple Edge-tier :dfn:`Cache Groups`. Edge-tier :dfn:`Cache Groups` are usually configured to have a single "parent" :dfn:`Cache Group`, but in general Mid-tier :dfn:`Cache Groups` have many "children".
 
 		..  Note:: Often the Edge-tier to Mid-tier relationship is based on network distance, and does not necessarily match the geographic distance.
 
@@ -238,8 +238,8 @@ Glossary
 	geo localization or geo routing
 		Localizing clients to the nearest caches using a geo database like the one from Maxmind.
 
- 	Health Protocol
- 		The protocol to monitor the health of all the caches. See :ref:`health-proto`.
+	Health Protocol
+		The protocol to monitor the health of all the caches. See :ref:`health-proto`.
 
 	Inner-tier
 	Inner-tier cache
@@ -255,8 +255,8 @@ Glossary
 	Last-tier cache servers
 		The tier above the First and Inner tiers. The last tier in a :term:`Topology` is the tier that forwards requests from other caches to :term:`Origins`.
 
- 	localization
- 		Finding location on the network, or on planet earth
+	localization
+		Finding location on the network, or on planet earth
 
 	Mid
 	Mid-tier

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,9 +28,9 @@ CDN Basics
 A review of the basic functionality of a Content Delivery Network.
 
 .. toctree::
-   :maxdepth: 2
+	:maxdepth: 2
 
-   basics/index
+	basics/index
 
 
 Traffic Control Overview
@@ -38,60 +38,58 @@ Traffic Control Overview
 An introduction to the Traffic Control architecture, components, and their integration.
 
 .. toctree::
-   :maxdepth: 0
+	:maxdepth: 0
 
-   overview/index
+	overview/index
 
 Administrator's Guide
 =====================
 How to deploy and manage a Traffic Control CDN.
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   admin/index
+	admin/index
 
 Developer's Guide
 ==================
 A guide to the various internal and external APIs, and an introduction for the Traffic Control developer.
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   development/index
+	development/index
 
 APIs
 ====
 A guide to external RESTful APIs for Traffic Ops
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   api/index
+	api/index
 
 Tools
 =====
 A living list of tools for testing, interacting with, and developing for the Traffic Control CDN
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   tools/index
+	tools/index
 
 FAQ
 ===
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   faq
+	faq
 
 Indices and Tables
 ==================
 
 .. toctree::
-   :maxdepth: 3
+	:maxdepth: 3
 
-   glossary.rst
-
-
+	glossary.rst

--- a/docs/source/overview/delivery_service_requests.rst
+++ b/docs/source/overview/delivery_service_requests.rst
@@ -99,7 +99,7 @@ update
 
 Created At
 ----------
-This is the date and time at which the :abbr:`DSR (Delivery Service Request)` was created. In the context of the :ref:`to-api`, it is formatted as an :rfc:`3339` date string.
+This is the date and time at which the :abbr:`DSR (Delivery Service Request)` was created. In the context of the :ref:`to-api`, it is formatted as an :rfc:`3339` date string except where otherwise noted.
 
 ID
 --

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -522,10 +522,10 @@ Max DNS Answers
 ---------------
 
 DNS-routed Delivery Service
-  The maximum number of :term:`Edge-tier cache server` IP addresses that the Traffic Router will include in responses to DNS requests. When provided, the :term:`cache server` IP addresses included are rotated in each response to spread traffic evenly. This number should scale according to the amount of traffic the Delivery Service is expected to serve.
+	The maximum number of :term:`Edge-tier cache server` IP addresses that the Traffic Router will include in responses to DNS requests. When provided, the :term:`cache server` IP addresses included are rotated in each response to spread traffic evenly. This number should scale according to the amount of traffic the Delivery Service is expected to serve.
 
 HTTP-routed Delivery Service
-  If the Traffic Router profile parameter "edge.http.limit" is set, setting this to a non-zero value will override that parameter for this delivery service, limiting the number of Traffic Router IP addresses (A records) that are included in responses to DNS requests for this delivery service.
+	If the Traffic Router profile parameter "edge.http.limit" is set, setting this to a non-zero value will override that parameter for this delivery service, limiting the number of Traffic Router IP addresses (A records) that are included in responses to DNS requests for this delivery service.
 
 .. _ds-max-origin-connections:
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes mixed tabs and spaces in indention, as well as instances of using tabs in alignment within the documentation.

This PR also changes several places in the API documentation that referred to dates/times being formatted according to RFC3339 that, in fact, use the custom `lib/go-tc.TimeLayout` format ("2006-01-02 15:04:05-07"). These times are now referred to as being "ISO-like".

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure documentation builds with no errors or warnings, ensure indentation and alignment are consistent and in accordance with [the relevant documentation guidelines](https://traffic-control-cdn.readthedocs.io/en/latest/development/documentation_guidelines.html#indentation). Ensure all date/times that are _not_ presented in RFC3339 format are not documented as though they were, and that those that _are_ are correctly documented as being RFC3339.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.x probably
- 4.x probably

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary for documentation changes
- [x] This PR includes documentation
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**