### PR TITLE
Fix t3c parent.config gen for EDGE/MID+ Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5548](https://github.com/apache/trafficcontrol/issues/5548) - Don't return a `403 Forbidden` when the user tries to get servers of a non-existent DS using `GET /servers?dsId={{nonexistent DS ID}}`
 - [#5732](https://github.com/apache/trafficcontrol/issues/5732) - TO API POST /cdns/dnsseckeys/generate times out with large numbers of delivery services
 - Fixed server creation through legacy API versions to default `monitor` to `true`.
+- Fixed t3c to generate topology parents correctly for parents with the Type MID+ or EDGE+ versus just the literal. Naming cache types to not be exactly 'EDGE' or 'MID' is still discouraged and not guaranteed to work, but it's unfortunately somewhat common, so this fixes it in one particular case.
 - Fixed t3c to create config files and directories as ats.ats
 
 ### Changed

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -1055,7 +1055,7 @@ func getTopologyParents(
 			continue
 		}
 
-		if tc.CacheType(sv.Type) != tc.CacheTypeEdge && tc.CacheType(sv.Type) != tc.CacheTypeMid && sv.Type != tc.OriginTypeName {
+		if !strings.HasPrefix(sv.Type, tc.EdgeTypePrefix) && !strings.HasPrefix(sv.Type, tc.MidTypePrefix) && sv.Type != tc.OriginTypeName {
 			continue // only consider edges, mids, and origins in the CacheGroup.
 		}
 		if _, dsHasOrigin := dsOrigins[ServerID(*sv.ID)]; sv.Type == tc.OriginTypeName && !dsHasOrigin {


### PR DESCRIPTION
Fixed t3c to generate topology parents correctly for parents with the Type MID+ or EDGE+ versus just the literal. Naming cache types to not be exactly 'EDGE' or 'MID' is still discouraged and not guaranteed to work, but it's unfortutely somewhat common, so this fixes it in one particular case.

Includes tests.
Includes changelog.
No docs, no interface change.

- [x] This PR is not related to any other Issue

Labelling "bug" even though the behavior it "fixes" isn't guaranteed, because it's a non-uncommon user behavior that it does fix. 

Long-term, cache config generation for Topologies needs to entirely remove "Edge" and "Mid" terminology, though it will still need some way to distinguish Caches from non-cache Servers (unless TO is made more Normal).

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run lib/go-atscfg unit tests. Create a Topology with a parent server of type "MID_FOO," assign to a DS, generate config for an child server, verify the MID_FOO type parent is in the child's parent.config.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 
## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information