### PR TITLE
Fix integration test

### DIFF
--- a/.github/workflows/traffic-ops.yml
+++ b/.github/workflows/traffic-ops.yml
@@ -61,7 +61,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:13
         env:
           POSTGRES_USER: traffic_ops
           POSTGRES_PASSWORD: twelve

--- a/lib/go-tc/constants.go
+++ b/lib/go-tc/constants.go
@@ -26,6 +26,8 @@ type ErrorConstant string
 func (e ErrorConstant) Error() string { return string(e) }
 
 // DBError is an error message for database errors.
+//
+// Deprecated: Since internal errors are not returned to users, there's no reason not to include more detail in an error message than this.
 const DBError = ErrorConstant("database access error")
 
 // NilTenantError can used when a Tenantable object finds that TentantID in the

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -43,15 +43,15 @@ func TestDeliveryServices(t *testing.T) {
 		header.Set(rfc.IfModifiedSince, ti)
 		header.Set(rfc.IfUnmodifiedSince, ti)
 		if includeSystemTests {
-			SSLDeliveryServiceCDNUpdateTest(t)
-			CreateTestDeliveryServicesURLSignatureKeys(t)
-			GetTestDeliveryServicesURLSignatureKeys(t)
-			DeleteTestDeliveryServicesURLSignatureKeys(t)
-			CreateTestDeliveryServicesURISigningKeys(t)
-			GetTestDeliveryServicesURISigningKeys(t)
-			DeleteTestDeliveryServicesURISigningKeys(t)
-			DeleteCDNOldSSLKeys(t)
-			DeliveryServiceSSLKeys(t)
+			t.Run("Update CDN for a Delivery Service with SSL keys", SSLDeliveryServiceCDNUpdateTest)
+			t.Run("Create URL Signature keys for a Delivery Service", CreateTestDeliveryServicesURLSignatureKeys)
+			t.Run("Retrieve URL Signature keys for a Delivery Service", GetTestDeliveryServicesURLSignatureKeys)
+			t.Run("Delete URL Signature keys for a Delivery Service", DeleteTestDeliveryServicesURLSignatureKeys)
+			t.Run("Create URI Signing Keys for a Delivery Service", CreateTestDeliveryServicesURISigningKeys)
+			t.Run("Retrieve URI Signing keys for a Delivery Service", GetTestDeliveryServicesURISigningKeys)
+			t.Run("Delete URI Signing keys for a Delivery Service", DeleteTestDeliveryServicesURISigningKeys)
+			t.Run("Delete old CDN SSL keys", DeleteCDNOldSSLKeys)
+			t.Run("Create and retrieve SSL keys for a Delivery Service", DeliveryServiceSSLKeys)
 		}
 
 		CreateTestDeliveryServiceWithLongDescFields(t)
@@ -2079,8 +2079,12 @@ func CreateTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Errorf("failed to unmarshal uri sig keys")
 	}
 
-	if len(firstKeys) == 0 {
-		t.Errorf("failed to create uri sig keys")
+	kabletownFirstKeys, ok := firstKeys["Kabletown URI Authority 1"]
+	if !ok {
+		t.Fatal("failed to create uri sig keys: 'Kabletown URI Authority 1' not found in response after creation")
+	}
+	if len(kabletownFirstKeys.Keys) < 1 {
+		t.Fatal("failed to create URI signing keys: 'Kabletown URI Authority 1' had zero keys after creation")
 	}
 
 	// Create new keys again and check that they are different
@@ -2105,12 +2109,16 @@ func CreateTestDeliveryServicesURISigningKeys(t *testing.T) {
 		t.Errorf("failed to unmarshal uri sig keys")
 	}
 
-	if len(secondKeys) == 0 {
-		t.Errorf("failed to create uri sig keys")
+	kabletownSecondKeys, ok := secondKeys["Kabletown URI Authority 1"]
+	if !ok {
+		t.Fatal("failed to create uri sig keys: 'Kabletown URI Authority 1' not found in response after creation")
+	}
+	if len(kabletownSecondKeys.Keys) < 1 {
+		t.Fatal("failed to create URI signing keys: 'Kabletown URI Authority 1' had zero keys after creation")
 	}
 
-	if secondKeys["Kabletown URI Authority 1"].Keys[0].KeyID == firstKeys["Kabletown URI Authority 1"].Keys[0].KeyID {
-		t.Errorf("second create did not generate new uri sig keys")
+	if kabletownSecondKeys.Keys[0].KeyID == kabletownFirstKeys.Keys[0].KeyID {
+		t.Errorf("second create did not generate new uri sig keys - key mismatch")
 	}
 }
 

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -53,43 +53,43 @@ func TestDeliveryServices(t *testing.T) {
 			t.Run("Create and retrieve SSL keys for a Delivery Service", DeliveryServiceSSLKeys)
 		}
 
-		CreateTestDeliveryServiceWithLongDescFields(t)
-		UpdateTestDeliveryServiceWithLongDescFields(t)
-		GetTestDeliveryServicesIMS(t)
-		GetAccessibleToTest(t)
-		UpdateTestDeliveryServices(t)
-		UpdateValidateORGServerCacheGroup(t)
-		UpdateTestDeliveryServicesWithHeaders(t, header)
-		UpdateNullableTestDeliveryServices(t)
-		UpdateDeliveryServiceWithInvalidRemapText(t)
-		UpdateDeliveryServiceWithInvalidSliceRangeRequest(t)
-		UpdateDeliveryServiceWithInvalidTopology(t)
-		GetTestDeliveryServicesIMSAfterChange(t, header)
-		UpdateDeliveryServiceTopologyHeaderRewriteFields(t)
-		GetTestDeliveryServices(t)
-		GetInactiveTestDeliveryServices(t)
-		GetTestDeliveryServicesCapacity(t)
-		DeliveryServiceMinorVersionsTest(t)
-		DeliveryServiceTenancyTest(t)
-		PostDeliveryServiceTest(t)
+		t.Run("Create a Delivery Service with the removed Long Description 2 and 3 fields", CreateTestDeliveryServiceWithLongDescFields)
+		t.Run("Update a Delivery Service, setting its removed Long Description 2 and 3 fields", UpdateTestDeliveryServiceWithLongDescFields)
+		t.Run("Getting unmodified Delivery Services using the If-Modified-Since header", GetTestDeliveryServicesIMS)
+		t.Run("Getting Delivery Services accessible to a Tenant", GetAccessibleToTest)
+		t.Run("Basic update of some Delivery Service fields", UpdateTestDeliveryServices)
+		t.Run("Assign an Origin not in a Cache Group used by a Delivery Service's Topology to that Delivery Service", UpdateValidateORGServerCacheGroup)
+		t.Run("Attempt to update a Delivery Service with If-Unmodified-Since", testUpdatingDeliveryServicesWithIUSOrIfMatch(header))
+		t.Run("Basic update of some other Delivery Service fields", UpdateNullableTestDeliveryServices)
+		t.Run("Update a Delivery Service giving it invalid Raw Remap text", UpdateDeliveryServiceWithInvalidRemapText)
+		t.Run("Update a Delivery Service giving it invalid combinations of Range Slice Block Size and Range Request Handling", UpdateDeliveryServiceWithInvalidSliceRangeRequest)
+		t.Run("Invalid Topology-to-Delivery Service assignments", UpdateDeliveryServiceWithInvalidTopology)
+		t.Run("Getting modified Delivery Services using the If-Modified-Since header", testGettingDeliveryServicesWithIMSAfterModification(header))
+		t.Run("Basic update of Delivery Service header rewrite fields", UpdateDeliveryServiceTopologyHeaderRewriteFields)
+		t.Run("Basic GET request", GetTestDeliveryServices)
+		t.Run("GET requests using the 'active' query string parameter", GetInactiveTestDeliveryServices)
+		t.Run("Basic GET request for /deliveryservices/{{ID}}/capacity", GetTestDeliveryServicesCapacity)
+		t.Run("Update fields added in new minor versions of the API", DeliveryServiceMinorVersionsTest)
+		t.Run("Verify Tenancy-restricted Delivery Service access", DeliveryServiceTenancyTest)
+		t.Run("Attempt to create invalid Delivery Services", PostDeliveryServiceTest)
 		header = make(map[string][]string)
 		etag := rfc.ETag(currentTime)
 		header.Set(rfc.IfMatch, etag)
-		UpdateTestDeliveryServicesWithHeaders(t, header)
-		VerifyPaginationSupportDS(t)
-		GetDeliveryServiceByCdn(t)
-		GetDeliveryServiceByInvalidCdn(t)
-		GetDeliveryServiceByInvalidProfile(t)
-		GetDeliveryServiceByInvalidTenant(t)
-		GetDeliveryServiceByInvalidType(t)
-		GetDeliveryServiceByInvalidAccessibleTo(t)
-		GetDeliveryServiceByInvalidXmlId(t)
-		GetDeliveryServiceByLogsEnabled(t)
-		GetDeliveryServiceByValidProfile(t)
-		GetDeliveryServiceByValidTenant(t)
-		GetDeliveryServiceByValidType(t)
-		GetDeliveryServiceByValidXmlId(t)
-		SortTestDeliveryServicesDesc(t)
+		t.Run("Attempt to update a Delivery Service with If-Match", testUpdatingDeliveryServicesWithIUSOrIfMatch(header))
+		t.Run("GET requests using pagination-controlling query string parameters", VerifyPaginationSupportDS)
+		t.Run("GET requests using the 'cdn' query string parameter", GetDeliveryServiceByCdn)
+		t.Run("Check behavior of 'cdn' query string parameter when CDN doesn't exist", GetDeliveryServiceByInvalidCdn)
+		t.Run("Check behavior of 'profile' query string parameter when Profile doesn't exist", GetDeliveryServiceByInvalidProfile)
+		t.Run("Check behavior of 'tenant' query string parameter when Tenant doesn't exist", GetDeliveryServiceByInvalidTenant)
+		t.Run("Check behavior of 'type' query string parameter when Type doesn't exist", GetDeliveryServiceByInvalidType)
+		t.Run("Check behavior of 'accessibleTo' query string parameter when the Tenant doesn't exist", GetDeliveryServiceByInvalidAccessibleTo)
+		t.Run("Check behavior of 'xmlId' query string parameter when xmlId doesn't exist", GetDeliveryServiceByInvalidXmlId)
+		t.Run("GET request using the 'logsEnabled' query string parameter", GetDeliveryServiceByLogsEnabled)
+		t.Run("GET request using the 'profile' query string parameter", GetDeliveryServiceByValidProfile)
+		t.Run("GET request using the 'tenant' query string parameter", GetDeliveryServiceByValidTenant)
+		t.Run("GET request using the 'type' query string parameter", GetDeliveryServiceByValidType)
+		t.Run("GET request using the 'xmlId' query string parameter", GetDeliveryServiceByValidXmlId)
+		t.Run("Descending order sorted response to GET request", SortTestDeliveryServicesDesc)
 	})
 }
 
@@ -180,6 +180,12 @@ func UpdateTestDeliveryServiceWithLongDescFields(t *testing.T) {
 	}
 	if reqInf.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected a 400 status code, but got %d", reqInf.StatusCode)
+	}
+}
+
+func testUpdatingDeliveryServicesWithIUSOrIfMatch(h http.Header) func(*testing.T) {
+	return func(t *testing.T) {
+		UpdateTestDeliveryServicesWithHeaders(t, h)
 	}
 }
 
@@ -684,6 +690,12 @@ func SSLDeliveryServiceCDNUpdateTest(t *testing.T) {
 	}
 	if len(keys.Response) != len(oldCDNKeys) {
 		t.Fatalf("expected %v key, got %v", len(oldCDNKeys), len(keys.Response))
+	}
+}
+
+func testGettingDeliveryServicesWithIMSAfterModification(h http.Header) func(*testing.T) {
+	return func(t *testing.T) {
+		GetTestDeliveryServicesIMSAfterChange(t, h)
 	}
 }
 

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -91,7 +90,6 @@ func TestDeliveryServices(t *testing.T) {
 		GetDeliveryServiceByValidType(t)
 		GetDeliveryServiceByValidXmlId(t)
 		SortTestDeliveryServicesDesc(t)
-		SortTestDeliveryServices(t)
 	})
 }
 
@@ -2367,25 +2365,5 @@ func SortTestDeliveryServicesDesc(t *testing.T) {
 		if !reflect.DeepEqual(respDesc[0].XMLID, respAsc[0].XMLID) {
 			t.Errorf("Delivery Service responses are not equal after reversal: %v - %v", *respDesc[0].XMLID, *respAsc[0].XMLID)
 		}
-	}
-}
-
-func SortTestDeliveryServices(t *testing.T) {
-	resp, _, err := TOSession.GetDeliveryServices(client.RequestOptions{})
-	if err != nil {
-		t.Errorf("Unexpected error getting Delivery Services: %v - alerts: %+v", err, resp.Alerts)
-	}
-
-	sortedList := make([]string, 0, len(resp.Response))
-	for _, ds := range resp.Response {
-		if ds.XMLID == nil {
-			t.Error("Traffic Ops returned a representation for a Delivery Service with null or undefined XMLID")
-			continue
-		}
-		sortedList = append(sortedList, *ds.XMLID)
-	}
-
-	if !sort.StringsAreSorted(sortedList) {
-		t.Errorf("list is not sorted by their XML Id: %v", sortedList)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
@@ -23,9 +23,11 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -203,5 +205,179 @@ func TestMakeExampleURLs(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("MakeExampleURLs expected %v actual %v", expected, actual)
+	}
+}
+
+func TestReadGetDeliveryServices(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+
+	db := sqlx.NewDb(mockDB, "sqlmock")
+	defer db.Close()
+
+	u := auth.CurrentUser{
+		TenantID: 1,
+	}
+
+	mock.ExpectBegin()
+	tenantRows := sqlmock.NewRows([]string{"id"})
+	tenantRows.AddRow(u.TenantID)
+	mock.ExpectQuery("WITH RECURSIVE").WillReturnRows(tenantRows)
+	dsRows := sqlmock.NewRows([]string{
+		"active",
+		"anonymous_blocking_enabled",
+		"ccr_dns_ttl",
+		"cdn_id",
+		"cdnName",
+		"check_path",
+		"consistent_hash_regex",
+		"deep_caching_type",
+		"display_name",
+		"dns_bypass_cname",
+		"dns_bypass_ip",
+		"dns_bypass_ip6",
+		"dns_bypass_ttl",
+		"dscp",
+		"ecs_enabled",
+		"edge_header_rewrite",
+		"first_header_rewrite",
+		"geolimit_redirect_url",
+		"geo_limit",
+		"geo_limit_countries",
+		"geo_provider",
+		"global_max_mbps",
+		"global_max_tps",
+		"fq_pacing_rate",
+		"http_bypass_fqdn",
+		"id",
+		"info_url",
+		"initial_dispersion",
+		"inner_header_rewrite",
+		"ipv6_routing_enabled",
+		"last_header_rewrite",
+		"last_updated",
+		"logs_enabled",
+		"long_desc",
+		"long_desc_1",
+		"long_desc_2",
+		"max_dns_answers",
+		"max_origin_connections",
+		"max_request_header_bytes",
+		"mid_header_rewrite",
+		"miss_lat",
+		"miss_long",
+		"multi_site_origin",
+		"org_server_fqdn",
+		"origin_shield",
+		"profileID",
+		"profile_name",
+		"profile_description",
+		"protocol",
+		"qstring_ignore",
+		"query_keys",
+		"range_request_handling",
+		"regex_remap",
+		"regional_geo_blocking",
+		"remap_text",
+		"routing_name",
+		"service_category",
+		"signing_algorithm",
+		"range_slice_block_size",
+		"ssl_key_version",
+		"tenant_id",
+		"tenant.name",
+		"topology",
+		"tr_request_headers",
+		"tr_response_headers",
+		"name",
+		"type_id",
+		"xml_id",
+		"cdn_domain",
+	})
+	dsRows.AddRow(
+		true,
+		false,
+		nil,
+		1,
+		"test",
+		"",
+		"",
+		"NEVER",
+		"Demo 1",
+		nil,
+		nil,
+		nil,
+		nil,
+		1,
+		false,
+		nil,
+		nil,
+		nil,
+		0,
+		nil,
+		0,
+		nil,
+		nil,
+		nil,
+		nil,
+		1,
+		nil,
+		1,
+		nil,
+		true,
+		nil,
+		time.Now(),
+		false,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		0.0,
+		0.0,
+		false,
+		"origin.infra.ciab.test",
+		nil,
+		nil,
+		nil,
+		nil,
+		0,
+		0,
+		"{}",
+		0,
+		nil,
+		false,
+		nil,
+		"video",
+		nil,
+		nil,
+		nil,
+		nil,
+		1,
+		"test",
+		nil,
+		nil,
+		nil,
+		"test",
+		1,
+		"demo1",
+		"mycdn.ciab.test",
+	)
+	mock.ExpectQuery("^SELECT.*ORDER BY ds.xml_id$").WillReturnRows(dsRows)
+	regexRows := sqlmock.NewRows([]string{"ds_name", "type", "pattern", "set_number"})
+	regexRows.AddRow("demo1", "hostregexp", "", 0)
+	mock.ExpectQuery("SELECT ds\\.xml_id as ds_name, t\\.name as type, r\\.pattern, COALESCE\\(dsr\\.set_number, 0\\) FROM regex").WillReturnRows(regexRows)
+
+	_, userErr, sysErr, _, _ := readGetDeliveryServices(nil, nil, db.MustBegin(), &u, false)
+	if userErr != nil {
+		t.Errorf("Unexpected user error reading Delivery Services: %v", userErr)
+	}
+	if sysErr != nil {
+		t.Errorf("Unexpected system error reading Delivery Services: %v", sysErr)
 	}
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_test.go
@@ -211,7 +211,7 @@ func TestMakeExampleURLs(t *testing.T) {
 func TestReadGetDeliveryServices(t *testing.T) {
 	mockDB, mock, err := sqlmock.New()
 	if err != nil {
-		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+		t.Fatalf("an error '%v' was not expected when opening a stub database connection", err)
 	}
 	defer mockDB.Close()
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR fixes integration tests known to be broken on master. Per [mailing list discussion](https://lists.apache.org/thread.html/r9e216e1f6ff378801c6a4f55e3cea554804171397076e84665d6f457%40%3Cdev.trafficcontrol.apache.org%3E) this removes the TO Go client/API integration test for default `/deliveryservice` response sort order and adds a unit test to the `github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice` package that verifies that an `ORDER BY xml_id` clause is generated for the relevant query when no query string parameters were provided in the client request.

This also upgrades the postgresql service used by the integration tests' GHA to version 13, to be the same as that used by CDN-in-a-Box, and adds a deprecation notice to [`github.com/apache/trafficcontrol/lib/go-tc.DBError`](https://pkg.go.dev/github.com/apache/trafficcontrol@v5.1.2+incompatible/lib/go-tc#pkg-constants) since it's too vague to ever be useful, and changes one place where it was previously used to instead return an error that previously was logged immediately.

### Update
I also found a problem with some `/cachegroupparameters` tests that weren't resetting query parameters that I'm going to tentatively declare fixed even before the actions are done running.

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client (Go) (tests only)
- Traffic Ops
- CI tests

## What is the best way to verify this PR?
Make sure all of the tests pass - for real this time.

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**