### PR TITLE
Add t3c test for dispersion flag

### DIFF
--- a/cache-config/testing/ort-tests/t3c-apply-dispersion_test.go
+++ b/cache-config/testing/ort-tests/t3c-apply-dispersion_test.go
@@ -1,0 +1,104 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"fmt"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"testing"
+	"time"
+)
+
+func TestDispersion(t *testing.T) {
+	fmt.Println("------------- Starting TestDispersion ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		const cacheHostName = `atlanta-edge-03`
+
+		// get config once, because it'll take longer the first time
+
+		if err := runApply(cacheHostName, "badass", 0); err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+
+		// get the average time to run with dispersion=0
+
+		numAvgRuns := 5
+		runSpans := make([]time.Duration, numAvgRuns)
+		for i := 0; i < numAvgRuns; i++ {
+			if err := ExecTOUpdater(cacheHostName, false, true); err != nil {
+				t.Fatalf("t3c-update failed: %v\n", err)
+			}
+			start := time.Now()
+			if err := runApply(cacheHostName, "syncds", 0); err != nil {
+				t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+			}
+			runSpans[i] = time.Since(start)
+		}
+
+		avgNoDispersionRunSpan := time.Duration(0)
+		for i := 0; i < numAvgRuns; i++ {
+			n := time.Duration(i + 1)
+			avgNoDispersionRunSpan -= avgNoDispersionRunSpan / n
+			avgNoDispersionRunSpan += runSpans[i] / n
+		}
+
+		t.Logf("t3c no-dispersion run times: %+v average %v\n", runSpans, avgNoDispersionRunSpan)
+
+		// set the dispersion time to double the average runtime, or at least 2s
+
+		dispersionValue := avgNoDispersionRunSpan * 4 // dispersion is randomly between 0 and d, so the amortized time here will be double, not 4x
+		minDispersion := time.Second * 4
+		if dispersionValue < minDispersion {
+			dispersionValue = minDispersion
+		}
+
+		t.Logf("set dispersion to %v (average was %v)\n", dispersionValue, avgNoDispersionRunSpan)
+
+		dispRunSpans := make([]time.Duration, numAvgRuns)
+		for i := 0; i < numAvgRuns; i++ {
+			if err := ExecTOUpdater(cacheHostName, false, true); err != nil {
+				t.Fatalf("t3c-update failed: %v\n", err)
+			}
+			start := time.Now()
+			if err := runApply(cacheHostName, "syncds", dispersionValue); err != nil {
+				t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+			}
+			dispRunSpans[i] = time.Since(start)
+		}
+
+		avgDispersionRunSpan := time.Duration(0)
+		for i := 0; i < numAvgRuns; i++ {
+			n := time.Duration(i + 1)
+			avgDispersionRunSpan -= avgDispersionRunSpan / n
+			avgDispersionRunSpan += dispRunSpans[i] / n
+		}
+
+		t.Logf("t3c dispersion run times: %+v average %v\n", dispRunSpans, avgDispersionRunSpan)
+
+		if expected := avgNoDispersionRunSpan.Seconds() * 1.5; avgDispersionRunSpan.Seconds() < expected {
+			t.Errorf("expected dispersion flag %v to average at least %v seconds, actual: %v dispersion runs averaged %v no dispersion averaged %v", dispersionValue, expected, numAvgRuns, avgDispersionRunSpan, avgNoDispersionRunSpan)
+		} else {
+			t.Logf("success: dispersion %v runs %v averaged %v dispersion=0 averaged %v, expectation met %v > %v", dispersionValue, numAvgRuns, avgDispersionRunSpan, avgNoDispersionRunSpan, avgDispersionRunSpan.Seconds(), expected)
+		}
+
+	})
+	fmt.Println("------------- End of TestDispersion ---------------")
+}

--- a/cache-config/testing/ort-tests/t3c_mode_test.go
+++ b/cache-config/testing/ort-tests/t3c_mode_test.go
@@ -78,7 +78,7 @@ func TestT3cBadassAndSyncDs(t *testing.T) {
 		}()
 
 		// run badass and check config files.
-		if err := runApply("atlanta-edge-03", "badass"); err != nil {
+		if err := runApply("atlanta-edge-03", "badass", 0); err != nil {
 			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
 		}
 
@@ -160,7 +160,7 @@ func TestT3cBadassAndSyncDs(t *testing.T) {
 		// remap.config is removed and atlanta-edge-03 should have
 		// queue updates enabled.  run t3c to verify a new remap.config
 		// is pulled down.
-		err = runApply("atlanta-edge-03", "syncds")
+		err = runApply("atlanta-edge-03", "syncds", 0)
 		if err != nil {
 			t.Fatalf("ERROR: t3c syncds failed: %v\n", err)
 		}

--- a/cache-config/testing/ort-tests/t3c_update_to_flags_test.go
+++ b/cache-config/testing/ort-tests/t3c_update_to_flags_test.go
@@ -74,7 +74,7 @@ func TestT3cTOUpdates(t *testing.T) {
 		}
 
 		// run t3c syncds and verify only the queue update flag is reset to 'false'
-		err = runApply("atlanta-edge-03", "syncds")
+		err = runApply("atlanta-edge-03", "syncds", 0)
 		if err != nil {
 			t.Fatalf("ERROR: t3c syncds failed: %v\n", err)
 		}
@@ -95,7 +95,7 @@ func TestT3cTOUpdates(t *testing.T) {
 
 		// run t3c revalidate and verify only the queue update flag is still 'false'
 		// and that the revalidate flag is now 'false'
-		err = runApply("atlanta-edge-03", "revalidate")
+		err = runApply("atlanta-edge-03", "revalidate", 0)
 		if err != nil {
 			t.Fatalf("ERROR: t3c syncds failed: %v\n", err)
 		}

--- a/cache-config/testing/ort-tests/traffic_ops_ort_test.go
+++ b/cache-config/testing/ort-tests/traffic_ops_ort_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"testing"
 	"time"
 
@@ -165,11 +166,11 @@ func runRequest(host string, getData string) ([]byte, error) {
 	return out.Bytes(), nil
 }
 
-func runApply(host string, run_mode string) error {
+func runApply(host string, run_mode string, dispersion time.Duration) error {
 	args := []string{
 		"apply",
 		"--traffic-ops-insecure=true",
-		"--dispersion=0",
+		"--dispersion=" + strconv.FormatInt(int64(dispersion/time.Second), 10),
 		"--login-dispersion=0",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,


### PR DESCRIPTION
Adds tests for the t3c-apply --dispersion flag.

Is tests.
No docs, is tests.
No changelog, is tests.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT
- 
## What is the best way to verify this PR?
Run tests.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information