### PR TITLE
Prevent unassigning all ONLINE ORG servers from an active, MSO-enabled DS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops: Adds API endpoints to fetch (GET), create (POST) or delete (DELETE) a cdn notification. Create and delete are limited to users with operations or admin role.
 - Added ACME certificate renewals and ACME account registration using external account binding
 - Added functionality to automatically renew ACME certificates.
+- Traffic Ops: [#6069](https://github.com/apache/trafficcontrol/issues/6069) - prevent unassigning all ONLINE ORG servers from an MSO-enabled delivery service
 - Added ORT flag to set local.dns bind address from server service addresses
 - Added an endpoint for statuses on asynchronous jobs and applied it to the ACME renewal endpoint.
 - Added two new cdn.conf options to make Traffic Vault configuration more backend-agnostic: `traffic_vault_backend` and `traffic_vault_config`

--- a/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v2/deliveryserviceservers_test.go
@@ -51,7 +51,7 @@ func CreateTestDeliveryServiceServersWithRequiredCapabilities(t *testing.T) {
 		{
 			serverName:  "atlanta-edge-01",
 			description: "missing requirements for server -> DS assignment",
-			err:         errors.New(`Caching server cannot be assigned to this delivery service without having the required delivery service capabilities`),
+			err:         errors.New("cannot be assigned to this delivery service"),
 			ssc:         sscs[0],
 			capability: tc.DeliveryServicesRequiredCapability{
 				DeliveryServiceID:  helperGetDeliveryServiceID(t, util.StrPtr("ds-test-minor-versions")),

--- a/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
+++ b/traffic_ops/testing/api/v3/deliveryserviceservers_test.go
@@ -414,7 +414,7 @@ func CreateTestDeliveryServiceServersWithRequiredCapabilities(t *testing.T) {
 		{
 			serverName:  "atlanta-edge-01",
 			description: "missing requirements for server -> DS assignment",
-			err:         errors.New(`Caching server cannot be assigned to this delivery service without having the required delivery service capabilities`),
+			err:         errors.New("cannot be assigned to this delivery service"),
 			ssc:         sscs[0],
 			capability: tc.DeliveryServicesRequiredCapability{
 				DeliveryServiceID:  helperGetDeliveryServiceID(t, util.StrPtr("ds-test-minor-versions")),

--- a/traffic_ops/testing/api/v4/servers_test.go
+++ b/traffic_ops/testing/api/v4/servers_test.go
@@ -884,6 +884,7 @@ func GetTestServersQueryParameters(t *testing.T) {
 		"midInParentCachegroup":          false,
 		"midInSecondaryCachegroup":       false,
 		"midInSecondaryCachegroupInCDN1": false,
+		"test-mso-org-01":                false,
 	}
 	response, _, err = TOSession.GetServers(opts)
 	if err != nil {
@@ -1212,7 +1213,7 @@ func UpdateTestServers(t *testing.T) {
 
 	typeOpts := client.NewRequestOptions()
 	typeOpts.QueryParameters.Set("useInTable", "server")
-	serverTypes, _, err := TOSession.GetTypes(opts)
+	serverTypes, _, err := TOSession.GetTypes(typeOpts)
 	if err != nil {
 		t.Fatalf("cannot get Server Types: %v - alerts: %+v", err, serverTypes.Alerts)
 	}
@@ -1237,7 +1238,7 @@ func UpdateTestServers(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected error when updating Server Type of a server assigned to DSes")
 	} else {
-		t.Logf("type change update alerts: %+v", alerts)
+		t.Logf("got expected error when updating Server Type of a server assigned to DSes - type change update alerts: %+v, err: %v", alerts, err)
 	}
 }
 

--- a/traffic_ops/testing/api/v4/tc-fixtures.json
+++ b/traffic_ops/testing/api/v4/tc-fixtures.json
@@ -1446,7 +1446,7 @@
             "logsEnabled": false,
             "missLat": 0,
             "missLong": 0,
-            "multiSiteOrigin": false,
+            "multiSiteOrigin": true,
             "orgServerFqdn": "https://example.com",
             "protocol": 0,
             "qstringIgnore": 0,
@@ -3130,6 +3130,55 @@
             "type": "ORG",
             "updPending": true,
             "xmppId": "denver-mso-org-01\\\\@ocdn.kabletown.net",
+            "xmppPasswd": "X"
+        },
+        {
+            "cachegroup": "multiOriginCachegroup",
+            "cdnName": "cdn1",
+            "domainName": "ga.denver.kabletown.net",
+            "guid": null,
+            "hostName": "test-mso-org-01",
+            "httpsPort": 443,
+            "iloIpAddress": "",
+            "iloIpGateway": "",
+            "iloIpNetmask": "",
+            "iloPassword": "",
+            "iloUsername": "",
+            "interfaces": [
+                {
+                    "ipAddresses": [
+                        {
+                            "address": "127.0.4.1/30",
+                            "gateway": "127.0.4.1",
+                            "serviceAddress": true
+                        },
+                        {
+                            "address": "2345:1244:12:8::20/64",
+                            "gateway": "2345:1244:12:8::20",
+                            "serviceAddress": false
+                        }
+                    ],
+                    "maxBandwidth": null,
+                    "monitor": true,
+                    "mtu": 9000,
+                    "name": "bond0",
+                    "routerHostName": "router16",
+                    "routerPort": "9015"
+                }
+            ],
+            "mgmtIpAddress": "",
+            "mgmtIpGateway": "",
+            "mgmtIpNetmask": "",
+            "offlineReason": null,
+            "physLocation": "Denver",
+            "profile": "MSO",
+            "rack": "RR 119.02",
+            "revalPending": false,
+            "status": "ONLINE",
+            "tcpPort": 80,
+            "type": "ORG",
+            "updPending": false,
+            "xmppId": "test-mso-org-01\\\\@ocdn.kabletown.net",
             "xmppPasswd": "X"
         },
         {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -40,7 +40,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 
 const lastEdgeAndLastOriginQuery = `
 SELECT (
-  SELECT (CASE WHEN t.name LIKE '` + string(tc.EdgeTypePrefix) + `%' THEN TRUE ELSE FALSE END) AS available
+  SELECT (SELECT t.name LIKE '` + string(tc.EdgeTypePrefix) + `%') AS available
   FROM type t
   JOIN server s ON s.type = t.id
   WHERE s.id = $2)
@@ -55,7 +55,7 @@ SELECT (
   AND deliveryservice = $1
   AND server <> $2),
 (
-  SELECT (CASE WHEN t.name LIKE '` + string(tc.OriginTypeName) + `%' THEN TRUE ELSE FALSE END) AS available
+  SELECT (SELECT t.name LIKE '` + string(tc.OriginTypeName) + `%') AS available
   FROM type t
   JOIN server s ON s.type = t.id
   WHERE s.id = $2)

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/delete.go
@@ -35,50 +35,68 @@ import (
 
 // Delete handler for deleting the association between a Delivery Service and a Server
 func Delete(w http.ResponseWriter, r *http.Request) {
-	delete(w, r)
+	deleteDSS(w, r)
 }
 
-const lastServerQuery = `
-SELECT
-(SELECT (CASE WHEN t.name LIKE '` + string(tc.EdgeTypePrefix) + `%' THEN TRUE ELSE FALSE END) AS available
-FROM type t
-JOIN server s ON s.type = t.id
-WHERE s.id = $2)
-AND
-(SELECT COUNT(*) = 0 AS available
-FROM deliveryservice_server
-JOIN server s ON deliveryservice_server.server = s.id
-JOIN type t ON t.id = s.type
-JOIN status st ON st.id = s.status
-WHERE (st.name = '` + string(tc.CacheStatusOnline) + `' OR st.name = '` + string(tc.CacheStatusReported) + `')
-AND t.name LIKE '` + string(tc.EdgeTypePrefix) + `%'
-AND deliveryservice = $1
-AND server <> $2)
+const lastEdgeAndLastOriginQuery = `
+SELECT (
+  SELECT (CASE WHEN t.name LIKE '` + string(tc.EdgeTypePrefix) + `%' THEN TRUE ELSE FALSE END) AS available
+  FROM type t
+  JOIN server s ON s.type = t.id
+  WHERE s.id = $2)
+  AND (
+  SELECT COUNT(*) = 0 AS available
+  FROM deliveryservice_server
+  JOIN server s ON deliveryservice_server.server = s.id
+  JOIN type t ON t.id = s.type
+  JOIN status st ON st.id = s.status
+  WHERE (st.name = '` + string(tc.CacheStatusOnline) + `' OR st.name = '` + string(tc.CacheStatusReported) + `')
+  AND t.name LIKE '` + string(tc.EdgeTypePrefix) + `%'
+  AND deliveryservice = $1
+  AND server <> $2),
+(
+  SELECT (CASE WHEN t.name LIKE '` + string(tc.OriginTypeName) + `%' THEN TRUE ELSE FALSE END) AS available
+  FROM type t
+  JOIN server s ON s.type = t.id
+  WHERE s.id = $2)
+  AND (
+  SELECT COUNT(*) = 0 AS available
+  FROM deliveryservice_server
+  JOIN server s ON deliveryservice_server.server = s.id
+  JOIN type t ON t.id = s.type
+  JOIN status st ON st.id = s.status
+  WHERE (st.name = '` + string(tc.CacheStatusOnline) + `' OR st.name = '` + string(tc.CacheStatusReported) + `')
+  AND t.name LIKE '` + string(tc.OriginTypeName) + `%'
+  AND deliveryservice = $1
+  AND server <> $2)
 `
 
-// checkLastServer checks if the given Server ID identifies the last server
-// assigned to the Delivery Service identified by its passed ID. It returns -
-// in order - an HTTP status code (useful only if an error occurs), an error
-// suitable for reporting back to the user, and an error that must not be shown
-// to the user. If the server is, in fact, the last server assigned to the
-// Delivery Service, the "user error" will be set to an appropriate, non-nil
-// value.
-func checkLastServer(dsID, serverID int, tx *sql.Tx) (int, error, error) {
-	var isLast bool
+// checkLastAvailableEdgeOrOrigin checks if the given Server ID identifies the last ONLINE/REPORTED
+// edge or origin assigned to the Delivery Service identified by its passed ID. It returns - in
+// order - an HTTP status code (useful only if an error occurs), an error suitable for reporting
+// back to the user, and an error that must not be shown to the user. If the server is, in fact,
+// the last available edge or origin assigned to the Delivery Service, the "user error" will be
+// set to an appropriate, non-nil value.
+func checkLastAvailableEdgeOrOrigin(dsID, serverID int, usesMSO bool, tx *sql.Tx) (int, error, error) {
+	var isLastEdge bool
+	var isLastOrigin bool
 	if tx == nil {
 		return http.StatusInternalServerError, nil, errors.New("nil transaction")
 	}
-	err := tx.QueryRow(lastServerQuery, dsID, serverID).Scan(&isLast)
+	err := tx.QueryRow(lastEdgeAndLastOriginQuery, dsID, serverID).Scan(&isLastEdge, &isLastOrigin)
 	if err != nil {
 		return http.StatusInternalServerError, nil, fmt.Errorf("checking if server #%d is the last one assigned to DS #%d: %v", serverID, dsID, err)
 	}
-	if isLast {
-		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no REPORTED/ONLINE assigned servers", serverID, dsID), nil
+	if isLastEdge {
+		return http.StatusConflict, fmt.Errorf("removing server #%d from active Delivery Service #%d would leave it with no REPORTED/ONLINE EDGE servers", serverID, dsID), nil
+	}
+	if usesMSO && isLastOrigin {
+		return http.StatusConflict, fmt.Errorf("removing server #%d from active, MSO-enabled Delivery Service #%d would leave it with no REPORTED/ONLINE ORG servers", serverID, dsID), nil
 	}
 	return http.StatusOK, nil, nil
 }
 
-func delete(w http.ResponseWriter, r *http.Request) {
+func deleteDSS(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, []string{"serverid", "dsid"}, []string{"serverid", "dsid"})
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
@@ -132,7 +150,8 @@ func delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if *ds.Active {
-		errCode, userErr, sysErr = checkLastServer(dsID, serverID, tx)
+		usesMSO := ds.MultiSiteOrigin == nil || *ds.MultiSiteOrigin
+		errCode, userErr, sysErr = checkLastAvailableEdgeOrOrigin(dsID, serverID, usesMSO, tx)
 		if userErr != nil || sysErr != nil {
 			api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
 			return

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -548,8 +548,7 @@ func validateDSSAssignments(tx *sql.Tx, ds DSInfo, serverInfos []tc.ServerInfo, 
 				anyAvailableServers = true
 				if inf.Type == tc.OriginTypeName {
 					newOrgCount++
-				}
-				if strings.HasPrefix(inf.Type, tc.CacheTypeEdge.String()) {
+				} else if strings.HasPrefix(inf.Type, tc.CacheTypeEdge.String()) {
 					newAvailableEdgeCount++
 				}
 			}

--- a/traffic_ops/traffic_ops_golang/server/put_status.go
+++ b/traffic_ops/traffic_ops_golang/server/put_status.go
@@ -60,7 +60,7 @@ func InvalidStatusForDeliveryServicesAlertText(prefix, serverType string, dsIDs 
 	if strings.HasPrefix(serverType, tc.OriginTypeName) {
 		typeMsg = tc.OriginTypeName
 	}
-	alertText += fmt.Sprintf("  with no '%s' or '%s' %s servers", tc.CacheStatusOnline, tc.CacheStatusReported, typeMsg)
+	alertText += fmt.Sprintf(" with no '%s' or '%s' %s servers", tc.CacheStatusOnline, tc.CacheStatusReported, typeMsg)
 	return alertText
 }
 

--- a/traffic_ops/traffic_ops_golang/server/put_status.go
+++ b/traffic_ops/traffic_ops_golang/server/put_status.go
@@ -40,11 +40,11 @@ import (
 // identified in 'dsIDs'.
 //
 // If 'dsIDs' is empty/nil, returns an empty string.
-func InvalidStatusForDeliveryServicesAlertText(status string, dsIDs []int) string {
+func InvalidStatusForDeliveryServicesAlertText(prefix, serverType string, dsIDs []int) string {
 	if len(dsIDs) < 1 {
 		return ""
 	}
-	alertText := fmt.Sprintf("setting server status to '%s' would leave Active Delivery Service", status)
+	alertText := prefix
 	if len(dsIDs) == 1 {
 		alertText += fmt.Sprintf(" #%d", dsIDs[0])
 	} else if len(dsIDs) == 2 {
@@ -56,7 +56,11 @@ func InvalidStatusForDeliveryServicesAlertText(status string, dsIDs []int) strin
 		}
 		alertText += fmt.Sprintf("s %s, and #%d", strings.Join(dsNums, ", "), dsIDs[len(dsIDs)-1])
 	}
-	alertText += fmt.Sprintf("  with no '%s' or '%s' servers", tc.CacheStatusOnline, tc.CacheStatusReported)
+	typeMsg := tc.CacheTypeEdge.String()
+	if strings.HasPrefix(serverType, tc.OriginTypeName) {
+		typeMsg = tc.OriginTypeName
+	}
+	alertText += fmt.Sprintf("  with no '%s' or '%s' %s servers", tc.CacheStatusOnline, tc.CacheStatusReported, typeMsg)
 	return alertText
 }
 
@@ -129,14 +133,15 @@ func UpdateStatusHandler(w http.ResponseWriter, r *http.Request) {
 
 	existingStatus, existingStatusUpdatedTime := checkExistingStatusInfo(id, tx)
 	if *status.Name != string(tc.CacheStatusOnline) && *status.Name != string(tc.CacheStatusReported) && *status.ID != existingStatus {
-		dsIDs, err := getActiveDeliveryServicesThatOnlyHaveThisServerAssigned(id, tx)
+		dsIDs, err := getActiveDeliveryServicesThatOnlyHaveThisServerAssigned(id, serverInfo.Type, tx)
 		if err != nil {
 			sysErr = fmt.Errorf("getting Delivery Services to which server #%d is assigned that have no other servers: %v", id, err)
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, sysErr)
 			return
 		}
 		if len(dsIDs) > 0 {
-			alertText := InvalidStatusForDeliveryServicesAlertText(*status.Name, dsIDs)
+			prefix := fmt.Sprintf("setting server status to '%s' would leave Active Delivery Service", *status.Name)
+			alertText := InvalidStatusForDeliveryServicesAlertText(prefix, serverInfo.Type, dsIDs)
 			api.WriteAlerts(w, r, http.StatusConflict, tc.CreateAlerts(tc.ErrorLevel, alertText))
 			return
 		}


### PR DESCRIPTION
Prevent unassigning all ONLINE ORG servers from an active, MSO-enabled DS. Also, fix some cases where it was possible to delete/unassign all `EDGE`-type servers from a delivery service if there were also `ORG`-type servers assigned.

Closes: #6069
Closes: #5212

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Review the test updates, ensure the tests pass.

## The following criteria are ALL met by this PR
- [x] This PR includes tests
- [x] This validation doesn't really require documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)
