### PR TITLE
ATS TSB Dockerfile: Define RHEL_VERSION in CMD

### DIFF
--- a/pkg
+++ b/pkg
@@ -83,10 +83,6 @@ if [ ${#COMPOSECMD[@]} -eq 0 ]; then
 	COMPOSECMD=(docker run --rm "${DOCKER_ADDR[@]}" $COMPOSE_OPTIONS "${VOLUMES[@]}" -w "$(pwd)" $IMAGE)
 fi
 
-# Mark RHEL_VERSION for export, although it is not set yet
-export RHEL_VERSION
-RUN_OPTIONS=(-e RHEL_VERSION)
-
 # Parse command line arguments
 verbose=0
 debug=0
@@ -160,6 +156,12 @@ while getopts :?78abdf:lopqv opt; do
 done
 
 shift $((OPTIND-1))
+
+# Mark RHEL_VERSION for export
+export RHEL_VERSION
+if [[ -v RHEL_VERSION ]]; then
+	RUN_OPTIONS+=(-e RHEL_VERSION)
+fi
 
 # If no specific packages are listed, or -a is used, run them all.
 if (( ! "$#" || "$all" == 1 )); then

--- a/pkg
+++ b/pkg
@@ -168,6 +168,9 @@ if (( ! "$#" || "$all" == 1 )); then
 	set -- `$SELF -f "$COMPOSE_FILE" -l`
 fi
 
+# Create the dist directory if it does not exist.
+mkdir -p dist
+
 # Build each project in turn.
 failure=0
 badproj=""

--- a/pkg
+++ b/pkg
@@ -190,12 +190,9 @@ while (( "$#" )); do
 		# A chained compose file will be named exactly the same as main docker-compose, with .service added,
 		# where <service> is the name of the specific service to be chained. The file may be a symlink to another
 		# compose file, in which case the symlink will be followed before it is processed.
-		# A "dist" symlink will be temporarily created in that directory to facilitate the collation of artefacts.
 		if [ -e "$COMPOSE_FILE.$1" ] ; then
-			ln -sfT "$(dirname -- "$(realpath -e -- "$SELF")")/dist" "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist" || exit 1
 			$SELF -f $(realpath -e "$COMPOSE_FILE.$1") $([ "$verbose" == 0 ] || echo "-v") $([ "$quiet" == 0 ] || echo "-q") $([ "$debug" == 0 ] || echo "-d") $([ "$build" == 0 ] || echo "-b") $("${COMPOSECMD[@]}" -f $(realpath -e "$COMPOSE_FILE.$1") config --services)
 			chained_exit=$?
-			rm -r "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist"
 			[ $chained_exit == 0 ] || exit $chained_exit
 		fi
 	) || {

--- a/pkg
+++ b/pkg
@@ -192,10 +192,10 @@ while (( "$#" )); do
 		# compose file, in which case the symlink will be followed before it is processed.
 		# A "dist" symlink will be temporarily created in that directory to facilitate the collation of artefacts.
 		if [ -e "$COMPOSE_FILE.$1" ] ; then
-			ln -sf "$(dirname -- "$(realpath -e -- "$SELF")")/dist" "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist" || exit 1
+			ln -sfT "$(dirname -- "$(realpath -e -- "$SELF")")/dist" "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist" || exit 1
 			$SELF -f $(realpath -e "$COMPOSE_FILE.$1") $([ "$verbose" == 0 ] || echo "-v") $([ "$quiet" == 0 ] || echo "-q") $([ "$debug" == 0 ] || echo "-d") $([ "$build" == 0 ] || echo "-b") $("${COMPOSECMD[@]}" -f $(realpath -e "$COMPOSE_FILE.$1") config --services)
 			chained_exit=$?
-			rm "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist"
+			rm -r "$(dirname -- "$(realpath -e -- "$COMPOSE_FILE.$1")")/dist"
 			[ $chained_exit == 0 ] || exit $chained_exit
 		fi
 	) || {

--- a/traffic_server/_tsb/Dockerfile
+++ b/traffic_server/_tsb/Dockerfile
@@ -46,6 +46,8 @@ RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 ### ats specific requirements
 FROM ats-common-dependencies AS build-ats-specific
 ARG RHEL_VERSION=8
+# Makes RHEL_VERSION accessible to CMD
+ENV RHEL_VERSION="$RHEL_VERSION"
 
 RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 		os_pkgs=( \

--- a/traffic_server/_tsb/docker-compose.yml
+++ b/traffic_server/_tsb/docker-compose.yml
@@ -30,4 +30,4 @@ services:
     - ./src/openssl:/opt/src/openssl:Z
     - ./src/ats:/rpmbuilddir/SOURCES/src:Z
     - ./src/trafficcontrol/traffic_server/plugins/astats_over_http:/opt/src/astats_over_http:Z
-    - ./dist:/rpmbuilddir/RPMS/x86_64:Z
+    - ../../dist:/rpmbuilddir/RPMS/x86_64:Z

--- a/traffic_server/_tsb/run.sh
+++ b/traffic_server/_tsb/run.sh
@@ -23,6 +23,13 @@ die() {
 	{ test -n "$@" && echo "$@"; exit 1; } >&2
 }
 
+setowner() {
+	own="$(stat -c%u:%g "$1")"
+	shift
+	chown -R "${own}" "$@"
+}
+trap 'exit_code=$?; setowner /rpmbuilddir/RPMS/x86_64 /rpmbuilddir/RPMS/x86_64; exit $exit_code' EXIT;
+
 mkdir /opt/build
 cp -fa /opt/{src,build}/jansson
 cp -fa /opt/{src,build}/cjose


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5916<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

-  Traffic Server (Transitive Source Build)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Try to build ATS:

```shell
./pkg -vo ats
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (5ad059f0af)
- 5.1.2

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Build system changed only, no tests necessary
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
