### PR TITLE
Add atscfg volume.config tests.

### DIFF
--- a/lib/go-atscfg/volumedotconfig.go
+++ b/lib/go-atscfg/volumedotconfig.go
@@ -56,11 +56,12 @@ func MakeVolumeDotConfig(
 	paramData, paramWarns := paramsToMap(filterParams(serverParams, VolumeFileName, "", "", ""))
 	warnings = append(warnings, paramWarns...)
 
-	text := makeHdrComment(opt.HdrComment)
+	hdr := makeHdrComment(opt.HdrComment)
 
 	numVolumes := getNumVolumes(paramData)
 
-	text += "# TRAFFIC OPS NOTE: This is running with forced volumes - the size is irrelevant\n"
+	hdr += "# TRAFFIC OPS NOTE: This is running with forced volumes - the size is irrelevant\n"
+	text := ""
 	nextVolume := 1
 	if drivePrefix := paramData["Drive_Prefix"]; drivePrefix != "" {
 		text += volumeText(strconv.Itoa(nextVolume), numVolumes)
@@ -80,7 +81,7 @@ func MakeVolumeDotConfig(
 	}
 
 	return Cfg{
-		Text:        text,
+		Text:        hdr + text,
 		ContentType: ContentTypeVolumeDotConfig,
 		LineComment: LineCommentVolumeDotConfig,
 		Warnings:    warnings,

--- a/lib/go-atscfg/volumedotconfig_test.go
+++ b/lib/go-atscfg/volumedotconfig_test.go
@@ -93,3 +93,101 @@ func TestMakeVolumeDotConfig(t *testing.T) {
 		t.Errorf("expected size=100%% for one volume, actual: '%v'", txt)
 	}
 }
+
+func TestMakeVolumeDotConfigNoParams(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+	paramData := map[string]string{}
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	params := makeParamsFromMap(*server.Profile, VolumeFileName, paramData)
+
+	cfg, err := MakeVolumeDotConfig(server, params, &VolumeDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 3 { // two comments, plus a blank line to prevent clients from thinking the file doesn't exist.
+		t.Errorf("expected 2 comments and blank line, actual: '%v' count %v", txt, count)
+	}
+
+	lines := strings.Split(txt, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("expected 3 lines, 2 comments and blank line, actual: '%v' count %v", txt, len(lines))
+	}
+	line := strings.TrimSpace(lines[2])
+	if line != "" {
+		t.Fatalf("expected non-comment line to be blank, actual: '%v'", txt)
+	}
+}
+
+func TestMakeVolumeDotConfigNoLetters(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+	paramData := map[string]string{
+		"Drive_Prefix":     "/dev/sd",
+		"RAM_Drive_Prefix": "/dev/ra",
+		"SSD_Drive_Prefix": "/dev/ss",
+	}
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	params := makeParamsFromMap(*server.Profile, VolumeFileName, paramData)
+
+	cfg, err := MakeVolumeDotConfig(server, params, &VolumeDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 5 { // one line for each volume, plus 2 comments
+		// it's important we create volumes and sizes if the prefixes exist, even without letters,
+		// because storage.config will still increment its volumes, even without letters.
+		// If we didn't, the volume numbers wouldn't match.
+		t.Errorf("expected one line for each drive plus 2 comments, even without letters, actual: '%v' count %v", txt, count)
+	}
+
+	if !strings.Contains(txt, "size=33%") {
+		t.Errorf("expected size=33%% for three volumes even without letters, actual: '%v'", txt)
+	}
+}
+
+func TestMakeVolumeDotConfigSomePrefixes(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+	paramData := map[string]string{
+		"Drive_Prefix":     "/dev/sd",
+		"SSD_Drive_Prefix": "/dev/ss",
+	}
+
+	server := makeGenericServer()
+	server.Profile = &profileName
+
+	params := makeParamsFromMap(*server.Profile, VolumeFileName, paramData)
+
+	cfg, err := MakeVolumeDotConfig(server, params, &VolumeDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if count := strings.Count(txt, "\n"); count != 4 { // one line for each volume, plus 2 comments
+		t.Errorf("expected one line for each drive parameter plus 2 comment, actual: '%v' count %v", txt, count)
+	}
+
+	if !strings.Contains(txt, "size=50%") {
+		t.Errorf("expected size=50%% for two volume parameters, actual: '%v'", txt)
+	}
+}


### PR DESCRIPTION
Also fixes an edge failover case, when no params exist, adding
a blank line to prevent clients from thinking the file doesn't exist.

Is tests.
No changelog, is tests.
No docs, is tests.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?

- Traffic Ops ORT

## What is the best way to verify this PR?
Run lib/go-atscfg unit tests.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

## Additional Information