### PR TITLE
Remove test that isn't working properly

### DIFF
--- a/traffic_ops/testing/api/v3/profile_parameters_test.go
+++ b/traffic_ops/testing/api/v3/profile_parameters_test.go
@@ -18,7 +18,6 @@ package v3
 import (
 	"fmt"
 	"net/http"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -31,10 +30,9 @@ const queryParamFormat = "?profileId=%d&parameterId=%d"
 
 func TestProfileParameters(t *testing.T) {
 	WithObjs(t, []TCObj{CDNs, Types, Parameters, Profiles, ProfileParameters}, func() {
-		SortTestProfileParameters(t)
-		GetTestProfileParametersIMS(t)
-		GetTestProfileParameters(t)
-		InvalidCreateTestProfileParameters(t)
+		t.Run("Get /profileparameters with the If-Modified-Since HTTP header", GetTestProfileParametersIMS)
+		t.Run("Basic GET request", GetTestProfileParameters)
+		t.Run("Attempt to create an invalid Profile-Parameter relationship", InvalidCreateTestProfileParameters)
 	})
 }
 
@@ -101,25 +99,6 @@ func InvalidCreateTestProfileParameters(t *testing.T) {
 		t.Errorf("expected: error message to contain 'parameterId', actual: %v", err)
 	}
 
-}
-
-func SortTestProfileParameters(t *testing.T) {
-	var header http.Header
-	var sortedList []string
-	resp, _, err := TOSession.GetProfileParametersWithHdr(header)
-	if err != nil {
-		t.Fatalf("Expected no error, but got %v", err.Error())
-	}
-	for i, _ := range resp {
-		sortedList = append(sortedList, resp[i].Parameter)
-	}
-
-	res := sort.SliceIsSorted(sortedList, func(p, q int) bool {
-		return sortedList[p] < sortedList[q]
-	})
-	if res != true {
-		t.Errorf("list is not sorted by their names: %v", sortedList)
-	}
 }
 
 func GetTestProfileParameters(t *testing.T) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5793

This removes a `/profileparameters` Go client/API integration test that doesn't actually test anything. For details, refer to #5793.

## Which Traffic Control components are affected by this PR?
- Traffic Control Client (Go) (API integration tests only)

## What is the best way to verify this PR?
Make sure the Go client/API integration tests pass (v3 is the version of interest, but they should *all* pass once #5957 is merged)

## If this is a bug fix, what versions of Traffic Control are affected?
- master

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**