### PR TITLE
Fix Internal server error in update cachegroups by already exist cg name

### DIFF
--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -688,7 +688,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 	}
 
 	if err = cg.updateCoordinate(); err != nil {
-		return nil, err, tc.DBError, http.StatusBadRequest
+		return nil, err, tc.DBError, http.StatusInternalServerError
 	}
 	return coordinateID, nil, nil, http.StatusOK
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -707,7 +707,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 
 	err = cg.updateCoordinate()
 	if err != nil {
-		if err == errors.New("cachegroup name already exists, please choose a different name") {
+		if errors.Is(err, errors.New("cachegroup name already exists, please choose a different name")) {
 			return nil, err, tc.DBError, http.StatusBadRequest
 		}
 		return nil, nil, tc.DBError, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -423,7 +423,7 @@ func (cg *TOCacheGroup) updateCoordinate() error {
 		}
 		rowsAffected, _ := result.RowsAffected()
 		if rowsAffected > 0 {
-			return errors.New("cachegroup name already exist, please choose a different name")
+			return errors.New("cachegroup name already exists, please choose a different name")
 		}
 		q = `UPDATE coordinate SET name = $1, latitude = $2, longitude = $3 WHERE id = (SELECT coordinate FROM cachegroup WHERE id = $4)`
 		result, err = cg.ReqInfo.Tx.Tx.Exec(q, tc.CachegroupCoordinateNamePrefix+*cg.Name, *cg.Latitude, *cg.Longitude, *cg.ID)
@@ -699,7 +699,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 
 	err = cg.updateCoordinate()
 	if err != nil {
-		if err == errors.New("cachegroup name already exist, please choose a different name") {
+		if err == errors.New("cachegroup name already exists, please choose a different name") {
 			return nil, err, tc.DBError, http.StatusBadRequest
 		}
 		return nil, nil, tc.DBError, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -42,8 +42,6 @@ import (
 	"github.com/lib/pq"
 )
 
-var ErrDuplicateExist = errors.New("cachegroup name already exist, give different name")
-
 type TOCacheGroup struct {
 	api.APIInfoImpl `json:"-"`
 	tc.CacheGroupNullable
@@ -425,7 +423,7 @@ func (cg *TOCacheGroup) updateCoordinate() error {
 		}
 		rowsAffected, _ := result.RowsAffected()
 		if rowsAffected > 0 {
-			return ErrDuplicateExist
+			return errors.New("cachegroup name already exist, please choose a different name")
 		}
 		q = `UPDATE coordinate SET name = $1, latitude = $2, longitude = $3 WHERE id = (SELECT coordinate FROM cachegroup WHERE id = $4)`
 		result, err = cg.ReqInfo.Tx.Tx.Exec(q, tc.CachegroupCoordinateNamePrefix+*cg.Name, *cg.Latitude, *cg.Longitude, *cg.ID)
@@ -701,7 +699,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 
 	err = cg.updateCoordinate()
 	if err != nil {
-		if err == ErrDuplicateExist {
+		if err == errors.New("cachegroup name already exist, please choose a different name") {
 			return nil, err, tc.DBError, http.StatusBadRequest
 		}
 		return nil, nil, tc.DBError, http.StatusInternalServerError

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -37,7 +37,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 )
@@ -688,7 +688,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 	}
 
 	if err = cg.updateCoordinate(); err != nil {
-		return nil, nil, tc.DBError, http.StatusInternalServerError
+		return nil, err, tc.DBError, http.StatusBadRequest
 	}
 	return coordinateID, nil, nil, http.StatusOK
 }

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -681,7 +681,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 		return nil, fmt.Errorf("no cachegroup with id %d found", *cg.ID), nil, http.StatusNotFound
 	}
 	if err != nil {
-		return nil, nil, tc.DBError, http.StatusInternalServerError
+		return nil, nil, nil, http.StatusInternalServerError
 	}
 
 	// If partial coordinate information is given or the coordinate information is wholly
@@ -698,7 +698,7 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 	//
 	if cg.Latitude == nil || cg.Longitude == nil {
 		if err = cg.deleteCoordinate(*coordinateID); err != nil {
-			return nil, nil, tc.DBError, http.StatusInternalServerError
+			return nil, nil, nil, http.StatusInternalServerError
 		}
 		cg.Latitude = nil
 		cg.Longitude = nil
@@ -708,9 +708,9 @@ func (cg *TOCacheGroup) handleCoordinateUpdate() (*int, error, error, int) {
 	err = cg.updateCoordinate()
 	if err != nil {
 		if errors.Is(err, errors.New("cachegroup name already exists, please choose a different name")) {
-			return nil, err, tc.DBError, http.StatusBadRequest
+			return nil, err, err, http.StatusBadRequest
 		}
-		return nil, nil, tc.DBError, http.StatusInternalServerError
+		return nil, nil, nil, http.StatusInternalServerError
 	}
 	return coordinateID, nil, nil, http.StatusOK
 }


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #4442  <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This fixes the internal server error causing in update cache group with the already existing cache group name

## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops
- CI tests

## What is the best way to verify this PR?
Execute all the Integration tests and make sure the tests are passed.

## If this is a bug fix, what versions of Traffic Control are affected?
* Master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
