### PR TITLE
Fix Traffic Monitor warning logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5739](https://github.com/apache/trafficcontrol/issues/5739) - Prevent looping in case of a failed login attempt
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
+- [#5863](https://github.com/apache/trafficcontrol/issues/5863) - Traffic Monitor logs warnings to `log_location_info` instead of `log_location_warning`
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -131,7 +131,7 @@ type Config struct {
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
-func (c Config) WarningLog() log.LogLocation { return log.LogLocation(c.LogLocationInfo) }
+func (c Config) WarningLog() log.LogLocation { return log.LogLocation(c.LogLocationWarning) }
 func (c Config) InfoLog() log.LogLocation    { return log.LogLocation(c.LogLocationInfo) }
 func (c Config) DebugLog() log.LogLocation   { return log.LogLocation(c.LogLocationDebug) }
 func (c Config) EventLog() log.LogLocation   { return log.LogLocation(c.LogLocationEvent) }

--- a/traffic_monitor/config/config_test.go
+++ b/traffic_monitor/config/config_test.go
@@ -1,0 +1,73 @@
+package config
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"testing"
+)
+
+const exampleTMConfig = `
+{
+	"cache_health_polling_interval_ms": 120000,
+	"cache_stat_polling_interval_ms": 120000,
+	"monitor_config_polling_interval_ms": 5000,
+	"http_timeout_ms": 30000,
+	"peer_polling_interval_ms": 120000,
+	"peer_optimistic": true,
+	"peer_optimistic_quorum_min": 0,
+	"max_events": 200,
+	"max_stat_history": 5,
+	"max_health_history": 5,
+	"health_flush_interval_ms": 1000,
+	"stat_flush_interval_ms": 1000,
+	"log_location_event": "event.log",
+	"log_location_error": "error.log",
+	"log_location_warning": "warning.log",
+	"log_location_info": "info.log",
+	"log_location_debug": "debug.log",
+	"serve_read_timeout_ms": 10000,
+	"serve_write_timeout_ms": 10000,
+	"stat_buffer_interval_ms": 20000,
+	"http_poll_no_sleep": false,
+	"static_file_dir": "static/"
+}
+`
+
+func TestLoggingConfig(t *testing.T) {
+	c, err := LoadBytes([]byte(exampleTMConfig))
+	if err != nil {
+		t.Fatalf("loading config bytes - expected: no error, actual: %v", err)
+	}
+	if string(c.WarningLog()) != c.LogLocationWarning {
+		t.Errorf("warning log location - expected: %s, actual: %s\n", c.LogLocationWarning, string(c.WarningLog()))
+	}
+	if string(c.ErrorLog()) != c.LogLocationError {
+		t.Errorf("error log location - expected: %s, actual: %s\n", c.LogLocationError, string(c.ErrorLog()))
+	}
+	if string(c.EventLog()) != c.LogLocationEvent {
+		t.Errorf("event log location - expected: %s, actual: %s\n", c.LogLocationEvent, string(c.EventLog()))
+	}
+	if string(c.InfoLog()) != c.LogLocationInfo {
+		t.Errorf("info log location - expected: %s, actual: %s\n", c.LogLocationInfo, string(c.InfoLog()))
+	}
+	if string(c.DebugLog()) != c.LogLocationDebug {
+		t.Errorf("debug log location - expected: %s, actual: %s\n", c.LogLocationDebug, string(c.DebugLog()))
+	}
+}


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
Initialize the warning logger to log_location_warning instead of
log_location_info.

- [x] This PR fixes #5863 

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
Unfortunately, Traffic Monitor needs to produce a warning in order for this to be verified. To make that easier, what I did was set the `serve_write_timeout_ms` in traffic_monitor.cfg to `500`, then added a `time.sleep(1*time.Second)` in the `srvLegacyCacheStats` function in datareq/cachestat.go. I then requested the `/publish/CacheStats` TM API route. The sleep causes the request to surpass the timeout, which should produce a warning. This warning should be logged to whatever `log_location_warning` is set to (e.g. "stdout"). For verification, make sure this is different than `log_location_info`.

## If this is a bug fix, what versions of Traffic Control are affected?
- master
- 5.x
- 4.x

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bugfix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)