### PR TITLE
Fix t3c docs missing commands

### DIFF
--- a/cache-config/t3c/README.md
+++ b/cache-config/t3c/README.md
@@ -51,7 +51,7 @@ The latest version and documentation can be found at https://github.com/apache/t
 
 # OPTIONS
 
---help
+\-\-help
     Prints the synopsis and usage information.
 
 # COMMANDS
@@ -69,6 +69,14 @@ t3c-check
 t3c-diff
 
     Diff config files, like diff or git-diff but with config-specific logic.
+
+t3c-generate
+
+    Generate configuration files from Traffic Ops data.
+
+t3c-preprocess
+
+    Preprocess generated config files.
 
 t3c-request
 

--- a/cache-config/t3c/t3c.go
+++ b/cache-config/t3c/t3c.go
@@ -29,12 +29,13 @@ import (
 )
 
 var commands = map[string]struct{}{
-	"apply":    struct{}{},
-	"check":    struct{}{},
-	"diff":     struct{}{},
-	"generate": struct{}{},
-	"request":  struct{}{},
-	"update":   struct{}{},
+	"apply":      struct{}{},
+	"check":      struct{}{},
+	"diff":       struct{}{},
+	"generate":   struct{}{},
+	"preprocess": struct{}{},
+	"request":    struct{}{},
+	"update":     struct{}{},
 }
 
 const ExitCodeSuccess = 0
@@ -89,12 +90,13 @@ For the arguments of a command, see 't3c <command> --help'.
 
 These are the available commands:
 
-  apply     generate and apply configuration
+  apply      generate and apply configuration
 
-  check     check that new config can be applied
-  diff      diff config files, with logic like ignoring comments
-  generate  generate configuration from Traffic Ops data
-  request   request Traffic Ops data
-  update    update a cache's queue and reval status in Traffic Ops
+  check      check that new config can be applied
+  diff       diff config files, with logic like ignoring comments
+  generate   generate configuration from Traffic Ops data
+  preprocess preprocess generated config files
+  request    request Traffic Ops data
+  update     update a cache's queue and reval status in Traffic Ops
 `
 }


### PR DESCRIPTION
Fixes the t3c docs missing a few newer commands.

Is docs.
No tests, is docs.
No changelog, is docs, and not in a release.

- [x] This PR fixes is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Check t3c manpage, check t3c help flag, verify all sub-commands are present.

## If this is a bug fix, what versions of Traffic Control are affected?
Not  a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
