### PR TITLE
Fix t3c rpm to create var/lib dir

### DIFF
--- a/cache-config/build/trafficcontrol-cache-config.spec
+++ b/cache-config/build/trafficcontrol-cache-config.spec
@@ -185,6 +185,8 @@ t3c_preprocess_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-preprocess
 cp -p "$t3c_preprocess_src"/t3c-preprocess ${RPM_BUILD_ROOT}/"$installdir"
 gzip -c -9 "$src"/t3c-preprocess/t3c-preprocess.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-preprocess.1.gz
 
+mkdir -p ${RPM_BUILD_ROOT}/var/lib/trafficcontrol-cache-config
+
 ls ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/
 
 %clean
@@ -237,6 +239,8 @@ fi
 /usr/share/man/man1/t3c-preprocess.1.gz
 /usr/share/man/man1/t3c-request.1.gz
 /usr/share/man/man1/t3c-update.1.gz
+
+%dir /var/lib/trafficcontrol-cache-config
 
 %config(noreplace) /etc/logrotate.d/atstccfg
 %config(noreplace) /var/log/trafficcontrol-cache-config/atstccfg.log

--- a/cache-config/testing/docker/ort_test/Dockerfile
+++ b/cache-config/testing/docker/ort_test/Dockerfile
@@ -43,7 +43,6 @@ RUN sed -i 's/HOME\/bin/HOME\/bin:\/usr\/local\/go\/bin:/g' /root/.bash_profile
 RUN echo "GOPATH=/root/go; export GOPATH" >> /root/.bash_profile
 RUN echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
 RUN mkdir /root/go
-RUN mkdir -p /var/lib/trafficcontrol-cache-config/status
 
 EXPOSE 80 443
 ADD ort_test/run.sh /

--- a/cache-config/testing/ort-tests/t3c-dirs_test.go
+++ b/cache-config/testing/ort-tests/t3c-dirs_test.go
@@ -1,0 +1,45 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"os"
+	"testing"
+)
+
+// TestDirs tests that the t3c rpm creates directories that t3c-apply requires to run.
+// Right now, that's just /var/lib/trafficcontrol-cache-config, but in the future it may include others like /var/log/trafficcontrol-cache-config or /etc/trafficcontrol-cache-config.
+func TestDirs(t *testing.T) {
+	t.Logf("------------- Starting TestDirs ---------------")
+
+	requiredDirs := []string{
+		`/var/lib/trafficcontrol-cache-config`,
+	}
+
+	for _, dir := range requiredDirs {
+		dirInf, err := os.Stat(dir)
+		if os.IsNotExist(err) {
+			t.Errorf("directory '%v' must exist for t3c-apply to run successfully, expected: exists, actual: not found", dir)
+		} else if err != nil {
+			t.Errorf("checking if directory '%v' exists, expected: no error, actual: %v", dir, err)
+		} else if !dirInf.IsDir() {
+			t.Errorf("directory '%v' must exist for t3c-apply to run successfully, expected: exists, actual: is a file, not a directory", dir)
+		} else {
+			t.Logf("successfully verified '%v' exists and is a directory", dir)
+		}
+	}
+
+	t.Logf("------------- End of TestDirs ---------------")
+}


### PR DESCRIPTION
Fixes the t3c rpm to create the var/lib dir that t3c-apply needs when running.

This is a minor issue, it's only used to write the 'status' file. When that fails, nothing else fails, everything else seems to work fine. I'm not sure that file is even needed for anything, it's something ort.pl did so t3c does as well.

Includes tests.
No docs, no changelog, no interface change and issue isn't in a release.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Install trafficcontrol-cache-config RPM, verify /var/lib/trafficcontrol-cache-config dir is created, run t3c-apply, verify /var/lib/trafficcontrol-cache-config/status is created.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information