### PR TITLE
Deprecate old Traffic Ops API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 ### Added
-- [#4982](https://github.com/apache/trafficcontrol/issues/4982) Added the ability to support queueing updates by server type and profile 
+- [#4982](https://github.com/apache/trafficcontrol/issues/4982) Added the ability to support queueing updates by server type and profile
 - [#5412](https://github.com/apache/trafficcontrol/issues/5412) Added last authenticated time to user API's (`GET /user/current, GET /users, GET /user?id=`) response payload
 - [#5451](https://github.com/apache/trafficcontrol/issues/5451) Added change log count to user API's response payload and query param (username) to logs API
 - Added support for CDN locks
@@ -60,7 +60,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Enhanced ort integration test for reload states
 - Added a new field to Delivery Services - `tlsVersions` - that explicitly lists the TLS versions that may be used to retrieve their content from Cache Servers.
 - Added support for DS plugin parameters for cachekey, slice, cache_range_requests, background_fetch, url_sig  as remap.config parameters.
-- Updated T3C changes in Ansible playbooks 
+- Updated T3C changes in Ansible playbooks
 - Updated all endpoints in infrastructure code to use API version 2.0
 
 ### Fixed
@@ -89,7 +89,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5965](https://github.com/apache/trafficcontrol/issues/5965) - Fixed Traffic Ops /deliveryserviceservers If-Modified-Since requests.
 - Fixed t3c to create config files and directories as ats.ats
 - Fixed t3c-apply service restart and ats config reload logic.
-- Reduced TR dns.max-threads ansible default from 10000 to 100. 
+- Reduced TR dns.max-threads ansible default from 10000 to 100.
 - Converted TP Delivery Service Servers Assignment table to ag-grid
 - Converted TP Cache Checks table to ag-grid
 - [#5981](https://github.com/apache/trafficcontrol/issues/5891) - `/deliveryservices/{{ID}}/safe` returns incorrect response for the requested API version
@@ -127,11 +127,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The Traffic Ops API routes `GET /api/{version}/cachegroupparameters`, `POST /api/{version}/cachegroupparameters`, `GET /api/{version}/cachegroups/{id}/parameters`, and `DELETE /api/{version}/cachegroupparameters/{cachegroupID}/{parameterId}` have been deprecated and will no longer be available as of Traffic Ops API v4
 - The `riak_port` option in cdn.conf is now deprecated. Please use the `"port"` field in `traffic_vault_config` instead.
 - The `traffic_ops_ort.pl` tool has been deprecated in favor of `t3c`, and will be removed in the next major version.
+- With the release of Traffic Ops API version 4.0, major API versions 2 and 3 are now deprecated, subject to removal with the next ATC major version release, at the earliest.
 
 ### Removed
 - Removed the unused `backend_max_connections` option from `cdn.conf`.
 - Removed the unused `http_poll_no_sleep`, `max_stat_history`, and `max_health_history` Traffic Monitor config options.
-- Removed the `Long Description 2` and `Long Description 3` fields of `DeliveryService` from the UI, and changed the backend so that routes corresponding API 4.0 and above no longer accept or return these fields. 
+- Removed the `Long Description 2` and `Long Description 3` fields of `DeliveryService` from the UI, and changed the backend so that routes corresponding API 4.0 and above no longer accept or return these fields.
 - The Perl implementation of Traffic Ops has been stripped out, along with the Go implementation's "fall-back to Perl" behavior.
 - Traffic Ops no longer includes an `app/public` directory, as the static webserver has been removed along with the Perl Traffic Ops implementation. Traffic Ops also no longer attempts to download MaxMind GeoIP City databases when running the Traffic Ops Postinstall script.
 - The `compare` tool stack has been removed, as it no longer serves a purpose.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -302,12 +302,14 @@ The rest of the API documentation will only document the ``200 OK`` case, where 
 
 TrafficOps Native Client Libraries
 ==================================
-TrafficOps client libraries are available in Java, Go and Python. You can read (very little) more about them in `the client README <https://github.com/apache/trafficcontrol/tree/master/traffic_control/clients>`_.
-
+TrafficOps client libraries are available in Java, Go and Python. You can read (very little) more about them in the client README at :atc-file:`traffic_control/clients`.
 
 API V2 Routes
 =============
 API routes available in version 2.
+
+.. deprecated:: ATCv6
+	Traffic Ops API version 2 is deprecated in favor of version 4.
 
 .. toctree::
 	:maxdepth: 4
@@ -318,6 +320,9 @@ API routes available in version 2.
 API V3 Routes
 =============
 API routes available in version 3.
+
+.. deprecated:: ATCv6
+	Traffic Ops API version 3 is deprecated in favor of version 4.
 
 .. toctree::
 	:maxdepth: 4

--- a/traffic_ops/v2-client/README.md
+++ b/traffic_ops/v2-client/README.md
@@ -1,4 +1,9 @@
-# TO Client Library Golang
+# Traffic Ops Go Client
+
+## Deprecated
+The version of the Traffic Ops API supported by this client is deprecated.
+Please switch to the `github.com/apache/trafficcontrol/traffic_ops/v4-client`
+package.
 
 ## Getting Started
 1. Obtain the latest version of the library
@@ -15,7 +20,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v2-client"
 )
 
 const TOURL = "http://localhost"

--- a/traffic_ops/v3-client/README.md
+++ b/traffic_ops/v3-client/README.md
@@ -1,4 +1,9 @@
-# TO Client Library Golang
+# Traffic Ops Go Client
+
+## Deprecated
+The version of the Traffic Ops API supported by this client is deprecated.
+Please switch to the `github.com/apache/trafficcontrol/traffic_ops/v4-client`
+package.
 
 ## Getting Started
 1. Obtain the latest version of the library
@@ -15,7 +20,7 @@ import (
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
-	toclient "github.com/apache/trafficcontrol/traffic_ops/client"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
 )
 
 const TOURL = "http://localhost"

--- a/traffic_ops/v4-client/README.md
+++ b/traffic_ops/v4-client/README.md
@@ -1,4 +1,4 @@
-# TO Client Library Golang
+# Traffic Ops Go Client
 
 ## Getting Started
 1. Obtain the latest version of the library


### PR DESCRIPTION
## What does this PR (Pull Request) do?
- [x] This PR closes #6082 

Adds deprecation notices to CHANGELOG, documentation, and client READMEs.

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the deprecation notices are appropriate, accurate, and render correctly.

## The following criteria are ALL met by this PR
- [x] Tests are unnecessary
- [x] This PR includes documentation
- [x] This PR includes an update to CHANGELOG.md
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**