### PR TITLE
Expect redirect to edge-cache-010 through 012, not edge-cache-900 through edge-cache-902

### DIFF
--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/RouterTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/RouterTest.java
@@ -519,9 +519,9 @@ public class RouterTest {
 			assertThat(response.getStatusLine().getStatusCode(), equalTo(302));
 			String location = response.getFirstHeader("Location").getValue();
 			assertThat(location, isOneOf(
-				"http://edge-cache-900.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78",
-				"http://edge-cache-901.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78",
-				"http://edge-cache-902.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78"
+				"http://edge-cache-010.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78",
+				"http://edge-cache-011.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78",
+				"http://edge-cache-012.http-only-test.thecdn.example.com:8090/stuff?fakeClientIpAddress=12.34.56.78"
 			));
 		}
 

--- a/traffic_router/core/src/test/resources/publish/CrConfig3.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig3.json
@@ -491,57 +491,6 @@
       "deliveryServices": {
         "https-nocert": ["edge-cache-092.https-nocert.thecdn.example.com"]
       }
-    },
-    "edge-cache-900": {
-      "type": "EDGE",
-      "profile": "EDGE_STATIC",
-      "status": "REPORTED",
-      "hashId": "edge-cache-900@xmpp.cdn.example.com",
-      "fqdn": "edge-cache-900.thecdn.example.com",
-      "port": "8090",
-      "ip": "12.34.90.100",
-      "ip6": "2001:dead:beef:1:C::1A/64",
-      "cacheGroup": "cache-group-1",
-      "locationId": "location-1",
-      "hashCount": 1000,
-      "interfaceName": "bond0",
-      "deliveryServices": {
-        "http-only-test": ["edge-cache-900.http-only-test.thecdn.example.com"]
-      }
-    },
-    "edge-cache-901": {
-      "type": "EDGE",
-      "profile": "EDGE_STATIC",
-      "status": "REPORTED",
-      "hashId": "edge-cache-901@xmpp.cdn.example.com",
-      "fqdn": "edge-cache-901.thecdn.example.com",
-      "port": "8090",
-      "ip": "12.34.90.101",
-      "ip6": "2001:dead:beef:1:C::11/64",
-      "cacheGroup": "cache-group-1",
-      "locationId": "location-1",
-      "hashCount": 1000,
-      "interfaceName": "bond0",
-      "deliveryServices": {
-        "http-only-test": ["edge-cache-901.http-only-test.thecdn.example.com"]
-      }
-    },
-    "edge-cache-902": {
-      "type": "EDGE",
-      "profile": "EDGE_STATIC",
-      "status": "REPORTED",
-      "hashId": "edge-cache-902@xmpp.cdn.example.com",
-      "fqdn": "edge-cache-902.thecdn.example.com",
-      "port": "8090",
-      "ip": "12.34.90.102",
-      "ip6": "2001:dead:beef:1:C::12/64",
-      "cacheGroup": "cache-group-1",
-      "locationId": "location-1",
-      "hashCount": 1000,
-      "interfaceName": "bond0",
-      "deliveryServices": {
-        "http-only-test": ["edge-cache-902.http-only-test.thecdn.example.com"]
-      }
     }
   },
   "contentRouters": {


### PR DESCRIPTION
<!--
************ STOP!! ************
If this Pull Request is intended to fix a security vulnerability, DO NOT submit it! Instead, contact
the Apache Software Foundation Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://www.apache.org/security/ regarding vulnerability disclosure.
-->
## What does this PR (Pull Request) do?
<!-- Explain the changes you made here. If this fixes an Issue, identify it by
replacing the text in the checkbox item with the Issue number e.g.

- [x] This PR fixes #9001 OR is not related to any Issue

^ This will automatically close Issue number 9001 when the Pull Request is
merged (The '#' is important).

Be sure you check the box properly, see the "The following criteria are ALL
met by this PR" section for details.
-->

- [x] This PR fixes #5881 by<!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->
    1. Expecting the edge host to be one of
        * edge-cache-010.http-only-test.thecdn.example.com
        * edge-cache-011.http-only-test.thecdn.example.com
        * edge-cache-012.http-only-test.thecdn.example.com

    2. Removing these caches from mock CrConfig 3:
        * edge-cache-900.http-only-test.thecdn.example.com
        * edge-cache-901.http-only-test.thecdn.example.com
        * edge-cache-902.http-only-test.thecdn.example.com

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this
Pull Request. Also, feel free to add the name of a tool or script that is
affected but not on the list.

Additionally, if this Pull Request does NOT affect documentation, please
explain why documentation is not required. -->

- Traffic Router (external tests)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your Pull Request. If
it includes tests (and most should), outline here the steps needed to run the
tests. If not, lay out the manual testing procedure and please explain why
tests are unnecessary for this Pull Request. -->
Run the Traffic Router external tests and verify that RoutingTest passes:

```java
mvn -Djava.library.path=/usr/share/java:/usr/lib64 verify
```

## If this is a bug fix, what versions of Traffic Control are affected?
<!-- If this PR fixes a bug, please list here all of the affected versions - to
the best of your knowledge. It's also pretty helpful to include a commit hash
of where 'master' is at the time this PR is opened (if it affects master),
because what 'master' means will change over time. For example, if this PR
fixes a bug that's present in master (at commit hash '1df853c8'), in v4.0.0,
and in the current 4.0.1 Release candidate (e.g. RC1), then this list would
look like:

- master (1df853c8)
- 4.0.0
- 4.0.1 (RC1)

If you don't know what other versions might have this bug, AND don't know how
to find the commit hash of 'master', then feel free to leave this section
blank (or, preferably, delete it entirely).
 -->
- master (72af148e85)
- 5.1.2
- 4.1.1

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests
- [x] Test structure is unchanged, documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->