### PR TITLE
Remove API 1.x references

### DIFF
--- a/test/router/js/load-test.jsx
+++ b/test/router/js/load-test.jsx
@@ -247,7 +247,7 @@ var LabBox = React.createClass({
         this.opsHost = formData.opsHost.trim();
 
         $.ajax({
-            url: "http://localhost:8888/api/1.2/user/login?" + params,
+            url: "http://localhost:8888/api/4.0/user/login?" + params,
             dataType: 'json',
             type: 'POST',
             crossDomain: true,
@@ -256,7 +256,7 @@ var LabBox = React.createClass({
     },
     handleGetDeliveryServicesSubmit: function(data) {
         return $.ajax({
-            url: "http://localhost:8888/api/1.2/deliveryservices.json?opsHost=" + this.opsHost,
+            url: "http://localhost:8888/api/4.0/deliveryservices.json?opsHost=" + this.opsHost,
             dataType: 'json',
             type: 'GET',
             success: function(data) {
@@ -298,10 +298,10 @@ var LabBox = React.createClass({
         console.log("handle submit");
         var opsHost = this.state.opsHost.trim();
 
-        console.log("http://localhost:8888/api/1.2/deliveryservices.json?opsHost=" + opsHost);
+        console.log("http://localhost:8888/api/4.0/deliveryservices.json?opsHost=" + opsHost);
 
         $.ajax({
-            url: "http://localhost:8888/api/1.2/deliveryservices.json?opsHost=" + opsHost,
+            url: "http://localhost:8888/api/4.0/deliveryservices.json?opsHost=" + opsHost,
             dataType: 'json',
             type: 'GET',
             success: function(data) {

--- a/test/router/server/server.go
+++ b/test/router/server/server.go
@@ -56,7 +56,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, string(data))
 	}
 
-	if r.Method == "POST" && r.URL.Path == "/api/1.2/user/login" {
+	if r.Method == "POST" && r.URL.Path == "/api/4.0/user/login" {
 
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -64,7 +64,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 		client := &http.Client{Transport: tr}
 
-		url := fmt.Sprintf("https://%v/api/1.2/user/login", r.URL.Query().Get("opsHost"))
+		url := fmt.Sprintf("https://%v/api/4.0/user/login", r.URL.Query().Get("opsHost"))
 
 		resp, err := client.Post(url, "application/json", r.Body)
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #4461

This updates API 1.x references in `test/router` to 4.0

## Which Traffic Control components are affected by this PR?
None.

## What is the best way to verify this PR?
You can't. Those tests don't run.

## The following criteria are ALL met by this PR
- [x] Tests are impossible
- [x] Documentation is unnecessary
- [x] An update to CHANGELOG.md is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**