### PR TITLE
TM: do not populate delivery service disabled locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#2471](https://github.com/apache/trafficcontrol/issues/2471) - A PR check to ensure added db migration file is the latest.
 - [#5609](https://github.com/apache/trafficcontrol/issues/5609) - Fixed GET /servercheck filter for an extra query param.
 - [#5954](https://github.com/apache/trafficcontrol/issues/5954) - Traffic Ops HTTP response write errors are ignored
+- [#6048](https://github.com/apache/trafficcontrol/issues/6048) - TM sometimes sets cachegroups to unavailable even though all caches are online
 - [#5288](https://github.com/apache/trafficcontrol/issues/5288) - Fixed the ability to create and update a server with MTU value >= 1280.
 - [#5284](https://github.com/apache/trafficcontrol/issues/5284) - Fixed error message when creating a server with non-existent profile
 - Fixed a NullPointerException in TR when a client passes a null SNI hostname in a TLS request

--- a/traffic_monitor/datareq/datareq_test.go
+++ b/traffic_monitor/datareq/datareq_test.go
@@ -79,14 +79,8 @@ func getMockLastHealthTimes() map[tc.CacheName]time.Duration {
 }
 
 func getMockCRStatesDeliveryService() tc.CRStatesDeliveryService {
-	numCGs := 10
-	disabledLocations := []tc.CacheGroupName{}
-	for i := 0; i < numCGs; i++ {
-		disabledLocations = append(disabledLocations, tc.CacheGroupName(randStr()))
-	}
-
 	return tc.CRStatesDeliveryService{
-		DisabledLocations: disabledLocations,
+		DisabledLocations: []tc.CacheGroupName{},
 		IsAvailable:       randBool(),
 	}
 }

--- a/traffic_monitor/ds/stat.go
+++ b/traffic_monitor/ds/stat.go
@@ -130,18 +130,13 @@ func addAvailableData(dsStats *dsdata.Stats, crStates tc.CRStates, serverCachegr
 	}
 
 	// TODO move to its own func?
-	for dsName, ds := range crStates.DeliveryService {
+	for dsName := range crStates.DeliveryService {
 		stat, ok := dsStats.DeliveryService[dsName]
 		if !ok {
 			log.Infof("CreateStats not adding disabledLocations for '%s': not found in Stats\n", dsName)
 			continue // TODO log warning? Error?
 		}
-
-		// TODO determine if a deep copy is necessary
-		stat.CommonStats.CachesDisabled = make([]string, len(ds.DisabledLocations), len(ds.DisabledLocations))
-		for i, v := range ds.DisabledLocations {
-			stat.CommonStats.CachesDisabled[i] = string(v)
-		}
+		stat.CommonStats.CachesDisabled = make([]string, 0)
 	}
 }
 

--- a/traffic_monitor/health/cache_test.go
+++ b/traffic_monitor/health/cache_test.go
@@ -417,6 +417,7 @@ func TestCalcAvailabilityThresholds(t *testing.T) {
 
 	localCacheStatusThreadsafe := threadsafe.NewCacheAvailableStatus()
 	localStates := peer.NewCRStatesThreadsafe()
+	localStates.SetDeliveryService("myDS", tc.CRStatesDeliveryService{})
 	events := NewThreadsafeEvents(200)
 
 	// test that a normal stat poll over the kbps threshold marks down
@@ -432,6 +433,16 @@ func TestCalcAvailabilityThresholds(t *testing.T) {
 	results[0].Statistics.Interfaces = original
 
 	CalcAvailability(results, pollerName, statResultHistory, mc, toData, localCacheStatusThreadsafe, localStates, events, config.Both)
+
+	// ensure that the DisabledLocations is an empty, non-nil slice
+	for _, ds := range localStates.GetDeliveryServices() {
+		if ds.DisabledLocations == nil {
+			t.Error("expected: non-nil DisabledLocations, actual: nil")
+		}
+		if len(ds.DisabledLocations) > 0 {
+			t.Errorf("expected: empty DisabledLocations, actual: %d", len(ds.DisabledLocations))
+		}
+	}
 
 	localCacheStatuses := localCacheStatusThreadsafe.Get()
 	localCacheStatus, ok := localCacheStatuses[result.ID]

--- a/traffic_monitor/manager/statecombiner.go
+++ b/traffic_monitor/manager/statecombiner.go
@@ -21,7 +21,6 @@ package manager
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -148,7 +147,6 @@ func combineDSState(
 	if localDeliveryService.IsAvailable {
 		deliveryService.IsAvailable = true
 	}
-	deliveryService.DisabledLocations = localDeliveryService.DisabledLocations
 
 	for peerName, iPeerStates := range peerStates.GetCrstates() {
 		peerDeliveryService, ok := iPeerStates.DeliveryService[deliveryServiceName]
@@ -159,7 +157,6 @@ func combineDSState(
 		if peerDeliveryService.IsAvailable {
 			deliveryService.IsAvailable = true
 		}
-		deliveryService.DisabledLocations = intersection(deliveryService.DisabledLocations, peerDeliveryService.DisabledLocations)
 	}
 	combinedStates.SetDeliveryService(deliveryServiceName, deliveryService)
 }
@@ -218,18 +215,3 @@ type CacheGroupNameSlice []tc.CacheGroupName
 func (p CacheGroupNameSlice) Len() int           { return len(p) }
 func (p CacheGroupNameSlice) Less(i, j int) bool { return p[i] < p[j] }
 func (p CacheGroupNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-
-// intersection returns strings in both a and b.
-// Note this modifies a and b. Specifically, it sorts them. If that isn't acceptable, pass copies of your real data.
-func intersection(a []tc.CacheGroupName, b []tc.CacheGroupName) []tc.CacheGroupName {
-	sort.Sort(CacheGroupNameSlice(a))
-	sort.Sort(CacheGroupNameSlice(b))
-	c := []tc.CacheGroupName{} // important to initialize, so JSON is `[]` not `null`
-	for _, s := range a {
-		i := sort.Search(len(b), func(i int) bool { return b[i] >= s })
-		if i < len(b) && b[i] == s {
-			c = append(c, s)
-		}
-	}
-	return c
-}


### PR DESCRIPTION
## What does this PR (Pull Request) do?
The `disabledLocations` array is an unnecessary optimization for Traffic
Router, and it isn't always populated properly in certain cases, leading
to service outages. Therefore, never populate it, but keep the field
around for compatibility purposes.

- [x] This PR fixes #6048 

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
Ensure the TM tests pass.
Shut down all caches in a cachegroup for a CDN, request `GET /publish/CrStates` from TM, ensure that the `disabledLocations` arrays are all empty -- i.e. `[]`. 

## If this is a bug fix, what versions of Traffic Control are affected?
5.1.x, master

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] bug fix, no docs necessary
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
