### PR TITLE
Fix cache config integration tests

### DIFF
--- a/cache-config/testing/docker/ort_test/systemctl.sh
+++ b/cache-config/testing/docker/ort_test/systemctl.sh
@@ -32,7 +32,7 @@ else
   NAME=$2
 fi
 
-if [ "$2" != "trafficserver" ]; then
+if [ "$2" != "trafficserver.service" ]; then
   echo -e "\nFailed to start ${NAME}.service: Unit not found.n"
   exit 0
 fi
@@ -41,13 +41,17 @@ case $COMMAND in
   enable)
     ;;
   restart)
+    /opt/trafficserver/bin/trafficserver restart
     ;;
   status)
+    /opt/trafficserver/bin/trafficserver status
     ;;
   start)
+    /opt/trafficserver/bin/trafficserver start
     ;;
   stop)
+    /opt/trafficserver/bin/trafficserver stop
     ;;
 esac
 
-exit 0
+exit $?

--- a/cache-config/testing/ort-tests/baseline-configs/hdr_rw_first_ds-top.config
+++ b/cache-config/testing/ort-tests/baseline-configs/hdr_rw_first_ds-top.config
@@ -1,2 +1,3 @@
 # DO NOT EDIT - Generated for atlanta-edge-03 by  () on Fri Nov 13 18:49:10 UTC 2020
-first header rewrite
+cond %{REMAP_PSEUDO_HOOK}
+set-header CDN-SVCF "firstHeaderRewrite" [L]

--- a/cache-config/testing/ort-tests/baseline-configs/records.config
+++ b/cache-config/testing/ort-tests/baseline-configs/records.config
@@ -11,10 +11,10 @@ CONFIG proxy.config.http.enable_http_stats INT 1
 CONFIG proxy.config.http.insert_response_via_str INT 3
 CONFIG proxy.config.http.parent_proxy.retry_time INT 60
 CONFIG proxy.config.http.parent_proxy_routing_enable INT 1
-CONFIG proxy.config.http.server_ports STRING 80 80:ipv6
+CONFIG proxy.config.http.server_ports STRING 8080 8080:ipv6
 CONFIG proxy.config.http.slow.log.threshold INT 10000
 CONFIG proxy.config.http.transaction_active_timeout_in INT 0
-CONFIG proxy.config.log.logfile_dir STRING /var/log/trafficserver
+CONFIG proxy.config.log.logfile_dir STRING /opt/trafficserver/var/log/trafficserver
 CONFIG proxy.config.log.max_space_mb_for_logs INT 512
 CONFIG proxy.config.log.max_space_mb_headroom INT 50
 CONFIG proxy.config.proxy_name STRING atlanta-edge-03.ga.atlanta.kabletown.net

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -879,9 +879,9 @@
       "xmlId": "ds-top",
       "anonymousBlockingEnabled": false,
       "topology": "mso-topology",
-      "firstHeaderRewrite": "first header rewrite",
-      "innerHeaderRewrite": "inner header rewrite",
-      "lastHeaderRewrite": "last header rewrite"
+      "firstHeaderRewrite": "cond %{REMAP_PSEUDO_HOOK}__RETURN__set-header CDN-SVCF \"firstHeaderRewrite\" [L]",
+      "innerHeaderRewrite": "cond %{REMAP_PSEUDO_HOOK}__RETURN__set-header CDN-SVCI \"innerHeaderRewrite\" [L]",
+      "lastHeaderRewrite": "cond %{REMAP_PSEUDO_HOOK} __RETURN__ set-header CDN-SVCL \"lastHeaderRewrite\" [L]"
     },
     {
       "active": true,
@@ -1428,7 +1428,7 @@
           "configFile": "records.config",
           "name": "CONFIG proxy.config.http.server_ports",
           "secure": false,
-          "value": "STRING 80 80:ipv6"
+          "value": "STRING 8080 8080:ipv6"
         },
         {
           "configFile": "records.config",
@@ -1488,7 +1488,7 @@
           "configFile": "records.config",
           "name": "CONFIG proxy.config.log.logfile_dir",
           "secure": false,
-          "value": "STRING /var/log/trafficserver"
+          "value": "STRING /opt/trafficserver/var/log/trafficserver"
         },
         {
           "configFile": "records.config",


### PR DESCRIPTION
## What does this PR (Pull Request) do?

This PR fixes the cache-config integration test so that ATS is started in the ort_test container.

* fixed incorrect test fixture data.
* fixes the mocked systemctl.sh script to start ATS. This script is used as a work around to a known issue with using
  systemd commands in a docker container.

- [x] This PR fixes #5903 

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## What is the best way to verify this PR?

Run the cache-config integration tests.

## If this is a bug fix, what versions of Traffic Control are affected?

- master

## The following criteria are ALL met by this PR


- [X] This PR includes tests OR I have explained why tests are unnecessary
- [ ] This PR includes documentation OR I have explained why documentation is unnecessary
- [ ] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [X] This PR includes any and all required license headers
- [X] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information

