### PR TITLE
Add t3c arg to not set outgoing ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - atstccfg: add ##REFETCH## support to regex_revalidate.config processing.
 - Traffic Router: Added `svc="..."` field to request logging output.
 - Added t3c caching Traffic Ops data and using If-Modified-Since to avoid unnecessary requests.
+- Added t3c --no-outgoing-ip flags.
 - Added a Traffic Monitor integration test framework.
 - Added `traffic_ops/app/db/traffic_vault_migrate` to help with migrating Traffic Ops Traffic Vault backends
 - Added a tool at `/traffic_ops/app/db/reencrypt` to re-encrypt the data in the Postgres Traffic Vault with a new key.

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -87,6 +87,11 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
     Print usage information and exit
 
+-i, -\-no-outgoing-ip
+
+     Whether to not set the records.config outgoing IP to the
+     server's addresses in Traffic Ops. Default is false.
+
 -I, -\-traffic-ops-insecure
 
     [true | false] ignore certificate errors from Traffic Ops

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -98,6 +98,7 @@ type Cfg struct {
 	NoCache                     bool
 	SyncDSUpdatesIPAllow        bool
 	OmitViaStringRelease        bool
+	NoOutgoingIP                bool
 	DisableParentConfigComments bool
 	DefaultClientEnableH2       *bool
 	DefaultClientTLSVersions    *string
@@ -231,6 +232,7 @@ func GetCfg() (Cfg, error) {
 	noCachePtr := getopt.BoolLong("no-cache", 'n', "Whether to not use a cache and make conditional requests to Traffic Ops")
 	syncdsUpdatesIPAllowPtr := getopt.BoolLong("syncds-updates-ipallow", 'S', "Whether syncds mode will update ipallow. This exists because ATS had a bug where reloading after changing ipallow would block everything. Default is false.")
 	omitViaStringReleasePtr := getopt.BoolLong("omit-via-string-release", 'o', "Whether to set the records.config via header to the ATS release from the RPM. Default true.")
+	noOutgoingIP := getopt.BoolLong("no-outgoing-ip", 'i', "Whether to not set the records.config outgoing IP to the server's addresses in Traffic Ops. Default is false.")
 	disableParentConfigCommentsPtr := getopt.BoolLong("disable-parent-config-comments", 'c', "Whether to disable verbose parent.config comments. Default false.")
 	defaultEnableH2 := getopt.BoolLong("default-client-enable-h2", '2', "Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter. This is irrelevant if ATS records.config is not serving H2. If omitted, H2 is disabled.")
 	defaultClientTLSVersions := getopt.StringLong("default-client-tls-versions", 'V', "", "Comma-delimited list of default TLS versions for Delivery Services with no Parameter, e.g. --default-tls-versions='1.1,1.2,1.3'. If omitted, all versions are enabled.")
@@ -400,6 +402,7 @@ func GetCfg() (Cfg, error) {
 		NoCache:                     *noCachePtr,
 		SyncDSUpdatesIPAllow:        *syncdsUpdatesIPAllowPtr,
 		OmitViaStringRelease:        *omitViaStringReleasePtr,
+		NoOutgoingIP:                *noOutgoingIP,
 		DisableParentConfigComments: *disableParentConfigCommentsPtr,
 		DefaultClientEnableH2:       defaultEnableH2,
 		DefaultClientTLSVersions:    defaultClientTLSVersions,

--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -76,6 +76,7 @@ func generate(cfg config.Cfg) ([]t3cutil.ATSConfigFile, error) {
 		args = append(args, "--revalidate-only")
 	}
 	args = append(args, "--via-string-release="+strconv.FormatBool(!cfg.OmitViaStringRelease))
+	args = append(args, "--no-outgoing-ip="+strconv.FormatBool(cfg.NoOutgoingIP))
 	args = append(args, "--disable-parent-config-comments="+strconv.FormatBool(cfg.DisableParentConfigComments))
 
 	generatedFiles, stdErr, code := t3cutil.DoInput(configData, config.GenerateCmd, args...)

--- a/cache-config/t3c-generate/README.md
+++ b/cache-config/t3c-generate/README.md
@@ -81,6 +81,11 @@ The output is a JSON array of objects containing the file and its metadata.
 
     Print usage information and exit
 
+-i, -\-no-outgoing-ip
+
+    Whether to not set the records.config outgoing IP to the
+    server's addresses in Traffic Ops. Default is false.
+
 -l, -\-list-plugins
 
     Print the list of plugins.

--- a/cache-config/t3c-generate/cfgfile/wrappers.go
+++ b/cache-config/t3c-generate/cfgfile/wrappers.go
@@ -206,6 +206,7 @@ func MakeRecordsDotConfig(toData *t3cutil.ConfigData, fileName string, hdrCommen
 			ReleaseViaStr:           cfg.ViaRelease,
 			DNSLocalBindServiceAddr: cfg.SetDNSLocalBind,
 			HdrComment:              hdrCommentTxt,
+			NoOutgoingIP:            cfg.NoOutgoingIP,
 		},
 	)
 }

--- a/cache-config/t3c-generate/config/config.go
+++ b/cache-config/t3c-generate/config/config.go
@@ -55,6 +55,7 @@ type Cfg struct {
 	Dir                string
 	ViaRelease         bool
 	SetDNSLocalBind    bool
+	NoOutgoingIP       bool
 	ParentComments     bool
 	DefaultEnableH2    bool
 	DefaultTLSVersions []atscfg.TLSVersion
@@ -78,6 +79,7 @@ func GetCfg() (Cfg, error) {
 	disableParentConfigComments := getopt.BoolLong("disable-parent-config-comments", 'c', "Disable adding a comments to parent.config individual lines")
 	defaultEnableH2 := getopt.BoolLong("default-client-enable-h2", '2', "Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter. This is irrelevant if ATS records.config is not serving H2. If omitted, H2 is disabled.")
 	defaultTLSVersionsStr := getopt.StringLong("default-client-tls-versions", 'T', "", "Comma-delimited list of default TLS versions for Delivery Services with no Parameter, e.g. '--default-tls-versions=1.1,1.2,1.3'. If omitted, all versions are enabled.")
+	noOutgoingIP := getopt.BoolLong("no-outgoing-ip", 'i', "Whether to not set the records.config outgoing IP to the server's addresses in Traffic Ops. Default is false.")
 	verbosePtr := getopt.CounterLong("verbose", 'v', `Log verbosity. Logging is output to stderr. By default, errors are logged. To log warnings, pass '-v'. To log info, pass '-vv'. To omit error logging, see '-s'`)
 	silentPtr := getopt.BoolLong("silent", 's', `Silent. Errors are not logged, and the 'verbose' flag is ignored. If a fatal error occurs, the return code will be non-zero but no text will be output to stderr`)
 
@@ -139,6 +141,7 @@ func GetCfg() (Cfg, error) {
 		Dir:                *dir,
 		ViaRelease:         *viaRelease,
 		SetDNSLocalBind:    *dnsLocalBind,
+		NoOutgoingIP:       *noOutgoingIP,
 		ParentComments:     !(*disableParentConfigComments),
 		DefaultEnableH2:    *defaultEnableH2,
 		DefaultTLSVersions: defaultTLSVersions,

--- a/cache-config/testing/ort-tests/t3c-no-outgoing-ip-flag_test.go
+++ b/cache-config/testing/ort-tests/t3c-no-outgoing-ip-flag_test.go
@@ -1,0 +1,118 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestT3CNoOutgoingIP(t *testing.T) {
+	t.Logf("------------- Starting TestT3CNoOutgoingIP ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		{
+			if err := t3cUpdateNoOutgoingIP("atlanta-edge-03", nil); err != nil {
+				t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+			}
+
+			recordsName := filepath.Join(test_config_dir, "records.config")
+			recordsDotConfig, err := ioutil.ReadFile(recordsName)
+			if err != nil {
+				t.Fatalf("reading %v: %v\n", recordsName, err)
+			}
+
+			if !bytes.Contains(recordsDotConfig, []byte("outgoing_ip_to_bind")) {
+				t.Errorf("expected t3c with no --no-outgoing-ip to add records.config outgoing_ip_to_bind, actual: '%v'\n", string(recordsDotConfig))
+			}
+		}
+
+		{
+			if err := t3cUpdateNoOutgoingIP("atlanta-edge-03", util.BoolPtr(false)); err != nil {
+				t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+			}
+
+			recordsName := filepath.Join(test_config_dir, "records.config")
+			recordsDotConfig, err := ioutil.ReadFile(recordsName)
+			if err != nil {
+				t.Fatalf("reading %v: %v\n", recordsName, err)
+			}
+
+			if !bytes.Contains(recordsDotConfig, []byte("outgoing_ip_to_bind")) {
+				t.Errorf("expected t3c with --no-outgoing-ip=false to add records.config outgoing_ip_to_bind, actual: '%v'\n", string(recordsDotConfig))
+			}
+		}
+
+		{
+			if err := t3cUpdateNoOutgoingIP("atlanta-edge-03", util.BoolPtr(true)); err != nil {
+				t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+			}
+
+			recordsName := filepath.Join(test_config_dir, "records.config")
+			recordsDotConfig, err := ioutil.ReadFile(recordsName)
+			if err != nil {
+				t.Fatalf("reading %v: %v\n", recordsName, err)
+			}
+
+			if bytes.Contains(recordsDotConfig, []byte("outgoing_ip_to_bind")) {
+				t.Errorf("expected t3c with --no-outgoing-ip=true to not add records.config outgoing_ip_to_bind, actual: '%v'\n", string(recordsDotConfig))
+			}
+		}
+	})
+	t.Logf("------------- End of TestT3CNoOutgoingIP ---------------")
+}
+
+func t3cUpdateNoOutgoingIP(host string, noOutgoingIP *bool) error {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--dispersion=0",
+		"--login-dispersion=0",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"-vv",
+		"--run-mode=" + "badass",
+		"--git=no",
+	}
+	if noOutgoingIP != nil {
+		args = append(args, "--no-outgoing-ip="+strconv.FormatBool(*noOutgoingIP))
+	}
+	cmd := exec.Command("t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return nil
+}

--- a/lib/go-atscfg/recordsdotconfig.go
+++ b/lib/go-atscfg/recordsdotconfig.go
@@ -46,6 +46,15 @@ type RecordsConfigOpts struct {
 	// This should be the text desired, without comment syntax (like # or //). The file's comment syntax will be added.
 	// To omit the header comment, pass the empty string.
 	HdrComment string
+
+	// NoOutgoingIP is whether to omit adding a records.config entry for
+	// proxy.local.outgoing_ip_to_bind set to the server's IP addresses (V4 and V6).
+	// By default, this entry is added, unless it already exists in records.config
+	// (probably from a Parameter).
+	//
+	// The default, setting the IP to bind, is usually the right solution, unless
+	// the server's addresses are unusual or not public, such as NAT.
+	NoOutgoingIP bool
 }
 
 func MakeRecordsDotConfig(
@@ -87,8 +96,12 @@ func MakeRecordsDotConfig(
 // Returns the modified text and any warnings.
 func addRecordsDotConfigOverrides(txt string, server *Server, opt *RecordsConfigOpts) (string, []string) {
 	warnings := []string{}
-	txt, ipWarns := addRecordsDotConfigOutgoingIP(txt, server)
-	warnings = append(warnings, ipWarns...)
+
+	if !opt.NoOutgoingIP {
+		ipWarns := []string{}
+		txt, ipWarns = addRecordsDotConfigOutgoingIP(txt, server)
+		warnings = append(warnings, ipWarns...)
+	}
 
 	if opt.ReleaseViaStr {
 		viaWarns := []string{}


### PR DESCRIPTION
Adds a t3c flag to not add a records.config outgoing_ip entry of the Server's IP addresses.

Setting the outgoing_ip is almost always the correct and desired behavior. But this can be necessary if the Server's IP(s) are NAT or otherwise unusual and can't reach parents.

Includes tests.
Includes docs.
Includes changelog.

- [x] This PR is not related to any other Issue

## Which Traffic Control components are affected by this PR?
- Traffic Ops ORT

## What is the best way to verify this PR?
Run tests. Run `t3c apply --no-outgoing-ip=true` and verify the generated records.config does not have an outgoing_ip entry.

## If this is a bug fix, what versions of Traffic Control are affected?
Not a bug fix.

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)


## Additional Information