### PR TITLE
Add t3c dns_local not inserting if it exists

### DIFF
--- a/lib/go-atscfg/recordsdotconfig.go
+++ b/lib/go-atscfg/recordsdotconfig.go
@@ -172,14 +172,19 @@ func addRecordsDotConfigDNSLocal(txt string, server *Server) (string, []string) 
 	const dnsLocalV6 = `proxy.config.dns.local_ipv6`
 
 	v4, v6 := getServiceAddresses(server)
+
 	if v4 == nil {
 		warnings = append(warnings, "server had no IPv4 Service Address, not setting records.config dns v4 local bind addr!")
+	} else if strings.Contains(txt, dnsLocalV4) {
+		warnings = append(warnings, "dns local option was set, but proxy.config.dns.local_ipv4 was already in records.config, not overriding! Check the server's Parameters.")
 	} else {
 		txt += `CONFIG ` + dnsLocalV4 + ` STRING ` + v4.String() + "\n"
 	}
 
 	if v6 == nil {
 		warnings = append(warnings, "server had no IPv6 Service Address, not setting records.config dns v6 local bind addr!")
+	} else if strings.Contains(txt, dnsLocalV6) {
+		warnings = append(warnings, "dns local option was set, but proxy.config.dns.local_ipv6 was already in records.config, not overriding! Check the server's Parameters!")
 	} else {
 		txt += `CONFIG ` + dnsLocalV6 + ` STRING [` + v6.String() + `]` + "\n"
 	}

--- a/lib/go-atscfg/recordsdotconfig_test.go
+++ b/lib/go-atscfg/recordsdotconfig_test.go
@@ -163,3 +163,134 @@ STRING __FULL_HOSTNAME__
 		}
 	}
 }
+
+func TestMakeRecordsDotConfigDNSLocalBindNoOverrideV4(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	paramData := makeParamsFromMap("serverProfile", RecordsFileName, map[string]string{
+		"CONFIG proxy.config.dns.local_ipv4": "STRING 1.2.3.4",
+		"param1":                             "val1",
+		"param2":                             "val2",
+		"test-hostname-replacement":          "fooSTRING __HOSTNAME__",
+	})
+
+	server := makeTestRemapServer()
+	server.Interfaces = nil
+	ipStr := "192.163.2.99"
+	ipCIDR := ipStr + "/30" // set the ip to a cidr, to make sure addr logic removes it
+	setIP(server, ipCIDR)
+	ip6Str := "2001:db8::9"
+	ip6CIDR := ip6Str + "/48" // set the ip to a cidr, to make sure addr logic removes it
+	setIP6(server, ip6CIDR)
+	server.Profile = util.StrPtr(profileName)
+	opt := RecordsConfigOpts{}
+	opt.DNSLocalBindServiceAddr = true
+	cfg, err := MakeRecordsDotConfig(server, paramData, hdr, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv4 STRING "+ipStr) {
+		t.Errorf("expected config to not contain dns.local_ipv4 from server when Parameter exists, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv4 STRING "+"1.2.3.4") {
+		t.Errorf("expected config to contain dns.local_ipv4 Parameter when it exists, actual: '%v'", txt)
+	}
+
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv6 STRING ["+ip6Str+"]") {
+		t.Errorf("expected config to contain dns.local_ipv6 from server, actual: '%v'", txt)
+	}
+}
+
+func TestMakeRecordsDotConfigDNSLocalBindNoOverrideV6(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	paramData := makeParamsFromMap("serverProfile", RecordsFileName, map[string]string{
+		"CONFIG proxy.config.dns.local_ipv6": "STRING 2001:db8::11",
+		"param1":                             "val1",
+		"param2":                             "val2",
+		"test-hostname-replacement":          "fooSTRING __HOSTNAME__",
+	})
+
+	server := makeTestRemapServer()
+	server.Interfaces = nil
+	ipStr := "192.163.2.99"
+	ipCIDR := ipStr + "/30" // set the ip to a cidr, to make sure addr logic removes it
+	setIP(server, ipCIDR)
+	ip6Str := "2001:db8::9"
+	ip6CIDR := ip6Str + "/48" // set the ip to a cidr, to make sure addr logic removes it
+	setIP6(server, ip6CIDR)
+	server.Profile = util.StrPtr(profileName)
+	opt := RecordsConfigOpts{}
+	opt.DNSLocalBindServiceAddr = true
+	cfg, err := MakeRecordsDotConfig(server, paramData, hdr, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv6 STRING "+ip6Str) {
+		t.Errorf("expected config to not contain dns.local_ipv6 from server when Parameter exists, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv6 STRING "+"2001:db8::11") {
+		t.Errorf("expected config to contain dns.local_ipv4 Parameter when it exists, actual: '%v'", txt)
+	}
+
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv4 STRING "+ipStr) {
+		t.Errorf("expected config to contain dns.local_ipv4 from server, actual: '%v'", txt)
+	}
+}
+
+func TestMakeRecordsDotConfigDNSLocalBindNoOverrideBoth(t *testing.T) {
+	profileName := "myProfile"
+	hdr := "myHeaderComment"
+
+	paramData := makeParamsFromMap("serverProfile", RecordsFileName, map[string]string{
+		"CONFIG proxy.config.dns.local_ipv4": "STRING 9.10.11.12",
+		"CONFIG proxy.config.dns.local_ipv6": "STRING 2001:db8::11",
+		"param1":                             "val1",
+		"param2":                             "val2",
+		"test-hostname-replacement":          "fooSTRING __HOSTNAME__",
+	})
+
+	server := makeTestRemapServer()
+	server.Interfaces = nil
+	ipStr := "192.163.2.99"
+	ipCIDR := ipStr + "/30" // set the ip to a cidr, to make sure addr logic removes it
+	setIP(server, ipCIDR)
+	ip6Str := "2001:db8::9"
+	ip6CIDR := ip6Str + "/48" // set the ip to a cidr, to make sure addr logic removes it
+	setIP6(server, ip6CIDR)
+	server.Profile = util.StrPtr(profileName)
+	opt := RecordsConfigOpts{}
+	opt.DNSLocalBindServiceAddr = true
+	cfg, err := MakeRecordsDotConfig(server, paramData, hdr, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, hdr)
+
+	if strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv4 STRING "+ipStr) {
+		t.Errorf("expected config to not contain dns.local_ipv4 from server when Parameter exists, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv4 STRING "+"9.10.11.12") {
+		t.Errorf("expected config to contain dns.local_ipv4 Parameter when it exists, actual: '%v'", txt)
+	}
+
+	if strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv6 STRING "+ip6Str) {
+		t.Errorf("expected config to not contain dns.local_ipv6 from server when Parameter exists, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "CONFIG proxy.config.dns.local_ipv6 STRING "+"2001:db8::11") {
+		t.Errorf("expected config to contain dns.local_ipv4 Parameter when it exists, actual: '%v'", txt)
+	}
+
+}


### PR DESCRIPTION
Adds the t3c code that injects dns_local records.config values to check if they already exist from Parameters, and not add and log a warning.

This is on the line between a bug and feature. It's really an operator's data bug if they pass the t3c flag and also have a Parameter. But makes it warn and not add duplicate settings, which would have inconsistent behavior.

Includes tests.
No changelog, no interface change.
No docs, no interface change.

- [x] This PR is not related to any Issue <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->


## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Add a `proxy.config.dns.local_ipv*` Parameter and run `t3c apply --dns-local-bind=true` and verify the Parameter is added to records.config, the Server's IP is not added, and a warning is logged.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information
