### PR TITLE
Remove references to unused use_tenancy parameter

### DIFF
--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -1334,13 +1334,6 @@
     },
     {
       "configFile": "global",
-      "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
-      "name": "use_tenancy",
-      "secure": false,
-      "value": "1"
-    },
-    {
-      "configFile": "global",
       "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
       "name": "tm.instance_name",
       "secure": false,

--- a/docs/source/api/v4/profiles_id_parameters.rst
+++ b/docs/source/api/v4/profiles_id_parameters.rst
@@ -90,14 +90,6 @@ Response Structure
 			"value": "Traffic Ops"
 		},
 		{
-			"configFile": "global",
-			"id": 6,
-			"lastUpdated": "2018-12-05 17:50:51+00",
-			"name": "use_tenancy",
-			"secure": false,
-			"value": "1"
-		},
-		{
 			"configFile": "regex_revalidate.config",
 			"id": 7,
 			"lastUpdated": "2018-12-05 17:50:49+00",

--- a/docs/source/api/v4/profiles_name_name_parameters.rst
+++ b/docs/source/api/v4/profiles_name_name_parameters.rst
@@ -89,14 +89,6 @@ Response Structure
 			"value": "Traffic Ops"
 		},
 		{
-			"configFile": "global",
-			"id": 6,
-			"lastUpdated": "2018-12-05 17:50:51+00",
-			"name": "use_tenancy",
-			"secure": false,
-			"value": "1"
-		},
-		{
 			"configFile": "regex_revalidate.config",
 			"id": 7,
 			"lastUpdated": "2018-12-05 17:50:49+00",

--- a/docs/source/api/v4/system_info.rst
+++ b/docs/source/api/v4/system_info.rst
@@ -47,13 +47,6 @@ Response Structure
 		"1"
 			Use pending revalidations - this effectively enables the use of "Content Invalidation Jobs"
 
-	:use_tenancy: A string containing an integer which represents a boolean value; one of:
-
-		"0"
-			Do not use tenancy - this effectively disables all ``*tenant*`` endpoints and removes tenancy restrictions on origins and :term:`Delivery Services`
-		"1"
-			Use tenancy - this effectively enables all ``*tenant*`` endpoints and enforces tenancy restrictions on origins and :term:`Delivery Services`
-
 .. code-block:: http
 	:caption: Response Example
 
@@ -76,7 +69,6 @@ Response Structure
 			"tm.instance_name": "CDN-In-A-Box",
 			"tm.toolname": "Traffic Ops",
 			"tm.url": "https://trafficops.infra.ciab.test:443/",
-			"use_reval_pending": "0",
-			"use_tenancy": "1"
+			"use_reval_pending": "0"
 		}
 	}}

--- a/docs/source/overview/profiles_and_parameters.rst
+++ b/docs/source/overview/profiles_and_parameters.rst
@@ -200,9 +200,6 @@ There is a special Profile of Type_ UNK_PROFILE that holds global configuration 
 	|                          |                         | updates and pending content invalidation jobs. This behavior should be enabled by default, and disabling it, while still possible, is |
 	|                          |                         | **EXTREMELY DISCOURAGED**.                                                                                                            |
 	+--------------------------+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------+
-	| use_tenancy              | global                  | This :ref:`Parameter <parameters>`, when it exists and has a Value_ of exactly "1" enables the use :term:`Tenants` in Traffic         |
-	|                          |                         | Control. This should be enabled by default, and while disabling this is still possible, it is **EXTREMELY DISCOURAGED**.              |
-	+--------------------------+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------+
 	| geolocation.polling.url  | CRConfig.json           | The location of a geographic IP mapping database for Traffic Router instances to use.                                                 |
 	+--------------------------+-------------------------+---------------------------------------------------------------------------------------------------------------------------------------+
 	| geolocation6.polling.url | CRConfig.json           | The location of a geographic IPv6 mapping database for Traffic Router instances to use.                                               |

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -407,10 +407,6 @@ dl_ds_default_profiles:
         configFile: global
         value: '1'
         secure: 0
-      - name: use_tenancy
-        configFile: global
-        value: '1'
-        secure: 0
       - name: visual_status_panel_1
         configFile: global
         value: "{{ dl_ts_url }}/dashboard-solo/db/cdn-stats-by-type?panelId=1"

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/000-GLOBAL.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/000-GLOBAL.json
@@ -35,11 +35,6 @@
       "name": "use_reval_pending"
     },
     {
-      "name": "use_tenancy",
-      "configFile": "global",
-      "value": "1"
-    },
-    {
       "name": "default_geo_miss_latitude",
       "configFile": "global",
       "value": "0"

--- a/traffic_ops/app/db/patches.sql
+++ b/traffic_ops/app/db/patches.sql
@@ -16,10 +16,6 @@
 
 -- THIS FILE INCLUDES POST-MIGRATION DATA FIXES REQUIRED OF TRAFFIC OPS
 
--- set use_tenancy to 1 -- this should remain until code that depends on it is removed from both TO and TP
--- NOTE that we know use_tenancy exists b/c it's inserted in seeds.sql
-UPDATE parameter SET value = '1' WHERE name = 'use_tenancy' AND config_file = 'global';
-
 -- Mapping roles and capabilities: (used to be in a migration)
 
 -- For role 'federation'

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -44,10 +44,6 @@ BEGIN
                 insert into parameter (name, config_file, value) values ('tm.toolname', 'global', 'Traffic Ops');
                 insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'tm.toolname' and config_file = 'global' and value = 'Traffic Ops') ) ON CONFLICT (profile, parameter) DO NOTHING;
         END IF;
-        IF NOT EXISTS (SELECT id FROM PARAMETER WHERE name = 'use_tenancy' AND config_file = 'global') THEN
-                insert into parameter (name, config_file, value) values ('use_tenancy', 'global', '1');
-                insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'use_tenancy' and config_file = 'global' and value = '1') ) ON CONFLICT (profile, parameter) DO NOTHING;
-        END IF;
         IF NOT EXISTS (SELECT id FROM PARAMETER WHERE name = 'maxRevalDurationDays' AND config_file = 'regex_revalidate.config') THEN
                 insert into parameter (name, config_file, value) values ('maxRevalDurationDays', 'regex_revalidate.config', '90');
                 insert into profile_parameter (profile, parameter) values ( (select id from profile where name = 'GLOBAL'), (select id from parameter where name = 'maxRevalDurationDays' and config_file = 'regex_revalidate.config' and value = '90') ) ON CONFLICT (profile, parameter) DO NOTHING;

--- a/traffic_ops/testing/api/v4/tc-fixtures.json
+++ b/traffic_ops/testing/api/v4/tc-fixtures.json
@@ -1794,13 +1794,6 @@
         },
         {
             "configFile": "global",
-            "lastUpdated": "2018-01-19T19:01:21.501151+00:00",
-            "name": "use_tenancy",
-            "secure": false,
-            "value": "1"
-        },
-        {
-            "configFile": "global",
             "lastUpdated": "2020-04-21T05:19:43.853831+00:00",
             "name": "tm.instance_name",
             "secure": false,

--- a/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
+++ b/traffic_ops/traffic_ops_golang/cdnfederation/cdnfederations.go
@@ -233,8 +233,7 @@ func (fed TOCDNFederation) isTenantAuthorized() (error, error, int) {
 		return nil, errors.New("getting tenant id from federation: " + err.Error()), http.StatusInternalServerError
 	}
 
-	// TODO: After IsResourceAuthorizedToUserTx is updated to no longer have `use_tenancy`,
-	// that will probably be better to use. For now, use the list. Issue #2602
+	// TODO: use IsResourceAuthorizedToUserTx instead
 	list, err := tenant.GetUserTenantIDListTx(fed.APIInfo().Tx.Tx, fed.APIInfo().User.TenantID)
 	if err != nil {
 		return nil, errors.New("getting federation tenant list: " + err.Error()), http.StatusInternalServerError


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #2685

NOTE: some references to `use_tenancy` still exist in the old API v1-3 docs. Since those are just examples and will be removed w/ v1-3, I didn't think it necessary to remove them now.

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Make sure `db/admin upgrade` still works successfully (this uses `seeds.sql` and `patches.sql`). Make sure the docs build successfully and aren't malformed.

## The following criteria are ALL met by this PR
- [x] no new tests needed
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] changelog entry seems unnecessary, param hasn't been used in a long time
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
