### PR TITLE
Change warning on Server mask length to trigger at < 24 and reword message

### DIFF
--- a/traffic_portal/app/src/common/modules/form/server/FormServerController.js
+++ b/traffic_portal/app/src/common/modules/form/server/FormServerController.js
@@ -141,12 +141,12 @@ var FormServerController = function(server, $scope, $location, $state, $uibModal
     };
 
     $scope.isLargeCIDR = function(address) {
-        if($scope.IPWithCIDRPattern.test(address) && /.+\/(\d+)/.test(address)) {
-            let ip = address.split("/")[0],
-                cidr = parseInt(address.split("/")[1],10);
-
+        const matches = /^(.+)\/(\d+)$/.exec(address);
+        if (matches && matches.length === 3) {
+            const ip = matches[1];
+            const cidr = parseInt(matches[2], 10);
             if ($scope.IPv4Pattern.test(ip)) {
-                if (cidr < 27) {
+                if (cidr < 24) {
                     return true;
                 }
             } else {

--- a/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
@@ -272,7 +272,7 @@ under the License.
                                 <input id="{{inf.name}}-{{ip.address}}" name="{{inf.name}}-{{ip.address}}" class="ip-input" type="text" ng-model="ip.address" ng-pattern="IPWithCIDRPattern" required placeholder="192.0.2.0/27" />
                                 <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address], 'pattern')">Invalid address</small>
                                 <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address], 'required')">Required</small>
-                                <small class="input-warning" ng-show="isLargeCIDR(ip.address)">Large CIDR detected. IPv4 with CIDR &lt; 27 or IPv6 with CIDR &lt; 64 can be problematic.</small>
+                                <small class="input-warning" ng-show="isLargeCIDR(ip.address)">Large CIDR block detected (IPv4 with CIDR &lt; 24 or IPv6 with CIDR &lt; 64)</small>
                                 <label for="{{inf.name}}-{{ip.address}}-gateway">Gateway</label>
                                 <input type="text" id="{{inf.name}}-{{ip.address}}-gateway" name="{{inf.name}}-{{ip.address}}-gateway" ng-model="ip.gateway" ng-pattern="IPPattern"/>
                                 <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-'+ip.address+'-gateway'], 'pattern')">Invalid gateway</small>


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #5676 

This PR changes the warning that appears on large CIDR blocks in Traffic Portal server forms from triggering on < 27 to < 24 and rewords the warning message itself to avoid calling things "problematic".

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure TP tests pass, run TP and try to enter an IPv4 address for a server with a netmask < 27 but not < 24 and observe no warning message, then make it less than 24 and observe that there is a new warning message that doesn't use the word "problematic".

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 