### PR TITLE
Add atscfg storage.config generation tests

### DIFF
--- a/lib/go-atscfg/storagedotconfig.go
+++ b/lib/go-atscfg/storagedotconfig.go
@@ -94,6 +94,10 @@ func MakeStorageDotConfig(
 func makeStorageVolumeText(prefix string, letters string, volume int) string {
 	text := ""
 	for _, letter := range strings.Split(letters, ",") {
+		letter = strings.TrimSpace(letter)
+		if letter == "" {
+			continue
+		}
 		text += prefix + letter + " volume=" + strconv.Itoa(volume) + "\n"
 	}
 	return text

--- a/lib/go-atscfg/storagedotconfig_test.go
+++ b/lib/go-atscfg/storagedotconfig_test.go
@@ -62,6 +62,11 @@ func TestMakeStorageDotConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if len(cfg.Warnings) > 0 {
+		t.Fatalf("expected no warnings, actual: %+v\n", cfg.Warnings)
+	}
+
 	txt := cfg.Text
 
 	testComment(t, txt, hdr)
@@ -81,5 +86,118 @@ func TestMakeStorageDotConfig(t *testing.T) {
 	}
 	if !strings.Contains(txt, paramData["SSD_Drive_Prefix"]) {
 		t.Errorf("expected to contain SSD_Drive_Prefix '" + paramData["SSD_Drive_Prefix"] + "', actual: '" + txt + "'")
+	}
+}
+
+func TestMakeStorageDotConfigNoParams(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	paramData := map[string]string{}
+
+	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
+
+	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cfg.Warnings) > 0 {
+		t.Fatalf("expected no warnings, actual: %+v\n", cfg.Warnings)
+	}
+
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 2 { // comment plus a blank line
+		t.Errorf("expected one line for comment, plus one blank line (it's important to send a blank line, to prevent many callers from returning a 404), actual: '"+txt+"' count %v", count)
+	}
+
+	lines := strings.Split(txt, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, actual: '"+txt+"' count %v", len(lines))
+	}
+	line := strings.TrimSpace(lines[1])
+	if line != "" {
+		t.Errorf("expected line after comment to be blank, actual: '" + txt + "'")
+	}
+}
+
+func TestMakeStorageDotConfigNoDriveLetters(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	paramData := map[string]string{
+		"Drive_Prefix":     "/dev/sd",
+		"RAM_Drive_Prefix": "/dev/ra",
+		"SSD_Drive_Prefix": "/dev/ss",
+	}
+
+	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
+
+	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Warnings) != 3 {
+		t.Fatalf("expected 3 warnings for drive letters of each type not existing, actual: %+v\n", cfg.Warnings)
+	}
+
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 2 { // comment plus a blank line
+		t.Errorf("expected one line for comment, plus one blank line (it's important to send a blank line, to prevent many callers from returning a 404), actual: '"+txt+"' count %v", count)
+	}
+
+	lines := strings.Split(txt, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least 2 lines, actual: '"+txt+"' count %v", len(lines))
+	}
+	line := strings.TrimSpace(lines[1])
+	if line != "" {
+		t.Errorf("expected line after comment to be blank, actual: '" + txt + "'")
+	}
+}
+
+func TestMakeStorageDotConfigSomeDriveLetters(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	paramData := map[string]string{
+		"Drive_Prefix":     "/dev/sd",
+		"RAM_Drive_Prefix": "/dev/ra",
+		"SSD_Drive_Prefix": "/dev/ss",
+		"Drive_Letters":    "a,b,c,d,e",
+	}
+
+	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
+
+	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.Warnings) != 2 {
+		t.Fatalf("expected 2 warnings for 2 prefixes with no letters, actual: %+v\n", cfg.Warnings)
+	}
+
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 6 { // comment plus each letter
+		t.Errorf("expected one line for comment, plus one line for each drive letter, actual: '"+txt+"' count %v", count)
 	}
 }


### PR DESCRIPTION
Also fixes a poorly behaving failsafe. If a drive prefix parameter
exists but no drive letters, it should warn but not insert it.
It was inserting a malformed prefix with no letter, e.g. '/dev/sd'.
This fixes it to not insert, in the event someone's Parameters are
malformed and have a prefix but no letters.

Is tests.
No docs, no interface change.
No changelog, no interface change and not a bug.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run lib/go-atscfg unit tests.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.


## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information
