### PR TITLE
Remove unused TM profile parameters

### DIFF
--- a/docs/source/api/v2/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v2/cdns_name_configs_monitoring.rst
@@ -52,14 +52,7 @@ Response Structure
 
 :config: A collection of parameters used to configure the monitoring behaviour of Traffic Monitor
 
-	:hack.ttl:                    Unknown
-	:health.event-count:          The total number of health events to store
 	:health.polling.interval:     An interval in milliseconds on which to poll for health statistics
-	:health.threadPool:           The number of threads to be used for health polling
-	:health.timepad:              A 'padding time' to add to requests to spread them out for Traffic Control systems that use a large number of Traffic Monitors
-	:tm.crConfig.polling.url:     The URL from which a :term:`Snapshot` can be obtained
-	:tm.dataServer.polling.url:   The URL from which a list of data servers can be obtained
-	:tm.healthParams.polling.url: The URL from which a list of health-polling parameters can be obtained
 	:tm.polling.interval:         The interval at which to poll for configuration updates
 
 :deliveryServices: An array of objects representing each :term:`Delivery Service` provided by this CDN
@@ -215,17 +208,9 @@ Response Structure
 		],
 		"deliveryServices": [],
 		"config": {
-			"hack.ttl": 30,
-			"health.event-count": 200,
 			"health.polling.interval": 6000,
-			"health.threadPool": 4,
-			"health.timepad": 0,
 			"heartbeat.polling.interval": 3000,
-			"location": "/opt/traffic_monitor/conf",
 			"peers.polling.interval": 3000,
-			"tm.crConfig.polling.url": "https://${tmHostname}/CRConfig-Snapshots/${cdnName}/CRConfig.xml",
-			"tm.dataServer.polling.url": "https://${tmHostname}/dataserver/orderby/id",
-			"tm.healthParams.polling.url": "https://${tmHostname}/health/${cdnName}",
 			"tm.polling.interval": 2000
 		}
 	}}

--- a/docs/source/api/v3/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v3/cdns_name_configs_monitoring.rst
@@ -52,14 +52,7 @@ Response Structure
 
 :config: A collection of parameters used to configure the monitoring behaviour of Traffic Monitor
 
-	:hack.ttl:                    Unknown
-	:health.event-count:          The total number of health events to store
 	:health.polling.interval:     An interval in milliseconds on which to poll for health statistics
-	:health.threadPool:           The number of threads to be used for health polling
-	:health.timepad:              A 'padding time' to add to requests to spread them out for Traffic Control systems that use a large number of Traffic Monitors
-	:tm.crConfig.polling.url:     The URL from which a :term:`Snapshot` can be obtained
-	:tm.dataServer.polling.url:   The URL from which a list of data servers can be obtained
-	:tm.healthParams.polling.url: The URL from which a list of health-polling parameters can be obtained
 	:tm.polling.interval:         The interval at which to poll for configuration updates
 
 :deliveryServices: An array of objects representing each :term:`Delivery Service` provided by this CDN
@@ -261,17 +254,9 @@ Response Structure
 		],
 		"deliveryServices": [],
 		"config": {
-			"hack.ttl": 30,
-			"health.event-count": 200,
 			"health.polling.interval": 6000,
-			"health.threadPool": 4,
-			"health.timepad": 0,
 			"heartbeat.polling.interval": 3000,
-			"location": "/opt/traffic_monitor/conf",
 			"peers.polling.interval": 3000,
-			"tm.crConfig.polling.url": "https://${tmHostname}/CRConfig-Snapshots/${cdnName}/CRConfig.xml",
-			"tm.dataServer.polling.url": "https://${tmHostname}/dataserver/orderby/id",
-			"tm.healthParams.polling.url": "https://${tmHostname}/health/${cdnName}",
 			"tm.polling.interval": 2000
 		}
 	}}

--- a/docs/source/api/v4/cdns_name_configs_monitoring.rst
+++ b/docs/source/api/v4/cdns_name_configs_monitoring.rst
@@ -52,14 +52,7 @@ Response Structure
 
 :config: A collection of parameters used to configure the monitoring behaviour of Traffic Monitor
 
-	:hack.ttl:                    Unknown
-	:health.event-count:          The total number of health events to store
 	:health.polling.interval:     An interval in milliseconds on which to poll for health statistics
-	:health.threadPool:           The number of threads to be used for health polling
-	:health.timepad:              A 'padding time' to add to requests to spread them out for Traffic Control systems that use a large number of Traffic Monitors
-	:tm.crConfig.polling.url:     The URL from which a :term:`Snapshot` can be obtained
-	:tm.dataServer.polling.url:   The URL from which a list of data servers can be obtained
-	:tm.healthParams.polling.url: The URL from which a list of health-polling parameters can be obtained
 	:tm.polling.interval:         The interval at which to poll for configuration updates
 
 :deliveryServices: An array of objects representing each :term:`Delivery Service` provided by this CDN
@@ -261,17 +254,9 @@ Response Structure
 		],
 		"deliveryServices": [],
 		"config": {
-			"hack.ttl": 30,
-			"health.event-count": 200,
 			"health.polling.interval": 6000,
-			"health.threadPool": 4,
-			"health.timepad": 0,
 			"heartbeat.polling.interval": 3000,
-			"location": "/opt/traffic_monitor/conf",
 			"peers.polling.interval": 3000,
-			"tm.crConfig.polling.url": "https://${tmHostname}/CRConfig-Snapshots/${cdnName}/CRConfig.xml",
-			"tm.dataServer.polling.url": "https://${tmHostname}/dataserver/orderby/id",
-			"tm.healthParams.polling.url": "https://${tmHostname}/health/${cdnName}",
 			"tm.polling.interval": 2000
 		}
 	}}

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -616,49 +616,17 @@ dl_ds_default_profile_cdntemplates:
     type: TM_PROFILE
     routingDisabled: false
     parameters:
-      - name: hack.ttl
-        configFile: rascal-config.txt
-        value: '30'
-        secure: 0
-      - name: health.event-count
-        configFile: rascal-config.txt
-        value: '200'
-        secure: 0
       - name: health.polling.interval
         configFile: rascal-config.txt
         value: '6000'
-        secure: 0
-      - name: health.threadPool
-        configFile: rascal-config.txt
-        value: '4'
-        secure: 0
-      - name: health.timepad
-        configFile: rascal-config.txt
-        value: '0'
         secure: 0
       - name: heartbeat.polling.interval
         configFile: rascal-config.txt
         value: '2000'
         secure: 0
-      - name: location
-        configFile: rascal-config.txt
-        value: "/opt/traffic_monitor/conf"
-        secure: 0
       - name: peers.polling.interval
         configFile: rascal-config.txt
         value: '1000'
-        secure: 0
-      - name: tm.crConfig.polling.url
-        configFile: rascal-config.txt
-        value: https://${tmHostname}/CRConfig-Snapshots/${cdnName}/CRConfig.xml
-        secure: 0
-      - name: tm.dataServer.polling.url
-        configFile: rascal-config.txt
-        value: https://${tmHostname}/dataserver/orderby/id
-        secure: 0
-      - name: tm.healthParams.polling.url
-        configFile: rascal-config.txt
-        value: https://${tmHostname}/health/${cdnName}
         secure: 0
       - name: tm.polling.interval
         configFile: rascal-config.txt

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/070-RASCAL-Traffic_Monitor.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/070-RASCAL-Traffic_Monitor.json
@@ -6,28 +6,8 @@
   "params": [
     {
       "configFile": "rascal-config.txt",
-      "name": "hack.ttl",
-      "value": "30"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "health.event-count",
-      "value": "200"
-    },
-    {
-      "configFile": "rascal-config.txt",
       "name": "health.polling.interval",
       "value": "6000"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "health.threadPool",
-      "value": "4"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "health.timepad",
-      "value": "0"
     },
     {
       "configFile": "rascal-config.txt",
@@ -36,28 +16,8 @@
     },
     {
       "configFile": "rascal-config.txt",
-      "name": "location",
-      "value": "/opt/traffic_monitor/conf"
-    },
-    {
-      "configFile": "rascal-config.txt",
       "name": "peers.polling.interval",
       "value": "3000"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "tm.crConfig.polling.url",
-      "value": "https://${tmHostname}/CRConfig-Snapshots/${cdnName}/CRConfig.xml"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "tm.dataServer.polling.url",
-      "value": "https://${tmHostname}/dataserver/orderby/id"
-    },
-    {
-      "configFile": "rascal-config.txt",
-      "name": "tm.healthParams.polling.url",
-      "value": "https://${tmHostname}/health/${cdnName}"
     },
     {
       "configFile": "rascal-config.txt",


### PR DESCRIPTION
The following TM profile parameters are unused and will be removed from documentation, CiaB profiles, and Ansible dataset_loader default profiles:
- tm.crConfig.polling.url
- tm.dataServer.polling.url
- tm.healthParams.polling.url
- location
- health.threadPool
- health.event-count
- hack.ttl
- health.timepad

NOTE: they all have a config file of "rascal-config.txt"

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


-----------------------------------------------
<!-- **^ Add meaningful description above** -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Monitor
- CDN in a Box
- Automation (ansible)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Ensure that TM starts up and runs successfully without these profile parameters and ensure that there are no more references to the aforementioned profile parameters in the codebase.


## PR submission checklist
- [x] removal of unused profile params, no tests needed for that
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] since this just removes some profile parameter cruft, I don't feel like a changelog entry is warranted
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
