### PR TITLE
Fix t3c reval to reload

### DIFF
--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -120,7 +120,9 @@ func main() {
 		syncdsUpdate, err = trops.CheckRevalidateState(false)
 		if err != nil || syncdsUpdate == torequest.UpdateTropsNotNeeded {
 			if err != nil {
-				log.Errorln(err)
+				log.Errorln("Checking revalidate state: " + err.Error())
+			} else {
+				log.Infoln("Checking revalidate state: returned UpdateTropsNotNeeded")
 			}
 			GitCommitAndExit(RevalidationError, cfg)
 		}


### PR DESCRIPTION
Reval reload was failing because reval doesn't get and check packages
from Traffic Ops. Which it doesn't need to, but the func to check
if a package was installed was only checking the cache populated by
the TO fetch.

This fixes it to check rpm if the requested package isn't in the
cache, which then fixes the call to know trafficserver is installed,
which then fixes the thing that calls that to reload ATS correctly.

Includes an integration test to verify a reval triggers a reload properly from now on.
No changelog, no docs, no interface change, and bug isn't in a release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run t3c/ORT Integration tests. Create a Reval and set the Reval Flag on a server, then run `t3c apply --run-mode=revalidate`, verify it gets the new file and Reloads ATS.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information