### PR TITLE
Traffic Portal controls for Delivery Service TLS Versions

### DIFF
--- a/traffic_portal/.gitignore
+++ b/traffic_portal/.gitignore
@@ -22,3 +22,9 @@ node_modules
 app/bower_components
 app/dist
 Gemfile.lock
+
+# SSL keys/certs for testing with the dev configuration
+localhost.cert
+localhost.crt
+localhost.key
+localhost.csr

--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -120,7 +120,7 @@ form label.has-tooltip {
 		position: absolute;
 		bottom: 2em;
 		padding-bottom: 1em;
-		z-index: 2;
+		z-index: 3;
 		color: default;
 		background-color: transparent;
 		transition: opacity 0.2s ease-in-out;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -29,7 +29,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     const knownVersions = new Set(["1.0", "1.1", "1.2", "1.3"]);
     $scope.tlsVersionUnknown = v => v && !knownVersions.has(v);
 
-    const insecureVersions = new Set(["1.0", "1.1"])
+    const insecureVersions = new Set(["1.0", "1.1"]);
     $scope.tlsVersionInsecure = v => v && insecureVersions.has(v);
 
     /**
@@ -65,11 +65,11 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 
     $scope.removeTLSVersion = function(index) {
         deliveryService.tlsVersions.splice(index, 1);
-    }
+    };
 
     $scope.addTLSVersion = function(index) {
         deliveryService.tlsVersions.splice(index+1, 0, "");
-    }
+    };
 
     /**
      * This function is called on 'change' events for any and all TLS Version

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -19,6 +19,72 @@
 
 var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin, topologies, type, types, $scope, $location, $uibModal, $window, formUtils, locationUtils, tenantUtils, deliveryServiceUtils, cdnService, profileService, tenantService, propertiesModel, userModel, serviceCategoryService) {
 
+    const knownVersions = new Set(["1.0", "1.1", "1.2", "1.3"]);
+    $scope.tlsVersionUnknown = v => v && !knownVersions.has(v);
+
+    const insecureVersions = new Set(["1.0", "1.1"])
+    $scope.tlsVersionInsecure = v => v && insecureVersions.has(v);
+
+    $scope.toggleTLSRestrict = () => {
+        deliveryService.tlsVersions = $scope.restrictTLS ? [""] : null;
+    }
+
+    $scope.removeTLSVersion = function(index) {
+        deliveryService.tlsVersions.splice(index, 1);
+    }
+
+    $scope.addTLSVersion = function(index) {
+        deliveryService.tlsVersions.splice(index+1, 0, "");
+    }
+
+    /**
+     * This function is called on 'change' events for any and all TLS Version
+     * inputs, and sets validity states of duplicates.
+     *
+     * This can't use a normal validator because it depends on a value checking
+     * against a list containing itself. AngularJS sets values that fail
+     * validation to `undefined`, so if there's a set of TLS versions
+     * `["1.3", "1.3"]`, then the validator will set one of them to `undefined`.
+     * Now the set is `["1.3", undefined]`, so there are no more duplicates, so
+     * the set is marked as valid.
+     */
+    function validateTLS() {
+        if (!$scope.generalConfig || !($scope.deliveryService.tlsVersions instanceof Array)) {
+            return;
+        }
+
+        const verMap = new Map();
+        for (let i = 0; i < $scope.deliveryService.tlsVersions.length; ++i) {
+            const propName = `tlsVersion${i+1}`;
+            if (propName in $scope.generalConfig) {
+                $scope.generalConfig[propName].$setValidity("duplicates", true);
+            }
+
+            const ver = $scope.deliveryService.tlsVersions[i];
+            if (ver === undefined) {
+                continue;
+            }
+            const current = verMap.get(ver);
+            if (current) {
+                current.count++;
+                current.indices.push(i);
+            } else {
+                verMap.set(ver, {
+                    count: 1,
+                    indices: [i]
+                });
+            }
+        }
+
+        for (const index of Array.from(verMap).filter(v=>v[1].count>1).flatMap(v=>v[1].indices)) {
+            const propName = `tlsVersion${index+1}`;
+            if (propName in $scope.generalConfig) {
+                $scope.generalConfig[propName].$setValidity("duplicates", false);
+            }
+        }
+    }
+    $scope.validateTLS = validateTLS;
+
     var getCDNs = function() {
         cdnService.getCDNs()
             .then(function(result) {
@@ -300,6 +366,46 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
     $scope.navigateToPath = locationUtils.navigateToPath;
 
     $scope.hasError = formUtils.hasError;
+
+    /**
+     * Checks if a TLS Version has a specific error.
+     *
+     * @param {number} index The index of the TLS Version to check into the
+     * form's Delivery Service's `tlsVersions` array.
+     * @param {string} property The name of the error to check.
+     * @returns {boolean} Whether or not the indicated TLS Version has the given
+     * error.
+     */
+    function tlsVersionHasPropertyError(index, property) {
+        if (!$scope.generalConfig) {
+            return false;
+        }
+        const propName = `tlsVersion${index+1}`;
+        if (!(propName in $scope.generalConfig)) {
+            return false;
+        }
+        return formUtils.hasPropertyError($scope.generalConfig[propName], property);
+    };
+    $scope.tlsVersionHasPropertyError = tlsVersionHasPropertyError;
+
+    /**
+     * Checks if a TLS Version has any error.
+     *
+     * @param {number} index The index of the TLS Version to check into the
+     * form's Delivery Service's `tlsVersions` array.
+     * @returns {boolean} Whether or not the indicated TLS Version has an error.
+     */
+     function tlsVersionHasError(index) {
+        if (!$scope.generalConfig) {
+            return false;
+        }
+        const propName = `tlsVersion${index+1}`;
+        if (!(propName in $scope.generalConfig)) {
+            return false;
+        }
+        return formUtils.hasError($scope.generalConfig[propName]);
+    };
+    $scope.tlsVersionHasError = tlsVersionHasError;
 
     $scope.hasPropertyError = formUtils.hasPropertyError;
 

--- a/traffic_portal/app/src/common/modules/form/deliveryService/clone/FormCloneDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/clone/FormCloneDeliveryServiceController.js
@@ -26,6 +26,8 @@ var FormCloneDeliveryServiceController = function(deliveryService, origin, topol
 
 	$scope.advancedShowing = true;
 
+    $scope.restrictTLS = deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0;
+
 	$scope.settings = {
 		isNew: true,
 		saveLabel: 'Clone'

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -64,7 +64,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 				original: deliveryService
 			};
 
-			// if the user chooses to complete/fulfill the delete request immediately, a delivery service request will be made and marked as complete, 
+			// if the user chooses to complete/fulfill the delete request immediately, a delivery service request will be made and marked as complete,
 			// then if that is successful, the DS will be deleted
 			if (options.status.id === $scope.COMPLETE) {
 				// first create the ds request
@@ -167,6 +167,8 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 		deleteLabel: 'Delete'
 	};
 
+    $scope.restrictTLS = deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0;
+
 	$scope.save = function(deliveryService) {
 		if (deliveryService.sslKeyVersion !== null && deliveryService.sslKeyVersion !== 0 &&
 			($scope.originalRoutingName !== deliveryService.routingName || $scope.originalCDN !== deliveryService.cdnId) &&
@@ -192,6 +194,11 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 			});
 			return;
 		}
+
+		if (!$scope.restrictTLS) {
+			deliveryService.tlsVersions = null;
+		}
+
 		// if ds requests are enabled in traffic_portal_properties.json, we'll create a ds request, else just update the ds
 		if ($scope.dsRequestsEnabled) {
 			var params = {

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -167,7 +167,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 		deleteLabel: 'Delete'
 	};
 
-    $scope.restrictTLS = deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0;
+	$scope.restrictTLS = deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0;
 
 	$scope.save = function(deliveryService) {
 		if (deliveryService.sslKeyVersion !== null && deliveryService.sslKeyVersion !== 0 &&

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -254,6 +254,90 @@ under the License.
                             </aside>
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="restrictTLS">
+                            Restrict TLS Versions
+                            <div class="helptooltip">
+                                <div class="helptext">
+                                    Limit the TLS versions that cache servers will accept for HTTPs connections.
+                                    <aside class="warning">
+                                        <h6>Warning</h6>
+                                        <p>Setting TLS Versions that are explicitly supported may break older clients that can't use the specified versions</p>
+                                    </aside>
+                                </div>
+                            </div>
+                        </label>
+                        <div class="col-md-10 col-sm-10 col-xs-12" style="display:inline-grid;grid-template-columns:auto;justify-content:start;">
+                            <input
+                                type="checkbox"
+                                id="restrictTLS"
+                                name="restrictTLS"
+                                class="form-control"
+                                ng-model="restrictTLS"
+                                style="max-width: max-content; min-width: 1em;"
+                                ng-change="toggleTLSRestrict()"
+                            />
+                            <small class="input-warning" ng-if="restrictTLS && dsCurrent.protocol === 0">Delivery Service doesn't use HTTPS - this will have no effect</small>
+                        </div>
+                    </div>
+                    <div
+                        class="form-group"
+                        ng-if="restrictTLS"
+                        ng-repeat="ver in deliveryService.tlsVersions track by $index"
+                        ng-class="{'has-error': tlsVersionHasError($index), 'has-feedback': tlsVersionHasError($index)}"
+                    >
+                        <div>
+                            <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tlsVersion1">
+                                TLS Version #{{$index+1}}
+                            </label>
+                            <div class="col-md-10 col-sm-10 col-xs-12">
+                                <div>
+                                    <div class="input-group add-more-inputs">
+                                        <input
+                                            id="tlsVersion{{$index+1}}"
+                                            name="tlsVersion{{$index+1}}"
+                                            type="text"
+                                            class="form-control"
+                                            ng-model="deliveryService.tlsVersions[$index]"
+                                            pattern="[0-9]+\.[0-9]+"
+                                            placeholder="1.3"
+                                            required
+                                            ng-change="validateTLS()"
+                                        />
+                                        <span class="form-input-group-btn input-group-btn">
+                                            <button
+                                                type="button"
+                                                title="remove support for this TLS version"
+                                                class="btn btn-default"
+                                                ng-show="deliveryService.tlsVersions.length > 1"
+                                                ng-click="removeTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-minus"></i>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="add a supported TLS version"
+                                                class="btn btn-default"
+                                                ng-click="addTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-plus"></i>
+                                            </button>
+                                        </span>
+                                    </div>
+                                </div>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'duplicates')">Duplicate TLS Version</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'required')">Required</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'pattern')">Invalid version number - must be "X.Y"</small>
+                                <small class="input-warning" ng-show="tlsVersionUnknown(ver)">Unknown version</small>
+                                <small class="input-warning" ng-show="tlsVersionInsecure(ver)">TLS Version {{ver}} is known to be insecure!</small>
+                                <aside class="current-value" ng-if="settings.isRequest" ng-show="dsCurrent.tlsVersions instanceof Array && dsCurrent.tlsVersions.length === deliveryService.tlsVersions.length && dsCurrent.tlsVersions[$index] !== dsCurrent.tlsVersions[$index]">
+                                    <h3 ng-if="open()">Current Value</h3>
+                                    <h3 ng-if="!open()">Previous Value</h3>
+                                    <pre>{{::dsCurrent.tlsVersions[$index]}}</pre>
+                                </aside>
+                            </div>
+                        </div>
+                    </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.serviceCategory), 'has-feedback': hasError(generalConfig.serviceCategory)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="serviceCategory">Service Category<div class="helptooltip">
                                 <div class="helptext">The type of content being delivered. Some examples are linear and vod.</div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -254,6 +254,90 @@ under the License.
                             </aside>
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="restrictTLS">
+                            Restrict TLS Versions
+                            <div class="helptooltip">
+                                <div class="helptext">
+                                    Limit the TLS versions that cache servers will accept for HTTPs connections.
+                                    <aside class="warning">
+                                        <h6>Warning</h6>
+                                        <p>Setting TLS Versions that are explicitly supported may break older clients that can't use the specified versions</p>
+                                    </aside>
+                                </div>
+                            </div>
+                        </label>
+                        <div class="col-md-10 col-sm-10 col-xs-12" style="display:inline-grid;grid-template-columns:auto;justify-content:start;">
+                            <input
+                                type="checkbox"
+                                id="restrictTLS"
+                                name="restrictTLS"
+                                class="form-control"
+                                ng-model="restrictTLS"
+                                style="max-width: max-content; min-width: 1em;"
+                                ng-change="toggleTLSRestrict()"
+                            />
+                            <small class="input-warning" ng-if="restrictTLS && dsCurrent.protocol === 0">Delivery Service doesn't use HTTPS - this will have no effect</small>
+                        </div>
+                    </div>
+                    <div
+                        class="form-group"
+                        ng-if="restrictTLS"
+                        ng-repeat="ver in deliveryService.tlsVersions track by $index"
+                        ng-class="{'has-error': tlsVersionHasError($index), 'has-feedback': tlsVersionHasError($index)}"
+                    >
+                        <div>
+                            <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tlsVersion1">
+                                TLS Version #{{$index+1}}
+                            </label>
+                            <div class="col-md-10 col-sm-10 col-xs-12">
+                                <div>
+                                    <div class="input-group add-more-inputs">
+                                        <input
+                                            id="tlsVersion{{$index+1}}"
+                                            name="tlsVersion{{$index+1}}"
+                                            type="text"
+                                            class="form-control"
+                                            ng-model="deliveryService.tlsVersions[$index]"
+                                            pattern="[0-9]+\.[0-9]+"
+                                            placeholder="1.3"
+                                            required
+                                            ng-change="validateTLS()"
+                                        />
+                                        <span class="form-input-group-btn input-group-btn">
+                                            <button
+                                                type="button"
+                                                title="remove support for this TLS version"
+                                                class="btn btn-default"
+                                                ng-show="deliveryService.tlsVersions.length > 1"
+                                                ng-click="removeTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-minus"></i>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="add a supported TLS version"
+                                                class="btn btn-default"
+                                                ng-click="addTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-plus"></i>
+                                            </button>
+                                        </span>
+                                    </div>
+                                </div>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'duplicates')">Duplicate TLS Version</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'required')">Required</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'pattern')">Invalid version number - must be "X.Y"</small>
+                                <small class="input-warning" ng-show="tlsVersionInsecure(ver)">TLS Version {{ver}} is known to be insecure!</small>
+                                <small class="input-warning" ng-show="tlsVersionUnknown(ver)">Unknown version</small>
+                                <aside class="current-value" ng-if="settings.isRequest" ng-show="dsCurrent.tlsVersions instanceof Array && dsCurrent.tlsVersions.length === deliveryService.tlsVersions.length && dsCurrent.tlsVersions[$index] !== dsCurrent.tlsVersions[$index]">
+                                    <h3 ng-if="open()">Current Value</h3>
+                                    <h3 ng-if="!open()">Previous Value</h3>
+                                    <pre>{{::dsCurrent.tlsVersions[$index]}}</pre>
+                                </aside>
+                            </div>
+                        </div>
+                    </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.serviceCategory), 'has-feedback': hasError(generalConfig.serviceCategory)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="serviceCategory">Service Category<div class="helptooltip">
                                 <div class="helptext">The type of content being delivered. Some examples are linear and vod.</div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -191,6 +191,90 @@ under the License.
                             </aside>
                         </div>
                     </div>
+                    <div class="form-group">
+                        <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="restrictTLS">
+                            Restrict TLS Versions
+                            <div class="helptooltip">
+                                <div class="helptext">
+                                    Limit the TLS versions that cache servers will accept for HTTPs connections.
+                                    <aside class="warning">
+                                        <h6>Warning</h6>
+                                        <p>Setting TLS Versions that are explicitly supported may break older clients that can't use the specified versions</p>
+                                    </aside>
+                                </div>
+                            </div>
+                        </label>
+                        <div class="col-md-10 col-sm-10 col-xs-12" style="display:inline-grid;grid-template-columns:auto;justify-content:start;">
+                            <input
+                                type="checkbox"
+                                id="restrictTLS"
+                                name="restrictTLS"
+                                class="form-control"
+                                ng-model="restrictTLS"
+                                style="max-width: max-content; min-width: 1em;"
+                                ng-change="toggleTLSRestrict()"
+                            />
+                            <small class="input-warning" ng-if="restrictTLS && dsCurrent.protocol === 0">Delivery Service doesn't use HTTPS - this will have no effect</small>
+                        </div>
+                    </div>
+                    <div
+                        class="form-group"
+                        ng-if="restrictTLS"
+                        ng-repeat="ver in deliveryService.tlsVersions track by $index"
+                        ng-class="{'has-error': tlsVersionHasError($index), 'has-feedback': tlsVersionHasError($index)}"
+                    >
+                        <div>
+                            <label class="control-label col-md-2 col-sm-2 col-xs-12" for="tlsVersion1">
+                                TLS Version #{{$index+1}}
+                            </label>
+                            <div class="col-md-10 col-sm-10 col-xs-12">
+                                <div>
+                                    <div class="input-group add-more-inputs">
+                                        <input
+                                            id="tlsVersion{{$index+1}}"
+                                            name="tlsVersion{{$index+1}}"
+                                            type="text"
+                                            class="form-control"
+                                            ng-model="deliveryService.tlsVersions[$index]"
+                                            pattern="[0-9]+\.[0-9]+"
+                                            placeholder="1.3"
+                                            required
+                                            ng-change="validateTLS()"
+                                        />
+                                        <span class="form-input-group-btn input-group-btn">
+                                            <button
+                                                type="button"
+                                                title="remove support for this TLS version"
+                                                class="btn btn-default"
+                                                ng-show="deliveryService.tlsVersions.length > 1"
+                                                ng-click="removeTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-minus"></i>
+                                            </button>
+                                            <button
+                                                type="button"
+                                                title="add a supported TLS version"
+                                                class="btn btn-default"
+                                                ng-click="addTLSVersion($index)"
+                                            >
+                                                <i class="fa fa-plus"></i>
+                                            </button>
+                                        </span>
+                                    </div>
+                                </div>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'duplicates')">Duplicate TLS Version</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'required')">Required</small>
+                                <small class="input-error" ng-show="tlsVersionHasPropertyError($index, 'pattern')">Invalid version number - must be "X.Y"</small>
+                                <small class="input-warning" ng-show="tlsVersionInsecure(ver)">TLS Version {{ver}} is known to be insecure!</small>
+                                <small class="input-warning" ng-show="tlsVersionUnknown(ver)">Unknown version</small>
+                                <aside class="current-value" ng-if="settings.isRequest" ng-show="dsCurrent.tlsVersions instanceof Array && dsCurrent.tlsVersions.length === deliveryService.tlsVersions.length && dsCurrent.tlsVersions[$index] !== dsCurrent.tlsVersions[$index]">
+                                    <h3 ng-if="open()">Current Value</h3>
+                                    <h3 ng-if="!open()">Previous Value</h3>
+                                    <pre>{{::dsCurrent.tlsVersions[$index]}}</pre>
+                                </aside>
+                            </div>
+                        </div>
+                    </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.serviceCategory), 'has-feedback': hasError(generalConfig.serviceCategory)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="serviceCategory">Service Category<div class="helptooltip">
                                 <div class="helptext">The type of content being delivered. Some examples are linear and vod.</div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
@@ -31,6 +31,8 @@ var FormNewDeliveryServiceController = function(deliveryService, origin, topolog
 		saveLabel: 'Create'
 	};
 
+	$scope.restrictTLS = false;
+
 	var createDeliveryServiceCreateRequest = function(dsRequest, dsRequestComment, autoFulfilled) {
 		deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
 			then(
@@ -64,6 +66,9 @@ var FormNewDeliveryServiceController = function(deliveryService, origin, topolog
 
 
 	$scope.save = function(deliveryService) {
+		if (!$scope.restrictTLS) {
+			deliveryService.tlsVersions = null;
+		}
 		// if ds requests are enabled in traffic_portal_properties.json, we'll create a ds request, else just create the ds
 		if ($scope.dsRequestsEnabled) {
 			var params = {

--- a/traffic_portal/conf/configDev.js
+++ b/traffic_portal/conf/configDev.js
@@ -21,8 +21,10 @@
 module.exports = {
     timeout: '120s',
     useSSL: true, // set to true if you plan to use https (self-signed or trusted certs).
-    port: 80, // set to http port
-    sslPort: 443, // set to https port
+    // These ports are chosen to not collide with the default CDN-in-a-Box
+    // exposed port numbers
+    port: 60444,
+    sslPort: 60443,
     // if useSSL is true, generate ssl certs and provide the proper locations.
     ssl: {
         key:    './localhost.key',
@@ -30,6 +32,7 @@ module.exports = {
         ca:     [ './localhost.crt' ]
     },
     // set api 'base_url' to the traffic ops api url (all api calls made from the traffic portal will be proxied to the api base_url)
+    // this is the default exposed port for the CDN-in-a-Box Traffic Ops service
     api: {
         base_url: 'https://localhost:6443/api/'
     },
@@ -43,4 +46,3 @@ module.exports = {
     },
     reject_unauthorized: 0 // 0 if using self-signed certs, 1 if trusted certs
 };
-


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR is not related to any Issue

This PR adds controls to Traffic Portal for manipulating the allowed TLS versions of a Delivery Service.

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Create and edit DNS-routed, HTTP-routed, ANY_MAP-routed, and STEERING-routed Delivery Services. Ensure that no TLS versions controls appear for STEERING-routed Delivery Services, and for all the others:

- TLS versions can be manipulated when "Restrict TLS Versions" is checked (and they are submitted as `null` in POST and PUT requests to `/deliveryservices` when it isn't)
- Empty TLS version inputs show an error because they are required
- TLS versions that don't match `^\d+\.\d+$` show an error because they are malformed
- TLS versions that appear more than once in the list are marked as duplicates
- TLS versions that are not known to exist (anything besides 1.0, 1.1, 1.2, and 1.3) display a warning because they are unknown
- TLS versions that are known to be insecure (1.0 and 1.1) display a warning because they are insecure

## The following criteria are ALL met by this PR
- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**