### PR TITLE
Traffic Ops API Age Filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a Traffic Monitor integration test framework.
 - Added `traffic_ops/app/db/traffic_vault_migrate` to help with migrating Traffic Ops Traffic Vault backends
 - Added a tool at `/traffic_ops/app/db/reencrypt` to re-encrypt the data in the Postgres Traffic Vault with a new key.
+- Added support for age filtering via the `newerThan` and `olderThan` query string parameters to the Traffic Ops API endpoints `/users`, `/topologies`, `/servers`, `/profiles`, `/parameters`, `/origins`, `/jobs`, `/federation_resolvers`, `/deliveryservices/{{ID}}/regexes`, `/servers/{{ID}}/deliveryservices`, `/deliveryservice_requests`, `/deliveryservices`, `/cdn_notifications`, `/cdn_locks`, `/capabilities`, `/cachegroups/{{ID}}/unassigned_parameters`, `/cachegroupparameters`, `/cachegroups`, and `/api_capabilities`.
 
 ### Fixed
 - [#5690](https://github.com/apache/trafficcontrol/issues/5690) - Fixed github action for added/modified db migration file.

--- a/docs/source/api/v1/api_capabilities.rst
+++ b/docs/source/api/v1/api_capabilities.rst
@@ -32,11 +32,41 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+----------------+----------+--------+------------------------------------+
-	|    Name        | Required | Type   |         Description                |
-	+================+==========+========+====================================+
-	|   capability   |   no     | string | Capability name                    |
-	+----------------+----------+--------+------------------------------------+
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                            |
+	+================+==========+========================================================================================================+
+	| capability     | no       | Return only the Capability that has this name                                                          |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| id             | no       | Return only the Capability that has this integral, unique identifier                                   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| httpMethod     | no       | Return only Capabilities which have this ``httpMethod``                                                |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| route          | no       | Return only Capabilities which have this ``route``                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| lastUpdated    | no       | Return only Capabilites which were last updated at this **exact** date and time\ [#lastUpdatedFormat]_ |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| sortOrder      | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")               |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| limit          | no       | Choose the maximum number of results to return                                                         |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| offset         | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| page           | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are           |
+	|                |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no         |
+	|                |          | effect. ``limit`` must be defined to make use of ``page``.                                             |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only Capabilities that were most recently updated no earlier than this date/time, which may be  |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only Capabilities that were most recently updated no later than this date/time, which may be    |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example
@@ -182,3 +212,5 @@ Response Structure
 		"id": 273,
 		"capability": "types-write"
 	}}
+
+.. [#lastUpdatedFormat] Unlike the ``newerThan`` and ``olderThan`` query string parameters which can accept either RFC3339 strings or nanoseconds, this **must** be RFC3339 and **must not** have sub-second precision. This also means that the format of the returned ``lastUpdated`` fields on the actual response objects is unnacceptable as input for this query string parameter.

--- a/docs/source/api/v1/cachegroupparameters.rst
+++ b/docs/source/api/v1/cachegroupparameters.rst
@@ -49,6 +49,15 @@ Response Structure
 	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
 	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no earlier than this date/time, which may be given as an   |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no later than this date/time, which may be given as an     |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v1/cachegroups.rst
+++ b/docs/source/api/v1/cachegroups.rst
@@ -50,6 +50,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of |
 	|           |          | ``page``.                                                                                                                |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Cache Groups` that were most recently updated no earlier than this date/time, which may be given as   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Cache Groups` that were most recently updated no later than this date/time, which may be given as an  |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/cachegroups_id_unassigned_parameters.rst
+++ b/docs/source/api/v1/cachegroups_id_unassigned_parameters.rst
@@ -51,6 +51,17 @@ Request Structure
 	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|             |          | defined to make use of ``page``.                                                                              |
 	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Parameters` that were most recently updated no earlier than this date/time, which may be   |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Parameters` that were most recently updated no later than this date/time, which may be     |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were in :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. table:: Request Path Parameters
 

--- a/docs/source/api/v1/capabilities.rst
+++ b/docs/source/api/v1/capabilities.rst
@@ -48,7 +48,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make   |
 	|           |          | use of ``page``.                                                                                                    |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only capabilities that were most recently updated no earlier than this date/time, which may be given as an   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`  |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only capabilities that were most recently updated no later than this date/time, which may be given as an     |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`     |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/deliveryservices.rst
+++ b/docs/source/api/v1/deliveryservices.rst
@@ -48,8 +48,7 @@ Request Structure
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId       | no       | Show only the :term:`Delivery Service` that has this text-based, unique identifier                                                   |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby     | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                        |
-	|             |          | array                                                                                                                                |
+	| orderby     | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                  |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder   | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                             |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
@@ -60,6 +59,15 @@ Request Structure
 	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
 	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which may be given as an       |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may be given as an         |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v1/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v1/deliveryservices_id_regexes.rst
@@ -39,18 +39,30 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| Name        | Required | Description                                                                                                                          |
-	+=============+==========+======================================================================================================================================+
-	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| limit       | no       | Choose the maximum number of results to return                                                                                       |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
-	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                                                          |
+	+===========+==========+======================================================================================================================================+
+	| id        | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                                                       |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no earlier than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no later than this date/time, which may be  |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/federation_resolvers.rst
+++ b/docs/source/api/v1/federation_resolvers.rst
@@ -31,29 +31,41 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| Name       | Required | Description                                                                                         |
-	+============+==========+=====================================================================================================+
-	| id         | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| ipAddress  | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| type       | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| orderby    | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
-	|            |          | ``response`` array                                                                                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| sortOrder  | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| limit      | no       | Choose the maximum number of results to return                                                      |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| offset     | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
-	|            |          | limit                                                                                               |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| page       | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
-	|            |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
-	|            |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                         |
+	+===========+==========+=====================================================================================================+
+	| id        | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| ipAddress | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| type      | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
+	|           |          | ``response`` array                                                                                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                      |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
+	|           |          | limit                                                                                               |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
+	|           |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
+	|           |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no earlier than this       |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no    later than this      |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/jobs.rst
+++ b/docs/source/api/v1/jobs.rst
@@ -48,7 +48,17 @@ Request Structure
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 	| userId          | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only invalidation jobs that were most recently updated no earlier than this date/time, which may be given as  |
+	|                 |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only invalidation jobs that were most recently updated no later than this date/time, which may be given as an |
+	|                 |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`      |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/origins.rst
+++ b/docs/source/api/v1/origins.rst
@@ -52,8 +52,7 @@ Request Structure
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant          | no       | Return only :term:`Origins` belonging to the tenant identified by this integral, unique identifier                                                                |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                                                     |
-	|                 |          | array                                                                                                                                                             |
+	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                                               |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder       | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                                          |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -64,6 +63,15 @@ Request Structure
 	| page            | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was defined,   |
 	|                 |          | this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                                                                            |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only :term:`Origins` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only :term:`Origins` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of   |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. note:: Several fields of origin definitions which are filterable by Query Parameters are allowed to be ``null``. ``null`` values in these fields will be filtered *out* appropriately by such Query Parameters, but do note that ``null`` is not a valid value accepted by any of these Query Parameters, and attempting to pass it will result in an error.
 

--- a/docs/source/api/v1/parameters.rst
+++ b/docs/source/api/v1/parameters.rst
@@ -55,9 +55,17 @@ Request Structure
 	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|             |          | defined to make use of ``page``.                                                                              |
 	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Parameters` that were most recently updated no earlier than this date/time, which may be   |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Parameters` that were most recently updated no later than this date/time, which may be     |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``value`` query parameter was added to all API versions in ATC version 6.0.
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/profiles.rst
+++ b/docs/source/api/v1/profiles.rst
@@ -29,17 +29,29 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  Name | Required | Description                                                                                            |
-	+=======+==========+========================================================================================================+
-	|  cdn  |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  id   |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| name  |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| param |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	|  Name     | Required | Description                                                                                            |
+	+===========+==========+========================================================================================================+
+	|  cdn      |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	|  id       |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| name      |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| param     |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Profiles` that were most recently updated no earlier than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Profiles` that were most recently updated no later than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | 1\ :sup:`st` 1970 UTC).                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/servers.rst
+++ b/docs/source/api/v1/servers.rst
@@ -58,6 +58,18 @@ Request Structure
 	|            |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
 	|            |          | make use of ``page``.                                                                                             |
 	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| newerThan  | no       | Return only servers that were most recently updated no earlier than this date/time, which may be given as an      |
+	|            |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|            |          | 1970 UTC).                                                                                                        |
+	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| olderThan  | no       | Return only servers that were most recently updated no later than this date/time, which may be given as an        |
+	|            |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|            |          | 1970 UTC).                                                                                                        |
+	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/servers_id_deliveryservices.rst
+++ b/docs/source/api/v1/servers_id_deliveryservices.rst
@@ -55,6 +55,17 @@ Request Structure
 	|           |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|           |          | defined to make use of ``page``.                                                                              |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which   |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on     |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v1/users.rst
+++ b/docs/source/api/v1/users.rst
@@ -56,6 +56,17 @@ Request Structure
 	|           |          | are ``limit`` long and the first page is 1. If ``offset`` was defined, this query        |
 	|           |          | parameter has no effect. ``limit`` must be defined to make use of ``page``.              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only users that were most recently updated no earlier than this date/time, which  |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only users that were most recently updated no later than this date/time, which    |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. versionadded:: ATCv4.1 The ``role`` query parameter was added in version 4.1 of :abbr:`ATC (Apache Traffic Control)`.
 

--- a/docs/source/api/v2/api_capabilities.rst
+++ b/docs/source/api/v2/api_capabilities.rst
@@ -32,11 +32,40 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+----------------+----------+--------+------------------------------------+
-	|    Name        | Required | Type   |         Description                |
-	+================+==========+========+====================================+
-	|   capability   |   no     | string | Capability name                    |
-	+----------------+----------+--------+------------------------------------+
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                            |
+	+================+==========+========================================================================================================+
+	| capability     | no       | Return only the Capability that has this name                                                          |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| id             | no       | Return only the Capability that has this integral, unique identifier                                   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| httpMethod     | no       | Return only Capabilities which have this ``httpMethod``                                                |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| route          | no       | Return only Capabilities which have this ``route``                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| lastUpdated    | no       | Return only Capabilites which were last updated at this **exact** date and time\ [#lastUpdatedFormat]_ |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| sortOrder      | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")               |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| limit          | no       | Choose the maximum number of results to return                                                         |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| offset         | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| page           | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are           |
+	|                |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no         |
+	|                |          | effect. ``limit`` must be defined to make use of ``page``.                                             |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only Capabilities that were most recently updated no earlier than this date/time, which may be  |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only Capabilities that were most recently updated no later than this date/time, which may be    |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example
@@ -102,3 +131,5 @@ Response Structure
 			"capability": "types-write"
 		}
 	]}
+
+.. [#lastUpdatedFormat] Unlike the ``newerThan`` and ``olderThan`` query string parameters which can accept either RFC3339 strings or nanoseconds, this **must** be RFC3339 and **must not** have sub-second precision. This also means that the format of the returned ``lastUpdated`` fields on the actual response objects is unnacceptable as input for this query string parameter.

--- a/docs/source/api/v2/cachegroupparameters.rst
+++ b/docs/source/api/v2/cachegroupparameters.rst
@@ -49,6 +49,15 @@ Response Structure
 	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
 	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no earlier than this date/time, which may be given as an   |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no later than this date/time, which may be given as an     |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v2/cachegroups.rst
+++ b/docs/source/api/v2/cachegroups.rst
@@ -50,6 +50,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of |
 	|           |          | ``page``.                                                                                                                |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Cache Groups` that were most recently updated no earlier than this date/time, which may be given as   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Cache Groups` that were most recently updated no later than this date/time, which may be given as an  |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/capabilities.rst
+++ b/docs/source/api/v2/capabilities.rst
@@ -48,7 +48,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make   |
 	|           |          | use of ``page``.                                                                                                    |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only capabilities that were most recently updated no earlier than this date/time, which may be given as an   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`  |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only capabilities that were most recently updated no later than this date/time, which may be given as an     |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`     |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/deliveryservice_requests.rst
+++ b/docs/source/api/v2/deliveryservice_requests.rst
@@ -53,8 +53,7 @@ Request Structure
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId     | no       | Filter for :ref:`ds_requests` that have the given :ref:`ds-xmlid`.                                                                      |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                           |
-	|           |          | array                                                                                                                                   |
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                     |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -65,9 +64,15 @@ Request Structure
 	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1.    |
 	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                       |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`DSRs` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted |
+	|           |          | string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                    |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`DSRs` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted   |
+	|           |          | string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                    |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``createdAt`` query parameter was added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+	The ``newerThan``, ``olderThan``, and ``createdAt`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/deliveryservices.rst
+++ b/docs/source/api/v2/deliveryservices.rst
@@ -50,8 +50,7 @@ Request Structure
 	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId        | no       | Show only the :term:`Delivery Service` that has this text-based, unique identifier                                                      |
 	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby      | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                           |
-	|              |          | array                                                                                                                                   |
+	| orderby      | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                     |
 	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder    | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                |
 	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -62,6 +61,15 @@ Request Structure
 	| page         | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1.    |
 	|              |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                       |
 	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan    | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which may be given as an          |
+	|              |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan    | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may be given as an            |
+	|              |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+--------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v2/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v2/deliveryservices_id_regexes.rst
@@ -39,18 +39,31 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| Name        | Required | Description                                                                                                                          |
-	+=============+==========+======================================================================================================================================+
-	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| limit       | no       | Choose the maximum number of results to return                                                                                       |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
-	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                                                          |
+	+===========+==========+======================================================================================================================================+
+	| id        | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                                                       |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no earlier than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no later than this date/time, which may be  |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/federation_resolvers.rst
+++ b/docs/source/api/v2/federation_resolvers.rst
@@ -31,29 +31,41 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| Name       | Required | Description                                                                                         |
-	+============+==========+=====================================================================================================+
-	| id         | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| ipAddress  | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| type       | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| orderby    | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
-	|            |          | ``response`` array                                                                                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| sortOrder  | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| limit      | no       | Choose the maximum number of results to return                                                      |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| offset     | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
-	|            |          | limit                                                                                               |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| page       | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
-	|            |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
-	|            |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                         |
+	+===========+==========+=====================================================================================================+
+	| id        | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| ipAddress | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| type      | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
+	|           |          | ``response`` array                                                                                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                      |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
+	|           |          | limit                                                                                               |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
+	|           |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
+	|           |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no earlier than this       |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no    later than this      |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/jobs.rst
+++ b/docs/source/api/v2/jobs.rst
@@ -48,7 +48,17 @@ Request Structure
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 	| userId          | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only invalidation jobs that were most recently updated no earlier than this date/time, which may be given as  |
+	|                 |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only invalidation jobs that were most recently updated no later than this date/time, which may be given as an |
+	|                 |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`      |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/origins.rst
+++ b/docs/source/api/v2/origins.rst
@@ -51,8 +51,7 @@ Request Structure
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant          | no       | Return only :term:`Origins` belonging to the tenant identified by this integral, unique identifier                                                                |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                                                     |
-	|                 |          | array                                                                                                                                                             |
+	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                                               |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder       | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                                          |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -63,6 +62,16 @@ Request Structure
 	| page            | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was defined,   |
 	|                 |          | this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                                                                            |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only :term:`Origins` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only :term:`Origins` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of   |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. note:: Several fields of origin definitions which are filterable by Query Parameters are allowed to be ``null``. ``null`` values in these fields will be filtered *out* appropriately by such Query Parameters, but do note that ``null`` is not a valid value accepted by any of these Query Parameters, and attempting to pass it will result in an error.
 

--- a/docs/source/api/v2/parameters.rst
+++ b/docs/source/api/v2/parameters.rst
@@ -55,9 +55,17 @@ Request Structure
 	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|             |          | defined to make use of ``page``.                                                                              |
 	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Parameters` that were most recently updated no earlier than this date/time, which may be   |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Parameters` that were most recently updated no later than this date/time, which may be     |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``value`` query parameter was added to all API versions in ATC version 6.0.
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/profiles.rst
+++ b/docs/source/api/v2/profiles.rst
@@ -29,17 +29,29 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  Name | Required | Description                                                                                            |
-	+=======+==========+========================================================================================================+
-	|  cdn  |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  id   |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| name  |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| param |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                            |
+	+===========+==========+========================================================================================================+
+	| cdn       |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| id        |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| name      |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| param     |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Profiles` that were most recently updated no earlier than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Profiles` that were most recently updated no later than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | 1\ :sup:`st` 1970 UTC).                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/servers.rst
+++ b/docs/source/api/v2/servers.rst
@@ -58,6 +58,17 @@ Request Structure
 	|            |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
 	|            |          | make use of ``page``.                                                                                             |
 	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| newerThan  | no       | Return only servers that were most recently updated no earlier than this date/time, which may be given as an      |
+	|            |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|            |          | 1970 UTC).                                                                                                        |
+	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| olderThan  | no       | Return only servers that were most recently updated no later than this date/time, which may be given as an        |
+	|            |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|            |          | 1970 UTC).                                                                                                        |
+	+------------+----------+-------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/servers_id_deliveryservices.rst
+++ b/docs/source/api/v2/servers_id_deliveryservices.rst
@@ -55,6 +55,17 @@ Request Structure
 	|           |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|           |          | defined to make use of ``page``.                                                                              |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which   |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on     |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v2/users.rst
+++ b/docs/source/api/v2/users.rst
@@ -56,6 +56,17 @@ Request Structure
 	|           |          | are ``limit`` long and the first page is 1. If ``offset`` was defined, this query        |
 	|           |          | parameter has no effect. ``limit`` must be defined to make use of ``page``.              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only users that were most recently updated no earlier than this date/time, which  |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only users that were most recently updated no later than this date/time, which    |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/api_capabilities.rst
+++ b/docs/source/api/v3/api_capabilities.rst
@@ -32,11 +32,40 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+----------------+----------+--------+------------------------------------+
-	|    Name        | Required | Type   |         Description                |
-	+================+==========+========+====================================+
-	|   capability   |   no     | string | Capability name                    |
-	+----------------+----------+--------+------------------------------------+
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                            |
+	+================+==========+========================================================================================================+
+	| capability     | no       | Return only the Capability that has this name                                                          |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| id             | no       | Return only the Capability that has this integral, unique identifier                                   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| httpMethod     | no       | Return only Capabilities which have this ``httpMethod``                                                |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| route          | no       | Return only Capabilities which have this ``route``                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| lastUpdated    | no       | Return only Capabilites which were last updated at this **exact** date and time\ [#lastUpdatedFormat]_ |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| sortOrder      | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")               |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| limit          | no       | Choose the maximum number of results to return                                                         |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| offset         | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| page           | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are           |
+	|                |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no         |
+	|                |          | effect. ``limit`` must be defined to make use of ``page``.                                             |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only Capabilities that were most recently updated no earlier than this date/time, which may be  |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only Capabilities that were most recently updated no later than this date/time, which may be    |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example
@@ -102,3 +131,5 @@ Response Structure
 			"capability": "types-write"
 		}
 	]}
+
+.. [#lastUpdatedFormat] Unlike the ``newerThan`` and ``olderThan`` query string parameters which can accept either RFC3339 strings or nanoseconds, this **must** be RFC3339 and **must not** have sub-second precision. This also means that the format of the returned ``lastUpdated`` fields on the actual response objects is unnacceptable as input for this query string parameter.

--- a/docs/source/api/v3/cachegroupparameters.rst
+++ b/docs/source/api/v3/cachegroupparameters.rst
@@ -49,6 +49,15 @@ Response Structure
 	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
 	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no earlier than this date/time, which may be given as an   |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no later than this date/time, which may be given as an     |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v3/cachegroups.rst
+++ b/docs/source/api/v3/cachegroups.rst
@@ -54,6 +54,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of |
 	|           |          | ``page``.                                                                                                                |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Cache Groups` that were most recently updated no earlier than this date/time, which may be given as   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Cache Groups` that were most recently updated no later than this date/time, which may be given as an  |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/capabilities.rst
+++ b/docs/source/api/v3/capabilities.rst
@@ -48,7 +48,17 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make   |
 	|           |          | use of ``page``.                                                                                                    |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only capabilities that were most recently updated no earlier than this date/time, which may be given as an   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`  |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only capabilities that were most recently updated no later than this date/time, which may be given as an     |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`     |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/deliveryservice_requests.rst
+++ b/docs/source/api/v3/deliveryservice_requests.rst
@@ -53,8 +53,7 @@ Request Structure
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId     | no       | Filter for :ref:`ds_requests` that have the given :ref:`ds-xmlid`.                                                                      |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                           |
-	|           |          | array                                                                                                                                   |
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                     |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -65,9 +64,15 @@ Request Structure
 	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1.    |
 	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                       |
 	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`DSRs` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted |
+	|           |          | string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                    |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`DSRs` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted   |
+	|           |          | string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                    |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``createdAt`` query parameter was added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+	The ``newerThan``, ``olderThan``, and ``createdAt`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/deliveryservices.rst
+++ b/docs/source/api/v3/deliveryservices.rst
@@ -54,8 +54,7 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId             | no       | Show only the :term:`Delivery Service` that has this text-based, unique identifier                                                      |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby           | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                           |
-	|                   |          | array                                                                                                                                   |
+	| orderby           | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                     |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder         | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -68,6 +67,15 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan         | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which may be given as an          |
+	|                   |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan         | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may be given as an            |
+	|                   |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 Response Structure
 ------------------

--- a/docs/source/api/v3/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v3/deliveryservices_id_regexes.rst
@@ -39,18 +39,30 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| Name        | Required | Description                                                                                                                          |
-	+=============+==========+======================================================================================================================================+
-	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| limit       | no       | Choose the maximum number of results to return                                                                                       |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
-	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                                                          |
+	+===========+==========+======================================================================================================================================+
+	| id        | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                                                       |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no earlier than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no later than this date/time, which may be  |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/federation_resolvers.rst
+++ b/docs/source/api/v3/federation_resolvers.rst
@@ -31,29 +31,41 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| Name       | Required | Description                                                                                         |
-	+============+==========+=====================================================================================================+
-	| id         | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| ipAddress  | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| type       | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| orderby    | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
-	|            |          | ``response`` array                                                                                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| sortOrder  | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| limit      | no       | Choose the maximum number of results to return                                                      |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| offset     | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
-	|            |          | limit                                                                                               |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| page       | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
-	|            |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
-	|            |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                         |
+	+===========+==========+=====================================================================================================+
+	| id        | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| ipAddress | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| type      | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
+	|           |          | ``response`` array                                                                                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                      |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
+	|           |          | limit                                                                                               |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
+	|           |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
+	|           |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no earlier than this       |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no    later than this      |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/jobs.rst
+++ b/docs/source/api/v3/jobs.rst
@@ -48,7 +48,17 @@ Request Structure
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 	| userId          | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only invalidation jobs that were most recently updated no earlier than this date/time, which may be given as  |
+	|                 |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only invalidation jobs that were most recently updated no later than this date/time, which may be given as an |
+	|                 |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`      |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/origins.rst
+++ b/docs/source/api/v3/origins.rst
@@ -51,8 +51,7 @@ Request Structure
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant          | no       | Return only :term:`Origins` belonging to the tenant identified by this integral, unique identifier                                                                |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                                                     |
-	|                 |          | array                                                                                                                                                             |
+	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                                               |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder       | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                                          |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -63,6 +62,16 @@ Request Structure
 	| page            | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was defined,   |
 	|                 |          | this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                                                                            |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only :term:`Origins` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only :term:`Origins` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of   |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. note:: Several fields of origin definitions which are filterable by Query Parameters are allowed to be ``null``. ``null`` values in these fields will be filtered *out* appropriately by such Query Parameters, but do note that ``null`` is not a valid value accepted by any of these Query Parameters, and attempting to pass it will result in an error.
 

--- a/docs/source/api/v3/parameters.rst
+++ b/docs/source/api/v3/parameters.rst
@@ -55,9 +55,17 @@ Request Structure
 	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|             |          | defined to make use of ``page``.                                                                              |
 	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Parameters` that were most recently updated no earlier than this date/time, which may be   |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Parameters` that were most recently updated no later than this date/time, which may be     |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``value`` query parameter was added to all API versions in ATC version 6.0.
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/profiles.rst
+++ b/docs/source/api/v3/profiles.rst
@@ -29,17 +29,28 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  Name | Required | Description                                                                                            |
-	+=======+==========+========================================================================================================+
-	|  cdn  |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  id   |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| name  |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| param |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                            |
+	+===========+==========+========================================================================================================+
+	| cdn       |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| id        |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| name      |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| param     |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Profiles` that were most recently updated no earlier than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Profiles` that were most recently updated no later than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | 1\ :sup:`st` 1970 UTC).                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``value``, ``newerThan``, and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/servers.rst
+++ b/docs/source/api/v3/servers.rst
@@ -68,6 +68,18 @@ Request Structure
 	|                |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
 	|                |          | make use of ``page``.                                                                                             |
 	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only servers that were most recently updated no earlier than this date/time, which may be given as an      |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                |          | 1970 UTC).                                                                                                        |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only servers that were most recently updated no later than this date/time, which may be given as an        |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                |          | 1970 UTC).                                                                                                        |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -55,6 +55,17 @@ Request Structure
 	|           |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|           |          | defined to make use of ``page``.                                                                              |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which   |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on     |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/topologies.rst
+++ b/docs/source/api/v3/topologies.rst
@@ -31,11 +31,21 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------+----------+-----------------------------------------------------+
-	| Name | Required | Description                                         |
-	+======+==========+=====================================================+
-	| name | no       | Return the :term:`Topology` with this name          |
-	+------+----------+-----------------------------------------------------+
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                                                  |
+	+================+==========+==============================================================================================================================+
+	| name           | no       | Return the :term:`Topology` with this name                                                                                   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only :term:`Topologies` that were most recently updated no earlier than this date/time, which may be given as an      |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only :term:`Topologies` that were most recently updated no later than this date/time, which may be given as an        |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/users.rst
+++ b/docs/source/api/v3/users.rst
@@ -56,6 +56,17 @@ Request Structure
 	|           |          | are ``limit`` long and the first page is 1. If ``offset`` was defined, this query        |
 	|           |          | parameter has no effect. ``limit`` must be defined to make use of ``page``.              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only users that were most recently updated no earlier than this date/time, which  |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only users that were most recently updated no later than this date/time, which    |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/api_capabilities.rst
+++ b/docs/source/api/v4/api_capabilities.rst
@@ -32,11 +32,37 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+----------------+----------+--------+------------------------------------+
-	|    Name        | Required | Type   |         Description                |
-	+================+==========+========+====================================+
-	|   capability   |   no     | string | Capability name                    |
-	+----------------+----------+--------+------------------------------------+
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                            |
+	+================+==========+========================================================================================================+
+	| capability     | no       | Return only the Capability that has this name                                                          |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| id             | no       | Return only the Capability that has this integral, unique identifier                                   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| httpMethod     | no       | Return only Capabilities which have this ``httpMethod``                                                |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| route          | no       | Return only Capabilities which have this ``route``                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| lastUpdated    | no       | Return only Capabilites which were last updated at this **exact** date and time\ [#lastUpdatedFormat]_ |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| sortOrder      | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")               |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| limit          | no       | Choose the maximum number of results to return                                                         |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| offset         | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit   |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| page           | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are           |
+	|                |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no         |
+	|                |          | effect. ``limit`` must be defined to make use of ``page``.                                             |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only Capabilities that were most recently updated no earlier than this date/time, which may be  |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only Capabilities that were most recently updated no later than this date/time, which may be    |
+	|                |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|                |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+----------------+----------+--------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example
@@ -102,3 +128,5 @@ Response Structure
 			"capability": "types-write"
 		}
 	]}
+
+.. [#lastUpdatedFormat] Unlike the ``newerThan`` and ``olderThan`` query string parameters which can accept either RFC3339 strings or nanoseconds, this **must** be RFC3339 and **must not** have sub-second precision. This also means that the format of the returned ``lastUpdated`` fields on the actual response objects is unnacceptable as input for this query string parameter.

--- a/docs/source/api/v4/cachegroupparameters.rst
+++ b/docs/source/api/v4/cachegroupparameters.rst
@@ -49,6 +49,12 @@ Response Structure
 	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
 	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
 	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no earlier than this date/time, which may be given as an   |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :ref:`cache-group-parameters` that were most recently updated no later than this date/time, which may be given as an     |
+	|             |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).           |
+	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
 
 Response Structure
 ------------------

--- a/docs/source/api/v4/cachegroups.rst
+++ b/docs/source/api/v4/cachegroups.rst
@@ -54,6 +54,14 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of |
 	|           |          | ``page``.                                                                                                                |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Cache Groups` that were most recently updated no earlier than this date/time, which may be given as   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Cache Groups` that were most recently updated no later than this date/time, which may be given as an  |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/capabilities.rst
+++ b/docs/source/api/v4/capabilities.rst
@@ -48,6 +48,14 @@ Request Structure
 	|           |          | first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make   |
 	|           |          | use of ``page``.                                                                                                    |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only capabilities that were most recently updated no earlier than this date/time, which may be given as an   |
+	|           |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`  |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only capabilities that were most recently updated no later than this date/time, which may be given as an     |
+	|           |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`     |
+	|           |          | 1970 UTC).                                                                                                          |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------------+
 
 
 .. code-block:: http

--- a/docs/source/api/v4/cdn_locks.rst
+++ b/docs/source/api/v4/cdn_locks.rst
@@ -33,13 +33,25 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+---------------+----------+-----------------------------------------------------------------------------------+
-	| Parameter     | Required | Description                                                                       |
-	+===============+==========+===================================================================================+
-	| username      | no       | Return only the CDN lock that the user with ``username`` possesses                |
-	+---------------+----------+-----------------------------------------------------------------------------------+
-	| cdn           | no       | Return only the CDN lock for the CDN that has the name ``cdn``                    |
-	+---------------+----------+-----------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| Parameter | Required | Description                                                                                            |
+	+===========+==========+========================================================================================================+
+	| username  | no       | Return only the CDN lock that the user with ``username`` possesses                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| cdn       | no       | Return only the CDN lock for the CDN that has the name ``cdn``                                         |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only CDN locks that were most recently updated no earlier than this date/time, which may be     |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only CDN locks that were most recently updated no later than this date/time, which may be       |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight    |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+
+.. versionadded:: ATCv6
+	The ``newerThan`` and ``olderThan`` query string parameters were added to all API versions as of :abbr:`ATC (Apache Traffic Control)` version 6.0.
+
 
 Response Structure
 ------------------

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -41,6 +41,14 @@ Request Structure
 	+------------+----------+-----------------------------------------------------------------------------------------------------+
 	| user       | no       | The username of the user responsible for creating the CDN notifications.                            |
 	+------------+----------+-----------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only CDN locks that were most recently updated no earlier than this date/time, which may be   |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight  |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                   |
+	+-----------+----------+------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only CDN locks that were most recently updated no later than this date/time, which may be     |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight  |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                   |
+	+-----------+----------+------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/deliveryservice_requests.rst
+++ b/docs/source/api/v4/deliveryservice_requests.rst
@@ -64,9 +64,15 @@ Request Structure
 	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. If ``offset``     |
 	|           |          | was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                                                    |
 	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`DSRs` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted string or as   |
+	|           |          | number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`DSRs` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted string or as     |
+	|           |          | number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. versionadded:: ATCv6
-	The ``createdAt`` query parameter was added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
+	The ``newerThan``, ``olderThan``, and ``createdAt`` query parameters were added to this in endpoint across all API versions in :abbr:`ATC (Apache Traffic Control)` version 6.0.0.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/deliveryservices.rst
+++ b/docs/source/api/v4/deliveryservices.rst
@@ -54,8 +54,7 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| xmlId             | no       | Show only the :term:`Delivery Service` that has this text-based, unique identifier                                                      |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby           | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                           |
-	|                   |          | array                                                                                                                                   |
+	| orderby           | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                     |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder         | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
@@ -68,11 +67,17 @@ Request Structure
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 	| active            | no       | Show only the :term:`Delivery Services` that have :ref:`ds-active` set or not based on this boolean (whether or not they are active)    |
 	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan         | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which may be given as an          |
+	|                   |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan         | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may be given as an            |
+	|                   |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).              |
+	+-------------------+----------+-----------------------------------------------------------------------------------------------------------------------------------------+
 
 Response Structure
 ------------------
-:active:                   A boolean that defines :ref:`ds-active`.
-:anonymousBlockingEnabled: A boolean that defines :ref:`ds-anonymous-blocking`
+:active:                    A boolean that defines :ref:`ds-active`.
+:anonymousBlockingEnabled:  A boolean that defines :ref:`ds-anonymous-blocking`
 :ccrDnsTtl:                 The :ref:`ds-dns-ttl` - named "ccrDnsTtl" for legacy reasons
 :cdnId:                     The integral, unique identifier of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs
 :cdnName:                   Name of the :ref:`ds-cdn` to which the :term:`Delivery Service` belongs

--- a/docs/source/api/v4/deliveryservices_id_regexes.rst
+++ b/docs/source/api/v4/deliveryservices_id_regexes.rst
@@ -39,18 +39,26 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| Name        | Required | Description                                                                                                                          |
-	+=============+==========+======================================================================================================================================+
-	| id          | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| limit       | no       | Choose the maximum number of results to return                                                                                       |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| offset      | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
-	| page        | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
-	|             |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
-	+-------------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                                                          |
+	+===========+==========+======================================================================================================================================+
+	| id        | no       | Show only the :term:`Delivery Service` regular expression that has this integral, unique identifier                                  |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                                                       |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                 |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. |
+	|           |          | If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                    |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no earlier than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970  |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Service` regular expressions that were most recently updated no later than this date/time, which may be  |
+	|           |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970     |
+	|           |          | UTC).                                                                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/federation_resolvers.rst
+++ b/docs/source/api/v4/federation_resolvers.rst
@@ -31,29 +31,37 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| Name       | Required | Description                                                                                         |
-	+============+==========+=====================================================================================================+
-	| id         | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| ipAddress  | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| type       | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| orderby    | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
-	|            |          | ``response`` array                                                                                  |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| sortOrder  | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| limit      | no       | Choose the maximum number of results to return                                                      |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| offset     | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
-	|            |          | limit                                                                                               |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
-	| page       | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
-	|            |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
-	|            |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
-	+------------+----------+-----------------------------------------------------------------------------------------------------+
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                         |
+	+===========+==========+=====================================================================================================+
+	| id        | no       | Return only the Federation Resolver identified by this integral, unique identifier                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| ipAddress | no       | Return only the Federation Resolver(s) that has/have this IP Address                                |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| type      | no       | Return only the Federation Resolvers of this :term:`Type`                                           |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| orderby   | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the    |
+	|           |          | ``response`` array                                                                                  |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| sortOrder | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")            |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| limit     | no       | Choose the maximum number of results to return                                                      |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with      |
+	|           |          | limit                                                                                               |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| page      | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are        |
+	|           |          | ``limit`` long and the first page is 1. If ``offset`` was defined, this query parameter has no      |
+	|           |          | effect. ``limit`` must be defined to make use of ``page``.                                          |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no earlier than this       |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Federation` Resolvers that were most recently updated no    later than this      |
+	|           |          | date/time, which may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since  |
+	|           |          | the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                         |
+	+-----------+----------+-----------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/jobs.rst
+++ b/docs/source/api/v4/jobs.rst
@@ -48,7 +48,14 @@ Request Structure
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 	| userId          | no       | Return only invalidation jobs created by the user identified by this integral, unique identifier                     |
 	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
-
+	| newerThan       | no       | Return only invalidation jobs that were most recently updated no earlier than this date/time, which may be given as  |
+	|                 |          | an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only invalidation jobs that were most recently updated no later than this date/time, which may be given as an |
+	|                 |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`      |
+	|                 |          | 1970 UTC).                                                                                                           |
+	+-----------------+----------+----------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/origins.rst
+++ b/docs/source/api/v4/origins.rst
@@ -51,8 +51,7 @@ Request Structure
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| tenant          | no       | Return only :term:`Origins` belonging to the tenant identified by this integral, unique identifier                                                                |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response``                                                     |
-	|                 |          | array                                                                                                                                                             |
+	| orderby         | no       | Choose the ordering of the results - must be the name of one of the fields of the objects in the ``response`` array                                               |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| sortOrder       | no       | Changes the order of sorting. Either ascending (default or "asc") or descending ("desc")                                                                          |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -62,6 +61,12 @@ Request Structure
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 	| page            | no       | Return the n\ :sup:`th` page of results, where "n" is the value of this parameter, pages are ``limit`` long and the first page is 1. If ``offset`` was defined,   |
 	|                 |          | this query parameter has no effect. ``limit`` must be defined to make use of ``page``.                                                                            |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan       | no       | Return only :term:`Origins` that were most recently updated no earlier than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
+	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan       | no       | Return only :term:`Origins` that were most recently updated no later than this date/time, which may be given as an :rfc:`3339`-formatted string or as number of   |
+	|                 |          | nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                                                                     |
 	+-----------------+----------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 .. note:: Several fields of origin definitions which are filterable by Query Parameters are allowed to be ``null``. ``null`` values in these fields will be filtered *out* appropriately by such Query Parameters, but do note that ``null`` is not a valid value accepted by any of these Query Parameters, and attempting to pass it will result in an error.

--- a/docs/source/api/v4/parameters.rst
+++ b/docs/source/api/v4/parameters.rst
@@ -55,6 +55,14 @@ Request Structure
 	|             |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|             |          | defined to make use of ``page``.                                                                              |
 	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan   | no       | Return only :term:`Parameters` that were most recently updated no earlier than this date/time, which may be   |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan   | no       | Return only :term:`Parameters` that were most recently updated no later than this date/time, which may be     |
+	|             |          | given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on        |
+	|             |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-------------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/profiles.rst
+++ b/docs/source/api/v4/profiles.rst
@@ -29,17 +29,25 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  Name | Required | Description                                                                                            |
-	+=======+==========+========================================================================================================+
-	|  cdn  |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	|  id   |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| name  |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
-	| param |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
-	+-------+----------+--------------------------------------------------------------------------------------------------------+
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| Name      | Required | Description                                                                                            |
+	+===========+==========+========================================================================================================+
+	| cdn       |   no     | Used to filter :term:`Profiles` by the integral, unique identifier of the CDN to which they belong     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| id        |   no     | Filters :term:`Profiles` by :ref:`profile-id`                                                          |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| name      |   no     | Filters :term:`Profiles` by :ref:`profile-name`                                                        |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| param     |   no     | Used to filter :term:`Profiles` by the :ref:`parameter-id` of a :term:`Parameter` associated with them |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Profiles` that were most recently updated no earlier than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | on January 1\ :sup:`st` 1970 UTC).                                                                     |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Profiles` that were most recently updated no later than this date/time, which may   |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight |
+	|           |          | 1\ :sup:`st` 1970 UTC).                                                                                |
+	+-----------+----------+--------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/servers.rst
+++ b/docs/source/api/v4/servers.rst
@@ -68,6 +68,14 @@ Request Structure
 	|                |          | the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be defined to  |
 	|                |          | make use of ``page``.                                                                                             |
 	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only servers that were most recently updated no earlier than this date/time, which may be given as an      |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                |          | 1970 UTC).                                                                                                        |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only servers that were most recently updated no later than this date/time, which may be given as an        |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st`   |
+	|                |          | 1970 UTC).                                                                                                        |
+	+----------------+----------+-------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/servers_id_deliveryservices.rst
+++ b/docs/source/api/v4/servers_id_deliveryservices.rst
@@ -55,6 +55,14 @@ Request Structure
 	|           |          | and the first page is 1. If ``offset`` was defined, this query parameter has no effect. ``limit`` must be     |
 	|           |          | defined to make use of ``page``.                                                                              |
 	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only :term:`Delivery Services` that were most recently updated no earlier than this date/time, which   |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only :term:`Delivery Services` that were most recently updated no later than this date/time, which may |
+	|           |          | be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on     |
+	|           |          | January 1\ :sup:`st` 1970 UTC).                                                                               |
+	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/topologies.rst
+++ b/docs/source/api/v4/topologies.rst
@@ -31,11 +31,17 @@ Request Structure
 -----------------
 .. table:: Request Query Parameters
 
-	+------+----------+-----------------------------------------------------+
-	| Name | Required | Description                                         |
-	+======+==========+=====================================================+
-	| name | no       | Return the :term:`Topology` with this name          |
-	+------+----------+-----------------------------------------------------+
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| Name           | Required | Description                                                                                                                  |
+	+================+==========+==============================================================================================================================+
+	| name           | no       | Return the :term:`Topology` with this name                                                                                   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| newerThan      | no       | Return only :term:`Topologies` that were most recently updated no earlier than this date/time, which may be given as an      |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
+	| olderThan      | no       | Return only :term:`Topologies` that were most recently updated no later than this date/time, which may be given as an        |
+	|                |          | :rfc:`3339`-formatted string or as number of nanoseconds since the Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).   |
+	+----------------+----------+------------------------------------------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/users.rst
+++ b/docs/source/api/v4/users.rst
@@ -56,6 +56,14 @@ Request Structure
 	|           |          | are ``limit`` long and the first page is 1. If ``offset`` was defined, this query        |
 	|           |          | parameter has no effect. ``limit`` must be defined to make use of ``page``.              |
 	+-----------+----------+------------------------------------------------------------------------------------------+
+	| newerThan | no       | Return only users that were most recently updated no earlier than this date/time, which  |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
+	| olderThan | no       | Return only users that were most recently updated no later than this date/time, which    |
+	|           |          | may be given as an :rfc:`3339`-formatted string or as number of nanoseconds since the    |
+	|           |          | Unix Epoch (midnight on January 1\ :sup:`st` 1970 UTC).                                  |
+	+-----------+----------+------------------------------------------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/lib/go-tc/time_test.go
+++ b/lib/go-tc/time_test.go
@@ -21,6 +21,7 @@ package tc
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -50,5 +51,32 @@ func TestTimeJSON(t *testing.T) {
 		if string(got) != tm.json {
 			t.Errorf("expected %s, got %s", tm.json, got)
 		}
+	}
+}
+
+func ExampleParseUnixNanoOrRFC3339_nanoseconds() {
+	t, err := ParseUnixNanoOrRFC3339("1257894000000000000")
+	if err != nil {
+		fmt.Printf("Error parsing nanoseconds: %v\n", err)
+	} else {
+		fmt.Println(t)
+	}
+	// Output: 2009-11-10 23:00:00 +0000 UTC
+}
+
+func ExampleParseUnixNanoOrRFC3339_rfc3339() {
+	t, err := ParseUnixNanoOrRFC3339("2009-11-10T23:00:00Z")
+	if err != nil {
+		fmt.Printf("Error parsing RFC3339 timestamp: %v\n", err)
+	} else {
+		fmt.Println(t)
+	}
+	// Output: 2009-11-10 23:00:00 +0000 UTC
+}
+
+func TestParseUnixNanoOrRFC3339(t *testing.T) {
+	_, err := ParseUnixNanoOrRFC3339("10 Nov 09 23:00 UTC")
+	if err == nil {
+		t.Error("Expected an error parsing an invalid timestamp")
 	}
 }

--- a/traffic_ops/traffic_ops_golang/api/generic_crud.go
+++ b/traffic_ops/traffic_ops_golang/api/generic_crud.go
@@ -191,7 +191,10 @@ func GenericRead(h http.Header, val GenericReader, useIMS bool) ([]interface{}, 
 	code := http.StatusOK
 	var maxTime time.Time
 	var runSecond bool
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(val.APIInfo().Params, val.ParamColumns())
+	// 'last_updated' field is probably usually ambiguous due to joins, so we
+	// can't filter with it  without knowing more about the query than we're
+	// being given here.
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(val.APIInfo().Params, val.ParamColumns(), "")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}
@@ -261,7 +264,7 @@ func GenericUpdate(h http.Header, val GenericUpdater) (error, error, int) {
 // GenericDelete, there is no requirement that a specific key is used as the parameter.
 // GenericOptionsDeleter.DeleteKeyOptions() specifies which keys can be used.
 func GenericOptionsDelete(val GenericOptionsDeleter) (error, error, int) {
-	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(val.APIInfo().Params, val.DeleteKeyOptions())
+	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(val.APIInfo().Params, val.DeleteKeyOptions(), "")
 	if len(errs) > 0 {
 		return util.JoinErrs(errs), nil, http.StatusBadRequest
 	}

--- a/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
@@ -63,7 +63,7 @@ func getAPICapabilities(tx *sqlx.Tx, params map[string]string) ([]tc.APICapabili
 	}
 
 	where, orderBy, pagination, queryValues, errs :=
-		dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToQueryCols)
+		dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToQueryCols, "last_updated")
 
 	if len(errs) > 0 {
 		err = util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -371,10 +371,10 @@ func (cg *TOCacheGroup) createCacheGroupFallbacks() error {
 func (cg *TOCacheGroup) isValidCacheGroupFallback(fallbackName string) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT cachegroup.id 
-FROM cachegroup 
-JOIN type on type.id = cachegroup.type 
-WHERE cachegroup.name = $1 
+SELECT cachegroup.id
+FROM cachegroup
+JOIN type on type.id = cachegroup.type
+WHERE cachegroup.name = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -389,9 +389,9 @@ AND (type.name = 'EDGE_LOC')
 func (cg *TOCacheGroup) isAllowedToFallback(cacheGroupType int) (bool, error) {
 	var isValid bool
 	query := `SELECT(
-SELECT type.name 
-FROM type 
-WHERE type.id = $1 
+SELECT type.name
+FROM type
+WHERE type.id = $1
 AND (type.name = 'EDGE_LOC')
 ) IS NOT NULL;`
 
@@ -514,7 +514,7 @@ func (cg *TOCacheGroup) Read(h http.Header, useIMS bool) ([]interface{}, error, 
 		"type":      {Column: "cachegroup.type"},
 		"topology":  {Column: "topology_cachegroup.topology"},
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(cg.ReqInfo.Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(cg.ReqInfo.Params, queryParamsToQueryCols, "cachegroup.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/parameters.go
@@ -24,13 +24,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/jmoiron/sqlx"
 
@@ -71,7 +72,7 @@ func (cgparam *TOCacheGroupParameter) Read(h http.Header, useIMS bool) ([]interf
 	var runSecond bool
 	queryParamsToQueryCols := cgparam.ParamColumns()
 	parameters := cgparam.APIInfo().Params
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols, "p.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}
@@ -239,7 +240,7 @@ func GetAllCacheGroupParameters(tx *sqlx.Tx, parameters map[string]string) (tc.C
 		"parameter":  dbhelpers.WhereColumnInfo{Column: "cgp.parameter", Checker: api.IsInt},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols, "cgp.last_updated")
 	if len(errs) > 0 {
 		return tc.CacheGroupParametersList{}, util.JoinErrs(errs)
 	}
@@ -340,14 +341,14 @@ func AddCacheGroupParameters(w http.ResponseWriter, r *http.Request) {
 }
 
 func selectAllQuery() string {
-	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name 
-				FROM cachegroup_parameter AS cgp 
+	return `SELECT cgp.cachegroup, cgp.parameter, cgp.last_updated, cg.name
+				FROM cachegroup_parameter AS cgp
 				JOIN cachegroup AS cg ON cg.id = cachegroup`
 }
 
 func insertQuery() string {
-	return `INSERT INTO cachegroup_parameter 
-		(cachegroup, 
-		parameter) 
+	return `INSERT INTO cachegroup_parameter
+		(cachegroup,
+		parameter)
 		VALUES `
 }

--- a/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
+++ b/traffic_ops/traffic_ops_golang/cachegroupparameter/unassigned_parameters.go
@@ -22,11 +22,12 @@ package cachegroupparameter
 import (
 	"errors"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
@@ -59,7 +60,7 @@ func (cgunparam *TOCacheGroupUnassignedParameter) Read(h http.Header, useIMS boo
 	var runSecond bool
 	queryParamsToQueryCols := cgunparam.ParamColumns()
 	parameters := cgunparam.APIInfo().Params
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols, "p.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/capabilities/capabilities.go
+++ b/traffic_ops/traffic_ops_golang/capabilities/capabilities.go
@@ -19,17 +19,18 @@ package capabilities
  * under the License.
  */
 
-import "database/sql"
-import "encoding/json"
-import "errors"
-import "fmt"
-import "net/http"
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
 
-import "github.com/apache/trafficcontrol/lib/go-tc"
-import "github.com/apache/trafficcontrol/lib/go-util"
-
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
-import "github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
+)
 
 const readQuery = `
 SELECT description,
@@ -57,7 +58,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 		"name": dbhelpers.WhereColumnInfo{Column: "capability.name"},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, cols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, cols, "capability.last_updated")
 	if len(errs) > 0 {
 		errCode = http.StatusBadRequest
 		userErr = util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
+++ b/traffic_ops/traffic_ops_golang/cdn_lock/cdn_lock.go
@@ -54,7 +54,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 		"username": {Column: "cdn_lock.username", Checker: nil},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, cols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, cols, "cdn_lock.last_updated")
 	if len(errs) > 0 {
 		errCode = http.StatusBadRequest
 		userErr = util.JoinErrs(errs)

--- a/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
+++ b/traffic_ops/traffic_ops_golang/cdnnotification/cdnnotifications.go
@@ -33,10 +33,10 @@ import (
 
 const readQuery = `
 SELECT cn.id,
-	cn.cdn, 
+	cn.cdn,
 	cn.last_updated,
-	cn.user, 
-	cn.notification 
+	cn.user,
+	cn.notification
 FROM cdn_notification as cn
 INNER JOIN cdn ON cdn.name = cn.cdn
 INNER JOIN tm_user ON tm_user.username = cn.user
@@ -80,7 +80,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 		"user": dbhelpers.WhereColumnInfo{Column: "tm_user.username"},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "cn.last_updated")
 	if len(errs) > 0 {
 		sysErr = util.JoinErrs(errs)
 		errCode = http.StatusBadRequest

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -301,9 +301,13 @@ func parseCriteriaAndQueryValues(queryParamsToSQLCols map[string]WhereColumnInfo
 	clause, newerTime, olderTime, err := buildAgeFilter(parameters, fieldName)
 	if err != nil {
 		errs = append(errs, err)
-	} else {
-		queryValues["newerThan"] = newerTime
-		queryValues["olderThan"] = olderTime
+	} else if clause != "" {
+		if _, ok := parameters["newerThan"]; ok {
+			queryValues["newerThan"] = newerTime
+		}
+		if _, ok := parameters["olderThan"]; ok {
+			queryValues["olderThan"] = olderTime
+		}
 		criteriaArgs = append(criteriaArgs, clause)
 	}
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1226,7 +1226,7 @@ func readGetDeliveryServices(h http.Header, params map[string]string, tx *sqlx.T
 		"active":           {Column: "ds.active", Checker: api.IsBool},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols, "ds.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices_required_capabilities.go
@@ -201,7 +201,7 @@ func (rc *RequiredCapability) getCapabilities(h http.Header, tenantIDs []int, us
 	var maxTime time.Time
 	var runSecond bool
 	var results []tc.DeliveryServicesRequiredCapability
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(rc.APIInfo().Params, rc.ParamColumns())
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(rc.APIInfo().Params, rc.ParamColumns(), "")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}
@@ -327,8 +327,8 @@ func (rc *RequiredCapability) checkServerCap() (error, error, int) {
 	// Get server capability name
 	name := ""
 	if err := tx.QueryRow(`
-		SELECT name 
-		FROM server_capability 
+		SELECT name
+		FROM server_capability
 		WHERE name = $1`, rc.RequiredCapability).Scan(&name); err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("querying server capability for name '%v': %v", rc.RequiredCapability, err), http.StatusInternalServerError
 	}
@@ -419,7 +419,7 @@ func (rc *RequiredCapability) ensureDSServerCap() (error, error, int) {
 	dsServerIDs := []int64{}
 	if err := tx.Tx.QueryRow(`
 	SELECT ARRAY(
-		SELECT ds.server 
+		SELECT ds.server
 		FROM deliveryservice_server ds
 		JOIN server s ON ds.server = s.id
 		JOIN type t ON s.type = t.id
@@ -438,7 +438,7 @@ func (rc *RequiredCapability) ensureDSServerCap() (error, error, int) {
 	if err := tx.QueryRow(`
 	SELECT ARRAY(
 		SELECT server
-		FROM server_server_capability 
+		FROM server_server_capability
 		WHERE server = ANY($1)
 		AND server_capability=$2
 	)`, pq.Array(dsServerIDs), rc.RequiredCapability).Scan(pq.Array(&capServerIDs)); err != nil && err != sql.ErrNoRows {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/letsencrypt_dns_challenge.go
@@ -49,7 +49,7 @@ func GetDnsChallengeRecords(w http.ResponseWriter, r *http.Request) {
 		"fqdn": dbhelpers.WhereColumnInfo{Column: "fqdn"},
 	}
 
-	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "")
 	if len(errs) > 0 {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, util.JoinErrs(errs))
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -190,7 +190,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		inf.Params["orderby"] = "xmlId"
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "r.last_updated")
 	if len(errs) > 0 {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, util.JoinErrs(errs), nil)
 		return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -940,7 +940,7 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 		"xml_id": dbhelpers.WhereColumnInfo{Column: "ds.xml_id"},
 		"xmlId":  dbhelpers.WhereColumnInfo{Column: "ds.xml_id"},
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols, "ds.last_updated")
 	if len(errs) > 0 {
 		return nil, nil, errors.New("reading server dses: " + util.JoinErrsStr(errs)), http.StatusInternalServerError, nil
 	}

--- a/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservicesregexes/deliveryservicesregexes.go
@@ -104,7 +104,7 @@ JOIN type as rt ON r.type = rt.id
 	queryParamsToQueryCols := map[string]dbhelpers.WhereColumnInfo{
 		"dsid": dbhelpers.WhereColumnInfo{Column: "ds.ID", Checker: api.IsInt},
 		"id":   dbhelpers.WhereColumnInfo{Column: "r.id", Checker: api.IsInt}}
-	where, _, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, _, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "r.last_updated")
 	if len(errs) > 0 {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, util.JoinErrs(errs), nil)
 		return
@@ -267,10 +267,10 @@ func getCurrentDetails(tx *sql.Tx, dsID int, regexID int) error {
 	var setNumber int
 	var typeName string
 	err := tx.QueryRow(`
-select dsr.set_number, t.name 
-from deliveryservice_regex as dsr 
-join regex as r on dsr.regex = r.id 
-join type as t on t.id = r.type 
+select dsr.set_number, t.name
+from deliveryservice_regex as dsr
+join regex as r on dsr.regex = r.id
+join type as t on t.id = r.type
 where dsr.deliveryservice=$1 and r.id=$2`,
 		dsID, regexID).Scan(&setNumber, &typeName)
 	if err != nil {
@@ -357,7 +357,7 @@ func Put(w http.ResponseWriter, r *http.Request) {
 func canUpdate(tx *sql.Tx, dsr tc.DeliveryServiceRegexPost) error {
 	var name string
 	err := tx.QueryRow(`
-select name from type as t 
+select name from type as t
 where t.id=$1`,
 		dsr.Type).Scan(&name)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
+++ b/traffic_ops/traffic_ops_golang/federation_resolvers/federation_resolvers.go
@@ -126,7 +126,7 @@ func Read(w http.ResponseWriter, r *http.Request) {
 		"type":      dbhelpers.WhereColumnInfo{Column: "type.name"},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "federation_resolver.last_updated")
 	if len(errs) > 0 {
 		sysErr = util.JoinErrs(errs)
 		errCode = http.StatusBadRequest

--- a/traffic_ops/traffic_ops_golang/hwinfo/hwinfo.go
+++ b/traffic_ops/traffic_ops_golang/hwinfo/hwinfo.go
@@ -111,7 +111,7 @@ func getHWInfo(tx *sqlx.Tx, params map[string]string) ([]tc.HWInfo, error) {
 		"val":            dbhelpers.WhereColumnInfo{Column: "h.val"},
 		"lastUpdated":    dbhelpers.WhereColumnInfo{Column: "h.last_updated"}, //TODO: this doesn't appear to work needs debugging
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols, "")
 	if len(errs) > 0 {
 		return nil, fmt.Errorf("Building hwinfo query clauses: %v", util.JoinErrs(errs))
 	}

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -219,7 +219,7 @@ func (job *InvalidationJob) Read(h http.Header, useIMS bool) ([]interface{}, err
 		"dsId":            dbhelpers.WhereColumnInfo{Column: "job.job_deliveryservice", Checker: api.IsInt},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.APIInfo().Params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(job.APIInfo().Params, queryParamsToSQLCols, "job.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/origin/origins.go
+++ b/traffic_ops/traffic_ops_golang/origin/origins.go
@@ -165,7 +165,7 @@ func getOrigins(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth
 		"tenant":          dbhelpers.WhereColumnInfo{Column: "o.tenant", Checker: api.IsInt},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols, "o.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -148,7 +148,7 @@ func (param *TOParameter) Read(h http.Header, useIMS bool) ([]interface{}, error
 	var runSecond bool
 	code := http.StatusOK
 	queryParamsToQueryCols := param.ParamColumns()
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(param.APIInfo().Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(param.APIInfo().Params, queryParamsToQueryCols, "p.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -21,10 +21,11 @@ package profile
 
 import (
 	"errors"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -117,7 +118,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 		NameQueryParam: dbhelpers.WhereColumnInfo{Column: "prof.name"},
 		IDQueryParam:   dbhelpers.WhereColumnInfo{Column: "prof.id", Checker: api.IsInt},
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(prof.APIInfo().Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(prof.APIInfo().Params, queryParamsToQueryCols, "prof.last_updated")
 
 	// Narrow down if the query parameter is 'param'
 

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -483,9 +483,9 @@ RETURNING
 `
 
 const originServerQuery = `
-JOIN deliveryservice_server dsorg 
-ON dsorg.server = s.id 
-WHERE t.name = '` + tc.OriginTypeName + `' 
+JOIN deliveryservice_server dsorg
+ON dsorg.server = s.id
+WHERE t.name = '` + tc.OriginTypeName + `'
 AND dsorg.deliveryservice=:dsId
 `
 const deleteServerQuery = `DELETE FROM server WHERE id=$1`
@@ -1063,7 +1063,7 @@ func getServers(h http.Header, params map[string]string, tx *sqlx.Tx, user *auth
 `
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(params, queryParamsToSQLCols, "s.last_updated")
 	if dsHasRequiredCapabilities {
 		where += requiredCapabilitiesCondition
 	}
@@ -1274,8 +1274,8 @@ func getMidServers(edgeIDs []int, servers map[int]tc.ServerV40, dsID int, cdnID 
 		capabilities.array_agg
 		@>
 		(
-		SELECT ARRAY_AGG(drc.required_capability) 
-		FROM deliveryservices_required_capability drc 
+		SELECT ARRAY_AGG(drc.required_capability)
+		FROM deliveryservices_required_capability drc
 		WHERE drc.deliveryservice_id=:ds_id)
 		)`
 	} else {

--- a/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/extensions/extension.go
@@ -109,8 +109,8 @@ func createCheckExt(toExt tc.ServerCheckExtensionNullable, tx *sqlx.Tx) (int, er
 	scc := ""
 	if err := tx.Tx.QueryRow(`
 	SELECT id, servercheck_column_name
-	FROM to_extension 
-	WHERE type in 
+	FROM to_extension
+	WHERE type in
 		(SELECT id FROM type WHERE name = 'CHECK_EXTENSION_OPEN_SLOT')
 	ORDER BY servercheck_column_name
 	LIMIT 1`).Scan(&id, &scc); err != nil {
@@ -200,7 +200,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		"type":        dbhelpers.WhereColumnInfo{Column: "t.name"},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols, "")
 	if len(errs) > 0 {
 		handleError(w, r, r.Method, inf.Tx.Tx, version, http.StatusBadRequest, util.JoinErrs(errs), nil)
 		return

--- a/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
+++ b/traffic_ops/traffic_ops_golang/servercheck/servercheck.go
@@ -244,7 +244,7 @@ func handleReadServerCheck(inf *api.APIInfo, tx *sql.Tx) ([]tc.GenericServerChec
 		"hostName": dbhelpers.WhereColumnInfo{Column: "server.host_name"},
 	}
 
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols, "")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest
 	}

--- a/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
+++ b/traffic_ops/traffic_ops_golang/steeringtargets/steeringtargets.go
@@ -117,7 +117,8 @@ func read(h http.Header, tx *sqlx.Tx, parameters map[string]string, user *auth.C
 		"deliveryservice": dbhelpers.WhereColumnInfo{Column: "st.deliveryservice", Checker: api.IsInt},
 		"target":          dbhelpers.WhereColumnInfo{Column: "st.target", Checker: api.IsInt},
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols)
+	// This table stores a 'last_updated', but it isn't exposed through the API, it seems.
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(parameters, queryParamsToQueryCols, "")
 	if len(errs) > 0 {
 		return nil, nil, util.JoinErrs(errs), http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/topology/topologies.go
+++ b/traffic_ops/traffic_ops_golang/topology/topologies.go
@@ -431,7 +431,7 @@ func (topology *TOTopology) Read(h http.Header, useIMS bool) ([]interface{}, err
 	var maxTime time.Time
 	var runSecond bool
 	interfaces := make([]interface{}, 0)
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(topology.ReqInfo.Params, topology.ParamColumns())
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(topology.ReqInfo.Params, topology.ParamColumns(), "t.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}

--- a/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
+++ b/traffic_ops/traffic_ops_golang/trafficstats/stats_summary.go
@@ -54,7 +54,7 @@ func getLastSummaryDate(w http.ResponseWriter, r *http.Request, inf *api.APIInfo
 	queryParamsToSQLCols := map[string]dbhelpers.WhereColumnInfo{
 		"statName": dbhelpers.WhereColumnInfo{Column: "stat_name"},
 	}
-	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols)
+	where, _, _, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols, "")
 	if len(errs) > 0 {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, util.JoinErrs(errs))
 		return
@@ -78,7 +78,7 @@ func getStatsSummary(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) {
 		"cdnName":             dbhelpers.WhereColumnInfo{Column: "cdn_name"},
 		"deliveryServiceName": dbhelpers.WhereColumnInfo{Column: "deliveryservice_name"},
 	}
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols)
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToSQLCols, "")
 	if len(errs) > 0 {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, util.JoinErrs(errs))
 		return

--- a/traffic_ops/traffic_ops_golang/user/user.go
+++ b/traffic_ops/traffic_ops_golang/user/user.go
@@ -180,7 +180,7 @@ func (this *TOUser) Read(h http.Header, useIMS bool) ([]interface{}, error, erro
 	var runSecond bool
 	inf := this.APIInfo()
 	api.DefaultSort(inf, "username")
-	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, this.ParamColumns())
+	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, this.ParamColumns(), "u.last_updated")
 	if len(errs) > 0 {
 		return nil, util.JoinErrs(errs), nil, http.StatusBadRequest, nil
 	}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR adds support for the `newerThan` and `olderThan` query string parameters [as described in the documentation](https://traffic-control-cdn.readthedocs.io/en/latest/development/api_guidelines.html#age-filtering). It adds support in the internal query building helper function, `dbhelpers.BuildWhereAndOrderByAndPagination`, and implements it in the following API endpoints:

- `/users`
- `/topologies`
- `/servers`
- `/profiles`
- `/parameters`
- `/origins`
- `/jobs`
- `/federation_resolvers`
- `/deliveryservices/{{ID}}/regexes`
- `/servers/{{ID}}/deliveryservices`
- `/deliveryservice_requests`
- `/deliveryservices`
- `/cdn_notifications`
- `/cdn_locks`
- `/capabilities`
- `/cachegroups/{{ID}}/unassigned_parameters`
- `/cachegroupparameters`
- `/cachegroups`
- `/api_capabilities`

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops Client (Go) (tests only)
- Traffic Ops

## What is the best way to verify this PR?
Make sure the tests pass. This PR includes two unit tests for new functionality, and one integration test that checks the age filtering of Origins - other endpoints are possible to test (if harder, e.g. in the case of `/api_capabilities` where creating new objects through the API is not possible), they would end up testing the same functionality, so I didn't deem them valuable enough to write at this time.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**