### PR TITLE
Fix codeql t3c false positives

### DIFF
--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -205,11 +205,11 @@ func getATSMajorVersionFromATSVersion(atsVersion string) (int, error) {
 	}
 	majorVerStr := atsVersion[:dotPos]
 
-	majorVer, err := strconv.ParseUint(majorVerStr, 10, 64)
-	if err != nil {
+	majorVer, err := strconv.Atoi(majorVerStr)
+	if err != nil || majorVer < 0 {
 		return 0, errors.New("unexpected version format '" + majorVerStr + "', expected e.g. '7.1.2.whatever'")
 	}
-	return int(majorVer), nil
+	return majorVer, nil
 }
 
 // genericProfileConfig generates a generic profile config text, from the profile's parameters with the given config file name.

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -928,20 +928,18 @@ func serverParentageParams(sv *Server, params []parameterWithProfilesMap) (profi
 		case ParentConfigCacheParamWeight:
 			profileCache.Weight = param.Value
 		case ParentConfigCacheParamPort:
-			i, err := strconv.ParseInt(param.Value, 10, 64)
-			if err != nil {
+			if i, err := strconv.Atoi(param.Value); err != nil {
 				warnings = append(warnings, "port param is not an integer, skipping! : "+err.Error())
 			} else {
-				profileCache.Port = int(i)
+				profileCache.Port = i
 			}
 		case ParentConfigCacheParamUseIP:
 			profileCache.UseIP = param.Value == "1"
 		case ParentConfigCacheParamRank:
-			i, err := strconv.ParseInt(param.Value, 10, 64)
-			if err != nil {
+			if i, err := strconv.Atoi(param.Value); err != nil {
 				warnings = append(warnings, "rank param is not an integer, skipping! : "+err.Error())
 			} else {
-				profileCache.Rank = int(i)
+				profileCache.Rank = i
 			}
 		case ParentConfigCacheParamNotAParent:
 			profileCache.NotAParent = param.Value != "false"
@@ -1449,20 +1447,18 @@ func getParentConfigProfileParams(
 				// TODO validate float?
 				profileCache.Weight = val
 			case ParentConfigCacheParamPort:
-				i, err := strconv.ParseInt(val, 10, 64)
-				if err != nil {
+				if i, err := strconv.Atoi(val); err != nil {
 					warnings = append(warnings, "port param is not an integer, skipping! : "+err.Error())
 				} else {
-					profileCache.Port = int(i)
+					profileCache.Port = i
 				}
 			case ParentConfigCacheParamUseIP:
 				profileCache.UseIP = val == "1"
 			case ParentConfigCacheParamRank:
-				i, err := strconv.ParseInt(val, 10, 64)
-				if err != nil {
+				if i, err := strconv.Atoi(val); err != nil {
 					warnings = append(warnings, "rank param is not an integer, skipping! : "+err.Error())
 				} else {
-					profileCache.Rank = int(i)
+					profileCache.Rank = i
 				}
 			case ParentConfigCacheParamNotAParent:
 				profileCache.NotAParent = val != "false"


### PR DESCRIPTION
"Fixes" codeql false positives.

None of these are actual issues. Checking for overflows is deceptive and not useful. For example, the Parent Rank being `2147483649` is no more invalid than `2147483645`, but we don't have a hard limit on Parent Rank, so there's no sane max we can impose.

But this is the path of least resistance. Much as it frustrates me to make code worse for bad tools, this will make tools stop bothering us every few months to fix things they don't have the context to understand aren't issues.

No new tests, code already has tests, and any specific tests around the overflow would be deceptive, misleading, and fallacious.
No docs, no interface change.
No changelog, no interface change, and these aren't real bugs.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Observe code is obviously identical in behavior, except for overflows astronomically larger than valid values.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
