### PR TITLE
Make TC Cache Config RPM dependencies platform-agnostic

### DIFF
--- a/build/functions.sh
+++ b/build/functions.sh
@@ -239,6 +239,7 @@ buildRpm() {
 				--define "commit $(getCommit)" \
 				--define "build_number $BUILD_NUMBER.$RHEL_VERSION" \
 				--define "_target_os $RPM_TARGET_OS" \
+				--define "${RHEL_VERSION} 1" \
 				 -ba SPECS/$package.spec \
 				"$@" # variable number of arguments
 				) || \

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -239,7 +239,6 @@ buildRpm() {
 				--define "commit $(getCommit)" \
 				--define "build_number $BUILD_NUMBER.$RHEL_VERSION" \
 				--define "_target_os $RPM_TARGET_OS" \
-				--define "${RHEL_VERSION} 1" \
 				 -ba SPECS/$package.spec \
 				"$@" # variable number of arguments
 				) || \

--- a/cache-config/build/trafficcontrol-cache-config.spec
+++ b/cache-config/build/trafficcontrol-cache-config.spec
@@ -26,10 +26,15 @@ Source0:  trafficcontrol-cache-config-%{version}.tgz
 URL:      https://github.com/apache/trafficcontrol/
 Vendor:   Apache Software Foundation
 Packager: dev at trafficcontrol dot Apache dot org
-%{?el6:Requires: git, perl}
-%{?el7:Requires: git, perl}
-%{?el8:Requires: git, perl}
-
+%if 0%{?el6}
+Requires: git, perl
+%elif 0%{?el7}
+Requires: git, perl
+%elif 0%{?el8}
+Requires: git, perl
+%else
+Requires: git, perl
+%endif
 
 %description
 Installs Traffic Control Cache Configuration utilities. See the `t3c` application.

--- a/cache-config/build/trafficcontrol-cache-config.spec
+++ b/cache-config/build/trafficcontrol-cache-config.spec
@@ -26,15 +26,7 @@ Source0:  trafficcontrol-cache-config-%{version}.tgz
 URL:      https://github.com/apache/trafficcontrol/
 Vendor:   Apache Software Foundation
 Packager: dev at trafficcontrol dot Apache dot org
-%if 0%{?el6}
 Requires: git, perl
-%elif 0%{?el7}
-Requires: git, perl
-%elif 0%{?el8}
-Requires: git, perl
-%else
-Requires: git, perl
-%endif
 
 %description
 Installs Traffic Control Cache Configuration utilities. See the `t3c` application.


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5898<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

-  Traffic Control Cache Config (`t3c`) RPM spec

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
1. Go through the steps to [build the ATC RPMs natively](https://traffic-control-cdn.readthedocs.io/en/latest/development/building.html#build-the-rpms-natively)
2. Build the TC Cache Config RPM outside of Docker, assuming you are not on CentOS 8, CentOS 7, or CentOS 6, and verify that its dependencies include `git` and `perl`.
    ```shell
    cd infrastructure/cdn-in-a-box
    make native cache/trafficcontrol-cache-config.rpm
    rpm -q --requires cache/trafficcontrol-cache-config.rpm
    ```
    Expected output of `rpm -q --requires cache/trafficcontrol-cache-config.rpm`:
    ```
    /bin/sh
    /bin/sh
    /usr/bin/perl
    config(trafficcontrol-cache-config) = 6.0.0-11403.c5e036f3.el8
    git
    perl
    perl(Getopt::Long)
    perl(strict)
    perl(warnings)
    rpmlib(CompressedFileNames) <= 3.0.4-1
    rpmlib(FileDigests) <= 4.6.0-1
    rpmlib(PayloadFilesHavePrefix) <= 4.0-1
    rpmlib(PayloadIsXz) <= 5.2-1
    ```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (60a9ffdcab)
- 5.1.2

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] CDN in a Box tests building and installing the RPM
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->