### PR TITLE
Add t3c mode flags

### DIFF
--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -38,7 +38,7 @@ t3c-apply - Traffic Control Cache Configuration applicator
 
 # SYNOPSIS
 
-t3c-apply [-2bchIpsSvW] [-D seconds] [-d location] [-e location] [-g \<yes|no|auto\>] [-H hostname] [-i location] [-l seconds] [-M location] [-m \<badass|report|revalidate|syncds\>] [-P password] [-r retries] [-R path] [-T seconds] [-t milliseconds] [-u url] [-U username] [-V versions] [-w \<true|false\>]
+t3c-apply [-2AbceFhIknopsSvW] [-a service-action] [-D seconds] [-f \<all|reval|none\>] [-g \<yes|no|auto\>] [-H hostname] [-l seconds] [-M location] [-m \<badass|report|revalidate|syncds\>] [-P password] [-r retries] [-R path] [-T seconds] [-t milliseconds] [-u url] [-U username] [-V tls-versions]
 
 [\-\-help]
 
@@ -52,40 +52,79 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
 -2, -\-default-client-enable-h2
 
-    Whether to enable HTTP/2 on Delivery Services by default, if
-    they have no explicit Parameter. This is irrelevant if ATS
-    records.config is not serving H2. If omitted, H2 is
-    disabled.
+                    Whether to enable HTTP/2 on Delivery Services by default, if
+                    they have no explicit Parameter. This is irrelevant if ATS
+                    records.config is not serving H2. If omitted, H2 is
+                    disabled.
 
+-a, -\-service-action=value
+
+                    action to perform on Traffic Server and other system
+                    services. Only reloads if necessary, but always restarts.
+                    Default is 'reload'
+
+-A, -\-update-ipallow
+
+                    Whether ipallow file will be updated if necessary. This
+                    exists because ATS had a bug where reloading after changing
+                    ipallow would block everything. Default is false.
 -b, -\-dns-local-bind
 
-    [true | false] whether to use the server's Service Addresses
-    to set the ATS DNS local bind address
+                    [true | false] whether to use the server's Service Addresses
+                    to set the ATS DNS local bind address
 
 -c, -\-disable-parent-config-comments
 
-    Whether to disable verbose parent.config comments. Default
-    false.
+                    Whether to disable verbose parent.config comments. Default
+                    false.
+
+-C, -\-skip-os-check
+
+                    [false | true] skip os check, default is false
+
+-d, -\-no-unset-update-flag
+
+                    Whether to not unset the update flag in Traffic Ops after
+                    applying files. This option makes it possible to generate
+                    test or debug configuration from a production Traffic Ops
+                    without un-setting queue or reval flags. Default is false.
 
 -D, -\-dispersion=value
 
-    [seconds] wait a random number of seconds between 0 and
-    [seconds] before starting, default 300 [300]
+                    [seconds] wait a random number of seconds between 0 and
+                    [seconds] before starting, default 300 [300]
+
+-e, -\-omit-via-string-release
+
+                    Whether to set the records.config via header to the ATS
+                    release from the RPM. Default true.
+
+-f, -\-files=value  [all | reval]
+
+                    Which files to generate. If reval, the Traffic
+                    Ops server reval_pending flag is used instead of the
+                    upd_pending flag. Default is 'all'
+
+-F, -\-ignore-update-flag
+
+                    Whether to ignore the upd_pending or reval_pending flag in
+                    Traffic Ops, and always generate and apply files. If true,
+                    the flag is still unset in Traffic Ops after files are
+                    applied. Default is false.
 
 -g, -\-git=value
-
-    Create and use a git repo in the config directory. Options
-    are yes, no, and auto. If yes, create and use. If auto, use
-    if it exist. Default is auto. [auto]
+                    Create and use a git repo in the config directory. Options
+                    are yes, no, and auto. If yes, create and use. If auto, use
+                    if it exist. Default is auto. [auto]
 
 -H, -\-cache-host-name=value
 
-    Host name of the cache to generate config for. Must be the
-    server host name in Traffic Ops, not a URL, and not the FQDN
+                    Host name of the cache to generate config for. Must be the
+                    server host name in Traffic Ops, not a URL, and not the FQDN
 
 -h, -\-help
 
-    Print usage information and exit
+                    Print usage information and exit
 
 -i, -\-no-outgoing-ip
 
@@ -94,108 +133,119 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
 -I, -\-traffic-ops-insecure
 
-    [true | false] ignore certificate errors from Traffic Ops
+                    [true | false] ignore certificate errors from Traffic Ops
+
+-k, -\-install-packages
+
+                    Whether to install necessary packages. Default is false.
 
 -l, -\-login-dispersion=value
 
-    [seconds] wait a random number of seconds between 0 and
-    [seconds] before login to traffic ops, default 0
+                    [seconds] wait a random number of seconds between 0 and
+                    [seconds] before login to traffic ops, default 0
 
 -M, -\-maxmind-location=value
 
-    URL of a maxmind gzipped database file, to be installed into
-    the trafficserver etc directory.
+                    URL of a maxmind gzipped database file, to be installed into
+                    the trafficserver etc directory.
 
 -m, -\-run-mode=value
 
-    [badass | report | revalidate | syncds] run mode, default is
-    'report' [report]
+                    [badass | report | revalidate | syncds] run mode. Optional, convenience flag which sets other flags for common usage scenarios.
+                    syncds     keeps the defaults:
+                                    --report-only=false
+                                    --files=all
+                                    --install-packages=false
+                                    --service-action=reload
+                                    --ignore-update-flag=false
+                                    --update-ipallow=false
+                                    --no-unset-update-flag=false
+                    revalidate sets --files=reval
+                                    --wait-for-parents=true
+                    badass     sets --install-packages=true
+                                    --service-action=restart
+                                    --ignore-update-flag=true
+                                    --update-ipallow=true
+                    report     sets --report-only=true
+
+                    Note the 'syncds' settings are all the flag defaults. Hence, if no mode is set, the default is effectively 'syncds'.
+
+                    If any of the related flags are also set, they override the mode's default behavior.
 
  -n, -\-no-cache
 
     Whether to not use a cache and make conditional requests to
     Traffic Ops. Default is false: use cache.
 
--o, -\-omit-via-string-release
+-o, -\-report-only
 
-    Whether to set the records.config via header to the ATS
-    release from the RPM. Default true.
-
--O, -\-skip-os-check
-
-    [false | true] skip os check, default is false
+                    Log information about necessary files and actions, but take
+                    no action. Default is false
 
 -p, -\-reverse-proxy-disable
 
-    [false | true] bypass the reverse proxy even if one has been
-    configured default is false
+                    [false | true] bypass the reverse proxy even if one has been
+                    configured default is false
 
 -P, -\-traffic-ops-password=value
 
-    Traffic Ops password. Required. May also be set with the
-    environment variable TO_PASS
+                    Traffic Ops password. Required. May also be set with the
+                    environment variable TO_PASS
 
 -r, -\-num-retries=value
 
-    [number] retry connection to Traffic Ops URL [number] times,
-    default is 3 [3]
+                    [number] retry connection to Traffic Ops URL [number] times,
+                    default is 3 [3]
 
 -R, -\-trafficserver-home=value
 
-    Trafficserver Package directory. May also be set with the
-    environment variable TS_HOME
+                    Trafficserver Package directory. May also be set with the
+                    environment variable TS_HOME
 
 -s, -\-silent
 
-    Silent. Errors are not logged, and the 'verbose' flag is
-    ignored. If a fatal error occurs, the return code will be
-    non-zero but no text will be output to stderr
-
--S, -\-syncds-updates-ipallow
-
-    Whether syncds mode will update ipallow. This exists because
-    ATS had a bug where reloading after changing ipallow would
-    block everything. Default is false.
+                    Silent. Errors are not logged, and the 'verbose' flag is
+                    ignored. If a fatal error occurs, the return code will be
+                    non-zero but no text will be output to stderr
 
 -T, -\-reval-wait-time=value
 
-    [seconds] wait a random number of seconds between 0 and
-    [seconds] before revlidation, default is 60 [60]
+                    [seconds] wait a random number of seconds between 0 and
+                    [seconds] before revlidation, default is 60 [60]
 
 -t, -\-traffic-ops-timeout-milliseconds=value
 
-    Timeout in milli-seconds for Traffic Ops requests, default
-    is 30000 [30000]
+                    Timeout in milli-seconds for Traffic Ops requests, default
+                    is 30000 [30000]
 
 -u, -\-traffic-ops-url=value
 
-    Traffic Ops URL. Must be the full URL, including the scheme.
-    Required. May also be set with the environment variable
-    TO_URL
+                    Traffic Ops URL. Must be the full URL, including the scheme.
+                    Required. May also be set with the environment variable
+                    TO_URL
 
 -U, -\-traffic-ops-user=value
 
-    Traffic Ops username. Required. May also be set with the
-    environment variable TO_USER
+                    Traffic Ops username. Required. May also be set with the
+                    environment variable TO_USER
 
 -V, -\-default-client-tls-versions=value
 
-    Comma-delimited list of default TLS versions for Delivery
-    Services with no Parameter, e.g.
-    -\-default-tls-versions='1.1,1.2,1.3'. If omitted, all
-    versions are enabled.
+                    Comma-delimited list of default TLS versions for Delivery
+                    Services with no Parameter, e.g.
+                    --default-tls-versions='1.1,1.2,1.3'. If omitted, all
+                    versions are enabled.
 
 -v, -\-verbose
 
-    Log verbosity. Logging is output to stderr. By default,
-    errors are logged. To log warnings, pass '-v'. To log info,
-    pass '-vv'. To omit error logging, see '-s'.
+                    Log verbosity. Logging is output to stderr. By default,
+                    errors are logged. To log warnings, pass '-v'. To log info,
+                    pass '-vv'. To omit error logging, see '-s' [0]
 
 -W, -\-wait-for-parents
 
-    [true | false | reval] do not update if parent_pending = 1 in the
-    update json. Default is 'reval', wait for parents in revalidate
-    mode, but not syncds (unless Traffic Ops has !use_reval_pending)
+                    [true | false] do not update if parent_pending = 1 in the
+                    update json. Default is false
 
 # MODES
 

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -36,7 +36,8 @@ import (
 )
 
 var TSHome string = "/opt/trafficserver"
-var TSConfigDir string = "/opt/trafficserver/etc/trafficserver"
+
+const DefaultTSConfigDir = "/opt/trafficserver/etc/trafficserver"
 
 const (
 	StatusDir          = "/var/lib/trafficcontrol-cache-config/status"
@@ -81,7 +82,6 @@ type Cfg struct {
 	Retries             int
 	RevalWaitTime       time.Duration
 	ReverseProxyDisable bool
-	RunMode             t3cutil.Mode
 	SkipOSCheck         bool
 	TOInsecure          bool
 	TOTimeoutMS         time.Duration
@@ -89,7 +89,7 @@ type Cfg struct {
 	TOPass              string
 	TOURL               string
 	DNSLocalBind        bool
-	WaitForParents      WaitForParentsFlag
+	WaitForParents      bool
 	YumOptions          string
 	// UseGit is whether to create and maintain a git repo of config changes.
 	// Note this only applies to the ATS config directory inferred or set via the flag.
@@ -107,6 +107,14 @@ type Cfg struct {
 	MaxMindLocation string
 	TsHome          string
 	TsConfigDir     string
+
+	ServiceAction     t3cutil.ApplyServiceActionFlag
+	ReportOnly        bool
+	Files             t3cutil.ApplyFilesFlag
+	InstallPackages   bool
+	IgnoreUpdateFlag  bool
+	NoUnsetUpdateFlag bool
+	UpdateIPAllow     bool
 }
 
 type UseGitFlag string
@@ -217,21 +225,19 @@ func GetCfg() (Cfg, error) {
 	retriesPtr := getopt.IntLong("num-retries", 'r', 3, "[number] retry connection to Traffic Ops URL [number] times, default is 3")
 	revalWaitTimePtr := getopt.IntLong("reval-wait-time", 'T', 60, "[seconds] wait a random number of seconds between 0 and [seconds] before revlidation, default is 60")
 	reverseProxyDisablePtr := getopt.BoolLong("reverse-proxy-disable", 'p', "[false | true] bypass the reverse proxy even if one has been configured default is false")
-	runModePtr := getopt.StringLong("run-mode", 'm', "report", "[badass | report | revalidate | syncds] run mode, default is 'report'")
-	skipOSCheckPtr := getopt.BoolLong("skip-os-check", 'O', "[false | true] skip os check, default is false")
+	skipOSCheckPtr := getopt.BoolLong("skip-os-check", 'C', "[false | true] skip os check, default is false")
 	toInsecurePtr := getopt.BoolLong("traffic-ops-insecure", 'I', "[true | false] ignore certificate errors from Traffic Ops")
 	toTimeoutMSPtr := getopt.IntLong("traffic-ops-timeout-milliseconds", 't', 30000, "Timeout in milli-seconds for Traffic Ops requests, default is 30000")
 	toURLPtr := getopt.StringLong("traffic-ops-url", 'u', "", "Traffic Ops URL. Must be the full URL, including the scheme. Required. May also be set with the environment variable TO_URL")
 	toUserPtr := getopt.StringLong("traffic-ops-user", 'U', "", "Traffic Ops username. Required. May also be set with the environment variable TO_USER")
 	toPassPtr := getopt.StringLong("traffic-ops-password", 'P', "", "Traffic Ops password. Required. May also be set with the environment variable TO_PASS")
 	tsHomePtr := getopt.StringLong("trafficserver-home", 'R', "", "Trafficserver Package directory. May also be set with the environment variable TS_HOME")
-	waitForParentsPtr := getopt.StringLong("wait-for-parents", 'W', "reval", "[true | false | reval] do not update if parent_pending = 1 in the update json. default is reval, wait for parents in reval mode but not syncds (unless Traffic Ops !UseRevalPending, and then wait in syncds)")
 	dnsLocalBindPtr := getopt.BoolLong("dns-local-bind", 'b', "[true | false] whether to use the server's Service Addresses to set the ATS DNS local bind address")
 	helpPtr := getopt.BoolLong("help", 'h', "Print usage information and exit")
 	useGitStr := getopt.StringLong("git", 'g', "auto", "Create and use a git repo in the config directory. Options are yes, no, and auto. If yes, create and use. If auto, use if it exist. Default is auto.")
 	noCachePtr := getopt.BoolLong("no-cache", 'n', "Whether to not use a cache and make conditional requests to Traffic Ops")
 	syncdsUpdatesIPAllowPtr := getopt.BoolLong("syncds-updates-ipallow", 'S', "Whether syncds mode will update ipallow. This exists because ATS had a bug where reloading after changing ipallow would block everything. Default is false.")
-	omitViaStringReleasePtr := getopt.BoolLong("omit-via-string-release", 'o', "Whether to set the records.config via header to the ATS release from the RPM. Default true.")
+	omitViaStringReleasePtr := getopt.BoolLong("omit-via-string-release", 'e', "Whether to set the records.config via header to the ATS release from the RPM. Default true.")
 	noOutgoingIP := getopt.BoolLong("no-outgoing-ip", 'i', "Whether to not set the records.config outgoing IP to the server's addresses in Traffic Ops. Default is false.")
 	disableParentConfigCommentsPtr := getopt.BoolLong("disable-parent-config-comments", 'c', "Whether to disable verbose parent.config comments. Default false.")
 	defaultEnableH2 := getopt.BoolLong("default-client-enable-h2", '2', "Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter. This is irrelevant if ATS records.config is not serving H2. If omitted, H2 is disabled.")
@@ -240,7 +246,106 @@ func GetCfg() (Cfg, error) {
 	verbosePtr := getopt.CounterLong("verbose", 'v', `Log verbosity. Logging is output to stderr. By default, errors are logged. To log warnings, pass '-v'. To log info, pass '-vv'. To omit error logging, see '-s'`)
 	silentPtr := getopt.BoolLong("silent", 's', `Silent. Errors are not logged, and the 'verbose' flag is ignored. If a fatal error occurs, the return code will be non-zero but no text will be output to stderr`)
 
+	const waitForParentsFlagName = "wait-for-parents"
+	waitForParentsPtr := getopt.BoolLong(waitForParentsFlagName, 'W', "[true | false] do not update if parent_pending = 1 in the update json. Default is false")
+
+	const serviceActionFlagName = "service-action"
+	const defaultServiceAction = t3cutil.ApplyServiceActionFlagReload
+	serviceActionPtr := getopt.EnumLong(serviceActionFlagName, 'a', []string{string(t3cutil.ApplyServiceActionFlagReload), string(t3cutil.ApplyServiceActionFlagRestart), string(t3cutil.ApplyServiceActionFlagNone), ""}, "", "action to perform on Traffic Server and other system services. Only reloads if necessary, but always restarts. Default is 'reload'")
+
+	const reportOnlyFlagName = "report-only"
+	reportOnlyPtr := getopt.BoolLong(reportOnlyFlagName, 'o', "Log information about necessary files and actions, but take no action. Default is false")
+
+	const filesFlagName = "files"
+	const defaultFiles = t3cutil.ApplyFilesFlagAll
+	filesPtr := getopt.EnumLong(filesFlagName, 'f', []string{string(t3cutil.ApplyFilesFlagAll), string(t3cutil.ApplyFilesFlagReval), ""}, "", "[all | reval] Which files to generate. If reval, the Traffic Ops server reval_pending flag is used instead of the upd_pending flag. Default is 'all'")
+
+	const installPackagesFlagName = "install-packages"
+	installPackagesPtr := getopt.BoolLong(installPackagesFlagName, 'k', "Whether to install necessary packages. Default is false.")
+
+	const ignoreUpdateFlagName = "ignore-update-flag"
+	ignoreUpdateFlagPtr := getopt.BoolLong(ignoreUpdateFlagName, 'F', "Whether to ignore the upd_pending or reval_pending flag in Traffic Ops, and always generate and apply files. If true, the flag is still unset in Traffic Ops after files are applied. Default is false.")
+	noUnsetUpdateFlagPtr := getopt.BoolLong("no-unset-update-flag", 'd', "Whether to not unset the update flag in Traffic Ops after applying files. This option makes it possible to generate test or debug configuration from a production Traffic Ops without un-setting queue or reval flags. Default is false.")
+
+	const updateIPAllowFlagName = "update-ipallow"
+	updateIPAllowPtr := getopt.BoolLong(updateIPAllowFlagName, 'A', "Whether ipallow file will be updated if necessary. This exists because ATS had a bug where reloading after changing ipallow would block everything. Default is false.")
+
+	const runModeFlagName = "run-mode"
+	runModePtr := getopt.StringLong(runModeFlagName, 'm', "", `[badass | report | revalidate | syncds] run mode. Optional, convenience flag which sets other flags for common usage scenarios.
+syncds     keeps the defaults:
+                --report-only=false
+                --files=all
+                --install-packages=false
+                --service-action=reload
+                --ignore-update-flag=false
+                --update-ipallow=false
+                --no-unset-update-flag=false
+revalidate sets --files=reval
+                --wait-for-parents=true
+badass     sets --install-packages=true
+                --service-action=restart
+                --ignore-update-flag=true
+                --update-ipallow=true
+report     sets --report-only=true
+
+Note the 'syncds' settings are all the flag defaults. Hence, if no mode is set, the default is effectively 'syncds'.
+
+If any of the related flags are also set, they override the mode's default behavior.`)
+
 	getopt.Parse()
+
+	// The mode is never exposed outside this function to prevent accidentally changing behavior based on it,
+	// so we want to log what flags the mode set here, to aid debugging.
+	// But we can't do that until the loggers are initialized.
+	modeLogStrs := []string{}
+	if getopt.IsSet(runModeFlagName) {
+		runMode := t3cutil.StrToMode(*runModePtr)
+		if runMode == t3cutil.ModeInvalid {
+			return Cfg{}, errors.New(*runModePtr + " is an invalid mode.")
+		}
+		switch runMode {
+		case t3cutil.ModeSyncDS:
+			// syncds flags are all the defaults, no need to change anything
+		case t3cutil.ModeRevalidate:
+			if !getopt.IsSet(filesFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+filesFlagName+"="+t3cutil.ApplyFilesFlagReval.String())
+				*filesPtr = t3cutil.ApplyFilesFlagReval.String()
+			}
+			if !getopt.IsSet(waitForParentsFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+waitForParentsFlagName+"="+"true")
+				*waitForParentsPtr = true
+			}
+		case t3cutil.ModeBadAss:
+			if !getopt.IsSet(serviceActionFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+serviceActionFlagName+"="+t3cutil.ApplyServiceActionFlagRestart.String())
+				*serviceActionPtr = t3cutil.ApplyServiceActionFlagRestart.String()
+			}
+			if !getopt.IsSet(installPackagesFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+installPackagesFlagName+"="+"true")
+				*installPackagesPtr = true
+			}
+			if !getopt.IsSet(ignoreUpdateFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+ignoreUpdateFlagName+"="+"true")
+				*ignoreUpdateFlagPtr = true
+			}
+			if !getopt.IsSet(updateIPAllowFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+updateIPAllowFlagName+"="+"true")
+				*updateIPAllowPtr = true
+			}
+		case t3cutil.ModeReport:
+			if !getopt.IsSet(reportOnlyFlagName) {
+				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+reportOnlyFlagName+"="+"true")
+				*reportOnlyPtr = true
+			}
+		}
+	}
+
+	if *serviceActionPtr == "" {
+		*serviceActionPtr = defaultServiceAction.String()
+	}
+	if *filesPtr == "" {
+		*filesPtr = defaultFiles.String()
+	}
 
 	dispersion := time.Second * time.Duration(*dispersionPtr)
 	loginDispersion := time.Second * time.Duration(*loginDispersionPtr)
@@ -281,11 +386,6 @@ func GetCfg() (Cfg, error) {
 		return Cfg{}, errors.New("Invalid git flag '" + *useGitStr + "'. Valid options are yes, no, auto.")
 	}
 
-	waitForParents := StrToWaitForParentsFlag(*waitForParentsPtr)
-	if waitForParents == WaitForParentsInvalid {
-		return Cfg{}, errors.New("Invalid wait-for-parents flag '" + *waitForParentsPtr + "'. Valid options are true, false, reval.")
-	}
-
 	retries := *retriesPtr
 	revalWaitTime := time.Second * time.Duration(*revalWaitTimePtr)
 	reverseProxyDisable := *reverseProxyDisablePtr
@@ -302,11 +402,6 @@ func GetCfg() (Cfg, error) {
 	if help {
 		Usage()
 		return Cfg{}, nil
-	}
-
-	runMode := t3cutil.StrToMode(*runModePtr)
-	if runMode == t3cutil.ModeInvalid {
-		return Cfg{}, errors.New(*runModePtr + " is an invalid mode.")
 	}
 
 	urlSourceStr := "argument" // for error messages
@@ -346,10 +441,13 @@ func GetCfg() (Cfg, error) {
 			}
 		}
 	}
+
+	tsConfigDir := DefaultTSConfigDir
+
 	if tsHome != "" {
 		TSHome = tsHome
-		TSConfigDir = tsHome + "/etc/trafficserver"
-		fmt.Printf("TSHome: %s, TSConfigDir: %s\n", TSHome, TSConfigDir)
+		tsConfigDir = tsHome + "/etc/trafficserver"
+		fmt.Printf("TSHome: %s, TSConfigDir: %s\n", TSHome, tsConfigDir)
 	}
 
 	usageStr := "basic usage: t3c-apply --traffic-ops-url=myurl --traffic-ops-user=myuser --traffic-ops-password=mypass --cache-host-name=my-cache"
@@ -388,7 +486,6 @@ func GetCfg() (Cfg, error) {
 		Retries:                     retries,
 		RevalWaitTime:               revalWaitTime,
 		ReverseProxyDisable:         reverseProxyDisable,
-		RunMode:                     runMode,
 		SkipOSCheck:                 skipOsCheck,
 		TOInsecure:                  toInsecure,
 		TOTimeoutMS:                 toTimeoutMS,
@@ -396,11 +493,12 @@ func GetCfg() (Cfg, error) {
 		TOPass:                      toPass,
 		TOURL:                       toURL,
 		DNSLocalBind:                dnsLocalBind,
-		WaitForParents:              waitForParents,
+		WaitForParents:              *waitForParentsPtr,
 		YumOptions:                  yumOptions,
 		UseGit:                      useGit,
 		NoCache:                     *noCachePtr,
 		SyncDSUpdatesIPAllow:        *syncdsUpdatesIPAllowPtr,
+		UpdateIPAllow:               *updateIPAllowPtr,
 		OmitViaStringRelease:        *omitViaStringReleasePtr,
 		NoOutgoingIP:                *noOutgoingIP,
 		DisableParentConfigComments: *disableParentConfigCommentsPtr,
@@ -408,11 +506,22 @@ func GetCfg() (Cfg, error) {
 		DefaultClientTLSVersions:    defaultClientTLSVersions,
 		MaxMindLocation:             maxmindLocation,
 		TsHome:                      TSHome,
-		TsConfigDir:                 TSConfigDir,
+		TsConfigDir:                 tsConfigDir,
+
+		ServiceAction:     t3cutil.ApplyServiceActionFlag(*serviceActionPtr),
+		ReportOnly:        *reportOnlyPtr,
+		Files:             t3cutil.ApplyFilesFlag(*filesPtr),
+		InstallPackages:   *installPackagesPtr,
+		IgnoreUpdateFlag:  *ignoreUpdateFlagPtr,
+		NoUnsetUpdateFlag: *noUnsetUpdateFlagPtr,
 	}
 
 	if err = log.InitCfg(cfg); err != nil {
 		return Cfg{}, errors.New("Initializing loggers: " + err.Error() + "\n")
+	}
+
+	for _, str := range modeLogStrs {
+		log.Infoln(str)
 	}
 
 	printConfig(cfg)
@@ -460,6 +569,7 @@ func getOSSvcManagement() SvcManagement {
 }
 
 func printConfig(cfg Cfg) {
+	// TODO add new flags
 	log.Debugf("Dispersion: %d\n", cfg.Dispersion)
 	log.Debugf("LogLocationDebug: %s\n", cfg.LogLocationDebug)
 	log.Debugf("LogLocationErr: %s\n", cfg.LogLocationErr)
@@ -471,7 +581,6 @@ func printConfig(cfg Cfg) {
 	log.Debugf("Retries: %d\n", cfg.Retries)
 	log.Debugf("RevalWaitTime: %d\n", cfg.RevalWaitTime)
 	log.Debugf("ReverseProxyDisable: %t\n", cfg.ReverseProxyDisable)
-	log.Debugf("RunMode: %s\n", cfg.RunMode)
 	log.Debugf("SkipOSCheck: %t\n", cfg.SkipOSCheck)
 	log.Debugf("TOInsecure: %t\n", cfg.TOInsecure)
 	log.Debugf("TOTimeoutMS: %d\n", cfg.TOTimeoutMS)

--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -50,7 +50,7 @@ func generate(cfg config.Cfg) ([]t3cutil.ATSConfigFile, error) {
 		return nil, errors.New("requesting: " + err.Error())
 	}
 	args := []string{
-		"--dir=" + config.TSConfigDir,
+		"--dir=" + cfg.TsConfigDir,
 	}
 
 	if cfg.LogLocationErr == log.LogLocationNull {
@@ -72,7 +72,7 @@ func generate(cfg config.Cfg) ([]t3cutil.ATSConfigFile, error) {
 	if cfg.DefaultClientTLSVersions != nil {
 		args = append(args, "--default-client-tls-versions="+*cfg.DefaultClientTLSVersions+"")
 	}
-	if cfg.RunMode == t3cutil.ModeRevalidate {
+	if cfg.Files == t3cutil.ApplyFilesFlagReval {
 		args = append(args, "--revalidate-only")
 	}
 	args = append(args, "--via-string-release="+strconv.FormatBool(!cfg.OmitViaStringRelease))
@@ -322,11 +322,10 @@ func checkRefs(cfg config.Cfg, cfgFile []byte, filesAdding []string) error {
 }
 
 // checkReload is a helper for the sub-command t3c-check-reload.
-func checkReload(mode t3cutil.Mode, pluginPackagesInstalled []string, changedConfigFiles []string) (t3cutil.ServiceNeeds, error) {
-	log.Infof("t3c-check-reload calling with mode '%v' pluginPackagesInstalled '%v' changedConfigFiles '%v'\n", mode, pluginPackagesInstalled, changedConfigFiles)
+func checkReload(pluginPackagesInstalled []string, changedConfigFiles []string) (t3cutil.ServiceNeeds, error) {
+	log.Infof("t3c-check-reload calling with pluginPackagesInstalled '%v' changedConfigFiles '%v'\n", pluginPackagesInstalled, changedConfigFiles)
 
 	stdOut, stdErr, code := t3cutil.Do(`t3c`, `check`, `reload`,
-		"--run-mode="+mode.String(),
 		"--plugin-packages-installed="+strings.Join(pluginPackagesInstalled, ","),
 		"--changed-config-paths="+strings.Join(changedConfigFiles, ","),
 	)

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -286,7 +286,7 @@ func (r *TrafficOpsReq) checkStatusFiles(svrStatus string) error {
 			continue
 		}
 		fileExists, _ := util.FileExists(otherStatus)
-		if r.Cfg.RunMode != t3cutil.ModeReport && fileExists {
+		if !r.Cfg.ReportOnly && fileExists {
 			log.Errorf("Removing other status file %s that exists\n", otherStatus)
 			err = os.Remove(otherStatus)
 			if err != nil {
@@ -295,7 +295,7 @@ func (r *TrafficOpsReq) checkStatusFiles(svrStatus string) error {
 		}
 	}
 
-	if r.Cfg.RunMode != t3cutil.ModeReport {
+	if !r.Cfg.ReportOnly {
 		if !util.MkDir(config.StatusDir, r.Cfg) {
 			return fmt.Errorf("unable to create '%s'\n", config.StatusDir)
 		}
@@ -463,9 +463,8 @@ const configFileTempSuffix = `.tmp`
 
 // replaceCfgFile replaces an ATS configuration file with one from Traffic Ops.
 func (r *TrafficOpsReq) replaceCfgFile(cfg *ConfigFile) error {
-	if r.Cfg.RunMode != t3cutil.ModeBadAss &&
-		r.Cfg.RunMode != t3cutil.ModeSyncDS &&
-		r.Cfg.RunMode != t3cutil.ModeRevalidate {
+	if r.Cfg.ReportOnly ||
+		(r.Cfg.Files != t3cutil.ApplyFilesFlagAll && r.Cfg.Files != t3cutil.ApplyFilesFlagReval) {
 		log.Infof("You elected not to replace %s with the version from Traffic Ops.\n", cfg.Name)
 		cfg.ChangeApplied = false
 		return nil
@@ -530,7 +529,7 @@ func (r *TrafficOpsReq) sleepTimer(serverStatus *tc.ServerUpdateStatus) {
 		revalClockSec = r.Cfg.RevalWaitTime / time.Second
 	}
 
-	if serverStatus.UseRevalPending && r.Cfg.RunMode != t3cutil.ModeBadAss {
+	if serverStatus.UseRevalPending {
 		log.Infoln("Performing a revalidation check before sleeping...")
 		_, err := r.RevalidateWhileSleeping()
 		if err != nil {
@@ -539,7 +538,8 @@ func (r *TrafficOpsReq) sleepTimer(serverStatus *tc.ServerUpdateStatus) {
 			log.Infoln("Revalidation check complete.")
 		}
 	}
-	if randDispSec < revalClockSec || serverStatus.UseRevalPending == false || r.Cfg.RunMode == t3cutil.ModeBadAss {
+
+	if randDispSec < revalClockSec || serverStatus.UseRevalPending == false {
 		log.Infof("Sleeping for %d seconds: ", randDispSec)
 	} else {
 		log.Infof("%d seconds until next revalidation check.\n", revalClockSec)
@@ -551,7 +551,7 @@ func (r *TrafficOpsReq) sleepTimer(serverStatus *tc.ServerUpdateStatus) {
 		fmt.Printf(".")
 		time.Sleep(time.Second)
 		revalClockSec--
-		if revalClockSec < 1 && r.Cfg.RunMode != t3cutil.ModeBadAss && serverStatus.UseRevalPending {
+		if revalClockSec < 1 && serverStatus.UseRevalPending {
 			fmt.Printf("\n")
 			log.Infoln("Interrupting dispersion sleep period for revalidation check.")
 			_, err := r.RevalidateWhileSleeping()
@@ -580,7 +580,7 @@ func (r *TrafficOpsReq) sleepTimer(serverStatus *tc.ServerUpdateStatus) {
 // CheckSystemServices is used to verify that packages installed
 // are enabled for startup.
 func (r *TrafficOpsReq) CheckSystemServices() error {
-	if r.Cfg.RunMode != t3cutil.ModeBadAss {
+	if r.Cfg.ServiceAction != t3cutil.ApplyServiceActionFlagRestart {
 		return nil
 	}
 	result, err := getChkconfig(r.Cfg)
@@ -724,45 +724,50 @@ func (r *TrafficOpsReq) GetHeaderComment() string {
 
 // CheckRevalidateState retrieves and returns the revalidate status from Traffic Ops.
 func (r *TrafficOpsReq) CheckRevalidateState(sleepOverride bool) (UpdateStatus, error) {
-	updateStatus := UpdateTropsNotNeeded
 	log.Infoln("Checking revalidate state.")
+	if !sleepOverride &&
+		(r.Cfg.ReportOnly || r.Cfg.Files != t3cutil.ApplyFilesFlagReval) {
+		updateStatus := UpdateTropsNotNeeded
+		log.Infof("CheckRevalidateState returning %v\n", updateStatus)
+		return updateStatus, nil
+	}
 
-	if r.Cfg.RunMode == t3cutil.ModeRevalidate || sleepOverride {
-		serverStatus, err := getUpdateStatus(r.Cfg)
-		log.Infof("my status: %s\n", serverStatus.Status)
-		if err != nil {
-			log.Errorln("getting update status: " + err.Error())
-			return updateStatus, errors.New("getting update status: " + err.Error())
-		}
-		if serverStatus.UseRevalPending == false {
-			log.Errorln("Update URL: Instant invalidate is not enabled.  Separated revalidation requires upgrading to Traffic Ops version 2.2 and enabling this feature.")
-			return UpdateTropsNotNeeded, nil
-		}
-		if serverStatus.RevalPending == true {
-			log.Errorln("Traffic Ops is signaling that a revalidation is waiting to be applied.")
-			updateStatus = UpdateTropsNeeded
-			if serverStatus.ParentRevalPending == true {
-				if r.Cfg.WaitForParents == config.WaitForParentsReval || r.Cfg.WaitForParents == config.WaitForParentsTrue {
-					log.Infoln("Traffic Ops is signaling that my parents need to revalidate, not revalidating.")
-					updateStatus = UpdateTropsNotNeeded
-				} else {
-					log.Infoln("Traffic Ops is signaling that my parents need to revalidate, but wait-for-parents is false, revalidating anyway.")
-				}
+	updateStatus := UpdateTropsNotNeeded
+
+	serverStatus, err := getUpdateStatus(r.Cfg)
+	log.Infof("my status: %s\n", serverStatus.Status)
+	if err != nil {
+		log.Errorln("getting update status: " + err.Error())
+		return UpdateTropsNotNeeded, errors.New("getting update status: " + err.Error())
+	}
+	if serverStatus.UseRevalPending == false {
+		log.Errorln("Update URL: Instant invalidate is not enabled.  Separated revalidation requires upgrading to Traffic Ops version 2.2 and enabling this feature.")
+		return UpdateTropsNotNeeded, nil
+	}
+	if serverStatus.RevalPending == true {
+		log.Errorln("Traffic Ops is signaling that a revalidation is waiting to be applied.")
+		updateStatus = UpdateTropsNeeded
+		if serverStatus.ParentRevalPending == true {
+			if r.Cfg.WaitForParents {
+				log.Infoln("Traffic Ops is signaling that my parents need to revalidate, not revalidating.")
+				updateStatus = UpdateTropsNotNeeded
+			} else {
+				log.Infoln("Traffic Ops is signaling that my parents need to revalidate, but wait-for-parents is false, revalidating anyway.")
 			}
-		} else if serverStatus.RevalPending == false && r.Cfg.RunMode == t3cutil.ModeRevalidate {
-			log.Errorln("In revalidate mode, but no update needs to be applied. I'm outta here.")
-			return UpdateTropsNotNeeded, nil
-		} else {
-			log.Errorln("Traffic Ops is signaling that no revalidations are waiting to be applied.")
-			return UpdateTropsNotNeeded, nil
 		}
+	} else if serverStatus.RevalPending == false && !r.Cfg.ReportOnly && r.Cfg.Files == t3cutil.ApplyFilesFlagReval {
+		log.Errorln("In revalidate mode, but no update needs to be applied. I'm outta here.")
+		return UpdateTropsNotNeeded, nil
+	} else {
+		log.Errorln("Traffic Ops is signaling that no revalidations are waiting to be applied.")
+		return UpdateTropsNotNeeded, nil
+	}
 
-		err = r.checkStatusFiles(serverStatus.Status)
-		if err != nil {
-			log.Errorln(errors.New("checking status files: " + err.Error()))
-		} else {
-			log.Infoln("CheckRevalidateState checkStatusFiles returned nil error")
-		}
+	err = r.checkStatusFiles(serverStatus.Status)
+	if err != nil {
+		log.Errorln(errors.New("checking status files: " + err.Error()))
+	} else {
+		log.Infoln("CheckRevalidateState checkStatusFiles returned nil error")
 	}
 
 	log.Infof("CheckRevalidateState returning %v\n", updateStatus)
@@ -777,7 +782,8 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 		randDispSec = util.RandomDuration(r.Cfg.Dispersion)
 	}
 	log.Debugln("Checking syncds state.")
-	if r.Cfg.RunMode == t3cutil.ModeSyncDS || r.Cfg.RunMode == t3cutil.ModeBadAss || r.Cfg.RunMode == t3cutil.ModeReport {
+	//	if r.Cfg.RunMode == t3cutil.ModeSyncDS || r.Cfg.RunMode == t3cutil.ModeBadAss || r.Cfg.RunMode == t3cutil.ModeReport {
+	if r.Cfg.Files != t3cutil.ApplyFilesFlagReval {
 		serverStatus, err := getUpdateStatus(r.Cfg)
 		if err != nil {
 			log.Errorln("getting '" + r.Cfg.CacheHostName + "' update status: " + err.Error())
@@ -792,12 +798,11 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 			updateStatus = UpdateTropsNeeded
 			log.Errorln("Traffic Ops is signaling that an update is waiting to be applied")
 
-			if serverStatus.ParentPending &&
-				(r.Cfg.WaitForParents == config.WaitForParentsTrue ||
-					(r.Cfg.WaitForParents == config.WaitForParentsReval && !serverStatus.UseRevalPending)) {
+			if serverStatus.ParentPending && r.Cfg.WaitForParents {
 				log.Errorln("Traffic Ops is signaling that my parents need an update.")
-				if r.Cfg.RunMode == t3cutil.ModeSyncDS {
-					log.Infof("In syncds mode, sleeping for %ds to see if the update my parents need is cleared.", randDispSec/time.Second)
+				// TODO should reval really not sleep?
+				if !r.Cfg.ReportOnly && r.Cfg.Files != t3cutil.ApplyFilesFlagReval {
+					log.Infof("sleeping for %ds to see if the update my parents need is cleared.", randDispSec/time.Second)
 					r.sleepTimer(serverStatus)
 					serverStatus, err = getUpdateStatus(r.Cfg)
 					if err != nil {
@@ -813,8 +818,8 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 			} else {
 				log.Debugf("Processing with update: Traffic Ops server status %+v config wait-for-parents %+v", serverStatus, r.Cfg.WaitForParents)
 			}
-		} else if r.Cfg.RunMode == t3cutil.ModeSyncDS {
-			log.Errorln("In syncds mode, but no syncds update needs to be applied.  Running revalidation before exiting.")
+		} else if !r.Cfg.IgnoreUpdateFlag {
+			log.Errorln("no queued update needs to be applied.  Running revalidation before exiting.")
 			r.RevalidateWhileSleeping()
 			return UpdateTropsNotNeeded, nil
 		} else {
@@ -845,8 +850,8 @@ func (r *TrafficOpsReq) ProcessConfigFiles() (UpdateStatus, error) {
 		// add service metadata
 		if strings.Contains(cfg.Path, "/opt/trafficserver/") || strings.Contains(cfg.Dir, "udev") {
 			cfg.Service = "trafficserver"
-			if r.Cfg.RunMode == t3cutil.ModeSyncDS && !r.IsPackageInstalled("trafficserver") {
-				log.Errorln("In syncds mode, but trafficserver isn't installed. Continuing.")
+			if !r.Cfg.InstallPackages && !r.IsPackageInstalled("trafficserver") {
+				log.Errorln("Not installing packages, but trafficserver isn't installed. Continuing.")
 			}
 		} else if strings.Contains(cfg.Path, "/opt/ort") && strings.Contains(cfg.Name, "12M_facts") {
 			cfg.Service = "puppet"
@@ -858,7 +863,7 @@ func (r *TrafficOpsReq) ProcessConfigFiles() (UpdateStatus, error) {
 			cfg.Service = "unknown"
 		}
 
-		log.Debugf("In %s mode, I'm about to process config file: %s, service: %s\n", r.Cfg.RunMode, cfg.Path, cfg.Service)
+		log.Debugf("About to process config file: %s, service: %s\n", cfg.Path, cfg.Service)
 
 		err := r.checkConfigFile(cfg, filesAdding)
 		if err != nil {
@@ -884,7 +889,7 @@ func (r *TrafficOpsReq) ProcessConfigFiles() (UpdateStatus, error) {
 				updateStatus = UpdateTropsFailed
 				log.Errorln("remap.config changed however, prereqs failed for plugin.config so I am skipping updates for remap.config")
 				continue
-			} else if cfg.Name == "ip_allow.config" && !r.Cfg.SyncDSUpdatesIPAllow && r.Cfg.RunMode == t3cutil.ModeSyncDS {
+			} else if cfg.Name == "ip_allow.config" && !r.Cfg.UpdateIPAllow {
 				log.Warnln("ip_allow.config changed, not updating! Run with --mode=badass or --syncds-updates-ipallow=true to update!")
 				continue
 			} else {
@@ -940,7 +945,7 @@ func (r *TrafficOpsReq) ProcessPackages() error {
 		// check if the full package version is installed
 		fullPackage := pkgs[ii].Name + "-" + pkgs[ii].Version
 
-		if r.Cfg.RunMode == t3cutil.ModeBadAss {
+		if r.Cfg.InstallPackages {
 			if instpkg == fullPackage {
 				log.Infof("%s Currently installed and not marked for removal\n", reqpkg)
 				r.pkgs[fullPackage] = true
@@ -969,7 +974,7 @@ func (r *TrafficOpsReq) ProcessPackages() error {
 				log.Errorf("%s is Not installed and is marked for installation.\n", fullPackage)
 				install = append(install, fullPackage)
 			}
-		} else if r.Cfg.RunMode == t3cutil.ModeSyncDS {
+		} else {
 			// Only check if packages exist and complain if they are wrong.
 			if instpkg == fullPackage {
 				log.Infof("%s Currently installed.\n", reqpkg)
@@ -986,21 +991,21 @@ func (r *TrafficOpsReq) ProcessPackages() error {
 	}
 
 	log.Debugf("number of packages requiring installation: %d\n", len(install))
-	if r.Cfg.RunMode == t3cutil.ModeReport {
+	if r.Cfg.ReportOnly {
 		log.Errorf("number of packages requiring installation: %d\n", len(install))
 	}
 	log.Debugf("number of packages requiring removal: %d\n", len(uninstall))
-	if r.Cfg.RunMode == t3cutil.ModeReport {
+	if r.Cfg.ReportOnly {
 		log.Errorf("number of packages requiring removal: %d\n", len(uninstall))
 	}
 
-	if r.Cfg.RunMode == t3cutil.ModeBadAss {
+	if r.Cfg.InstallPackages {
 		log.Debugf("number of packages requiring installation: %d\n", len(install))
-		if r.Cfg.RunMode == t3cutil.ModeReport {
+		if r.Cfg.ReportOnly {
 			log.Errorf("number of packages requiring installation: %d\n", len(install))
 		}
 		log.Debugf("number of packages requiring removal: %d\n", len(uninstall))
-		if r.Cfg.RunMode == t3cutil.ModeReport {
+		if r.Cfg.ReportOnly {
 			log.Errorf("number of packages requiring removal: %d\n", len(uninstall))
 		}
 
@@ -1014,7 +1019,7 @@ func (r *TrafficOpsReq) ProcessPackages() error {
 			log.Infoln("All packages available.. proceding..")
 
 			// uninstall packages marked for removal
-			if len(install) > 0 && r.Cfg.RunMode == t3cutil.ModeBadAss {
+			if len(install) > 0 && r.Cfg.InstallPackages {
 				for jj := range uninstall {
 					log.Infof("Uninstalling %s\n", install[jj])
 					r, err := util.PackageAction("remove", uninstall[jj])
@@ -1040,7 +1045,7 @@ func (r *TrafficOpsReq) ProcessPackages() error {
 				}
 			}
 		}
-		if r.Cfg.RunMode == t3cutil.ModeReport && len(install) > 0 {
+		if r.Cfg.ReportOnly && len(install) > 0 {
 			for ii := range install {
 				log.Errorf("\nIn Report mode and %s needs installation.\n", install[ii])
 				return errors.New("In Report mode and packages need installation")
@@ -1056,7 +1061,11 @@ func (r *TrafficOpsReq) RevalidateWhileSleeping() (UpdateStatus, error) {
 		return updateStatus, err
 	}
 	if updateStatus != 0 {
-		r.Cfg.RunMode = t3cutil.ModeRevalidate
+		r.Cfg.Files = t3cutil.ApplyFilesFlagReval
+		// TODO verify? This is for revalidating after a syncds, so we probably do want to wait for parents here, and users probably don't for the main syncds run. But, this feels surprising.
+		// The better solution is to gut the RevalidateWhileSleeping stuff, once TO can handle more load
+		r.Cfg.WaitForParents = true
+
 		err = r.GetConfigFileList()
 		if err != nil {
 			return updateStatus, err
@@ -1087,9 +1096,14 @@ func (r *TrafficOpsReq) RevalidateWhileSleeping() (UpdateStatus, error) {
 // according to the changed config files and run mode.
 // Returns nil on success or any error.
 func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
-	serviceNeeds, err := checkReload(r.Cfg.RunMode, r.getPluginPackagesInstalled(), r.changedFiles)
-	if err != nil {
-		return errors.New("determining if service needs restarted - not reloading or restarting! : " + err.Error())
+	serviceNeeds := t3cutil.ServiceNeedsNothing
+	if r.Cfg.ServiceAction == t3cutil.ApplyServiceActionFlagRestart {
+		serviceNeeds = t3cutil.ServiceNeedsRestart
+	} else {
+		err := error(nil)
+		if serviceNeeds, err = checkReload(r.getPluginPackagesInstalled(), r.changedFiles); err != nil {
+			return errors.New("determining if service needs restarted - not reloading or restarting! : " + err.Error())
+		}
 	}
 
 	log.Infof("t3c-check-reload returned '%+v'\n", serviceNeeds)
@@ -1114,8 +1128,14 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
 		return errors.New("getting trafficserver service status: " + err.Error())
 	}
 
-	switch r.Cfg.RunMode {
-	case t3cutil.ModeBadAss:
+	if r.Cfg.ReportOnly {
+		if serviceNeeds == t3cutil.ServiceNeedsRestart {
+			log.Errorln("ATS configuration has changed.  The new config will be picked up the next time ATS is started.")
+		} else if serviceNeeds == t3cutil.ServiceNeedsReload {
+			log.Errorln("ATS configuration has changed. 'traffic_ctl config reload' needs to be run")
+		}
+		return nil
+	} else if r.Cfg.ServiceAction == t3cutil.ApplyServiceActionFlagRestart {
 		startStr := "restart"
 		if svcStatus != util.SvcRunning {
 			startStr = "start"
@@ -1128,16 +1148,7 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
 			*syncdsUpdate = UpdateTropsSuccessful
 		}
 		return nil // we restarted, so no need to reload
-	case t3cutil.ModeReport:
-		if serviceNeeds == t3cutil.ServiceNeedsRestart {
-			log.Errorln("ATS configuration has changed.  The new config will be picked up the next time ATS is started.")
-		} else if serviceNeeds == t3cutil.ServiceNeedsReload {
-			log.Errorln("ATS configuration has changed. 'traffic_ctl config reload' needs to be run")
-		}
-		return nil
-	case t3cutil.ModeSyncDS:
-		fallthrough
-	case t3cutil.ModeRevalidate:
+	} else if r.Cfg.ServiceAction == t3cutil.ApplyServiceActionFlagReload {
 		if serviceNeeds == t3cutil.ServiceNeedsRestart {
 			if *syncdsUpdate == UpdateTropsNeeded {
 				*syncdsUpdate = UpdateTropsSuccessful
@@ -1161,7 +1172,7 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
 		}
 		return nil
 	}
-	return errors.New("Unknown run mode '" + r.Cfg.RunMode.String() + "'! Not reloading or restarting!") // should never happen
+	return nil
 }
 
 func (r *TrafficOpsReq) getPluginPackagesInstalled() []string {
@@ -1199,27 +1210,27 @@ func (r *TrafficOpsReq) UpdateTrafficOps(syncdsUpdate *UpdateStatus) (bool, erro
 	if !updateResult {
 		return true, nil
 	}
-	if r.Cfg.RunMode == t3cutil.ModeReport {
+	if r.Cfg.ReportOnly {
 		log.Errorln("In Report mode and Traffic Ops needs updated you should probably do that manually.")
 		return true, nil
 	}
 
-	switch r.Cfg.RunMode {
-	case t3cutil.ModeBadAss:
-		fallthrough
-	case t3cutil.ModeSyncDS:
-		if serverStatus.RevalPending {
-			err = sendUpdate(r.Cfg, false, true)
-		} else {
-			err = sendUpdate(r.Cfg, false, false)
-		}
-	case t3cutil.ModeRevalidate:
-		if serverStatus.UpdatePending {
-			err = sendUpdate(r.Cfg, true, false)
-		} else {
-			err = sendUpdate(r.Cfg, false, false)
+	if !r.Cfg.ReportOnly && !r.Cfg.NoUnsetUpdateFlag {
+		if r.Cfg.Files == t3cutil.ApplyFilesFlagAll {
+			if serverStatus.RevalPending {
+				err = sendUpdate(r.Cfg, false, true)
+			} else {
+				err = sendUpdate(r.Cfg, false, false)
+			}
+		} else if r.Cfg.Files == t3cutil.ApplyFilesFlagReval {
+			if serverStatus.UpdatePending {
+				err = sendUpdate(r.Cfg, true, false)
+			} else {
+				err = sendUpdate(r.Cfg, false, false)
+			}
 		}
 	}
+
 	if err != nil {
 		return false, errors.New("Traffic Ops Update failed: " + err.Error())
 	}

--- a/cache-config/t3c-apply/torequest/torequest_test.go
+++ b/cache-config/t3c-apply/torequest/torequest_test.go
@@ -38,13 +38,13 @@ var testCfg config.Cfg = config.Cfg{
 	Retries:             3,
 	RevalWaitTime:       2,
 	ReverseProxyDisable: false,
-	RunMode:             t3cutil.ModeRevalidate,
+	Files:               t3cutil.ApplyFilesFlagReval,
 	SkipOSCheck:         false,
 	TOTimeoutMS:         1000,
 	TOUser:              "mickey",
 	TOPass:              "mouse",
 	TOURL:               "http://mouse.com",
-	WaitForParents:      "false",
+	WaitForParents:      false,
 	YumOptions:          "none",
 }
 

--- a/cache-config/t3c-apply/util/gitutil.go
+++ b/cache-config/t3c-apply/util/gitutil.go
@@ -25,15 +25,16 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/cache-config/t3c-apply/config"
 )
 
-func EnsureConfigDirIsGitRepo(atsConfigDir string) error {
+func EnsureConfigDirIsGitRepo(cfg config.Cfg) error {
 	cmd := exec.Command("git", "status")
-	cmd.Dir = atsConfigDir
+	cmd.Dir = cfg.TsConfigDir
 
 	errPipe, err := cmd.StderrPipe()
 	if err != nil {
@@ -66,29 +67,29 @@ func EnsureConfigDirIsGitRepo(atsConfigDir string) error {
 		return nil // it's already a git repo
 	}
 
-	if err := makeConfigDirGitRepo(atsConfigDir); err != nil {
-		return errors.New("making config dir '" + atsConfigDir + "' a git repo: " + err.Error())
+	if err := makeConfigDirGitRepo(cfg); err != nil {
+		return errors.New("making config dir '" + cfg.TsConfigDir + "' a git repo: " + err.Error())
 	}
 
 	return nil
 }
 
-func makeConfigDirGitRepo(atsConfigDir string) error {
+func makeConfigDirGitRepo(cfg config.Cfg) error {
 	cmd := exec.Command("git", "init")
-	cmd.Dir = atsConfigDir
+	cmd.Dir = cfg.TsConfigDir
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git init in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		return fmt.Errorf("git init in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 	}
 
-	if err := makeConfigDirGitUser(atsConfigDir); err != nil {
-		return fmt.Errorf("git creating user in config dir '%v': %v", atsConfigDir, err)
+	if err := makeConfigDirGitUser(cfg); err != nil {
+		return fmt.Errorf("git creating user in config dir '%v': %v", cfg.TsConfigDir, err)
 	}
 
-	if err := makeInitialGitCommit(atsConfigDir); err != nil {
+	if err := makeInitialGitCommit(cfg); err != nil {
 		return errors.New("creating initial git commit: " + err.Error())
 	}
 
-	if err := MakeGitCommitAll(atsConfigDir, GitChangeIsSelf, t3cutil.ModeBadAss, true); err != nil {
+	if err := MakeGitCommitAll(cfg, GitChangeIsSelf, true); err != nil {
 		return errors.New("creating first files git commit: " + err.Error())
 	}
 
@@ -98,19 +99,19 @@ func makeConfigDirGitRepo(atsConfigDir string) error {
 const gitEmail = "traffic-control-cache-config@apache-traffic-control.invalid"
 const gitUser = "t3c"
 
-func makeConfigDirGitUser(atsConfigDir string) error {
+func makeConfigDirGitUser(cfg config.Cfg) error {
 	{
 		cmd := exec.Command("git", "config", "user.email", gitEmail)
-		cmd.Dir = atsConfigDir
+		cmd.Dir = cfg.TsConfigDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 		}
 	}
 	{
 		cmd := exec.Command("git", "config", "user.name", gitUser)
-		cmd.Dir = atsConfigDir
+		cmd.Dir = cfg.TsConfigDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+			return fmt.Errorf("git config user.email in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 		}
 	}
 	return nil
@@ -118,13 +119,13 @@ func makeConfigDirGitUser(atsConfigDir string) error {
 
 // makeInitialGitCommit makes the initial commit for a new git repo.
 // An initial empty commit is desirable, because the first commit is difficult to manipulate.
-func makeInitialGitCommit(atsConfigDir string) error {
+func makeInitialGitCommit(cfg config.Cfg) error {
 	// TODO git config author?
 
 	cmd := exec.Command("git", "commit", "--allow-empty", "-m", "Initial commit")
-	cmd.Dir = atsConfigDir
+	cmd.Dir = cfg.TsConfigDir
 	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git initial commit error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+		return fmt.Errorf("git initial commit error: in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 	}
 	return nil
 }
@@ -132,15 +133,15 @@ func makeInitialGitCommit(atsConfigDir string) error {
 const GitChangeIsSelf = true
 const GitChangeNotSelf = false
 
-// makeGitCommitAll makes a git commit of all changes in atsConfigDir, including untracked files.
-func MakeGitCommitAll(atsConfigDir string, self bool, mode t3cutil.Mode, success bool) error {
+// makeGitCommitAll makes a git commit of all changes in cfg.TsConfigDir, including untracked files.
+func MakeGitCommitAll(cfg config.Cfg, self bool, success bool) error {
 	{
 		// if there are no changes, don't do anything
 		cmd := exec.Command("git", "status", "--porcelain")
-		cmd.Dir = atsConfigDir
+		cmd.Dir = cfg.TsConfigDir
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("git status error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+			return fmt.Errorf("git status error: in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 		}
 		if len(output) == 0 {
 			// no error and no output means there were zero changes, so just return
@@ -150,34 +151,44 @@ func MakeGitCommitAll(atsConfigDir string, self bool, mode t3cutil.Mode, success
 
 	{
 		cmd := exec.Command("git", "add", "-A")
-		cmd.Dir = atsConfigDir
+		cmd.Dir = cfg.TsConfigDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git add error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+			return fmt.Errorf("git add error: in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 		}
 	}
 
 	now := time.Now() // TODO get a single consistent time when ORT starts?
-	msg := makeGitCommitMsg(now, self, mode, success)
+	msg := makeGitCommitMsg(cfg, now, self, success)
 
 	{
 		cmd := exec.Command("git", "commit", "--message", msg)
-		cmd.Dir = atsConfigDir
+		cmd.Dir = cfg.TsConfigDir
 		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("git commit error: in config dir '%v' returned err %v msg '%v'", atsConfigDir, err, string(output))
+			return fmt.Errorf("git commit error: in config dir '%v' returned err %v msg '%v'", cfg.TsConfigDir, err, string(output))
 		}
 	}
 
 	return nil
 }
 
-func makeGitCommitMsg(now time.Time, self bool, mode t3cutil.Mode, success bool) string {
+func makeGitCommitMsg(cfg config.Cfg, now time.Time, self bool, success bool) string {
 	const appStr = "t3c"
 	selfStr := "other"
 	if self {
 		selfStr = "self"
 	}
 	timeStr := now.UTC().Format(time.RFC3339)
-	modeStr := strings.ToLower(mode.String())
+	// TODO use full args string literal instead?
+	modeStr := "report-only=" + strconv.FormatBool(cfg.ReportOnly) +
+		" files=" + cfg.Files.String() +
+		" install-packages=" + strconv.FormatBool(cfg.InstallPackages) +
+		" service-action=" + cfg.ServiceAction.String() +
+		" ignore-update-flag=" + strconv.FormatBool(cfg.IgnoreUpdateFlag) +
+		" update-ipallow=" + strconv.FormatBool(cfg.UpdateIPAllow) +
+		" wait-for-parents=" + strconv.FormatBool(cfg.WaitForParents) +
+		" no-unset-update-flag=" + strconv.FormatBool(cfg.NoUnsetUpdateFlag) +
+		" report-only=" + strconv.FormatBool(cfg.ReportOnly)
+
 	successStr := "fail"
 	if success {
 		successStr = "success"

--- a/cache-config/t3c-apply/util/util.go
+++ b/cache-config/t3c-apply/util/util.go
@@ -321,7 +321,6 @@ func RandomDuration(max time.Duration) time.Duration {
 }
 
 func CheckUser(cfg config.Cfg) bool {
-	result := true
 	userInfo, err := user.Current()
 
 	if err != nil {
@@ -329,24 +328,29 @@ func CheckUser(cfg config.Cfg) bool {
 		return false
 	}
 
-	switch cfg.RunMode {
-	case t3cutil.ModeBadAss:
-		fallthrough
-	case t3cutil.ModeSyncDS:
-		if userInfo.Username != "root" {
-			log.Errorf("Only the root user may run in BadAss, or SyncDS mode, current user: %s\n",
-				userInfo.Username)
-			result = false
+	log.Infof("user check: report-only=%v service-action=%v install-packages=%v files=%v user='%v'\n", cfg.ReportOnly, cfg.ServiceAction, cfg.InstallPackages, cfg.Files, userInfo.Username)
+
+	// TODO remove check? Let people run as any user, if it succeeds? Warn?
+	if userInfo.Username != "root" && !cfg.ReportOnly {
+		if cfg.ServiceAction == t3cutil.ApplyServiceActionFlagRestart {
+			log.Errorf("Only the root user may restart services, current user: %s\n", userInfo.Username)
+			return false
+		} else if cfg.InstallPackages {
+			log.Errorf("Only the root user may install packages, current user: %s\n", userInfo.Username)
+			return false
+		} else if cfg.Files == t3cutil.ApplyFilesFlagAll {
+			// TODO remove? Why would reval be ok, but not other files?
+			log.Errorf("Only the root user may set non-reval files, current user: %s\n", userInfo.Username)
+			return false
 		}
-	default:
-		log.Infof("current mode: %s, run user: %s\n", cfg.RunMode.String(), userInfo.Username)
 	}
-	return result
+
+	return true
 }
 
 func CleanTmpDir(cfg config.Cfg) bool {
-	if cfg.RunMode == t3cutil.ModeReport {
-		log.Infof("Mode is '%v', not cleaning tmp directory", cfg.RunMode)
+	if cfg.ReportOnly {
+		log.Infoln("Running report only, not cleaning tmp directory")
 		return true
 	}
 
@@ -403,34 +407,34 @@ func doMkDirWithOwner(name string, cfg config.Cfg, uid *int, gid *int, all bool)
 		return true
 	}
 	if err != nil {
-		if cfg.RunMode != t3cutil.ModeReport {
-			if err != nil { // the path does not exist.
-				if all {
-					err = os.MkdirAll(name, 0755)
-				} else {
-					err = os.Mkdir(name, 0755)
-				}
-				if err != nil {
-					log.Errorf("unable to create the directory '%s': %v", name, err)
-					return false
-				}
+		if cfg.ReportOnly {
+			log.Infof("Reporting only: the directory %s does not exist and was not created", name)
+			return true
+		}
 
-				if uid != nil && gid != nil {
-					err = os.Chown(name, *uid, *gid)
-					if err != nil {
-						log.Errorf("unable to chown directory uid/gid, '%s': %v", name, err)
-						return false
-					}
-				}
-			} else if fileInfo.Mode().IsDir() {
-				log.Debugf("the directory: %s, already exists\n", name)
+		if err != nil { // the path does not exist.
+			if all {
+				err = os.MkdirAll(name, 0755)
 			} else {
-				log.Errorf("there is a file named, '%s' that is not a directory: %v", name, err)
+				err = os.Mkdir(name, 0755)
+			}
+			if err != nil {
+				log.Errorf("unable to create the directory '%s': %v", name, err)
 				return false
 			}
+
+			if uid != nil && gid != nil {
+				err = os.Chown(name, *uid, *gid)
+				if err != nil {
+					log.Errorf("unable to chown directory uid/gid, '%s': %v", name, err)
+					return false
+				}
+			}
+		} else if fileInfo.Mode().IsDir() {
+			log.Debugf("the directory: %s, already exists\n", name)
 		} else {
-			log.Infof("the directory %s does not exist and was not created, runMode: %s", name, cfg.RunMode)
-			return true
+			log.Errorf("there is a file named, '%s' that is not a directory: %v", name, err)
+			return false
 		}
 	}
 	return false
@@ -452,7 +456,8 @@ func UpdateMaxmind(cfg config.Cfg) bool {
 	}
 
 	// Dont update for report mode
-	if cfg.RunMode == t3cutil.ModeReport {
+	if cfg.ReportOnly {
+		log.Infof("Reporting: maxmind location '%v', reporting only and not modifying file\n", cfg.MaxMindLocation)
 		return false
 	}
 

--- a/cache-config/t3c-check-reload/t3c-check-reload.go
+++ b/cache-config/t3c-check-reload/t3c-check-reload.go
@@ -30,7 +30,6 @@ import (
 )
 
 func main() {
-	modeStr := getopt.StringLong("run-mode", 'm', "report", "[badass | report | revalidate | syncds] run mode, default is 'report'")
 	// presumably calculated by by t3c-check-refs
 	// TODO remove? The blueprint says t3c/ORT will no longer install packages
 	pluginPackagesInstalledStr := getopt.StringLong("plugin-packages-installed", 'p', "", "comma-delimited list of ATS plugin packages which were installed by t3c")
@@ -56,13 +55,6 @@ func main() {
 	pluginPackagesInstalled = StrMap(pluginPackagesInstalled, strings.TrimSpace)
 	pluginPackagesInstalled = StrRemoveIf(pluginPackagesInstalled, StrIsEmpty)
 
-	mode := t3cutil.StrToMode(*modeStr)
-	if mode == t3cutil.ModeInvalid {
-		fmt.Fprintf(os.Stderr, "Unknown mode '"+*modeStr+"'")
-		getopt.PrintUsage(os.Stdout)
-		os.Exit(-1)
-	}
-
 	// ATS restart is needed if:
 	// [x] 1. mode was badass
 	// [x] 2. any ATS Plugin was installed
@@ -74,10 +66,6 @@ func main() {
 	// [ ] 2. any of the following were changed: url_sig*, uri_signing*, hdr_rw*, (plugin.config), (50-ats.rules),
 	//        ssl/*.cer, ssl/*.key, anything else in /trafficserver,
 	//
-
-	if mode == t3cutil.ModeBadAss {
-		ExitRestart()
-	}
 
 	if len(pluginPackagesInstalled) > 0 {
 		ExitRestart()

--- a/cache-config/t3cutil/enum.go
+++ b/cache-config/t3cutil/enum.go
@@ -58,6 +58,53 @@ func StrToServiceNeeds(str string) ServiceNeeds {
 	}
 }
 
+type ApplyServiceActionFlag string
+
+const (
+	ApplyServiceActionFlagNone    ApplyServiceActionFlag = "none"
+	ApplyServiceActionFlagReload  ApplyServiceActionFlag = "reload"
+	ApplyServiceActionFlagRestart ApplyServiceActionFlag = "restart"
+	ApplyServiceActionFlagInvalid ApplyServiceActionFlag = ""
+)
+
+func (af ApplyServiceActionFlag) String() string { return string(af) }
+
+func StrToApplyServiceActionFlag(str string) ApplyServiceActionFlag {
+	switch str {
+	case string(ApplyServiceActionFlagNone):
+		return ApplyServiceActionFlagNone
+	case string(ApplyServiceActionFlagReload):
+		return ApplyServiceActionFlagReload
+	case string(ApplyServiceActionFlagRestart):
+		return ApplyServiceActionFlagRestart
+	default:
+		return ApplyServiceActionFlagInvalid
+	}
+}
+
+type ApplyFilesFlag string
+
+const (
+	ApplyFilesFlagInvalid ApplyFilesFlag = ""
+	ApplyFilesFlagAll     ApplyFilesFlag = "all"
+	ApplyFilesFlagReval   ApplyFilesFlag = "reval"
+)
+
+func (ff ApplyFilesFlag) String() string {
+	return string(ff)
+}
+
+func StrToApplyFilesFlag(str string) ApplyFilesFlag {
+	switch ApplyFilesFlag(strings.TrimSpace(strings.ToLower(str))) {
+	case ApplyFilesFlagAll:
+		return ApplyFilesFlagAll
+	case ApplyFilesFlagReval:
+		return ApplyFilesFlagReval
+	default:
+		return ApplyFilesFlagInvalid
+	}
+}
+
 // Mode is the t3c run mode - syncds, badass, etc.
 type Mode string
 

--- a/cache-config/testing/ort-tests/t3c-check-reload_test.go
+++ b/cache-config/testing/ort-tests/t3c-check-reload_test.go
@@ -33,116 +33,90 @@ func TestCheckReload(t *testing.T) {
 		{
 			configs:  []string{"/etc/trafficserver/remap.config", "/etc/trafficserver/parent.config"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"/etc/trafficserver/anything.foo"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"/opt/trafficserver/etc/trafficserver/anything.foo"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"/foo/bar/hdr_rw_foo.config"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"/foo/bar/uri_signing_dsname.config"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"/foo/bar/url_sig_dsname.config", "foo"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"plugin.config", "foo"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "restart",
 		},
 		{
 			configs:  []string{"/etc/trafficserver/anything.foo"},
 			packages: []string{"anything"},
-			mode:     "syncds",
 			expected: "restart",
 		},
 		{
 			configs:  nil,
 			packages: []string{"anything"},
-			mode:     "syncds",
-			expected: "restart",
-		},
-		{
-			configs:  nil,
-			packages: []string{"anything"},
-			mode:     "syncds",
 			expected: "restart",
 		},
 		{
 			configs:  nil,
 			packages: []string{"anything", "anythingelse"},
-			mode:     "syncds",
 			expected: "restart",
 		},
 		{
 			configs:  []string{"/foo/bar/ssl_multicert.config"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "reload",
 		},
 		{
 			configs:  []string{"foo"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "",
 		},
 		{
 			configs:  []string{"/foo/bar/baz.config"},
 			packages: nil,
-			mode:     "syncds",
 			expected: "",
-		},
-		{
-			configs:  nil,
-			packages: nil,
-			mode:     "badass",
-			expected: "restart",
 		},
 	}
 
 	for _, ae := range argsExpected {
-		out, code := t3cCheckReload(ae.configs, ae.packages, ae.mode)
+		out, code := t3cCheckReload(ae.configs, ae.packages)
 		out = strings.TrimSpace(out)
 		if !ae.expectedErr && code != 0 {
-			t.Errorf("expected configs %+v packages %+v mode %v would not error, actual: code %v", ae.configs, ae.packages, ae.mode, code)
+			t.Errorf("expected configs %+v packages %+v would not error, actual: code %v output '%v'", ae.configs, ae.packages, code, out)
 			continue
 		} else if ae.expectedErr && code == 0 {
-			t.Errorf("expected configs %+v packages %+v mode %v would error, actual: no error", ae.configs, ae.packages, ae.mode)
+			t.Errorf("expected configs %+v packages %+v would error, actual: no error", ae.configs, ae.packages)
 			continue
 		}
 		if out != ae.expected {
-			t.Errorf("expected configs %+v packages %+v mode %v would need '%v', actual: '%v'", ae.configs, ae.packages, ae.mode, ae.expected, out)
+			t.Errorf("expected configs %+v packages %+v would need '%v', actual: '%v'", ae.configs, ae.packages, ae.expected, out)
 		}
 	}
 }
 
-func t3cCheckReload(changedConfigPaths []string, packagesInstalled []string, mode string) (string, int) {
+func t3cCheckReload(changedConfigPaths []string, packagesInstalled []string) (string, int) {
 	args := []string{
 		"check", "reload",
 		"--changed-config-paths=" + strings.Join(changedConfigPaths, ","),
-		"--run-mode=" + mode,
 		"--plugin-packages-installed=" + strings.Join(packagesInstalled, ","),
 	}
 	stdOut, _, exitCode := t3cutil.Do("t3c", args...)

--- a/lib/go-atscfg/storagedotconfig_test.go
+++ b/lib/go-atscfg/storagedotconfig_test.go
@@ -100,7 +100,7 @@ func TestMakeStorageDotConfigNoParams(t *testing.T) {
 
 	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
 
-	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	cfg, err := MakeStorageDotConfig(server, params, &StorageDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestMakeStorageDotConfigNoDriveLetters(t *testing.T) {
 
 	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
 
-	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	cfg, err := MakeStorageDotConfig(server, params, &StorageDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,7 +184,7 @@ func TestMakeStorageDotConfigSomeDriveLetters(t *testing.T) {
 
 	params := makeParamsFromMap(*server.Profile, StorageFileName, paramData)
 
-	cfg, err := MakeStorageDotConfig(server, params, hdr)
+	cfg, err := MakeStorageDotConfig(server, params, &StorageDotConfigOpts{HdrComment: hdr})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Adds flags for all the actual behaviors of t3c-apply (nee ORT) modes: `--report-only --files --install-packages --service-action --ignore-update-flag --update-ipallow --no-unset-update-flag --wait-for-parents --report-only`,
Changes the internal code for mode flags to set the real behavior flags,
Changes all config struct to not store the mode, and all behavioral logic to operate on the actual behavior flag.

The intent is to make the app more flexible and powerful, and to make it easier to work with and more obvious and less subtle and confusing exactly what each mode does.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Run t3c-apply with modes and new behavior flags, verify behavior is expected.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information