### PR TITLE
Search both trafficserver/run.sh or docker-compose-ats-build.yml the ATS release branch/ATS_VERSION

### DIFF
--- a/infrastructure/cdn-in-a-box/bin/ats-version.sh
+++ b/infrastructure/cdn-in-a-box/bin/ats-version.sh
@@ -27,7 +27,10 @@ remote_ats_version() {
 	local gitbox_url=https://gitbox.apache.org/repos/asf
 	local repo="${project}.git"
 	local branch refs commit last_tag release
-	branch="$(grep 'ATS_VERSION=' "${script_dir}/../../../cache-config/testing/docker/docker-compose-ats-build.yml" | cut -d= -f2)"
+	branch="$(grep -F ATS_VERSION "${script_dir}/../../../cache-config/testing/docker/trafficserver/run.sh" "${script_dir}/../../../cache-config/testing/docker/docker-compose-ats-build.yml" |
+		grep -Eo '[0-9]+\.[0-9]+\.x' |
+		tail -n1
+	)"
 	refs="$(curl -fs "${gitbox_url}/${repo}/info/refs?service=git-upload-pack" |
 		sed -E 's/^00[0-9a-f]{2}//g' |
 		tr -d '\0')"

--- a/infrastructure/cdn-in-a-box/bin/ats-version.sh
+++ b/infrastructure/cdn-in-a-box/bin/ats-version.sh
@@ -27,10 +27,14 @@ remote_ats_version() {
 	local gitbox_url=https://gitbox.apache.org/repos/asf
 	local repo="${project}.git"
 	local branch refs commit last_tag release
-	branch="$(grep -F ATS_VERSION "${script_dir}/../../../cache-config/testing/docker/trafficserver/run.sh" "${script_dir}/../../../cache-config/testing/docker/docker-compose-ats-build.yml" |
-		grep -Eo '[0-9]+\.[0-9]+\.x' |
-		tail -n1
-	)"
+	if [[ -n "${ATS_VERSION:-}" ]]; then
+		branch="$ATS_VERSION"
+	else
+		branch="$(grep -F ATS_VERSION "${script_dir}/../../../cache-config/testing/docker/trafficserver/run.sh" "${script_dir}/../../../cache-config/testing/docker/docker-compose-ats-build.yml" |
+			grep -Eo '[0-9]+\.[0-9]+\.x' |
+			tail -n1
+		)"
+	fi
 	refs="$(curl -fs "${gitbox_url}/${repo}/info/refs?service=git-upload-pack" |
 		sed -E 's/^00[0-9a-f]{2}//g' |
 		tr -d '\0')"


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->
On the ATC master branch, `cache-config/testing/docker/docker-compose-ats-build.yml` defines `ATS_VERSION`:
https://github.com/apache/trafficcontrol/blob/295c31e3467d13163ec4a3f87fac5450389801ec/cache-config/testing/docker/docker-compose-ats-build.yml#L30

In anticipation of #5938 moving the `ATS_VERSION` definition to [`.github/workflows/cache-config-tests.yml`](https://github.com/apache/trafficcontrol/pull/5938/commits/a3f3e2045b86e734f52c043c59d9dfd73641b29e#diff-9a2602bd05608dbecd16ec959a7188907ae7a753f7c01b9e2d810a1b05f08f68R22) and [`cache-config/testing/docker/trafficserver/run.sh`](https://github.com/apache/trafficcontrol/pull/5938/commits/a3f3e2045b86e734f52c043c59d9dfd73641b29e#diff-ed7a2061f6a4eebedf99e5efa12d82072a075fb7f80fa3d7f243529c4943dbf7R28), this PR updates `infrastructure/cdn-in-a-box/bin/ats-version.sh` (used by the `ATS_DIST_RPM` target of the CDN in a Box makefile) to look for an `ATS_VERSION` definition in either `cache-config/testing/docker/docker-compose-ats-build.yml` or `cache-config/testing/docker/trafficserver/run.sh`.

`infrastructure/cdn-in-a-box/bin/ats-version.sh` will alternatively get `ATS_VERSION` from the environment, if it is defined, and fall back to checking those files only if it is not.

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
In the CDN in a Box directory,
1. Confirm that `ats-version.sh` produces a valid ATS version at 295c31e346 (latest master)
    ```
    git checkout 295c31e346 &&
    rm -f cache/ATS_VERSION &&
    bin/ats-version.sh
    ```
    Expected output:
    ```
    8.1.1-45.55bbe4a64
    ```
2. Confirm that `ats-version.sh` produces a valid ATS version at a3f3e2045b (#5938 HEAD)
    ```
    git checkout a3f3e2045b &&
    rm -f cache/ATS_VERSION &&
    bin/ats-version.sh
    ```
    Expected output:
    ```
    8.1.1-45.55bbe4a64
    ```

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] Building and running CDN in a Box is a sufficient test
- [x] Preemptive bugfix, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

