### PR TITLE
Fix Internal server error in Get Profiles by invalid Params

### DIFF
--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -213,7 +213,7 @@ func GetTestProfiles(t *testing.T) {
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
-			if err != nil{
+			if err != nil {
 				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
 			}
 			if len(respParameter) > 0 {

--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -212,7 +212,10 @@ func GetTestProfiles(t *testing.T) {
 		profileID := resp[0].ID
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
-			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
+			if err != nil{
+				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
+			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {

--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -214,14 +214,14 @@ func GetTestProfiles(t *testing.T) {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
 			if err != nil {
-				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
+				t.Errorf("Cannot GET Parameter by name: %v", err)
 			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
 					resp, _, err = TOSession.GetProfileByParameterId(parameterID)
 					if err != nil {
-						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+						t.Errorf("cannot GET Profile by param: %v", err)
 					}
 					if len(resp) < 1 {
 						t.Errorf("Expected atleast one response for Get Profile by Parameters, but found %d", len(resp))

--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -16,6 +16,7 @@
 package v2
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -210,12 +211,26 @@ func GetTestProfiles(t *testing.T) {
 			t.Errorf("cannot GET Profile by name: %v - %v", err, resp)
 		}
 		profileID := resp[0].ID
-
-		resp, _, err = TOSession.GetProfileByParameter(pr.Parameter)
-		if err != nil {
-			t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+		if len(pr.Parameters) > 0 {
+			parameter := pr.Parameters[0]
+			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			if len(respParameter) > 0 {
+				parameterID := respParameter[0].ID
+				if parameterID > 0 {
+					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
+					if err != nil {
+						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+					}
+					if len(resp) < 1 {
+						t.Errorf("Expected atleast one response for Get Profile by Parameters, but found %d", len(resp))
+					}
+				} else {
+					t.Errorf("Invalid parameter ID %d", parameterID)
+				}
+			} else {
+				t.Errorf("No response found for GET Parameters by name")
+			}
 		}
-
 		resp, _, err = TOSession.GetProfileByCDNID(pr.CDNID)
 		if err != nil {
 			t.Errorf("cannot GET Profile by cdn: %v - %v", err, resp)

--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -16,7 +16,6 @@
 package v2
 
 import (
-	"strconv"
 	"strings"
 	"testing"
 
@@ -217,7 +216,7 @@ func GetTestProfiles(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
+					resp, _, err = TOSession.GetProfileByParameterId(parameterID)
 					if err != nil {
 						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
 					}

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -86,7 +86,7 @@ func GetTestProfilesIMS(t *testing.T) {
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
-			if err != nil{
+			if err != nil {
 				t.Errorf("Cannot GET Parameter by name: %v - %v", err, respParameter)
 			}
 			if len(respParameter) > 0 {
@@ -291,7 +291,7 @@ func GetTestProfiles(t *testing.T) {
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
-			if err != nil{
+			if err != nil {
 				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
 			}
 			if len(respParameter) > 0 {

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -87,7 +87,7 @@ func GetTestProfilesIMS(t *testing.T) {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
 			if err != nil {
-				t.Errorf("Cannot GET Parameter by name: %v - %v", err, respParameter)
+				t.Errorf("Cannot GET Parameter by name: %v", err)
 			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
@@ -292,7 +292,7 @@ func GetTestProfiles(t *testing.T) {
 			parameter := pr.Parameters[0]
 			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
 			if err != nil {
-				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
+				t.Errorf("Cannot GET Parameter by name: %v", err)
 			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -17,6 +17,7 @@ package v3
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -89,7 +90,7 @@ func GetTestProfilesIMS(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err := TOSession.GetProfileByParameterWithHdr(parameterID, nil)
+					resp, _, err := TOSession.GetProfileByParameterWithHdr(strconv.Itoa(parameterID), nil)
 					if err != nil {
 						t.Fatalf("Expected no error, but got %v", err.Error())
 					}
@@ -291,7 +292,7 @@ func GetTestProfiles(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err = TOSession.GetProfileByParameter(parameterID)
+					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
 					if err != nil {
 						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
 					}

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -17,6 +17,7 @@ package v3
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -83,12 +84,29 @@ func GetTestProfilesIMS(t *testing.T) {
 		if reqInf.StatusCode != http.StatusNotModified {
 			t.Fatalf("Expected 304 status code, got %v", reqInf.StatusCode)
 		}
-		_, reqInf, err = TOSession.GetProfileByParameterWithHdr(pr.Parameter, header)
-		if err != nil {
-			t.Fatalf("Expected no error, but got %v", err.Error())
-		}
-		if reqInf.StatusCode != http.StatusNotModified {
-			t.Fatalf("Expected 304 status code, got %v", reqInf.StatusCode)
+		if len(pr.Parameters) > 0 {
+			parameter := pr.Parameters[0]
+			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			if len(respParameter) > 0 {
+				parameterID := respParameter[0].ID
+				if parameterID > 0 {
+					t.Errorf("Parameter ID %d", parameterID)
+					resp, _, err := TOSession.GetProfileByParameterWithHdr(strconv.Itoa(parameterID), header)
+					if err != nil {
+						t.Fatalf("Expected no error, but got %v", err.Error())
+					}
+					if reqInf.StatusCode != http.StatusNotModified {
+						t.Fatalf("Expected 304 status code, got %v", reqInf.StatusCode)
+					}
+					if len(resp) < 1 {
+						t.Errorf("Expected atleast one response for Get Profile by Parameters, but found %d", len(resp))
+					}
+				} else {
+					t.Errorf("Invalid parameter ID %d", parameterID)
+				}
+			} else {
+				t.Errorf("No response found for GET Parameters by name")
+			}
 		}
 	}
 }
@@ -269,10 +287,25 @@ func GetTestProfiles(t *testing.T) {
 			t.Errorf("cannot GET Profile by name: %v - %v", err, resp)
 		}
 		profileID := resp[0].ID
-
-		resp, _, err = TOSession.GetProfileByParameter(pr.Parameter)
-		if err != nil {
-			t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+		if len(pr.Parameters) > 0 {
+			parameter := pr.Parameters[0]
+			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			if len(respParameter) > 0 {
+				parameterID := respParameter[0].ID
+				if parameterID > 0 {
+					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
+					if err != nil {
+						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+					}
+					if len(resp) < 1 {
+						t.Errorf("Expected atleast one response for Get Profile by Parameters, but found %d", len(resp))
+					}
+				} else {
+					t.Errorf("Invalid parameter ID %d", parameterID)
+				}
+			} else {
+				t.Errorf("No response found for GET Parameters by name")
+			}
 		}
 
 		resp, _, err = TOSession.GetProfileByCDNID(pr.CDNID)

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -17,7 +17,6 @@ package v3
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -90,7 +89,7 @@ func GetTestProfilesIMS(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err := TOSession.GetProfileByParameterWithHdr(strconv.Itoa(parameterID), nil)
+					resp, _, err := TOSession.GetProfileByParameterIdWithHdr(parameterID, nil)
 					if err != nil {
 						t.Fatalf("Expected no error, but got %v", err.Error())
 					}
@@ -292,7 +291,7 @@ func GetTestProfiles(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
+					resp, _, err = TOSession.GetProfileByParameterId(parameterID)
 					if err != nil {
 						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
 					}

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -85,7 +85,10 @@ func GetTestProfilesIMS(t *testing.T) {
 		}
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
-			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
+			if err != nil{
+				t.Errorf("Cannot GET Parameter by name: %v - %v", err, respParameter)
+			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
@@ -287,7 +290,10 @@ func GetTestProfiles(t *testing.T) {
 		profileID := resp[0].ID
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
-			respParameter, _, _ := TOSession.GetParameterByName(*parameter.Name)
+			respParameter, _, err := TOSession.GetParameterByName(*parameter.Name)
+			if err != nil{
+				t.Errorf("Cannot GET Parameter by name: %v - %v", err, resp)
+			}
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -17,7 +17,6 @@ package v3
 
 import (
 	"net/http"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -90,8 +89,7 @@ func GetTestProfilesIMS(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					t.Errorf("Parameter ID %d", parameterID)
-					resp, _, err := TOSession.GetProfileByParameterWithHdr(strconv.Itoa(parameterID), header)
+					resp, _, err := TOSession.GetProfileByParameterWithHdr(parameterID, nil)
 					if err != nil {
 						t.Fatalf("Expected no error, but got %v", err.Error())
 					}
@@ -293,7 +291,7 @@ func GetTestProfiles(t *testing.T) {
 			if len(respParameter) > 0 {
 				parameterID := respParameter[0].ID
 				if parameterID > 0 {
-					resp, _, err = TOSession.GetProfileByParameter(strconv.Itoa(parameterID))
+					resp, _, err = TOSession.GetProfileByParameter(parameterID)
 					if err != nil {
 						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
 					}

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -520,7 +520,10 @@ func GetTestProfiles(t *testing.T) {
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			opts.QueryParameters.Set("name", *parameter.Name)
-			respParameter, _, _ := TOSession.GetParameters(opts)
+			respParameter, _, err := TOSession.GetParameters(opts)
+			if err != nil {
+				t.Errorf("cannot get parameter '%s' by name: %v - alerts: %+v", *parameter.Name, err, resp.Alerts)
+			}
 			opts.QueryParameters.Del("name")
 			if len(respParameter.Response) > 0 {
 				parameterID := respParameter.Response[0].ID

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -517,7 +517,6 @@ func GetTestProfiles(t *testing.T) {
 		}
 		profileID := resp.Response[0].ID
 
-		// TODO: figure out what the 'Parameter' field of a Profile is and how
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			opts.QueryParameters.Set("name", *parameter.Name)

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -517,12 +517,31 @@ func GetTestProfiles(t *testing.T) {
 		}
 		profileID := resp.Response[0].ID
 
-		// TODO: figure out what the 'Parameter' field of a Profile is and how
-		// passing it to this is supposed to work.
-		// resp, _, err = TOSession.GetProfileByParameter(pr.Parameter)
-		// if err != nil {
-		// 	t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
-		// }
+		if len(pr.Parameters) > 0 {
+			parameter := pr.Parameters[0]
+			opts.QueryParameters.Set("name", *parameter.Name)
+			respParameter, _, _ := TOSession.GetParameters(opts)
+			opts.QueryParameters.Del("name")
+			if len(respParameter.Response) > 0 {
+				parameterID := respParameter.Response[0].ID
+				if parameterID > 0 {
+					opts.QueryParameters.Set("params", strconv.Itoa(parameterID))
+					resp, _, err = TOSession.GetProfiles(opts)
+					opts.QueryParameters.Del("params")
+					if err != nil {
+						t.Errorf("cannot GET Profile by param: %v - %v", err, resp)
+					}
+					if len(resp.Response) < 1 {
+						t.Errorf("Expected atleast one response for Get Profile by Parameters, but found %d", len(resp.Response))
+					}
+				} else {
+					t.Errorf("Invalid parameter ID %d", parameterID)
+				}
+			} else {
+				t.Errorf("No response found for GET Parameters by name")
+			}
+
+		}
 
 		opts.QueryParameters.Set("cdn", strconv.Itoa(pr.CDNID))
 		resp, _, err = TOSession.GetProfiles(opts)

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -517,6 +517,7 @@ func GetTestProfiles(t *testing.T) {
 		}
 		profileID := resp.Response[0].ID
 
+		// TODO: figure out what the 'Parameter' field of a Profile is and how
 		if len(pr.Parameters) > 0 {
 			parameter := pr.Parameters[0]
 			opts.QueryParameters.Set("name", *parameter.Name)

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -171,7 +171,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, errors.New("bad request"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
+		return nil, errors.New("bad request found"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
 	}
 	defer rows.Close()
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -26,6 +26,7 @@ package profile
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -171,7 +171,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, errors.New("bad request found"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
+		return nil, err, errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
 	}
 	defer rows.Close()
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -26,7 +26,6 @@ package profile
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -135,23 +134,19 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 	// Query Parameters to Database Query column mappings
 	// see the fields mapped in the SQL query
 	queryParamsToQueryCols := map[string]dbhelpers.WhereColumnInfo{
-		CDNQueryParam:  dbhelpers.WhereColumnInfo{Column: "c.id"},
-		NameQueryParam: dbhelpers.WhereColumnInfo{Column: "prof.name"},
-		IDQueryParam:   dbhelpers.WhereColumnInfo{Column: "prof.id", Checker: api.IsInt},
+		CDNQueryParam:   dbhelpers.WhereColumnInfo{Column: "c.id", Checker: api.IsInt},
+		NameQueryParam:  dbhelpers.WhereColumnInfo{Column: "prof.name"},
+		IDQueryParam:    dbhelpers.WhereColumnInfo{Column: "prof.id", Checker: api.IsInt},
+		ParamQueryParam: dbhelpers.WhereColumnInfo{Column: "pp.parameter", Checker: api.IsInt},
 	}
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(prof.APIInfo().Params, queryParamsToQueryCols)
 
 	// Narrow down if the query parameter is 'param'
-
 	// TODO add generic where clause to api.GenericRead
 	if paramValue, ok := prof.APIInfo().Params[ParamQueryParam]; ok {
-		//Check for interger value
-		if _, err := strconv.Atoi(fmt.Sprintf("%v", paramValue)); err != nil {
-			return nil, fmt.Errorf("parsing error, provide only integer value"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
-		}
 		queryValues["parameter_id"] = paramValue
 		if len(paramValue) > 0 {
-			where += " LEFT JOIN profile_parameter pp ON prof.id  = pp.profile where pp.parameter=:parameter_id"
+			where = " LEFT JOIN profile_parameter pp ON prof.id = pp.profile " + where + " AND pp.parameter=:parameter_id"
 		}
 	}
 
@@ -172,14 +167,6 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	query := selectProfilesQuery() + where + orderBy + pagination
 	log.Debugln("Query is ", query)
-
-	//if the parameter is CDN
-	value, ok := queryValues["cdn"]
-	if ok {
-		if _, err := strconv.Atoi(fmt.Sprintf("%v", value)); err != nil {
-			return nil, fmt.Errorf("parsing error, provide only integer value"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
-		}
-	}
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -141,12 +141,12 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 	}
 	where, orderBy, pagination, queryValues, errs := dbhelpers.BuildWhereAndOrderByAndPagination(prof.APIInfo().Params, queryParamsToQueryCols)
 
+	query := selectProfilesQuery()
 	// Narrow down if the query parameter is 'param'
 	// TODO add generic where clause to api.GenericRead
 	if paramValue, ok := prof.APIInfo().Params[ParamQueryParam]; ok {
-		queryValues["parameter_id"] = paramValue
 		if len(paramValue) > 0 {
-			where = " LEFT JOIN profile_parameter pp ON prof.id = pp.profile " + where + " AND pp.parameter=:parameter_id"
+			query += " LEFT JOIN profile_parameter pp ON prof.id = pp.profile"
 		}
 	}
 
@@ -165,7 +165,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 		log.Debugln("Non IMS request")
 	}
 
-	query := selectProfilesQuery() + where + orderBy + pagination
+	query += where + orderBy + pagination
 	log.Debugln("Query is ", query)
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -171,7 +171,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, err, errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
+		return nil, err, errors.New("profile read querying: " + err.Error()), http.StatusInternalServerError, nil
 	}
 	defer rows.Close()
 

--- a/traffic_ops/traffic_ops_golang/profile/profiles.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles.go
@@ -171,7 +171,7 @@ func (prof *TOProfile) Read(h http.Header, useIMS bool) ([]interface{}, error, e
 
 	rows, err := prof.ReqInfo.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, nil, errors.New("profile read querying: " + err.Error()), http.StatusInternalServerError, nil
+		return nil, errors.New("bad request"), errors.New("profile read querying: " + err.Error()), http.StatusBadRequest, nil
 	}
 	defer rows.Close()
 

--- a/traffic_ops/v2-client/profile.go
+++ b/traffic_ops/v2-client/profile.go
@@ -164,11 +164,22 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
-	paramId, err := strconv.Atoi(url.QueryEscape(param))
+	URI := fmt.Sprintf("%s?param=%s", API_PROFILES, url.QueryEscape(param))
+	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
+	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {
-		return nil, ReqInf{}, fmt.Errorf("error in converting integer to string %w", err)
+		return nil, reqInf, err
 	}
-	URI := fmt.Sprintf("%s?param=%d", API_PROFILES, paramId)
+	defer resp.Body.Close()
+
+	var data tc.ProfilesResponse
+	err = json.NewDecoder(resp.Body).Decode(&data)
+
+	return data.Response, reqInf, err
+}
+
+func (to *Session) GetProfileByParameterId(param int) ([]tc.Profile, ReqInf, error) {
+	URI := fmt.Sprintf("%s?param=%d", API_PROFILES, param)
 	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {

--- a/traffic_ops/v2-client/profile.go
+++ b/traffic_ops/v2-client/profile.go
@@ -164,7 +164,10 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
-	paramId, _ := strconv.Atoi(url.QueryEscape(param))
+	paramId, err := strconv.Atoi(url.QueryEscape(param))
+	if err != nil {
+		return nil, ReqInf{}, fmt.Errorf("error in converting integer to string %w", err)
+	}
 	URI := fmt.Sprintf("%s?param=%d", API_PROFILES, paramId)
 	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}

--- a/traffic_ops/v2-client/profile.go
+++ b/traffic_ops/v2-client/profile.go
@@ -164,7 +164,8 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, ReqInf, error) {
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, error) {
-	URI := fmt.Sprintf("%s?param=%s", API_PROFILES, url.QueryEscape(param))
+	paramId, _ := strconv.Atoi(url.QueryEscape(param))
+	URI := fmt.Sprintf("%s?param=%d", API_PROFILES, paramId)
 	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)
 	reqInf := ReqInf{CacheHitStatus: CacheHitStatusMiss, RemoteAddr: remoteAddr}
 	if err != nil {

--- a/traffic_ops/v2-client/profile.go
+++ b/traffic_ops/v2-client/profile.go
@@ -178,6 +178,7 @@ func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, ReqInf, er
 	return data.Response, reqInf, err
 }
 
+// GetProfileByParameterId GETs a Profile by Parameter ID
 func (to *Session) GetProfileByParameterId(param int) ([]tc.Profile, ReqInf, error) {
 	URI := fmt.Sprintf("%s?param=%d", API_PROFILES, param)
 	resp, remoteAddr, err := to.request(http.MethodGet, URI, nil)

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -126,8 +126,8 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqI
 	return to.GetProfileByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetProfileByParameterWithHdr(param int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
-	URI := fmt.Sprintf("%s?param=%d", APIProfiles, param)
+func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?param=%s", APIProfiles, param)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -135,7 +135,7 @@ func (to *Session) GetProfileByParameterWithHdr(param int, header http.Header) (
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 // Deprecated: GetProfileByParameter will be removed in 6.0. Use GetProfileByParameterWithHdr.
-func (to *Session) GetProfileByParameter(param int) ([]tc.Profile, toclientlib.ReqInf, error) {
+func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByParameterWithHdr(param, nil)
 }
 

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
@@ -127,7 +128,11 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqI
 }
 
 func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
-	URI := fmt.Sprintf("%s?param=%s", APIProfiles, param)
+	paramId, err := strconv.Atoi(url.QueryEscape(param))
+	if err != nil {
+		return nil, toclientlib.ReqInf{}, fmt.Errorf("error in converting integer to string %w", err)
+	}
+	URI := fmt.Sprintf("%s?param=%d", APIProfiles, paramId)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -126,8 +126,8 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqI
 	return to.GetProfileByNameWithHdr(name, nil)
 }
 
-func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
-	URI := fmt.Sprintf("%s?param=%s", APIProfiles, url.QueryEscape(param))
+func (to *Session) GetProfileByParameterWithHdr(param int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?param=%d", APIProfiles, param)
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -135,7 +135,7 @@ func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header
 
 // GetProfileByParameter GETs a Profile by the Profile "param".
 // Deprecated: GetProfileByParameter will be removed in 6.0. Use GetProfileByParameterWithHdr.
-func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientlib.ReqInf, error) {
+func (to *Session) GetProfileByParameter(param int) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByParameterWithHdr(param, nil)
 }
 

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -139,6 +139,7 @@ func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientli
 	return to.GetProfileByParameterWithHdr(param, nil)
 }
 
+// GetProfileByParameterIdWithHdr GETs a Profile by the ParameterID and Header.
 func (to *Session) GetProfileByParameterIdWithHdr(param int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
 	URI := fmt.Sprintf("%s?param=%d", APIProfiles, param)
 	var data tc.ProfilesResponse

--- a/traffic_ops/v3-client/profile.go
+++ b/traffic_ops/v3-client/profile.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
@@ -128,11 +127,7 @@ func (to *Session) GetProfileByName(name string) ([]tc.Profile, toclientlib.ReqI
 }
 
 func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
-	paramId, err := strconv.Atoi(url.QueryEscape(param))
-	if err != nil {
-		return nil, toclientlib.ReqInf{}, fmt.Errorf("error in converting integer to string %w", err)
-	}
-	URI := fmt.Sprintf("%s?param=%d", APIProfiles, paramId)
+	URI := fmt.Sprintf("%s?param=%s", APIProfiles, url.QueryEscape(param))
 	var data tc.ProfilesResponse
 	reqInf, err := to.get(URI, header, &data)
 	return data.Response, reqInf, err
@@ -142,6 +137,19 @@ func (to *Session) GetProfileByParameterWithHdr(param string, header http.Header
 // Deprecated: GetProfileByParameter will be removed in 6.0. Use GetProfileByParameterWithHdr.
 func (to *Session) GetProfileByParameter(param string) ([]tc.Profile, toclientlib.ReqInf, error) {
 	return to.GetProfileByParameterWithHdr(param, nil)
+}
+
+func (to *Session) GetProfileByParameterIdWithHdr(param int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {
+	URI := fmt.Sprintf("%s?param=%d", APIProfiles, param)
+	var data tc.ProfilesResponse
+	reqInf, err := to.get(URI, header, &data)
+	return data.Response, reqInf, err
+}
+
+// GetProfileByParameterId GETs a Profile by the Profile "param".
+// Deprecated: GetProfileByParameterId will be removed in 6.0. Use GetProfileByParameterIdWithHdr.
+func (to *Session) GetProfileByParameterId(param int) ([]tc.Profile, toclientlib.ReqInf, error) {
+	return to.GetProfileByParameterIdWithHdr(param, nil)
 }
 
 func (to *Session) GetProfileByCDNIDWithHdr(cdnID int, header http.Header) ([]tc.Profile, toclientlib.ReqInf, error) {


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #5510  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This updates the Error message in GET profiles?param=test and profiles?cdn=test

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops
- CI tests

## What is the best way to verify this PR?
Execute all the Integration tests and make sure the tests are passed.

## If this is a bug fix, what versions of Traffic Control are affected?
* Master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)