### PR TITLE
Locking down snap/ queue/ update status endpoints for a CDN

### DIFF
--- a/blueprints/to-locks.md
+++ b/blueprints/to-locks.md
@@ -168,7 +168,7 @@ response JSON:
 {
   "alerts": [
     {
-      "text": "CDN lock acquired!",
+      "text": "hard CDN lock acquired!",
       "level": "success"
     }
   ],

--- a/docs/source/api/v4/cdn_locks.rst
+++ b/docs/source/api/v4/cdn_locks.rst
@@ -122,7 +122,7 @@ Response Structure
 
 	{ "alerts": [
 		{
-			"text": "CDN lock acquired!",
+			"text": "soft CDN lock acquired!",
 			"level":"success"
 		}
 	],

--- a/traffic_ops/testing/api/v4/cdn_locks_test.go
+++ b/traffic_ops/testing/api/v4/cdn_locks_test.go
@@ -65,7 +65,7 @@ func getCDNNameAndServerID(t *testing.T) (string, int) {
 		if err != nil {
 			t.Errorf("could not get servers for cdn %s: %v", cdn.Name, err)
 		}
-		if len(serversResp.Response) != 0 {
+		if len(serversResp.Response) != 0 && serversResp.Response[0].ID != nil {
 			serverID = *serversResp.Response[0].ID
 			return cdn.Name, serverID
 		}
@@ -103,6 +103,7 @@ func getCDNDetailsAndTopologyName(t *testing.T) (int, string, string) {
 			}
 		}
 	}
+	t.Error("couldn't find a valid CDN and associated Topology name")
 	return -1, "", ""
 }
 
@@ -325,13 +326,13 @@ func SnapshotWithLock(t *testing.T) {
 		t.Errorf("expected error while snapping cdn %s by user admin, but got nothing", cdn)
 	}
 	if reqInf.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected a 403 status code, but got %d instead", reqInf.StatusCode)
+		t.Errorf("expected a 403 status code, but got %d instead", reqInf.StatusCode)
 	}
 
 	// Delete the lock
 	_, _, err = userSession.DeleteCDNLocks(client.RequestOptions{QueryParameters: url.Values{"cdn": []string{cdn}}})
 	if err != nil {
-		t.Fatalf("expected no error while deleting other user's lock using admin endpoint, but got %v", err)
+		t.Errorf("expected no error while deleting other user's lock using admin endpoint, but got %v", err)
 	}
 }
 

--- a/traffic_ops/testing/api/v4/cdn_locks_test.go
+++ b/traffic_ops/testing/api/v4/cdn_locks_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
@@ -28,9 +29,12 @@ import (
 )
 
 func TestCDNLocks(t *testing.T) {
-	WithObjs(t, []TCObj{Tenants, Roles, Users, CDNs}, func() {
+	WithObjs(t, []TCObj{Types, CacheGroups, CDNs, Parameters, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, ServerCapabilities, ServerServerCapabilitiesForTopologies, Topologies, Tenants, DeliveryServices, TopologyBasedDeliveryServiceRequiredCapabilities, Roles, Users}, func() {
 		CRDCdnLocks(t)
 		AdminCdnLocks(t)
+		SnapshotWithLock(t)
+		QueueUpdatesWithLock(t)
+		QueueUpdatesFromTopologiesWithLock(t)
 	})
 }
 
@@ -43,6 +47,63 @@ func getCDNName(t *testing.T) string {
 		t.Fatalf("no valid CDNs in response")
 	}
 	return cdnResp.Response[0].Name
+}
+
+func getCDNNameAndServerID(t *testing.T) (string, int) {
+	serverID := -1
+	cdnResp, _, err := TOSession.GetCDNs(client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("couldn't get CDNs: %v", err)
+	}
+	if len(cdnResp.Response) < 1 {
+		t.Fatalf("no valid CDNs in response")
+	}
+	for _, cdn := range cdnResp.Response {
+		opts := client.NewRequestOptions()
+		opts.QueryParameters.Set("cdn", strconv.Itoa(cdn.ID))
+		serversResp, _, err := TOSession.GetServers(opts)
+		if err != nil {
+			t.Errorf("could not get servers for cdn %s: %v", cdn.Name, err)
+		}
+		if len(serversResp.Response) != 0 {
+			serverID = *serversResp.Response[0].ID
+			return cdn.Name, serverID
+		}
+	}
+	return "", serverID
+}
+
+func getCDNDetailsAndTopologyName(t *testing.T) (int, string, string) {
+	opts := client.NewRequestOptions()
+	topologiesResp, _, err := TOSession.GetTopologies(client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("couldn't get topologies, err: %v", err)
+	}
+	if len(topologiesResp.Response) == 0 {
+		t.Fatal("no topologies returned")
+	}
+	for _, top := range topologiesResp.Response {
+		for _, node := range top.Nodes {
+			opts.QueryParameters.Set("name", node.Cachegroup)
+			cacheGroupResp, _, err := TOSession.GetCacheGroups(opts)
+			if err != nil {
+				t.Errorf("error while GETting cachegroups: %v", err)
+			}
+			if len(cacheGroupResp.Response) != 0 && cacheGroupResp.Response[0].ID != nil {
+				cacheGroupID := *cacheGroupResp.Response[0].ID
+				opts.QueryParameters.Del("name")
+				opts.QueryParameters.Set("cachegroup", strconv.Itoa(cacheGroupID))
+				serversResp, _, err := TOSession.GetServers(opts)
+				if err != nil {
+					t.Errorf("couldn't get servers: %v", err)
+				}
+				if len(serversResp.Response) != 0 && serversResp.Response[0].CDNName != nil && serversResp.Response[0].CDNID != nil {
+					return *serversResp.Response[0].CDNID, *serversResp.Response[0].CDNName, top.Name
+				}
+			}
+		}
+	}
+	return -1, "", ""
 }
 
 func CRDCdnLocks(t *testing.T) {
@@ -197,5 +258,229 @@ func AdminCdnLocks(t *testing.T) {
 	}
 	if reqInf.StatusCode != http.StatusOK {
 		t.Fatalf("expected a 200 status code, but got %d instead", reqInf.StatusCode)
+	}
+}
+
+func SnapshotWithLock(t *testing.T) {
+	resp, _, err := TOSession.GetTenants(client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not GET tenants: %v", err)
+	}
+	if len(resp.Response) == 0 {
+		t.Fatalf("didn't get any tenant in response")
+	}
+
+	// Create a new user with operations level privileges
+	user1 := tc.User{
+		Username:             util.StrPtr("lock_user1"),
+		RegistrationSent:     tc.TimeNoModFromTime(time.Now()),
+		LocalPassword:        util.StrPtr("test_pa$$word"),
+		ConfirmLocalPassword: util.StrPtr("test_pa$$word"),
+		RoleName:             util.StrPtr("operations"),
+	}
+	user1.Email = util.StrPtr("lockuseremail@domain.com")
+	user1.TenantID = util.IntPtr(resp.Response[0].ID)
+	user1.FullName = util.StrPtr("firstName LastName")
+	_, _, err = TOSession.CreateUser(user1, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not create test user with username: %s", *user1.Username)
+	}
+	defer ForceDeleteTestUsersByUsernames(t, []string{"lock_user1"})
+
+	// Establish a session with the newly created non admin level user
+	userSession, _, err := client.LoginWithAgent(Config.TrafficOps.URL, *user1.Username, *user1.LocalPassword, true, "to-api-v4-client-tests", false, toReqTimeout)
+	if err != nil {
+		t.Fatalf("could not login with user lock_user1: %v", err)
+	}
+
+	cdn := getCDNName(t)
+
+	// Currently, no user has a lock on the "bar" CDN, so when "lock_user1", which does not have the lock on CDN "bar", tries to snap it, this should pass
+	opts := client.NewRequestOptions()
+	opts.QueryParameters.Set("cdn", cdn)
+	_, _, err = userSession.SnapshotCRConfig(opts)
+	if err != nil {
+		t.Errorf("expected no error while snapping cdn %s by user %s, but got %v", cdn, *user1.Username, err)
+	}
+
+	// Create a lock for this user
+	_, _, err = userSession.CreateCDNLock(tc.CDNLock{
+		CDN:     cdn,
+		Message: util.StrPtr("test lock"),
+		Soft:    util.BoolPtr(true),
+	}, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("couldn't create cdn lock: %v", err)
+	}
+
+	// "lock_user1", which has the lock on CDN "bar", tries to snap it -> this should pass
+	_, _, err = userSession.SnapshotCRConfig(opts)
+	if err != nil {
+		t.Errorf("expected no error while snapping cdn %s by user %s, but got %v", cdn, *user1.Username, err)
+	}
+
+	// Admin user, which doesn't have the lock on the CDN "bar", is trying to snap it -> this should fail
+	_, reqInf, err := TOSession.SnapshotCRConfig(opts)
+	if err == nil {
+		t.Errorf("expected error while snapping cdn %s by user admin, but got nothing", cdn)
+	}
+	if reqInf.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected a 403 status code, but got %d instead", reqInf.StatusCode)
+	}
+
+	// Delete the lock
+	_, _, err = userSession.DeleteCDNLocks(client.RequestOptions{QueryParameters: url.Values{"cdn": []string{cdn}}})
+	if err != nil {
+		t.Fatalf("expected no error while deleting other user's lock using admin endpoint, but got %v", err)
+	}
+}
+
+func QueueUpdatesWithLock(t *testing.T) {
+	resp, _, err := TOSession.GetTenants(client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not GET tenants: %v", err)
+	}
+	if len(resp.Response) == 0 {
+		t.Fatalf("didn't get any tenant in response")
+	}
+
+	// Create a new user with operations level privileges
+	user1 := tc.User{
+		Username:             util.StrPtr("lock_user1"),
+		RegistrationSent:     tc.TimeNoModFromTime(time.Now()),
+		LocalPassword:        util.StrPtr("test_pa$$word"),
+		ConfirmLocalPassword: util.StrPtr("test_pa$$word"),
+		RoleName:             util.StrPtr("operations"),
+	}
+	user1.Email = util.StrPtr("lockuseremail@domain.com")
+	user1.TenantID = util.IntPtr(resp.Response[0].ID)
+	user1.FullName = util.StrPtr("firstName LastName")
+	_, _, err = TOSession.CreateUser(user1, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not create test user with username: %s", *user1.Username)
+	}
+	defer ForceDeleteTestUsersByUsernames(t, []string{"lock_user1"})
+
+	// Establish a session with the newly created non admin level user
+	userSession, _, err := client.LoginWithAgent(Config.TrafficOps.URL, *user1.Username, *user1.LocalPassword, true, "to-api-v4-client-tests", false, toReqTimeout)
+	if err != nil {
+		t.Fatalf("could not login with user lock_user1: %v", err)
+	}
+
+	cdn, serverID := getCDNNameAndServerID(t)
+	if serverID == -1 {
+		t.Fatalf("Could not get any valid servers to queue updates on")
+	}
+
+	// Currently, no user has a lock on the "bar" CDN, so when "lock_user1", which does not have the lock on CDN "bar", tries to queue updates on a server in the same CDN, this should pass
+	_, _, err = userSession.SetServerQueueUpdate(serverID, true, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("expected no error while queueing updates for a server in cdn %s by user %s, but got %v", cdn, *user1.Username, err)
+	}
+
+	// Create a lock for this user
+	_, _, err = userSession.CreateCDNLock(tc.CDNLock{
+		CDN:     cdn,
+		Message: util.StrPtr("test lock"),
+		Soft:    util.BoolPtr(true),
+	}, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("couldn't create cdn lock: %v", err)
+	}
+
+	// "lock_user1", which has the lock on CDN "bar", tries to queue updates on a server in it -> this should pass
+	_, _, err = userSession.SetServerQueueUpdate(serverID, true, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("expected no error while queueing updates for a server in cdn %s by user %s, but got %v", cdn, *user1.Username, err)
+	}
+
+	// Admin user, which doesn't have the lock on the CDN "bar", is trying to queue updates on a server in it -> this should fail
+	_, reqInf, err := TOSession.SetServerQueueUpdate(serverID, true, client.RequestOptions{})
+	if err == nil {
+		t.Errorf("expected error while queueing updates on a server in cdn %s by user admin, but got nothing", cdn)
+	}
+	if reqInf.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected a 403 status code, but got %d instead", reqInf.StatusCode)
+	}
+
+	// Delete the lock
+	_, _, err = userSession.DeleteCDNLocks(client.RequestOptions{QueryParameters: url.Values{"cdn": []string{cdn}}})
+	if err != nil {
+		t.Fatalf("expected no error while deleting other user's lock using admin endpoint, but got %v", err)
+	}
+}
+
+func QueueUpdatesFromTopologiesWithLock(t *testing.T) {
+	resp, _, err := TOSession.GetTenants(client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not GET tenants: %v", err)
+	}
+	if len(resp.Response) == 0 {
+		t.Fatalf("didn't get any tenant in response")
+	}
+
+	// Create a new user with operations level privileges
+	user1 := tc.User{
+		Username:             util.StrPtr("lock_user1"),
+		RegistrationSent:     tc.TimeNoModFromTime(time.Now()),
+		LocalPassword:        util.StrPtr("test_pa$$word"),
+		ConfirmLocalPassword: util.StrPtr("test_pa$$word"),
+		RoleName:             util.StrPtr("operations"),
+	}
+	user1.Email = util.StrPtr("lockuseremail@domain.com")
+	user1.TenantID = util.IntPtr(resp.Response[0].ID)
+	user1.FullName = util.StrPtr("firstName LastName")
+	_, _, err = TOSession.CreateUser(user1, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("could not create test user with username: %s", *user1.Username)
+	}
+	defer ForceDeleteTestUsersByUsernames(t, []string{"lock_user1"})
+
+	// Establish a session with the newly created non admin level user
+	userSession, _, err := client.LoginWithAgent(Config.TrafficOps.URL, *user1.Username, *user1.LocalPassword, true, "to-api-v4-client-tests", false, toReqTimeout)
+	if err != nil {
+		t.Fatalf("could not login with user lock_user1: %v", err)
+	}
+
+	cdnID, cdnName, topology := getCDNDetailsAndTopologyName(t)
+	if topology == "" || cdnName == "" || cdnID == -1 {
+		t.Fatalf("Could not get any valid topologies/ cdns to queue updates on")
+	}
+
+	// Currently, no user has a lock on the "bar" CDN, so when "lock_user1", which does not have the lock on CDN "bar", tries to queue updates on a topology in the same CDN, this should pass
+	_, _, err = userSession.TopologiesQueueUpdate(topology, tc.TopologiesQueueUpdateRequest{Action: "queue", CDNID: int64(cdnID)}, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("expected no error while queueing updates for a topology server in cdn %s by user %s, but got %v", cdnName, *user1.Username, err)
+	}
+
+	// Create a lock for this user
+	_, _, err = userSession.CreateCDNLock(tc.CDNLock{
+		CDN:     cdnName,
+		Message: util.StrPtr("test lock"),
+		Soft:    util.BoolPtr(true),
+	}, client.RequestOptions{})
+	if err != nil {
+		t.Fatalf("couldn't create cdn lock: %v", err)
+	}
+
+	// "lock_user1", which has the lock on CDN "bar", tries to queue updates on a topology in it -> this should pass
+	_, _, err = userSession.TopologiesQueueUpdate(topology, tc.TopologiesQueueUpdateRequest{Action: "queue", CDNID: int64(cdnID)}, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("expected no error while queueing updates for a topology server in cdn %s by user %s, but got %v", cdnName, *user1.Username, err)
+	}
+
+	// Admin user, which doesn't have the lock on the CDN "bar", is trying to queue updates on a topology in it -> this should fail
+	_, reqInf, err := TOSession.TopologiesQueueUpdate(topology, tc.TopologiesQueueUpdateRequest{Action: "queue", CDNID: int64(cdnID)}, client.RequestOptions{})
+	if err == nil {
+		t.Errorf("expected error while queueing updates on topology servers on cdn %s by user admin, but got nothing", cdnName)
+	}
+	if reqInf.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected a 403 status code, but got %d instead", reqInf.StatusCode)
+	}
+
+	// Delete the lock
+	_, _, err = userSession.DeleteCDNLocks(client.RequestOptions{QueryParameters: url.Values{"cdn": []string{cdnName}}})
+	if err != nil {
+		t.Fatalf("expected no error while deleting lock, but got %v", err)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/queueupdate.go
@@ -74,6 +74,11 @@ func QueueUpdates(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
 		return
 	}
+	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserHasCdnLock(inf.Tx.Tx, string(*reqObj.CDN), inf.User.UserName)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		return
+	}
 	queue := reqObj.Action == "queue"
 	updatedCaches, err := queueUpdates(inf.Tx.Tx, cgID, *reqObj.CDN, queue)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/cdn/queue.go
+++ b/traffic_ops/traffic_ops_golang/cdn/queue.go
@@ -48,17 +48,21 @@ func Queue(w http.ResponseWriter, r *http.Request) {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New("action must be 'queue' or 'dequeue'"), nil)
 		return
 	}
-	if err := queueUpdates(inf.Tx.Tx, int64(inf.IntParams["id"]), reqObj.Action == "queue"); err != nil {
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("CDN queueing updates: "+err.Error()))
-		return
-	}
-
 	cdnName, ok, err := dbhelpers.GetCDNNameFromID(inf.Tx.Tx, int64(inf.IntParams["id"]))
 	if err != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("getting cdn name from ID '"+inf.Params["id"]+"': "+err.Error()))
 		return
 	} else if !ok {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusNotFound, nil, nil)
+		return
+	}
+	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserHasCdnLock(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		return
+	}
+	if err := queueUpdates(inf.Tx.Tx, int64(inf.IntParams["id"]), reqObj.Action == "queue"); err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, errors.New("CDN queueing updates: "+err.Error()))
 		return
 	}
 	api.CreateChangeLogRawTx(api.ApiChange, "CDN: "+string(cdnName)+", ID: "+strconv.Itoa(inf.IntParams["id"])+", ACTION: CDN server updates "+reqObj.Action+"d", inf.User, inf.Tx.Tx)

--- a/traffic_ops/traffic_ops_golang/crconfig/handler.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/handler.go
@@ -223,7 +223,11 @@ func snapshotHandler(w http.ResponseWriter, r *http.Request, deprecated bool) {
 			return
 		}
 	}
-
+	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserHasCdnLock(inf.Tx.Tx, cdn, inf.User.UserName)
+	if userErr != nil || sysErr != nil {
+		api.HandleErrOptionalDeprecation(w, r, inf.Tx.Tx, statusCode, userErr, sysErr, deprecated, &alt)
+		return
+	}
 	// We never store tm_path, even though low API versions show it in responses.
 	crConfig, err := Make(inf.Tx.Tx, cdn, inf.User.UserName, r.Host, inf.Config.Version, inf.Config.CRConfigUseRequestHost, false)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -108,7 +108,7 @@ func CheckIfCurrentUserHasCdnLock(tx *sql.Tx, cdn, user string) (error, error, i
 	var userName string
 	rows, err := tx.Query(query, cdn)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil, http.StatusOK
 		}
 		return nil, errors.New("querying cdn_lock for user " + user + " and cdn " + cdn + ": " + err.Error()), http.StatusInternalServerError
@@ -563,7 +563,7 @@ func GetCDNNameFromID(tx *sql.Tx, id int64) (tc.CDNName, bool, error) {
 func GetCDNNameFromServerID(tx *sql.Tx, serverId int64) (tc.CDNName, error) {
 	name := ""
 	if err := tx.QueryRow(`SELECT name FROM cdn WHERE id = (SELECT cdn_id FROM server WHERE id=$1)`, serverId).Scan(&name); err != nil {
-		return "", errors.New("querying CDN name from server ID : " + err.Error())
+		return "", fmt.Errorf("querying CDN name from server ID: %w", err)
 	}
 	return tc.CDNName(name), nil
 }

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -559,7 +559,7 @@ func GetCDNNameFromID(tx *sql.Tx, id int64) (tc.CDNName, bool, error) {
 	return tc.CDNName(name), true, nil
 }
 
-// GetCDNNameFromServerID gets the CDN name for the server with the given ID
+// GetCDNNameFromServerID gets the CDN name for the server with the given ID.
 func GetCDNNameFromServerID(tx *sql.Tx, serverId int64) (tc.CDNName, error) {
 	name := ""
 	if err := tx.QueryRow(`SELECT name FROM cdn WHERE id = (SELECT cdn_id FROM server WHERE id=$1)`, serverId).Scan(&name); err != nil {

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -101,6 +101,31 @@ const getUserByEmailQuery = getUserBaseQuery + `
 WHERE tm_user.email = $1
 `
 
+// CheckIfCurrentUserHasCdnLock checks if the current user has the lock on the cdn that the requested operation is to be performed on.
+// This will succeed if the either there is no lock by any user on the CDN, or if the current user has the lock on the CDN.
+func CheckIfCurrentUserHasCdnLock(tx *sql.Tx, cdn, user string) (error, error, int) {
+	query := `SELECT username FROM cdn_lock WHERE cdn=$1`
+	var userName string
+	rows, err := tx.Query(query, cdn)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil, http.StatusOK
+		}
+		return nil, errors.New("querying cdn_lock for user " + user + " and cdn " + cdn + ": " + err.Error()), http.StatusInternalServerError
+	}
+	defer rows.Close()
+	for rows.Next() {
+		err = rows.Scan(&userName)
+		if err != nil {
+			return nil, errors.New("scanning cdn_lock for user " + user + " and cdn " + cdn + ": " + err.Error()), http.StatusInternalServerError
+		}
+	}
+	if userName != "" && user != userName {
+		return errors.New("user " + user + " currently does not have the lock on cdn " + cdn), nil, http.StatusForbidden
+	}
+	return nil, nil, http.StatusOK
+}
+
 func BuildWhereAndOrderByAndPagination(parameters map[string]string, queryParamsToSQLCols map[string]WhereColumnInfo) (string, string, string, map[string]interface{}, []error) {
 	whereClause := BaseWhere
 	orderBy := BaseOrderBy
@@ -532,6 +557,15 @@ func GetCDNNameFromID(tx *sql.Tx, id int64) (tc.CDNName, bool, error) {
 		return "", false, errors.New("querying CDN ID: " + err.Error())
 	}
 	return tc.CDNName(name), true, nil
+}
+
+// GetCDNNameFromServerID gets the CDN name for the server with the given ID
+func GetCDNNameFromServerID(tx *sql.Tx, serverId int64) (tc.CDNName, error) {
+	name := ""
+	if err := tx.QueryRow(`SELECT name FROM cdn WHERE id = (SELECT cdn_id FROM server WHERE id=$1)`, serverId).Scan(&name); err != nil {
+		return "", errors.New("querying CDN name from server ID : " + err.Error())
+	}
+	return tc.CDNName(name), nil
 }
 
 // GetCDNIDFromName returns the ID of the CDN if a CDN with the name exists

--- a/traffic_ops/traffic_ops_golang/server/update.go
+++ b/traffic_ops/traffic_ops_golang/server/update.go
@@ -42,6 +42,16 @@ func UpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 	idOrName := inf.Params["id-or-name"]
 	id, err := strconv.Atoi(idOrName)
+	cdnName, err := dbhelpers.GetCDNNameFromServerID(inf.Tx.Tx, int64(id))
+	if err != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, err)
+		return
+	}
+	userErr, sysErr, statusCode := dbhelpers.CheckIfCurrentUserHasCdnLock(inf.Tx.Tx, string(cdnName), inf.User.UserName)
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, statusCode, userErr, sysErr)
+		return
+	}
 	hostName := ""
 	if err == nil {
 		name, ok, err := dbhelpers.GetServerNameFromID(inf.Tx.Tx, id)


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR is not related to any Issue 
This PR adds the cdn locking capability to the snap/ queue/ update status endpoints.<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Ops
- CI tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->

Make sure all the unit/ API tests pass.
Run TO and TP locally.
As user `A`, send an API request to grab the lock for a particular CDN `foo`.
Now, try to snap `foo` as user `A` -> this should succeed
After this, log in to TO as another user `B`, and try to snap `foo` as user `B` -> this should fail because `A` has the lock for `foo`
Try to snap any other CDN as user `B` or `A` -> both operations should pass
Repeat the same tests for queueing and updating status of he servers on a CDN

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->

- master
## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] This PR does not include documentation 
- [x] This PR does not include an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
<!-- If you would like to include any additional information on the PR for
potential reviewers please put it here.

Some examples of this would be:

- Before and after screenshots/gifs of the Traffic Portal if it is affected
- Links to other dependent Pull Requests
- References to relevant context (e.g. new/updates to dependent libraries,
mailing list records, blueprints)

Feel free to leave this section blank (or, preferably, delete it entirely).
-->

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
