### PR TITLE
Add Go TO client method for getting servers by deliveryservice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - ORT config generation: Added a rule to ip_allow such that PURGE requests are allowed over localhost
 - Added integration to use ACME to generate new SSL certificates.
 - Add a Federation to the Ansible Dataset Loader
+- Added `GetServersByDeliveryService` method to the TO Go client
 - Added asynchronous status to ACME certificate generation.
 - Added per Delivery Service HTTP/2 and TLS Versions support, via ssl_server_name.yaml and sni.yaml. See overview/delivery_services and t3c docs.
 - Added headers to Traffic Portal, Traffic Ops, and Traffic Monitor to opt out of tracking users via Google FLoC.

--- a/lib/go-tc/deliveryservice_servers.go
+++ b/lib/go-tc/deliveryservice_servers.go
@@ -159,6 +159,11 @@ type DSServer struct {
 	ServerInterfaces *[]ServerInterfaceInfo `json:"interfaces" db:"interfaces"`
 }
 
+type DSServerResponseV30 struct {
+	Response []DSServer `json:"response"`
+	Alerts
+}
+
 // DSServerV4 contains information for a V4.x Delivery Service Server.
 type DSServerV4 struct {
 	DSServerBaseV4

--- a/traffic_ops/testing/api/v4/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v4/deliveryserviceservers_test.go
@@ -605,6 +605,17 @@ func DeleteTestDeliveryServiceServers(t *testing.T) {
 		t.Error("POST delivery service servers returned success, but ds-server not in GET")
 	}
 
+	serversByDS, _, err := TOSession.GetServersByDeliveryService(*ds.ID, client.RequestOptions{})
+	if err != nil {
+		t.Errorf("unexpected error getting servers by delivery service: %v", err)
+	}
+	if len(serversByDS.Response) != 1 {
+		t.Errorf("getting servers by delivery service - expected: 1 server, actual: %d servers", len(serversByDS.Response))
+	}
+	if *serversByDS.Response[0].ID != *server.ID {
+		t.Errorf("getting servers by delivery service - expected: server ID %d, actual: %d", *server.ID, *serversByDS.Response[0].ID)
+	}
+
 	if *ds.Active {
 		*ds.Active = false
 		_, _, err = TOSession.UpdateDeliveryService(*ds.ID, ds, client.RequestOptions{})

--- a/traffic_ops/v3-client/deliveryserviceserver.go
+++ b/traffic_ops/v3-client/deliveryserviceserver.go
@@ -60,6 +60,14 @@ func (to *Session) AssignServersToDeliveryService(servers []string, xmlId string
 	return resp, reqInf, err
 }
 
+// GetServersByDeliveryService gets the servers that are assigned to the delivery service with the given ID.
+func (to *Session) GetServersByDeliveryService(id int) (tc.DSServerResponseV30, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(APIDeliveryServicesServers, strconv.Itoa(id))
+	resp := tc.DSServerResponseV30{}
+	reqInf, err := to.get(route, nil, &resp)
+	return resp, reqInf, err
+}
+
 // GetDeliveryServiceServer returns associations between Delivery Services and servers using the
 // provided pagination controls.
 // Deprecated: GetDeliveryServiceServer will be removed in 6.0. Use GetDeliveryServiceServerWithHdr.

--- a/traffic_ops/v4-client/deliveryserviceserver.go
+++ b/traffic_ops/v4-client/deliveryserviceserver.go
@@ -18,6 +18,7 @@ package client
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
@@ -54,6 +55,14 @@ func (to *Session) AssignServersToDeliveryService(servers []string, xmlID string
 	dss := tc.DeliveryServiceServers{ServerNames: servers, XmlId: xmlID}
 	var resp tc.Alerts
 	reqInf, err := to.post(route, opts, dss, &resp)
+	return resp, reqInf, err
+}
+
+// GetServersByDeliveryService gets the servers that are assigned to the delivery service with the given ID.
+func (to *Session) GetServersByDeliveryService(id int, opts RequestOptions) (tc.DSServerResponseV4, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(apiDeliveryServicesServers, strconv.Itoa(id))
+	resp := tc.DSServerResponseV4{}
+	reqInf, err := to.get(route, opts, &resp)
 	return resp, reqInf, err
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
Adds `GetServersByDeliveryService` methods to the v3 and v4 TO Go clients.

## Which Traffic Control components are affected by this PR?
- Traffic Control Client (Go)

## What is the best way to verify this PR?
Ensure the added TO API test passes.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] added TO Go client method, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
