### PR TITLE
Improve the DNSSEC refresh API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Refactored the Traffic Ops - Traffic Vault integration to more easily support the development of new Traffic Vault backends
 - Changed the Traffic Router package structure from com.comcast.cdn.\* to org.apache.\*
 - Updated Apache Tomcat from 8.5.63 to 9.0.43
+- Improved the DNSSEC refresh Traffic Ops API (`/cdns/dnsseckeys/refresh`). As of TO API v4, its method is `PUT` instead of `GET`, its response format was changed to return an alert instead of a string-based response, it returns a 202 instead of a 200, and it now works with the `async_status` API in order for the client to check the status of the async job: [#3054](https://github.com/apache/trafficcontrol/issues/3054)
 - Delivery Service Requests now keep a record of the changes they make.
 - Changed the `goose` provider to the maintained fork [`github.com/kevinburke/goose`](https://github.com/kevinburke/goose)
 - The format of the `/servers/{{host name}}/update_status` Traffic Ops API endpoint has been changed to use a top-level `response` property, in keeping with (most of) the rest of the API.

--- a/docs/source/api/v4/cdns_dnsseckeys_refresh.rst
+++ b/docs/source/api/v4/cdns_dnsseckeys_refresh.rst
@@ -36,20 +36,26 @@ Response Structure
 .. code-block:: http
 	:caption: Response Example
 
-	HTTP/1.1 200 OK
+	HTTP/1.1 202 Accepted
 	Access-Control-Allow-Credentials: true
-	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
 	Access-Control-Allow-Origin: *
-	Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 	Content-Type: application/json
-	Date: Wed, 14 Nov 2018 21:37:30 GMT
-	X-Server-Name: traffic_ops_golang/
-	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Location: /api/4.0/async_status/3
+	Permissions-Policy: interest-cohort=()
+	Set-Cookie: mojolicious=...; Path=/; Expires=Tue, 20 Jul 2021 23:55:11 GMT; Max-Age=3600; HttpOnly
 	Vary: Accept-Encoding
-	Whole-Content-Sha512: Uwl+924m6Ye3NraFP+RBpldkhcNTTDyXHZbzRaYV95p9tP56Z61gckeKSr1oQIkNXjXcCsDN5Dmum7Zk1AR6Hw==
-	Content-Length: 69
+	Whole-Content-Sha512: yJUGNCYygBYvHft4z0nxJ0/p230s3PdPT5Tld+8hIWfxmpmKDciY4D7+1Bf8S69ckmZR/yxY95kIZEbg9/jFgw==
+	X-Server-Name: traffic_ops_golang/
+	Date: Tue, 20 Jul 2021 22:55:11 GMT
+	Content-Length: 176
 
 	{
-		"response": "Checking DNSSEC keys for refresh in the background"
+		"alerts": [
+			{
+				"text": "Starting DNSSEC key refresh in the background. This may take a few minutes. Status updates can be found here: /api/4.0/async_status/3",
+				"level": "success"
+			}
+		]
 	}

--- a/lib/go-tc/async_status.go
+++ b/lib/go-tc/async_status.go
@@ -1,0 +1,44 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"time"
+)
+
+// AsyncStatus represents an async job status.
+type AsyncStatus struct {
+	// Id is the integral, unique identifier for the asynchronous job status.
+	Id int `json:"id,omitempty" db:"id"`
+	// Status is the status of the asynchronous job. This will be PENDING, SUCCEEDED, or FAILED.
+	Status string `json:"status,omitempty" db:"status"`
+	// StartTime is the time the asynchronous job was started.
+	StartTime time.Time `json:"start_time,omitempty" db:"start_time"`
+	// EndTime is the time the asynchronous job completed. This will be null if it has not completed yet.
+	EndTime *time.Time `json:"end_time,omitempty" db:"end_time"`
+	// Message is the message about the job status.
+	Message *string `json:"message,omitempty" db:"message"`
+}
+
+// AsyncStatusResponse represents the response from the GET /async_status/{id} API.
+type AsyncStatusResponse struct {
+	Response AsyncStatus `json:"response"`
+	Alerts
+}

--- a/traffic_ops/app/bin/checks/DnssecRefresh/ToDnssecRefresh.go
+++ b/traffic_ops/app/bin/checks/DnssecRefresh/ToDnssecRefresh.go
@@ -45,7 +45,7 @@ func main() {
 		User:     cfg.TOUser,
 		Password: cfg.TOPass,
 	}
-	loginUrl := cfg.TOUrl + "/api/2.0/user/login"
+	loginUrl := cfg.TOUrl + "/api/4.0/user/login"
 	buf := &bytes.Buffer{}
 	err = json.NewEncoder(buf).Encode(body)
 	config.ErrCheck(err)
@@ -60,8 +60,8 @@ func main() {
 	res, err := client.Do(req)
 	config.ErrCheck(err)
 	defer config.Dclose(res.Body)
-	refreshUrl := cfg.TOUrl + "/api/2.0/cdns/dnsseckeys/refresh"
-	resp, err := http.NewRequest(http.MethodGet, refreshUrl, buf)
+	refreshUrl := cfg.TOUrl + "/api/4.0/cdns/dnsseckeys/refresh"
+	resp, err := http.NewRequest(http.MethodPut, refreshUrl, nil)
 	config.ErrCheck(err)
 	log.Debugf("Get req to: %s", refreshUrl)
 
@@ -71,7 +71,7 @@ func main() {
 	config.ErrCheck(err)
 	defer config.Dclose(refresh.Body)
 
-	if refresh.StatusCode != 200 {
+	if refresh.StatusCode < 200 || 299 < refresh.StatusCode {
 		log.Errorln(string(respData))
 		os.Exit(1)
 	}

--- a/traffic_ops/app/bin/checks/ToDnssecRefresh.pl
+++ b/traffic_ops/app/bin/checks/ToDnssecRefresh.pl
@@ -80,7 +80,7 @@ $ua->timeout(30);
 $ua->ssl_opts(verify_hostname => 0);
 $ua->cookie_jar( {} );
 
-my $login_url = "$b_url/api/2.0/user/login";
+my $login_url = "$b_url/api/4.0/user/login";
 TRACE "posting $login_url";
 my $req = HTTP::Request->new( 'POST', $login_url );
 $req->header( 'Content-Type' => 'application/json' );
@@ -92,9 +92,10 @@ if ( ! $login_response->is_success ) {
 	exit(1);
 }
 
-my $url       = "$b_url/api/2.0/cdns/dnsseckeys/refresh";
-TRACE "getting $url";
-my $response = $ua->get($url);
+my $url       = "$b_url/api/4.0/cdns/dnsseckeys/refresh";
+TRACE "putting $url";
+my $dns_req = HTTP::Request->new( 'PUT', $url );
+my $response = $ua->request($dns_req);
 if ( $response->is_success ) {
 	DEBUG "Successfully refreshed dnssec keys response was " . $response->decoded_content;
 }

--- a/traffic_ops/testing/api/v4/cdns_test.go
+++ b/traffic_ops/testing/api/v4/cdns_test.go
@@ -161,6 +161,9 @@ func RefreshDNSSECKeys(t *testing.T) {
 	if err != nil {
 		t.Errorf("unable to refresh DNSSEC keys: %v - alerts: %+v", err, resp.Alerts)
 	}
+	if reqInf.StatusCode != http.StatusAccepted {
+		t.Errorf("refreshing DNSSEC keys - expected: status code %d, actual: %d", http.StatusAccepted, reqInf.StatusCode)
+	}
 	loc := reqInf.RespHeaders.Get("Location")
 	if loc == "" {
 		t.Errorf("refreshing DNSSEC keys - expected: non-empty 'Location' response header, actual: empty")

--- a/traffic_ops/traffic_ops_golang/api/async_status.go
+++ b/traffic_ops/traffic_ops_golang/api/async_status.go
@@ -23,7 +23,8 @@ import (
 	"database/sql"
 	"errors"
 	"net/http"
-	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -35,14 +36,6 @@ const (
 )
 
 const CurrentAsyncEndpoint = "/api/4.0/async_status/"
-
-type AsyncStatus struct {
-	Id        int        `json:"id,omitempty" db:"id"`
-	Status    string     `json:"status,omitempty" db:"status"`
-	StartTime time.Time  `json:"start_time,omitempty" db:"start_time"`
-	EndTime   *time.Time `json:"end_time,omitempty" db:"end_time"`
-	Message   *string    `json:"message,omitempty" db:"message"`
-}
 
 const selectAsyncStatusQuery = `SELECT id, status, message, start_time, end_time from async_status WHERE id = $1`
 const insertAsyncStatusQuery = `INSERT INTO async_status (status, message) VALUES ($1, $2) RETURNING id`
@@ -67,7 +60,7 @@ func GetAsyncStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	defer rows.Close()
 
-	asyncStatus := AsyncStatus{}
+	asyncStatus := tc.AsyncStatus{}
 	rowCount := 0
 	for rows.Next() {
 		rowCount++

--- a/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
@@ -21,7 +21,6 @@ package cdn
 
 import (
 	"context"
-	// "context"
 	"database/sql"
 	"errors"
 	"net/http"
@@ -33,51 +32,90 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/deliveryservice"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/trafficvault"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 )
 
+var noTx = (*sql.Tx)(nil) // make a variable instead of passing nil directly, to reduce copy-paste errors
+
 func RefreshDNSSECKeys(w http.ResponseWriter, r *http.Request) {
+	_, _, status, usrErr, sysErr := refreshDNSSECKeys(r.Context())
+	if usrErr != nil || sysErr != nil {
+		api.HandleErr(w, r, noTx, status, usrErr, sysErr)
+		return
+	}
+
+	api.WriteResp(w, r, "Checking DNSSEC keys for refresh in the background")
+}
+
+func RefreshDNSSECKeysV4(w http.ResponseWriter, r *http.Request) {
+	asyncStatusID, started, status, usrErr, sysErr := refreshDNSSECKeys(r.Context())
+	if usrErr != nil || sysErr != nil {
+		api.HandleErr(w, r, noTx, status, usrErr, sysErr)
+		return
+	}
+	message := "the server is already executing a DNSSEC refresh"
+	if started {
+		message = "Starting DNSSEC key refresh in the background. This may take a few minutes. Status updates can be found here: " + api.CurrentAsyncEndpoint + strconv.Itoa(asyncStatusID)
+	}
+	w.Header().Add("Location", api.CurrentAsyncEndpoint+strconv.Itoa(asyncStatusID))
+	api.WriteAlerts(w, r, http.StatusAccepted, tc.CreateAlerts(tc.SuccessLevel, message))
+}
+
+// refreshDNSSECKeys starts a goroutine to refresh the DNSSEC keys for all delivery services in all CDNs (except for the CDN KSKs which need to be refreshed separately).
+// It returns the async status ID, a bool indicating whether the refresh job was started or not, an HTTP status, a user error, and a system error.
+func refreshDNSSECKeys(ctx context.Context) (int, bool, int, error, error) {
 	if setInDNSSECKeyRefresh() {
-		db, err := api.GetDB(r.Context())
-		noTx := (*sql.Tx)(nil) // make a variable instead of passing nil directly, to reduce copy-paste errors
+		db, err := api.GetDB(ctx)
 		if err != nil {
-			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys getting db from context: "+err.Error()))
 			unsetInDNSSECKeyRefresh()
-			return
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys getting db from context: " + err.Error())
 		}
-		cfg, err := api.GetConfig(r.Context())
+		cfg, err := api.GetConfig(ctx)
 		if err != nil {
-			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys getting config from context: "+err.Error()))
 			unsetInDNSSECKeyRefresh()
-			return
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys getting config from context: " + err.Error())
+		}
+		user, err := auth.GetCurrentUser(ctx)
+		if err != nil {
+			unsetInDNSSECKeyRefresh()
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys getting user from context: " + err.Error())
 		}
 		if !cfg.TrafficVaultEnabled {
-			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("refreshing DNSSEC keys: Traffic Vault not enabled"))
 			unsetInDNSSECKeyRefresh()
-			return
+			return 0, false, http.StatusInternalServerError, nil, errors.New("refreshing DNSSEC keys: Traffic Vault not enabled")
 		}
-		tv, err := api.GetTrafficVault(r.Context())
+		tv, err := api.GetTrafficVault(ctx)
 		if err != nil {
-			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys getting Traffic Vault from context: "+err.Error()))
 			unsetInDNSSECKeyRefresh()
-			return
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys getting Traffic Vault from context: " + err.Error())
 		}
 
 		tx, err := db.Begin()
 		if err != nil {
-			api.HandleErr(w, r, noTx, http.StatusInternalServerError, nil, errors.New("RefresHDNSSECKeys beginning tx: "+err.Error()))
 			unsetInDNSSECKeyRefresh()
-			return
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys beginning tx: " + err.Error())
 		}
-		go doDNSSECKeyRefresh(tx, tv) // doDNSSECKeyRefresh takes ownership of tx and MUST close it.
+		asyncTx, err := db.Begin()
+		if err != nil {
+			unsetInDNSSECKeyRefresh()
+			return 0, false, http.StatusInternalServerError, nil, errors.New("RefreshDNSSECKeys beginning tx: " + err.Error())
+		}
+		jobID, status, usrErr, sysErr := api.InsertAsyncStatus(asyncTx, "DNSSEC refresh started")
+		if usrErr != nil || sysErr != nil {
+			unsetInDNSSECKeyRefresh()
+			return 0, false, status, usrErr, sysErr
+		}
+		go doDNSSECKeyRefresh(tx, db, tv, jobID, user) // doDNSSECKeyRefresh takes ownership of tx and MUST close it.
+		return jobID, true, http.StatusAccepted, nil, nil
 	} else {
 		log.Infoln("RefreshDNSSECKeys called, while server was concurrently executing a refresh, doing nothing")
+		return 0, false, http.StatusAccepted, nil, nil
 	}
-
-	api.WriteResp(w, r, "Checking DNSSEC keys for refresh in the background")
 }
 
 const DNSSECKeyRefreshDefaultTTL = time.Duration(60) * time.Second
@@ -89,7 +127,7 @@ const DNSSECKeyRefreshDefaultZSKExpiration = time.Duration(30) * time.Hour * 24
 // doDNSSECKeyRefresh refreshes the CDN's DNSSEC keys, as necessary.
 // This takes ownership of tx, and MUST call `tx.Close()`.
 // This SHOULD only be called if setInDNSSECKeyRefresh() returned true, in which case this MUST call unsetInDNSSECKeyRefresh() before returning.
-func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
+func doDNSSECKeyRefresh(tx *sql.Tx, asyncDB *sqlx.DB, tv trafficvault.TrafficVault, jobID int, user *auth.CurrentUser) {
 	doCommit := true
 	defer func() {
 		if doCommit {
@@ -106,6 +144,9 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 	if err != nil {
 		log.Errorln("refreshing DNSSEC Keys: getting cdn parameters: " + err.Error())
 		doCommit = false
+		if asyncErr := api.UpdateAsyncStatus(asyncDB, api.AsyncFailed, "DNSSEC refresh failed", jobID, true); asyncErr != nil {
+			log.Errorf("updating async status for id %d: %v", jobID, asyncErr)
+		}
 		return
 	}
 	cdns := []string{}
@@ -119,6 +160,9 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 	if err != nil {
 		log.Errorln("refreshing DNSSEC Keys: getting ds info: " + err.Error())
 		doCommit = false
+		if asyncErr := api.UpdateAsyncStatus(asyncDB, api.AsyncFailed, "DNSSEC refresh failed", jobID, true); asyncErr != nil {
+			log.Errorf("updating async status for id %d: %v", jobID, asyncErr)
+		}
 		return
 	}
 	dses := []string{}
@@ -130,6 +174,9 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 	if err != nil {
 		log.Errorln("refreshing DNSSEC Keys: getting ds matchlists: " + err.Error())
 		doCommit = false
+		if asyncErr := api.UpdateAsyncStatus(asyncDB, api.AsyncFailed, "DNSSEC refresh failed", jobID, true); asyncErr != nil {
+			log.Errorf("updating async status for id %d: %v", jobID, asyncErr)
+		}
 		return
 	}
 	exampleURLs := map[tc.DeliveryServiceName][]string{}
@@ -137,6 +184,7 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 		exampleURLs[ds] = deliveryservice.MakeExampleURLs(inf.Protocol, inf.Type, inf.RoutingName, dsMatchlists[string(ds)], inf.CDNDomain)
 	}
 
+	anyErrors := false
 	for _, cdnInf := range cdnDNSSECKeyParams {
 		keys, ok, err := tv.GetDNSSECKeys(string(cdnInf.CDNName), tx, context.Background()) // TODO get all in a map beforehand
 		if err != nil {
@@ -186,13 +234,14 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 			if expiration.After(nowPlusTTL) {
 				continue
 			}
-			log.Infoln("The ZSK keys for '" + string(cdnInf.CDNName) + "' are expired!")
+			log.Infoln("The ZSK keys for '" + string(cdnInf.CDNName) + "' are expired! Regenerating them now.")
 			effectiveDate := expiration.Add(ttl * time.Duration(effectiveMultiplier) * -1) // -1 to subtract
 			isKSK := false
 			cdnDNSDomain := cdnInf.CDNDomain + "."
 			newKeys, err := regenExpiredKeys(isKSK, cdnDNSDomain, keys[string(cdnInf.CDNName)], effectiveDate, false, false)
 			if err != nil {
 				log.Errorln("refreshing DNSSEC Keys: regenerating expired ZSK keys: " + err.Error())
+				anyErrors = true
 			} else {
 				keys[string(cdnInf.CDNName)] = newKeys
 				updatedAny = true
@@ -214,6 +263,7 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 				cdnKeys, ok := keys[string(ds.CDNName)]
 				if !ok {
 					log.Errorln("refreshing DNSSEC Keys: cdn has no keys, cannot create ds keys")
+					anyErrors = true
 					continue
 				}
 
@@ -221,6 +271,7 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 				dsKeys, err := deliveryservice.CreateDNSSECKeys(exampleURLs[ds.DSName], cdnKeys, defaultKSKExpiration, defaultZSKExpiration, ttl, overrideTTL)
 				if err != nil {
 					log.Errorln("refreshing DNSSEC Keys: creating missing ds keys: " + err.Error())
+					anyErrors = true
 				}
 				keys[string(ds.DSName)] = dsKeys
 				updatedAny = true
@@ -235,12 +286,13 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 				if expiration.After(nowPlusTTL) {
 					continue
 				}
-				log.Infoln("The KSK keys for '" + ds.DSName + "' are expired!")
+				log.Infoln("The KSK keys for '" + ds.DSName + "' are expired! Regenerating them now.")
 				effectiveDate := expiration.Add(ttl * time.Duration(effectiveMultiplier) * -1) // -1 to subtract
 				isKSK := true
 				newKeys, err := regenExpiredKeys(isKSK, string(ds.DSName), dsKeys, effectiveDate, false, false)
 				if err != nil {
 					log.Errorln("refreshing DNSSEC Keys: regenerating expired KSK keys for ds '" + string(ds.DSName) + "': " + err.Error())
+					anyErrors = true
 				} else {
 					keys[string(ds.DSName)] = newKeys
 					updatedAny = true
@@ -255,12 +307,13 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 				if expiration.After(nowPlusTTL) {
 					continue
 				}
-				log.Infoln("The ZSK keys for '" + ds.DSName + "' are expired!")
+				log.Infoln("The ZSK keys for '" + ds.DSName + "' are expired! Regenerating them now.")
 				effectiveDate := expiration.Add(ttl * time.Duration(effectiveMultiplier) * -1) // -1 to subtract
 				isKSK := false
 				newKeys, err := regenExpiredKeys(isKSK, string(ds.DSName), dsKeys, effectiveDate, false, false)
 				if err != nil {
 					log.Errorln("refreshing DNSSEC Keys: regenerating expired ZSK keys for ds '" + string(ds.DSName) + "': " + err.Error())
+					anyErrors = true
 				} else {
 					if existingNewKeys, ok := keys[string(ds.DSName)]; ok {
 						existingNewKeys.ZSK = newKeys.ZSK
@@ -274,8 +327,19 @@ func doDNSSECKeyRefresh(tx *sql.Tx, tv trafficvault.TrafficVault) {
 		if updatedAny {
 			if err := tv.PutDNSSECKeys(string(cdnInf.CDNName), keys, tx, context.Background()); err != nil {
 				log.Errorln("refreshing DNSSEC Keys: putting keys into Traffic Vault for cdn '" + string(cdnInf.CDNName) + "': " + err.Error())
+				anyErrors = true
 			}
 		}
+	}
+	api.CreateChangeLogRawTx(api.ApiChange, "Refreshed DNSSEC keys", user, tx)
+	status := api.AsyncSucceeded
+	msg := "DNSSEC refresh completed successfully"
+	if anyErrors {
+		status = api.AsyncFailed
+		msg = "DNSSEC refresh failed"
+	}
+	if asyncErr := api.UpdateAsyncStatus(asyncDB, status, msg, jobID, true); asyncErr != nil {
+		log.Errorf("updating async status for id %d: %v", jobID, asyncErr)
 	}
 	log.Infoln("Done refreshing DNSSEC keys")
 }

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -202,7 +202,7 @@ func Routes(d ServerData) ([]Route, []RawRoute, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `cdns/name/{name}/dnsseckeys?$`, cdn.DeleteDNSSECKeys, auth.PrivLevelAdmin, Authenticated, nil, 4711042073},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/name/{name}/dnsseckeys/?$`, cdn.GetDNSSECKeys, auth.PrivLevelAdmin, Authenticated, nil, 4790106093},
 
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/dnsseckeys/refresh/?$`, cdn.RefreshDNSSECKeys, auth.PrivLevelOperations, Authenticated, nil, 47719971163},
+		{api.Version{Major: 4, Minor: 0}, http.MethodPut, `cdns/dnsseckeys/refresh/?$`, cdn.RefreshDNSSECKeysV4, auth.PrivLevelOperations, Authenticated, nil, 47719971163},
 
 		//CDN: Monitoring: Traffic Monitor
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdns/{cdn}/configs/monitoring?$`, crconfig.SnapshotGetMonitoringHandler, auth.PrivLevelReadOnly, Authenticated, nil, 42408478923},

--- a/traffic_ops/v4-client/async_status.go
+++ b/traffic_ops/v4-client/async_status.go
@@ -1,0 +1,34 @@
+package client
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"fmt"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
+// apiAsyncStatus is the API version-relative path for the /async_status/{id} API endpoint.
+const apiAsyncStatus = "/async_status/%d"
+
+// GetAsyncStatus gets an async_status from Traffic Ops.
+func (to *Session) GetAsyncStatus(id int, opts RequestOptions) (tc.AsyncStatusResponse, toclientlib.ReqInf, error) {
+	route := fmt.Sprintf(apiAsyncStatus, id)
+	var data tc.AsyncStatusResponse
+	reqInf, err := to.get(route, opts, &data)
+	return data, reqInf, err
+}

--- a/traffic_ops/v4-client/cdn_dnssec.go
+++ b/traffic_ops/v4-client/cdn_dnssec.go
@@ -53,9 +53,9 @@ func (to *Session) DeleteCDNDNSSECKeys(name string, opts RequestOptions) (tc.Del
 }
 
 // RefreshDNSSECKeys asynchronously regenerates any expired DNSSEC keys in all CDNs.
-func (to *Session) RefreshDNSSECKeys(opts RequestOptions) (tc.RefreshDNSSECKeysResponse, toclientlib.ReqInf, error) {
-	var resp tc.RefreshDNSSECKeysResponse
-	reqInf, err := to.get(apiCDNsDNSSECRefresh, opts, &resp)
+func (to *Session) RefreshDNSSECKeys(opts RequestOptions) (tc.Alerts, toclientlib.ReqInf, error) {
+	var resp tc.Alerts
+	reqInf, err := to.put(apiCDNsDNSSECRefresh, opts, nil, &resp)
 	return resp, reqInf, err
 }
 


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR fixes #3054

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Go)
- Traffic Ops

## What is the best way to verify this PR?
Ensure the added TO API test passes.
Build and view the DNSSEC refresh v4 API doc, make sure it renders properly without warnings.
`PUT /api/4.0/cdns/dnsseckeys/refresh` and verify that a `Location` response header is returned, and use the value to `GET /async_status/{some_id}` and verify the status message.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
