### PR TITLE
Update Ansible automation to initialize Traffic Vault Postgres backend

### DIFF
--- a/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
@@ -147,6 +147,7 @@ to_tvdb_username:
 to_tvdb_password:
 to_tvdb_ssl_enable: false
 to_tvdb_aes_key_loc: "{{ to_conf_installdir }}/aes.key"
+to_tvdb_aes_key:
 to_tvdb_dbconf:
   production:
     driver: postgres

--- a/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
@@ -112,7 +112,7 @@ to_go_supported_ds_metrics:
 
 to_plugin_config: {}
 
-to_traffic_vault_backend: "riak"
+to_traffic_vault_backend: "postgres"
 
 to_smtp_enabled: false
 to_smtp_username: ""
@@ -135,6 +135,26 @@ todb_dbconf:
     user: "{{ todb_username }}"
     password: "{{ todb_password }}"
     dbname: "{{ todb_db_name }}"
+    sslmode: disable
+    open_manual: ""
+
+# --- Traffic Vault Postgres backend traffic_vault_config (in cdn.conf) & dbconf.yml
+tvdb_db_name: traffic_vault
+tvdb_type: Pg
+tvdb_port: 5432
+tvdb_host: localhost
+tvdb_username:
+tvdb_password:
+tvdb_ssl_enable: false
+tvdb_aes_key_loc: /opt/traffic_ops/app/conf/aes.key
+tvdb_dbconf:
+  production:
+    driver: postgres
+    host: localhost
+    port: 5432
+    user: "{{ tvdb_username }}"
+    password: "{{ tvdb_password }}"
+    dbname: "{{ tvdb_db_name }}"
     sslmode: disable
     open_manual: ""
 

--- a/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
@@ -139,22 +139,22 @@ todb_dbconf:
     open_manual: ""
 
 # --- Traffic Vault Postgres backend traffic_vault_config (in cdn.conf) & dbconf.yml
-tvdb_db_name: traffic_vault
-tvdb_type: Pg
-tvdb_port: 5432
-tvdb_host: localhost
-tvdb_username:
-tvdb_password:
-tvdb_ssl_enable: false
-tvdb_aes_key_loc: /opt/traffic_ops/app/conf/aes.key
-tvdb_dbconf:
+to_tvdb_db_name: traffic_vault
+to_tvdb_type: Pg
+to_tvdb_port: 5432
+to_tvdb_host: localhost
+to_tvdb_username:
+to_tvdb_password:
+to_tvdb_ssl_enable: false
+to_tvdb_aes_key_loc: "{{ to_conf_installdir }}/aes.key"
+to_tvdb_dbconf:
   production:
     driver: postgres
     host: localhost
     port: 5432
-    user: "{{ tvdb_username }}"
-    password: "{{ tvdb_password }}"
-    dbname: "{{ tvdb_db_name }}"
+    user: "{{ to_tvdb_username }}"
+    password: "{{ to_tvdb_password }}"
+    dbname: "{{ to_tvdb_db_name }}"
     sslmode: disable
     open_manual: ""
 

--- a/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
+++ b/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
@@ -111,6 +111,15 @@
     dest: "{{ to_db_installdir }}/trafficvault/dbconf.yml"
   notify: Restart Traffic Ops
 
+- name: Render Traffic Vault database AES key file
+  template:
+    src: "aes.key.j2"
+    owner: "{{ to_user }}"
+    group: "{{ to_group }}"
+    mode: 0600
+    dest: "{{ to_tvdb_aes_key_loc }}"
+  notify: Restart Traffic Ops
+
 - name: Render Traffic Ops configuration files
   template:
     src: "{{item}}.j2"

--- a/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
+++ b/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
@@ -145,6 +145,15 @@
     GOPATH: /opt/traffic_ops/go
   run_once: true
 
+- name: Load Traffic Vault DB schema
+  command: ./db/admin --trafficvault -env=production load_schema
+  args:
+    chdir: "{{ to_app_installdir }}"
+  environment:
+    PATH: "{{ lookup('env', 'PATH') }}:{{ to_base_installdir }}/go/bin"
+    GOPATH: /opt/traffic_ops/go
+  run_once: true
+
 - name: Upgrade Traffic Vault DB
   command: ./db/admin --trafficvault -env=production upgrade
   args:

--- a/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
+++ b/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
@@ -102,6 +102,15 @@
     dest: "{{ to_db_installdir }}/dbconf.yml"
   notify: Restart Traffic Ops
 
+- name: Render Traffic Vault database configuration file
+  template:
+    src: "trafficvault_dbconf.yml.j2"
+    owner: "{{ to_user }}"
+    group: "{{ to_group }}"
+    mode: 0600
+    dest: "{{ to_db_installdir }}/trafficvault/dbconf.yml"
+  notify: Restart Traffic Ops
+
 - name: Render Traffic Ops configuration files
   template:
     src: "{{item}}.j2"
@@ -124,7 +133,15 @@
     chdir: "{{ to_app_installdir }}"
   environment:
     PATH: "{{ lookup('env', 'PATH') }}:{{ to_base_installdir }}/go/bin"
-    PERL5LIB: ./lib:./local/lib/perl5
+    GOPATH: /opt/traffic_ops/go
+  run_once: true
+
+- name: Upgrade Traffic Vault DB
+  command: ./db/admin --trafficvault -env=production upgrade
+  args:
+    chdir: "{{ to_app_installdir }}"
+  environment:
+    PATH: "{{ lookup('env', 'PATH') }}:{{ to_base_installdir }}/go/bin"
     GOPATH: /opt/traffic_ops/go
   run_once: true
 

--- a/infrastructure/ansible/roles/traffic_ops/templates/aes.key.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/aes.key.j2
@@ -1,0 +1,14 @@
+{#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#}
+{{ to_tvdb_aes_key }}

--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -80,9 +80,18 @@
       "plugin_config" : {{ to_plugin_config | to_nice_json(indent=2) }},
       "traffic_vault_backend": "{{ to_traffic_vault_backend }}",
       "traffic_vault_config": {
+{% if to_traffic_vault_backend == "postgres" %}
+         "dbname": "{{ tvdb_db_name }}",
+         "hostname": "{{ tvdb_host }}",
+         "port": "{{ tvdb_port }}",
+         "user": "{{ tvdb_username }}",
+         "password": "{{ tvdb_password }}",
+         "aes_key_location": "{{ tvdb_aes_key_loc }}"
+{% else %}
          "user": "{{ to_riak_username }}",
          "password": "{{ to_riak_username_password }}",
          "MaxTLSVersion": "{{ to_riak_tls_max_version }}"
+{% endif %}
       }
    }
 }

--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -81,12 +81,12 @@
       "traffic_vault_backend": "{{ to_traffic_vault_backend }}",
       "traffic_vault_config": {
 {% if to_traffic_vault_backend == "postgres" %}
-         "dbname": "{{ tvdb_db_name }}",
-         "hostname": "{{ tvdb_host }}",
-         "port": "{{ tvdb_port }}",
-         "user": "{{ tvdb_username }}",
-         "password": "{{ tvdb_password }}",
-         "aes_key_location": "{{ tvdb_aes_key_loc }}"
+         "dbname": "{{ to_tvdb_db_name }}",
+         "hostname": "{{ to_tvdb_host }}",
+         "port": "{{ to_tvdb_port }}",
+         "user": "{{ to_tvdb_username }}",
+         "password": "{{ to_tvdb_password }}",
+         "aes_key_location": "{{ to_tvdb_aes_key_loc }}"
 {% else %}
          "user": "{{ to_riak_username }}",
          "password": "{{ to_riak_username_password }}",

--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -83,7 +83,7 @@
 {% if to_traffic_vault_backend == "postgres" %}
          "dbname": "{{ to_tvdb_db_name }}",
          "hostname": "{{ to_tvdb_host }}",
-         "port": "{{ to_tvdb_port }}",
+         "port": {{ to_tvdb_port }},
          "user": "{{ to_tvdb_username }}",
          "password": "{{ to_tvdb_password }}",
          "aes_key_location": "{{ to_tvdb_aes_key_loc }}"

--- a/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
@@ -94,27 +94,27 @@
   ],
   "/opt/traffic_ops/app/conf/production/tv.conf": [
     {
-      "Traffic Vault Database type": "{{ tvdb_type }}",
+      "Traffic Vault Database type": "{{ to_tvdb_type }}",
       "config_var": "type"
     },
     {
-      "Traffic Vault Database name": "{{ tvdb_db_name }}",
+      "Traffic Vault Database name": "{{ to_tvdb_db_name }}",
       "config_var": "dbname"
     },
     {
-      "Traffic Vault Database server hostname IP or FQDN": "{{ tvdb_host }}",
+      "Traffic Vault Database server hostname IP or FQDN": "{{ to_tvdb_host }}",
       "config_var": "hostname"
     },
     {
-      "Traffic Vault Database port number": "{{ tvdb_port }}",
+      "Traffic Vault Database port number": "{{ to_tvdb_port }}",
       "config_var": "port"
     },
     {
-      "Traffic Vault database user": "{{ tvdb_username }}",
+      "Traffic Vault database user": "{{ to_tvdb_username }}",
       "config_var": "user"
     },
     {
-      "Traffic Vault database password": "{{ tvdb_password }}",
+      "Traffic Vault database password": "{{ to_tvdb_password }}",
       "config_var": "password",
       "hidden": "1"
     }

--- a/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/postinstall.input.j2
@@ -92,19 +92,31 @@
       "hidden": "1"
     }
   ],
-  "/opt/traffic_ops/app/db/dbconf.yml": [
+  "/opt/traffic_ops/app/conf/production/tv.conf": [
     {
-      "Database server root (admin) username": "{{ postgresql_admin_user }}",
-      "config_var": "pgUser"
+      "Traffic Vault Database type": "{{ tvdb_type }}",
+      "config_var": "type"
     },
     {
-      "Database server admin password": "{{ postgresql_admin_user_password }}",
-      "config_var": "pgPassword",
+      "Traffic Vault Database name": "{{ tvdb_db_name }}",
+      "config_var": "dbname"
+    },
+    {
+      "Traffic Vault Database server hostname IP or FQDN": "{{ tvdb_host }}",
+      "config_var": "hostname"
+    },
+    {
+      "Traffic Vault Database port number": "{{ tvdb_port }}",
+      "config_var": "port"
+    },
+    {
+      "Traffic Vault database user": "{{ tvdb_username }}",
+      "config_var": "user"
+    },
+    {
+      "Traffic Vault database password": "{{ tvdb_password }}",
+      "config_var": "password",
       "hidden": "1"
-    },
-    {
-      "Download Maxmind Database?": "{{ to_pi_maxmind_download }}",
-      "config_var": "maxmind"
     }
   ],
   "/opt/traffic_ops/install/data/json/openssl_configuration.json": [

--- a/infrastructure/ansible/roles/traffic_ops/templates/trafficvault_dbconf.yml.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/trafficvault_dbconf.yml.j2
@@ -14,13 +14,13 @@
 version: "1.0"
 name: dbconf.yml
 
-{% for db_env in todb_dbconf %}
+{% for db_env in tvdb_dbconf %}
 {{ db_env }}:
-    driver: {{ todb_dbconf[db_env]['driver'] }}
-{% if todb_dbconf[db_env]['open_manual'] | length %}
-    open: {{ todb_dbconf[db_env]['open_manual'] }}
+    driver: {{ tvdb_dbconf[db_env]['driver'] }}
+{% if tvdb_dbconf[db_env]['open_manual'] | length %}
+    open: {{ tvdb_dbconf[db_env]['open_manual'] }}
 {% else %}
-    open: host={{ todb_dbconf[db_env]['host'] }} port={{ todb_dbconf[db_env]['port'] }} user={{ todb_dbconf[db_env]['user'] }} password={{ todb_dbconf[db_env]['password'] }} dbname={{ todb_dbconf[db_env]['dbname'] }} sslmode={{ todb_dbconf[db_env]['sslmode'] }}
+    open: host={{ tvdb_dbconf[db_env]['host'] }} port={{ tvdb_dbconf[db_env]['port'] }} user={{ tvdb_dbconf[db_env]['user'] }} password={{ tvdb_dbconf[db_env]['password'] }} dbname={{ tvdb_dbconf[db_env]['dbname'] }} sslmode={{ tvdb_dbconf[db_env]['sslmode'] }}
 {% endif %}
 
 {% endfor %}

--- a/infrastructure/ansible/roles/traffic_ops/templates/trafficvault_dbconf.yml.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/trafficvault_dbconf.yml.j2
@@ -14,13 +14,13 @@
 version: "1.0"
 name: dbconf.yml
 
-{% for db_env in tvdb_dbconf %}
+{% for db_env in to_tvdb_dbconf %}
 {{ db_env }}:
-    driver: {{ tvdb_dbconf[db_env]['driver'] }}
-{% if tvdb_dbconf[db_env]['open_manual'] | length %}
-    open: {{ tvdb_dbconf[db_env]['open_manual'] }}
+    driver: {{ to_tvdb_dbconf[db_env]['driver'] }}
+{% if to_tvdb_dbconf[db_env]['open_manual'] | length %}
+    open: {{ to_tvdb_dbconf[db_env]['open_manual'] }}
 {% else %}
-    open: host={{ tvdb_dbconf[db_env]['host'] }} port={{ tvdb_dbconf[db_env]['port'] }} user={{ tvdb_dbconf[db_env]['user'] }} password={{ tvdb_dbconf[db_env]['password'] }} dbname={{ tvdb_dbconf[db_env]['dbname'] }} sslmode={{ tvdb_dbconf[db_env]['sslmode'] }}
+    open: host={{ to_tvdb_dbconf[db_env]['host'] }} port={{ to_tvdb_dbconf[db_env]['port'] }} user={{ to_tvdb_dbconf[db_env]['user'] }} password={{ to_tvdb_dbconf[db_env]['password'] }} dbname={{ to_tvdb_dbconf[db_env]['dbname'] }} sslmode={{ to_tvdb_dbconf[db_env]['sslmode'] }}
 {% endif %}
 
 {% endfor %}

--- a/infrastructure/ansible/roles/traffic_opsdb/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_opsdb/defaults/main.yml
@@ -45,3 +45,10 @@ todb_password:
 
 # TODB database name
 todb_db_name: traffic_ops
+
+# Traffic Vault Postgres database credentials
+tvdb_username:
+tvdb_password:
+
+# Traffic Vault Postgres database name
+tvdb_db_name: traffic_vault

--- a/infrastructure/ansible/roles/traffic_opsdb/tasks/initialize_traffic_opsdb.yml
+++ b/infrastructure/ansible/roles/traffic_opsdb/tasks/initialize_traffic_opsdb.yml
@@ -34,9 +34,27 @@
     ssl_rootcert: "{{ postgresql_certs_ca }}"
   no_log: true
 
+- name: Create Traffic Vault Database User
+  postgresql_user:
+    encrypted: yes
+    name: "{{ tvdb_username }}"
+    password: "{{ tvdb_password }}"
+    port: "{{ postgresql_port }}"
+    login_host: 127.0.0.1
+    role_attr_flags: SUPERUSER,LOGIN,CREATEDB
+    ssl_rootcert: "{{ postgresql_certs_ca }}"
+  no_log: true
+
 - name: Create Traffic Ops Database
   postgresql_db:
     login_host: 127.0.0.1
     name: "{{ todb_db_name }}"
     owner: "{{ todb_username }}"
+    port: "{{ postgresql_port }}"
+
+- name: Create Traffic Vault Database
+  postgresql_db:
+    login_host: 127.0.0.1
+    name: "{{ tvdb_db_name }}"
+    owner: "{{ tvdb_username }}"
     port: "{{ postgresql_port }}"

--- a/infrastructure/ansible/roles/traffic_opsdb/tasks/initialize_traffic_opsdb.yml
+++ b/infrastructure/ansible/roles/traffic_opsdb/tasks/initialize_traffic_opsdb.yml
@@ -41,7 +41,7 @@
     password: "{{ tvdb_password }}"
     port: "{{ postgresql_port }}"
     login_host: 127.0.0.1
-    role_attr_flags: SUPERUSER,LOGIN,CREATEDB
+    role_attr_flags: LOGIN
     ssl_rootcert: "{{ postgresql_certs_ca }}"
   no_log: true
 

--- a/infrastructure/ansible/roles/traffic_opsdb/templates/.pgpass.j2
+++ b/infrastructure/ansible/roles/traffic_opsdb/templates/.pgpass.j2
@@ -14,4 +14,5 @@
 {% for hostname in groups['traffic_opsdb'] %}
 {{ hostname }}:{{ postgresql_port }}:{{ postgresql_admin_user }}:{{ postgresql_admin_user_password }}
 {{ hostname }}:{{ postgresql_port }}:{{ todb_username }}:{{ todb_password }}
+{{ hostname }}:{{ postgresql_port }}:{{ tvdb_username }}:{{ tvdb_password }}
 {% endfor %}

--- a/infrastructure/ansible/roles/traffic_opsdb/templates/pg_hba.conf.j2
+++ b/infrastructure/ansible/roles/traffic_opsdb/templates/pg_hba.conf.j2
@@ -108,16 +108,19 @@
 # ------------------------------------------------------
    # --  Primary
    hostssl  {{ todb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-primary'] | map('extract', hostvars, ['ansible_host']) | first) }}/32  md5
+   hostssl  {{ tvdb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-primary'] | map('extract', hostvars, ['ansible_host']) | first) }}/32  md5
 
 {% if groups['traffic_opsdb-standby'] is defined %}
    # --  Secondary
    hostssl  {{ todb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-standby'] | map('extract', hostvars, ['ansible_host']) | first) }}/32  md5
+   hostssl  {{ tvdb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-standby'] | map('extract', hostvars, ['ansible_host']) | first) }}/32  md5
 
 {% endif %}
 {% if groups['traffic_opsdb-replicas'] is defined %}
    # --  Replicas
    {% for host_obj in (groups['traffic_opsdb-replicas']) %}
    hostssl  {{ todb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-replicas'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
+   hostssl  {{ tvdb_db_name }} {{ postgresql_user }} {{ (groups['traffic_opsdb-replicas'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
    {% endfor %}
 
 {% endif %}
@@ -130,6 +133,17 @@
 
    hostssl  {{ postgresql_user }} {{ todb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
    host  {{ postgresql_user }} {{ todb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
+{% endfor %}
+
+#-------------------------------------
+#  TRAFFIC VAULT
+# ------------------------------------------------------
+{% for host_obj in (groups['traffic_ops']) %}
+   hostssl  {{ tvdb_db_name }} {{ tvdb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
+   host  {{ tvdb_db_name }} {{ tvdb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
+
+   hostssl  {{ postgresql_user }} {{ tvdb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
+   host  {{ postgresql_user }} {{ tvdb_username }} {{ (groups['traffic_ops'] | map('extract', hostvars, ['ansible_host']) | list)[loop.index0] }}/32  md5
 {% endfor %}
 
 # ------------------------------------------------------


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Updates the Ansible automation to initialize and configure the Traffic Vault Postgres backend as an alternative to the legacy Riak backend.

## Which Traffic Control components are affected by this PR?
- Traffic Ops
- Traffic Vault
- Ansible roles

## What is the best way to verify this PR?
Run the Ansible automation to install Traffic Ops / TODB, ensure that the Traffic Vault Postgres backend is configured correctly and works.

## The following criteria are ALL met by this PR
- [x] No tests because the Ansible roles have no tests
- [x] No docs because Ansible roles are not documented at this level of detail
- [x] No changelog (overall feature already covered by a prior entry)
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)