### PR TITLE
Add t3c-apply flag to wait for parents in syncds mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `DELETE` request method for `deliveryservices/xmlId/{name}/urlkeys` and `deliveryservices/{id}/urlkeys`.
 - t3c now uses separate apps, full run syntax changed to `t3c apply ...`, moved to cache-config and RPM changed to trafficcontrol-cache-config. See cache-config README.md.
 - t3c: bug fix to consider plugin config files for reloading remap.config
+- t3c: add flag to wait for parents in syncds mode
 - t3c: Change syncds so that it only warns on package version mismatch.
 - atstccfg: add ##REFETCH## support to regex_revalidate.config processing.
 - Added a Traffic Monitor integration test framework.

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -191,8 +191,9 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
 -W, --wait-for-parents
 
-    [true | false] do not update if parent_pending = 1 in the
-    update json. default is false, wait for parents
+    [true | false | reval] do not update if parent_pending = 1 in the
+    update json. Default is 'reval', wait for parents in revalidate
+    mode, but not syncds (unless Traffic Ops has !use_reval_pending)
 
 # MODES
 

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -737,7 +737,7 @@ func (r *TrafficOpsReq) CheckRevalidateState(sleepOverride bool) (UpdateStatus, 
 			log.Errorln("Traffic Ops is signaling that a revalidation is waiting to be applied.")
 			updateStatus = UpdateTropsNeeded
 			if serverStatus.ParentRevalPending == true {
-				if r.Cfg.WaitForParents {
+				if r.Cfg.WaitForParents == config.WaitForParentsReval || r.Cfg.WaitForParents == config.WaitForParentsTrue {
 					log.Infoln("Traffic Ops is signaling that my parents need to revalidate, not revalidating.")
 					updateStatus = UpdateTropsNotNeeded
 				} else {
@@ -787,7 +787,9 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 			updateStatus = UpdateTropsNeeded
 			log.Errorln("Traffic Ops is signaling that an update is waiting to be applied")
 
-			if serverStatus.ParentPending && r.Cfg.WaitForParents && !serverStatus.UseRevalPending {
+			if serverStatus.ParentPending &&
+				(r.Cfg.WaitForParents == config.WaitForParentsTrue ||
+					(r.Cfg.WaitForParents == config.WaitForParentsReval && !serverStatus.UseRevalPending)) {
 				log.Errorln("Traffic Ops is signaling that my parents need an update.")
 				if r.Cfg.RunMode == t3cutil.ModeSyncDS {
 					log.Infof("In syncds mode, sleeping for %ds to see if the update my parents need is cleared.", randDispSec/time.Second)
@@ -804,7 +806,7 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 					}
 				}
 			} else {
-				log.Debugf("Traffic Ops is signaling that my parents do not need an update, or wait_for_parents is false.")
+				log.Debugf("Processing with update: Traffic Ops server status %+v config wait-for-parents %+v", serverStatus, r.Cfg.WaitForParents)
 			}
 		} else if r.Cfg.RunMode == t3cutil.ModeSyncDS {
 			log.Errorln("In syncds mode, but no syncds update needs to be applied.  Running revalidation before exiting.")

--- a/cache-config/t3c-apply/torequest/torequest_test.go
+++ b/cache-config/t3c-apply/torequest/torequest_test.go
@@ -44,7 +44,7 @@ var testCfg config.Cfg = config.Cfg{
 	TOUser:              "mickey",
 	TOPass:              "mouse",
 	TOURL:               "http://mouse.com",
-	WaitForParents:      false,
+	WaitForParents:      "false",
 	YumOptions:          "none",
 }
 

--- a/cache-config/testing/ort-tests/t3c-apply-wait-for-parents_test.go
+++ b/cache-config/testing/ort-tests/t3c-apply-wait-for-parents_test.go
@@ -1,0 +1,365 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	testutil "github.com/apache/trafficcontrol/cache-config/testing/ort-tests/util"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestWaitForParentsTrue(t *testing.T) {
+	testName := getFuncName()
+	t.Logf("------------- Starting " + testName + " ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		const childCacheHostName = "atlanta-edge-03"
+		const parentCacheHostName = "atlanta-mid-16"
+
+		// do an initial badass to get all configs
+
+		if _, err := t3cUpdateWaitForParents(childCacheHostName, "badass", util.StrPtr("false")); err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		fileNameToRemove := filepath.Join(test_config_dir, "records.config")
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Fatalf("expected: '%v' to exist after badass, actual: doesn't exist", fileNameToRemove)
+		}
+
+		if err := os.Remove(fileNameToRemove); err != nil {
+			t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+		}
+
+		// queue on both child and parent
+
+		if err := ExecTOUpdater(childCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on child failed: %v\n", err)
+		}
+		if err := ExecTOUpdater(parentCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on parent failed: %v\n", err)
+		}
+
+		// verify child has parent-pending in TO status endpoint.
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if !status.ParentPending {
+			t.Fatalf("expected: '%v' to have parent pending after queueing its parent %v, actual: %+v", childCacheHostName, parentCacheHostName, status)
+		} else {
+			t.Logf("Update Status of child right before running t3c-apply: %+v\n", status)
+		}
+
+		// syncds, and wait for parents
+
+		output, err := t3cUpdateWaitForParents(childCacheHostName, "syncds", util.StrPtr("true"))
+		if err != nil {
+			t.Fatalf("ERROR: t3c syncds failed: %v\n", err)
+		}
+
+		// should not have updated, because a parent is queued
+
+		if !strings.Contains(output, "My parents still need an update, bailing.") {
+			t.Fatalf("t3c wait-for-parents expected to wait for parents, actual: '''%v'''\n", output)
+		}
+
+		if testutil.FileExists(fileNameToRemove) {
+			t.Fatalf("t3c wait-for-parents expected to wait for parents, actual: created file '%v'\n", fileNameToRemove)
+		}
+
+		// verify both child and parent are still queued
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if !status.UpdatePending {
+			t.Errorf("expected: '%v' to still be queued after failed syncds run, actual: %+v", childCacheHostName, status)
+		}
+
+		if status, err := getUpdateStatus(parentCacheHostName); err != nil {
+			t.Fatalf("checking '" + parentCacheHostName + "' queue status: " + err.Error())
+		} else if !status.UpdatePending {
+			t.Errorf("expected: '%v' to still be queued after unrelated child failed syncds run, actual: %+v", parentCacheHostName, status)
+		}
+
+		// un-queue the parent
+
+		if err = ExecTOUpdater(parentCacheHostName, false, false); err != nil {
+			t.Fatalf("queue updates on child failed: %v\n", err)
+		}
+
+		// syncds, and wait for parents, with the parent not queued
+
+		if _, err := t3cUpdateWaitForParents(childCacheHostName, "syncds", util.StrPtr("true")); err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Errorf("expected: '%v' to exist after syncds wait-for-parents and no parents queued, actual: doesn't exist", fileNameToRemove)
+		}
+
+		// verify both child and parent are not queued now
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if status.UpdatePending {
+			t.Errorf("expected: '%v' to not be queued after successful syncds run, actual: %+v", childCacheHostName, status)
+		}
+
+		if status, err := getUpdateStatus(parentCacheHostName); err != nil {
+			t.Fatalf("checking '" + parentCacheHostName + "' queue status: " + err.Error())
+		} else if status.UpdatePending {
+			t.Errorf("expected: '%v' to still be queued after unrelated child successful syncds run, actual: %+v", parentCacheHostName, status)
+		}
+
+	})
+	t.Logf("------------- End of " + testName + " ---------------")
+}
+
+func TestWaitForParentsDefaultReval(t *testing.T) {
+	testName := getFuncName()
+	t.Logf("------------- Starting " + testName + " ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		const childCacheHostName = "atlanta-edge-03"
+		const parentCacheHostName = "atlanta-mid-16"
+
+		// do an initial badass to get all configs
+
+		if _, err := t3cUpdateWaitForParents(childCacheHostName, "badass", util.StrPtr("false")); err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		fileNameToRemove := filepath.Join(test_config_dir, "records.config")
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Fatalf("expected: '%v' to exist after badass, actual: doesn't exist", fileNameToRemove)
+		}
+
+		if err := os.Remove(fileNameToRemove); err != nil {
+			t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+		}
+
+		// queue both child and parent
+
+		if err := ExecTOUpdater(childCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on child failed: %v\n", err)
+		}
+		if err := ExecTOUpdater(parentCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on parent failed: %v\n", err)
+		}
+
+		// verify child has parent-pending in TO status endpoint.
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if !status.ParentPending {
+			t.Fatalf("expected: '%v' to have parent pending after queueing its parent %v, actual: %+v", childCacheHostName, parentCacheHostName, status)
+		} else if !status.UseRevalPending {
+			t.Fatalf("expected: Traffic Ops UseRevalPending must be true for this test, actual: false.")
+		} else {
+			t.Logf("Update Status of child right before running t3c-apply: %+v\n", status)
+		}
+
+		// syncds, and don't pass wait-for-parents, which should default to 'reval', which should *not* wait for parents since TO UseRevalPending is true.
+
+		if output, err := t3cUpdateWaitForParents(childCacheHostName, "syncds", nil); err != nil {
+			t.Fatalf("ERROR: t3c syncds failed: error '''%v''' output '''%v'''\n", err, output)
+		}
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Errorf("expected: '%v' to exist after syncds wait-for-parents=default=reval and parents queued, actual: doesn't exist", fileNameToRemove)
+		}
+
+		// verify child is not queued now
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if status.UpdatePending {
+			t.Errorf("expected: '%v' to not be queued after successful syncds run, actual: %+v", childCacheHostName, status)
+		}
+
+	})
+	t.Logf("------------- End of " + testName + " ---------------")
+}
+
+func TestWaitForParentsFalse(t *testing.T) {
+	testName := getFuncName()
+	t.Logf("------------- Starting " + testName + " ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		const childCacheHostName = "atlanta-edge-03"
+		const parentCacheHostName = "atlanta-mid-16"
+
+		// do an initial badass to get all configs
+
+		if _, err := t3cUpdateWaitForParents(childCacheHostName, "badass", util.StrPtr("false")); err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		fileNameToRemove := filepath.Join(test_config_dir, "records.config")
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Fatalf("expected: '%v' to exist after badass, actual: doesn't exist", fileNameToRemove)
+		}
+
+		if err := os.Remove(fileNameToRemove); err != nil {
+			t.Fatalf("failed to remove file '" + fileNameToRemove + "': " + err.Error())
+		}
+
+		// queue both child and parent
+
+		if err := ExecTOUpdater(childCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on child failed: %v\n", err)
+		}
+		if err := ExecTOUpdater(parentCacheHostName, false, true); err != nil {
+			t.Fatalf("queue updates on parent failed: %v\n", err)
+		}
+
+		// delete use_reval_pending parameter, because for a syncds run, wait-for-parents 'false' behaves like 'reval' if it exists,
+		// so we want to make sure it doesn't, to make sure wait-for-parents isn't actually executing 'reval'.
+
+		params, _, err := tcdata.TOSession.GetParametersWithHdr(nil)
+		if err != nil {
+			t.Fatalf("getting parameters: " + err.Error())
+		}
+
+		useRevalPendingParamID := -1
+		for _, param := range params {
+			if tc.ConfigFileName(param.ConfigFile) != tc.GlobalConfigFileName || tc.ParameterName(param.Name) != tc.UseRevalPendingParameterName {
+				continue
+			}
+			useRevalPendingParamID = param.ID
+			break
+		}
+		if useRevalPendingParamID != -1 {
+			if _, _, err := tcdata.TOSession.DeleteParameterByID(useRevalPendingParamID); err != nil {
+				t.Fatalf("deleting useReval param: queue status: " + err.Error())
+			}
+		} else {
+			t.Fatalf("expected '%v' '%v' Param to exist in test data, actually: missing", tc.GlobalConfigFileName, tc.UseRevalPendingParameterName)
+		}
+
+		// verify child has parent-pending in TO status endpoint.
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if !status.ParentPending {
+			t.Fatalf("expected: '%v' to have parent pending after queueing its parent %v, actual: %+v", childCacheHostName, parentCacheHostName, status)
+		} else if status.UseRevalPending {
+			t.Fatalf("expected: Traffic Ops UseRevalPending to be false after deleting Parameter, actual: true")
+		} else {
+			t.Logf("Update Status of child right before running t3c-apply: %+v\n", status)
+		}
+
+		// syncds, and pass wait-for-parents=false
+
+		if output, err := t3cUpdateWaitForParents(childCacheHostName, "syncds", util.StrPtr("false")); err != nil {
+			t.Fatalf("ERROR: t3c syncds failed: error '''%v''' output '''%v'''\n", err, output)
+		}
+
+		if !testutil.FileExists(fileNameToRemove) {
+			t.Errorf("expected: '%v' to exist after syncds wait-for-parents=false and parents queued, actual: doesn't exist", fileNameToRemove)
+		}
+
+		// verify child is not queued now
+
+		if status, err := getUpdateStatus(childCacheHostName); err != nil {
+			t.Fatalf("checking '" + childCacheHostName + "' queue status: " + err.Error())
+		} else if status.UpdatePending {
+			t.Errorf("expected: '%v' to not be queued after successful syncds run, actual: %+v", childCacheHostName, status)
+		}
+
+	})
+	t.Logf("------------- End of " + testName + " ---------------")
+}
+
+func getUpdateStatus(hostName string) (tc.ServerUpdateStatus, error) {
+	st := tc.ServerUpdateStatus{}
+	if output, err := runRequest(hostName, "update-status"); err != nil {
+		return tc.ServerUpdateStatus{}, errors.New("t3c-request failed: " + err.Error())
+	} else if err = json.Unmarshal([]byte(output), &st); err != nil {
+		return tc.ServerUpdateStatus{}, errors.New("unmarshalling t3c-request json output: " + err.Error())
+	}
+	return st, nil
+}
+
+func t3cUpdateWaitForParents(host string, runMode string, waitForParents *string) (string, error) {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"--log-location-error=stdout",
+		"--log-location-info=stdout",
+		"--log-location-debug=stdout",
+		"--run-mode=" + runMode,
+		"--git=no",
+		"--dns-local-bind",
+	}
+	if waitForParents != nil {
+		args = append(args, "--wait-for-parents="+*waitForParents)
+	}
+	cmd := exec.Command("t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return "", errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return out.String() + "\n" + errOut.String(), nil
+}
+
+// getFuncName() returns the function name of the calling function.
+func getFuncName() string {
+	pc := make([]uintptr, 1)
+	n := runtime.Callers(2, pc)
+	frames := runtime.CallersFrames(pc[:n])
+	frame, _ := frames.Next()
+	return frame.Function
+}


### PR DESCRIPTION
Adds a flag to `t3c-apply` to wait for parents in syncds mode. Currently, `--wait-for-parents=true` is the default, but doesn't actually wait in syncds mode, only reval mode.

This changes the flag to a ternary: true, false, and reval. The `reval` option is the new default, and behaves like the old default, so most users should see no change: it waits for parents in reval mode, but not syncds. And `true` now always waits.

The default `reval` is still the recommended option. Config deployments other than revalidations _probably_ don't need to wait for parents in most cases. But config deployment is so complex, it's impossible to say for sure that there are no cases that require waiting for parents. Which is why this flag is being added: so if anyone does encounter an case where it's required (potentially outage-inducing every time there's a change), it's possible to wait for parents in syncds with a flag change, rather than requiring a code change and a new deploy. And it's very little code for that safety, just a new flag and slight modification to the conditional.

Includes extensive tests for all 3 modes (previously wait-for-parents had no tests).
Includes docs.
Includes changelog.

- [x] This PR fixes #REPLACE_ME OR is not related to any Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run t3c integration tests. Run t3c-apply with various wait-for-parents arguments, with a cache with parents pending, verify flags do what they say.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information