### PR TITLE
Make Traffic Stats fail over to other Traffic Monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5407](https://github.com/apache/trafficcontrol/issues/5407) - Make sure that you cannot add two servers with identical content
 - [#2881](https://github.com/apache/trafficcontrol/issues/2881) - Some API endpoints have incorrect Content-Types
 - [#5863](https://github.com/apache/trafficcontrol/issues/5863) - Traffic Monitor logs warnings to `log_location_info` instead of `log_location_warning`
+- [#5492](https://github.com/apache/trafficcontrol/issues/5942) - Traffic Stats does not failover to another Traffic Monitor when one stops responding
 - [#5363](https://github.com/apache/trafficcontrol/issues/5363) - Postgresql version changeable by env variable
 - [#5405](https://github.com/apache/trafficcontrol/issues/5405) - Prevent Tenant update from choosing child as new parent
 - [#5384](https://github.com/apache/trafficcontrol/issues/5384) - New grids will now properly remember the current page number.


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5942

This PR also improves much of the error logging in Traffic Stats to make it easier to troubleshoot and contains some minor cleanup of unused parameters/functions.

## Which Traffic Control components are affected by this PR?
- Traffic Stats

## What is the best way to verify this PR?
1. Verify the included unit test passes.
2. In an environment with 2 or more TMs for TS to poll, shut down each of the TMs one at a time, view the logs, and verify that TS retries the available TM. Note: depending on which TM that TS tries first, shutting down the _other_ TM won't have any effect on TS. You can view the logs to see which TM that TS is querying.

## If this is a bug fix, what versions of Traffic Control are affected?
4.x, 5.x, master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] bugfix, no docs needed
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
