### PR TITLE
Less verbose CI test output

### DIFF
--- a/.github/actions/go-test/entrypoint.sh
+++ b/.github/actions/go-test/entrypoint.sh
@@ -37,5 +37,5 @@ fi
 
 # Need to fetch golang.org/x/* dependencies
 go mod vendor -v
-go test -v $INPUT_DIR
+go test $INPUT_DIR
 exit $?

--- a/.github/actions/tm-integration-tests/entrypoint.sh
+++ b/.github/actions/tm-integration-tests/entrypoint.sh
@@ -194,4 +194,4 @@ cd ${test_dir}
 jq ".trafficMonitor.URL = \"http://$TM_URI:$TM_PORT\"" \
   traffic-monitor-test.conf > tmt.conf.tmp && mv tmt.conf.tmp traffic-monitor-test.conf
 
-go test -test.v -cfg traffic-monitor-test.conf
+go test -cfg traffic-monitor-test.conf

--- a/.github/actions/to-integration-tests/cdn.json
+++ b/.github/actions/to-integration-tests/cdn.json
@@ -13,8 +13,8 @@
 	"traffic_ops_golang": {
 		"insecure": true,
 		"port": "6443",
-		"log_location_error": "error.log",
-		"log_location_warning": "warning.log",
+		"log_location_error": "traffic.ops.log",
+		"log_location_warning": "traffic.ops.log",
 		"log_location_info": null,
 		"log_location_debug": null,
 		"log_location_event": null,

--- a/.github/actions/to-integration-tests/entrypoint.sh
+++ b/.github/actions/to-integration-tests/entrypoint.sh
@@ -188,4 +188,4 @@ tail -f error.log 2>&1 | color_and_prefix "${red_bg}" 'Traffic Ops' &
 cd "../testing/api/v$INPUT_VERSION"
 
 cp "${resources}/traffic-ops-test.json" traffic-ops-test.conf
-go test -test.v --cfg traffic-ops-test.conf
+go test --cfg traffic-ops-test.conf

--- a/.github/actions/to-integration-tests/entrypoint.sh
+++ b/.github/actions/to-integration-tests/entrypoint.sh
@@ -91,9 +91,9 @@ start_traffic_vault() {
 		--rm \
 		"$trafficvault" \
 		/usr/lib/riak/riak-cluster.sh;
-	docker logs -f "$trafficvault" 2>&1 |
-		color_and_prefix "$gray_bg" 'Traffic Vault';
+	docker logs -f "$trafficvault" 2>&1 >"${ciab_dir}/traffic.vault.logs";
 }
+truncate -s0 "${ciab_dir}/traffic.vault.logs";
 start_traffic_vault & disown
 
 sudo apt-get install -y --no-install-recommends gettext
@@ -176,14 +176,8 @@ cp "${resources}/database.json" database.conf
 export $(<"${ciab_dir}/variables.env" sed '/^#/d') # defines TV_ADMIN_USER/PASSWORD
 envsubst <"${resources}/riak.json" >riak.conf
 
-truncate --size=0 warning.log error.log # Removes output from previous API versions and makes sure files exist
+truncate --size=0 traffic.ops.log # Removes output from previous API versions and makes sure files exist
 ./traffic_ops_golang --cfg ./cdn.conf --dbcfg ./database.conf -riakcfg riak.conf &
-
-# TODO - Make these logs build artifacts
-# 2>&1 makes terminal output go faster, even though stderr will not contain anything
-tail -f warning.log 2>&1 | color_and_prefix "${yellow_bg}" 'Traffic Ops' &
-tail -f error.log 2>&1 | color_and_prefix "${red_bg}" 'Traffic Ops' &
-
 
 cd "../testing/api/v$INPUT_VERSION"
 

--- a/.github/workflows/traffic-ops.yml
+++ b/.github/workflows/traffic-ops.yml
@@ -98,26 +98,79 @@ jobs:
       id: todb
       uses: ./.github/actions/todb-init
     - name: Run API v1 tests
+      id: v1Tests
+      if: ${{ steps.todb.outcome == 'success' && always() }}
       uses: ./.github/actions/to-integration-tests
       with:
         version: 1
+    - name: Upload v1 Vault logs
+      if: ${{ steps.v1Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v1 Traffic Vault logs
+        path: ${{ github.workspace }}/infrastructure/cdn-in-a-box/traffic.vault.logs
+    - name: Upload v1 Ops logs
+      if: ${{ steps.v1Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v1 Traffic Ops logs
+        path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
     - name: Run API v2 tests
+      id: v2Tests
       if: ${{ steps.todb.outcome == 'success' && always() }}
       uses: ./.github/actions/to-integration-tests
       with:
         version: 2
         smtp_address: 172.17.0.1
+    - name: Upload v2 Vault logs
+      if: ${{ steps.v2Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v2 Traffic Vault logs
+        path: ${{ github.workspace }}/infrastructure/cdn-in-a-box/traffic.vault.logs
+    - name: Upload v2 Ops logs
+      if: ${{ steps.v2Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v2 Traffic Ops logs
+        path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
     - name: Run API v3 tests
+      id: v3Tests
       if: ${{ steps.todb.outcome == 'success' && always() }}
       uses: ./.github/actions/to-integration-tests
       with:
         version: 3
         smtp_address: 172.17.0.1
+    - name: Upload v3 Vault logs
+      if: ${{ steps.v3Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v3 Traffic Vault logs
+        path: ${{ github.workspace }}/infrastructure/cdn-in-a-box/traffic.vault.logs
+    - name: Upload v3 Ops logs
+      if: ${{ steps.v3Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v3 Traffic Ops logs
+        path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
     - name: Run API v4 tests
+      id: v4Tests
       if: ${{ steps.todb.outcome == 'success' && always() }}
       uses: ./.github/actions/to-integration-tests
       with:
         version: 4
         smtp_address: 172.17.0.1
+    - name: Upload v4 Vault logs
+      if: ${{ steps.v4Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v4 Traffic Vault logs
+        path: ${{ github.workspace }}/infrastructure/cdn-in-a-box/traffic.vault.logs
+    - name: Upload v4 Ops logs
+      if: ${{ steps.v4Tests.outcome != 'success' && always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: v4 Traffic Ops logs
+        path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
     - name: Save Alpine Docker image
       run: .github/actions/save-alpine-tar/entrypoint.sh save ${{ env.ALPINE_VERSION }}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR removes the `-v` flag from calls to `go test` in the Go unit test, TO Go client/API integration tests, and TM integration test GitHub Actions CI workflows. That verbose output makes finding the actual problems unnecessarily difficult.

Additionally, the TV and TO logs for the TO Go client/API integration tests workflow are now uploaded as artifacts on failure, rather than interleaved with test output, to make reading the output easier. TV build output is still output directly.

## Which Traffic Control components are affected by this PR?
- CI tests

## What is the best way to verify this PR?
Make sure the CI tests still pass, verify that passing TO Go client/API integration tests output non-verbose testing logs, and don't upload artifacts of the the TV and TO logs. Then, break something on your own branch with these changes and push it, and make sure that only the part that's broken is logged, and that TV and TO logs are uploaded as artifacts for failing runs.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**