### PR TITLE
Use -p flag with `rpm -q` on the trafficserver RPM file

### DIFF
--- a/infrastructure/cdn-in-a-box/cache/Dockerfile
+++ b/infrastructure/cdn-in-a-box/cache/Dockerfile
@@ -88,7 +88,7 @@ RUN set -o errexit -o nounset -o xtrace; \
 
 RUN set -o errexit -o nounset -o pipefail -o xtrace && \
     # The ssl directory needs to exist or the first sslkey file will be skipped on badass
-    etc_trafficserver="$(rpm -ql trafficserver.rpm | grep '/etc/trafficserver$')"; \
+    etc_trafficserver="$(rpm -qpl trafficserver.rpm | grep '/etc/trafficserver$')"; \
     if [[ ! -e "${etc_trafficserver}/ssl" ]]; then \
         echo 'Creating ssl directory...'; \
         mkdir "${etc_trafficserver}/ssl"; \

--- a/infrastructure/cdn-in-a-box/cache/Dockerfile
+++ b/infrastructure/cdn-in-a-box/cache/Dockerfile
@@ -86,7 +86,7 @@ RUN set -o errexit -o nounset -o xtrace; \
     dnf remove -y gcc-c++ glibc-devel autoconf automake libtool && \
     rm -f /astats_over_http.c /Makefile.am
 
-RUN set -o errexit -o nounset -o pipefail && \
+RUN set -o errexit -o nounset -o pipefail -o xtrace && \
     # The ssl directory needs to exist or the first sslkey file will be skipped on badass
     etc_trafficserver="$(rpm -ql trafficserver.rpm | grep '/etc/trafficserver$')"; \
     if [[ ! -e "${etc_trafficserver}/ssl" ]]; then \

--- a/infrastructure/cdn-in-a-box/cache/run.sh
+++ b/infrastructure/cdn-in-a-box/cache/run.sh
@@ -42,8 +42,8 @@ set_trafficserver_parameters() {
 		mid) ats_profile=/traffic_ops_data/profiles/020-ATS_MID_TIER_CACHE.json;;
 	esac
 	local trafficserver_version
-	trafficserver_version="$(rpm -qp --qf '%{version}-%{release}.%{arch}\n' /trafficserver.rpm)"
-	logfile_dir="$(rpm -ql /trafficserver.rpm | grep '/var/log/trafficserver$')"
+	trafficserver_version="$(rpm -q --qf '%{version}-%{release}.%{arch}\n' trafficserver)"
+	logfile_dir="$(rpm -ql trafficserver | grep '/var/log/trafficserver$')"
 
 	until [[ -s "$ats_profile" ]]; do
 		echo "Waiting for ${ats_profile} to exist..."


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes an issue introduced in #5920 building CDN in a Box for CentOS 7.<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
RPMs can optionally be queried on CentOS 8 without `-p` using `rpm -q filename.rpm`, but on CentOS 7 (and earlier), it needs to be `rpm -qp filename.rpm`. This PR adds `-p` for CentOS 7 support.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Build CDN in a Box for CentOS 7 and verify it succeeds.

```shell
export RHEL_VERSION=7
make -j6
docker-compose build --parallel
docker-compose kill && docker-compose down -v && docker-compose up -d
docker-compose logs -f trafficmonitor
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (52436a75a2)

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] CDN in a Box is a test
- [x] Bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

