### PR TITLE
Adds the Traffic Monitor health client.

### DIFF
--- a/cache-config/build/build_rpm.sh
+++ b/cache-config/build/build_rpm.sh
@@ -121,6 +121,12 @@ initBuildArea() {
 		buildManpage 't3c-preprocess';
 	)
 
+	(
+		cd tm-health-client;
+		go build -v -gcflags "$gcflags" -ldflags "${ldflags} -X main.GitRevision=$(git rev-parse HEAD) -X main.BuildTimestamp=$(date +'%Y-%M-%dT%H:%M:%s') -X main.Version=${TC_VERSION}" -tags "$tags";
+		buildManpage 'tm-health-client';
+	)
+
 	cp -p traffic_ops_ort.pl "$dest";
 	cp -p supermicro_udev_mapper.pl "$dest";
 	mkdir -p "${dest}/build";

--- a/cache-config/build/trafficcontrol-cache-config.spec
+++ b/cache-config/build/trafficcontrol-cache-config.spec
@@ -107,7 +107,7 @@ go_t3c_diff_dir="$ccpath"/t3c-diff
 	cp "$TC_DIR"/"$ccdir"/t3c-diff/t3c-diff.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
-# copy t3c-diff binary
+# copy t3c-check-reload binary
 go_t3c_check_reload_dir="$ccpath"/t3c-check-reload
 ( mkdir -p "$go_t3c_check_reload_dir" && \
 	cd "$go_t3c_check_reload_dir" && \
@@ -123,7 +123,16 @@ go_t3c_preprocess_dir="$ccpath"/t3c-preprocess
 	cp "$TC_DIR"/"$ccdir"/t3c-preprocess/t3c-preprocess.1 .
 ) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
-
+# copy tm-health-client binary
+go_tm_health_client_dir="$ccpath"/tm-health-client
+( mkdir -p "$go_tm_health_client_dir" && \
+	cd "$go_tm_health_client_dir" && \
+	cp "$TC_DIR"/"$ccdir"/tm-health-client/tm-health-client .
+	cp "$TC_DIR"/"$ccdir"/tm-health-client/tm-health-client.1 .
+	cp "$TC_DIR"/"$ccdir"/tm-health-client/tm-health-client.json ./tm-health-client.json.sample
+	cp "$TC_DIR"/"$ccdir"/tm-health-client/tm-health-client-logrotate .
+	cp "$TC_DIR"/"$ccdir"/tm-health-client/tm-health-client.service .
+) || { echo "Could not copy go program at $(pwd): $!"; exit 1; }
 
 %install
 ccdir="cache-config/"
@@ -135,6 +144,8 @@ mkdir -p ${RPM_BUILD_ROOT}/"$installdir"
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/trafficcontrol-cache-config
 mkdir -p ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"
+mkdir -p ${RPM_BUILD_ROOT}/etc/trafficcontrol-cache-config
+mkdir -p ${RPM_BUILD_ROOT}/usr/lib/systemd/system
 
 cp -p ${RPM_SOURCE_DIR}/trafficcontrol-cache-config-%{version}/traffic_ops_ort.pl ${RPM_BUILD_ROOT}/"$installdir"
 cp -p ${RPM_SOURCE_DIR}/trafficcontrol-cache-config-%{version}/supermicro_udev_mapper.pl ${RPM_BUILD_ROOT}/"$installdir"
@@ -182,6 +193,13 @@ t3c_preprocess_src=src/github.com/apache/trafficcontrol/"$ccdir"/t3c-preprocess
 cp -p "$t3c_preprocess_src"/t3c-preprocess ${RPM_BUILD_ROOT}/"$installdir"
 gzip -c -9 "$src"/t3c-preprocess/t3c-preprocess.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/t3c-preprocess.1.gz
 
+tm_health_client_src=src/github.com/apache/trafficcontrol/"$ccdir"/tm-health-client
+cp -p "$tm_health_client_src"/tm-health-client ${RPM_BUILD_ROOT}/"$installdir"
+cp -p "$tm_health_client_src"/tm-health-client.json.sample ${RPM_BUILD_ROOT}/etc/trafficcontrol-cache-config
+cp -p "$tm_health_client_src"/tm-health-client-logrotate ${RPM_BUILD_ROOT}/etc/logrotate.d
+cp -p "$tm_health_client_src"/tm-health-client.service ${RPM_BUILD_ROOT}/usr/lib/systemd/system
+gzip -c -9 "$src"/tm-health-client/tm-health-client.1 > ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/tm-health-client.1.gz
+
 mkdir -p ${RPM_BUILD_ROOT}/var/lib/trafficcontrol-cache-config
 
 ls ${RPM_BUILD_ROOT}/"$mandir"/"$man1dir"/
@@ -226,6 +244,7 @@ fi
 /usr/bin/t3c-preprocess
 /usr/bin/t3c-request
 /usr/bin/t3c-update
+/usr/bin/tm-health-client
 /usr/share/man/man1/t3c.1.gz
 /usr/share/man/man1/t3c-apply.1.gz
 /usr/share/man/man1/t3c-check.1.gz
@@ -236,6 +255,10 @@ fi
 /usr/share/man/man1/t3c-preprocess.1.gz
 /usr/share/man/man1/t3c-request.1.gz
 /usr/share/man/man1/t3c-update.1.gz
+/usr/share/man/man1/tm-health-client.1.gz
+/etc/trafficcontrol-cache-config/tm-health-client.json.sample
+/etc/logrotate.d/tm-health-client-logrotate
+/usr/lib/systemd/system/tm-health-client.service
 
 %dir /var/lib/trafficcontrol-cache-config
 

--- a/cache-config/tm-health-client/README.md
+++ b/cache-config/tm-health-client/README.md
@@ -1,0 +1,167 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<!--
+
+  !!!
+      This file is both a Github Readme and manpage!
+      Please make sure changes appear properly with man,
+      and follow man conventions, such as:
+      https://www.bell-labs.com/usr/dmr/www/manintro.html
+
+      A primary goal of t3c is to follow POSIX and LSB standards
+      and conventions, so it's easy to learn and use by people
+      who know Linux and other *nix systems. Providing a proper
+      manpage is a big part of that.
+  !!!
+
+-->
+# NAME
+
+tm-health-client - Traffic Monitor Health Client service
+
+# SYNOPSIS
+
+tm-health-client [-f config-file]  -h  [-l logging-directory]  -v 
+
+# DESCRIPTION
+
+The tm-health-client command is used to manage **Apache Traffic Server** parents on a
+host running **Apache Traffic Server**.  The command should be started by **systemd** 
+and run as a service. On startup, the command reads its default configuration file
+**/etc/trafficcontrol-cache-config/tm-health-client.json**.  After reading the config
+file it polls the configured **Traffic OPs** to obtain a list of **Traffic Monitors**
+for the configured **CDN** and begins polling the available **Traffic Monitors** for
+Traffic Server cache statuses.
+
+On each polling cycle, defined in the configuration file, the Traffic Server parent
+statuses are updated from the Traffic Server **parent.config**, **strategies.yaml** 
+files, and the Traffic Server **HostStatus** subsystem.  If **Traffic Monitor** has
+determined that a parent utilized by the **Traffic Server** instance is un-healthy or
+otherwise unavailable, the tm-health-client will utilize the **Traffic Server** 
+**traffic_ctl** tool to mark down the parent host.  If a parent host is marked down 
+and **Traffic Monitor** has determined that the marked down host is now available, 
+the client will then utilize the **Traffic Server** tool to mark the host back up.
+
+# OPTIONS
+
+-f, -\-config-file=config-file 
+  
+  Specify the config file to use.  
+  Defaults to /etc/trafficcontro-cache-config/tm-health-client.json
+
+-h, -\-help 
+
+  Prints command line usage and exits
+
+-l, -\-logging-dir=logging-directory
+
+  Specify the directory where log files are kept.  The default location
+  is **/var/log/trafficcontrol-cache-config/**
+
+-v, -\-verbose
+
+  Logging verbosity.  Errors are logged to the default log file 
+  **/var/log/trafficcontrol-cache-config/tm-health-client.log**
+  To add Warnings, use -v.  To add Warnings and Informational 
+  logging, use -vv.  Finally you may add Debug logging using -vvv.
+
+# CONFIGURATION
+
+The configuration file is a **JSON** file and is looked for by default
+at **/etc/trafficcontrol-cache-config/tm-health-client.json**
+
+Sample configuarion file:
+
+```
+  {
+    "cdn-name": "over-the-top",
+    "enable-active-markdowns": false,
+    "reason-code": "active",
+    "to-credential-file": "/etc/credentials",
+    "to-url": "https://tp.cdn.com:443", 
+    "to-request-timeout-seconds": "5s",
+    "tm-poll-interval-seconds": "60s",
+    "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
+    "trafficserver-bin-dir": "/opt/trafficserver/bin",
+  }
+```
+
+### cdn-name 
+
+  The name of the CDN that the Traffic Server host is a member of.
+
+### enable-active-markdowns
+
+  When enabled, the client will actively mark down Traffic Server parents.
+  When disabled, the client will only log that it would have marked down
+  Traffic Server parents
+
+### reason-code
+
+  Use the reason code **active** or **local** when marking down Traffic Server
+  hosts in the Traffic Server **HostStatus** subsystem.
+
+### to-credential-file
+
+  The file where **Traffic Ops** credentials are read.  The file should define the 
+  following variables:
+
+  * TO_URL="https://trafficops.cdn.com"
+  * TO_USER="touser"
+  * TO_PASS="touser_password"
+
+### to-url
+
+  The **Traffic Ops** URL
+
+### to-request-timeout-seconds
+
+  The time in seconds to wait for a query response from both **Traffic Ops** and
+  the **Traffic Monitors**
+
+### tm-poll-interval-seconds
+
+  The polling interval in seconds used to update **Traffic Server** parent
+  status.
+
+### trafficserver-config-dir
+
+  The location on the host where **Traffic Server** configuration files are 
+  located.
+
+### trafficserver-bin-dir
+
+  The location on the host where **Traffic Server** **traffic_ctl** tool may
+  be found.
+
+# Files
+
+* /etc/trafficcontrol-cache-config/tm-health-client.json
+* /etc/logrotate.d/tm-health-client-logrotate
+* /usr/bin/tm-health-client
+* /usr/lib/systemd/system/tm-health-client.service
+* /var/log/trafficcontrol-cache-config/tm-health-client.json
+* Traffic Server **parent.config**
+* Traffic Server **strategies.yaml**
+* Traffic Server **traffic_ctl** command
+  
+   
+
+
+

--- a/cache-config/tm-health-client/config/config.go
+++ b/cache-config/tm-health-client/config/config.go
@@ -1,0 +1,260 @@
+package config
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
+
+	"github.com/pborman/getopt/v2"
+)
+
+var tmPollingInterval time.Duration
+var toRequestTimeout time.Duration
+
+const (
+	DefaultConfigFile             = "/etc/trafficcontrol-cache-config/tm-health-client.json"
+	DefaultLogDirectory           = "/var/log/trafficcontrol-cache-config"
+	DefaultLogFile                = "tm-health-client.log"
+	DefaultTrafficServerConfigDir = "/opt/trafficserver/etc/trafficserver"
+	DefaultTrafficServerBinDir    = "/opt/trafficserver/bin"
+)
+
+type Cfg struct {
+	CDNName                 string `json:"cdn-name"`
+	EnableActiveMarkdowns   bool   `json:"enable-active-markdowns"`
+	ReasonCode              string `json:"reason-code"`
+	TOCredentialFile        string `json:"to-credential-file"`
+	TORequestTimeOutSeconds string `json:"to-request-timeout-seconds"`
+	TOPass                  string
+	TOUrl                   string
+	TOUser                  string
+	TmPollIntervalSeconds   string          `json:"tm-poll-interval-seconds"`
+	TrafficServerConfigDir  string          `json:"trafficserver-config-dir"`
+	TrafficServerBinDir     string          `json:"trafficserver-bin-dir"`
+	TrafficMonitors         map[string]bool `json:"trafficmonitors,omitempty"`
+}
+
+type LogCfg struct {
+	LogLocationErr   string
+	LogLocationDebug string
+	LogLocationInfo  string
+	LogLocationWarn  string
+}
+
+func (lcfg LogCfg) ErrorLog() log.LogLocation   { return log.LogLocation(lcfg.LogLocationErr) }
+func (lcfg LogCfg) WarningLog() log.LogLocation { return log.LogLocation(lcfg.LogLocationWarn) }
+func (lcfg LogCfg) InfoLog() log.LogLocation    { return log.LogLocation(lcfg.LogLocationInfo) }
+func (lcfg LogCfg) DebugLog() log.LogLocation   { return log.LogLocation(lcfg.LogLocationDebug) }
+func (lcfg LogCfg) EventLog() log.LogLocation   { return log.LogLocation(log.LogLocationNull) } // not used
+
+func readCredentials(cfg *Cfg) error {
+	fn := cfg.TOCredentialFile
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return errors.New("failed to open + " + fn + " :" + err.Error())
+	}
+	defer f.Close()
+
+	var to_pass_found = false
+	var to_url_found = false
+	var to_user_found = false
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Split(line, " ")
+		for _, v := range fields {
+			if strings.HasPrefix(v, "TO_") {
+				sf := strings.Split(v, "=")
+				if len(sf) == 2 {
+					if sf[0] == "TO_URL" {
+						// parse the url after trimming off any surrounding double quotes
+						cfg.TOUrl = strings.Trim(sf[1], "\"")
+						to_url_found = true
+					}
+					if sf[0] == "TO_USER" {
+						// set the TOUser after trimming off any surrounding quotes.
+						cfg.TOUser = strings.Trim(sf[1], "\"")
+						to_user_found = true
+					}
+					// set the TOPass after trimming off any surrounding quotes.
+					if sf[0] == "TO_PASS" {
+						cfg.TOPass = strings.Trim(sf[1], "\"")
+						to_pass_found = true
+					}
+				}
+			}
+		}
+	}
+	if !to_url_found && !to_user_found && !to_pass_found {
+		return errors.New("failed to retrieve one or more TrafficOps credentails")
+	}
+
+	return nil
+}
+
+func GetConfig() (Cfg, error, bool) {
+	var err error
+	var configFile string
+	var logLocationErr = log.LogLocationStderr
+	var logLocationDebug = log.LogLocationNull
+	var logLocationInfo = log.LogLocationNull
+	var logLocationWarn = log.LogLocationNull
+
+	configFilePtr := getopt.StringLong("config-file", 'f', DefaultConfigFile, "full path to the json config file")
+	logdirPtr := getopt.StringLong("logging-dir", 'l', DefaultLogDirectory, "directory location for log files")
+	helpPtr := getopt.BoolLong("help", 'h', "Print usage information and exit")
+	verbosePtr := getopt.CounterLong("verbose", 'v', `Log verbosity. Logging is output to stderr. By default, errors are logged. To log warnings, pass '-v'. To log info, pass '-vv', debug pass '-vvv'`)
+
+	getopt.Parse()
+
+	if configFilePtr != nil {
+		configFile = *configFilePtr
+	} else {
+		configFile = DefaultConfigFile
+	}
+
+	var logfile string
+
+	logfile = filepath.Join(*logdirPtr, DefaultLogFile)
+
+	logLocationErr = logfile
+
+	if *verbosePtr == 1 {
+		logLocationWarn = logfile
+	} else if *verbosePtr == 2 {
+		logLocationInfo = logfile
+		logLocationWarn = logfile
+	} else if *verbosePtr == 3 {
+		logLocationInfo = logfile
+		logLocationWarn = logfile
+		logLocationDebug = logfile
+	}
+
+	if help := *helpPtr; help == true {
+		Usage()
+		return Cfg{}, nil, true
+	}
+
+	lcfg := LogCfg{
+		LogLocationDebug: logLocationDebug,
+		LogLocationErr:   logLocationErr,
+		LogLocationInfo:  logLocationInfo,
+		LogLocationWarn:  logLocationWarn,
+	}
+
+	if err := log.InitCfg(&lcfg); err != nil {
+		return Cfg{}, errors.New("Initializing loggers: " + err.Error() + "\n"), false
+	}
+
+	cfg := Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	if err = LoadConfig(&cfg, configFile); err != nil {
+		return Cfg{}, errors.New(err.Error() + "\n"), false
+	}
+
+	if err = readCredentials(&cfg); err != nil {
+		return cfg, err, false
+	}
+
+	err = GetTrafficMonitorsStatus(&cfg)
+	if err != nil {
+		return cfg, err, false
+	}
+
+	return cfg, nil, false
+}
+
+func GetTrafficMonitorsStatus(cfg *Cfg) error {
+	u, err := url.Parse(cfg.TOUrl)
+	if err != nil {
+		return errors.New("error parsing TOURL parameters: " + err.Error())
+	}
+	qry := u.Query()
+	qry.Add("type", "RASCAL")
+	qry.Add("status", "ONLINE")
+
+	// login to traffic ops.
+	session, _, err := toclient.LoginWithAgent(cfg.TOUrl, cfg.TOUser, cfg.TOPass, true, "tm-health-client", false, GetRequestTimeout())
+	srvs, _, err := session.GetServers(&qry)
+	if err != nil {
+		return errors.New("error fetching Trafficmonitor server list: " + err.Error())
+	}
+
+	for _, v := range srvs {
+		if v.CDNName == cfg.CDNName && v.Status == "ONLINE" {
+			hostname := v.HostName + "." + v.DomainName
+			cfg.TrafficMonitors[hostname] = true
+		}
+	}
+
+	return nil
+}
+
+func GetTMPollingInterval() time.Duration {
+	return tmPollingInterval
+}
+
+func GetRequestTimeout() time.Duration {
+	return toRequestTimeout
+}
+
+func LoadConfig(cfg *Cfg, configFile string) error {
+	content, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return errors.New(err.Error())
+	}
+	if err = json.Unmarshal(content, cfg); err == nil {
+		tmPollingInterval, err = time.ParseDuration(cfg.TmPollIntervalSeconds)
+		if err != nil {
+			return errors.New("parsing TMPollingIntervalSeconds: " + err.Error())
+		}
+		toRequestTimeout, err = time.ParseDuration(cfg.TORequestTimeOutSeconds)
+		if err != nil {
+			return errors.New("parsing TORequestTimeOutSeconds: " + err.Error())
+		}
+		if cfg.ReasonCode != "active" && cfg.ReasonCode != "local" {
+			return errors.New("invalid reason-code: " + cfg.ReasonCode + ", valid reason codes are 'active' or 'local'")
+		}
+	}
+
+	return err
+}
+
+func Usage() {
+	getopt.PrintUsage(os.Stdout)
+}

--- a/cache-config/tm-health-client/config/config_test.go
+++ b/cache-config/tm-health-client/config/config_test.go
@@ -1,0 +1,107 @@
+package config
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"testing"
+)
+
+const (
+	test_config_file = "test_files/tm-health-client.json"
+)
+
+func TestLoadConfig(t *testing.T) {
+	cfg := Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	err := LoadConfig(&cfg, test_config_file)
+	if err != nil {
+		t.Fatalf("failed to load %s: %s\n", test_config_file, err.Error())
+	}
+
+	expect := "over-the-top"
+	cdn := cfg.CDNName
+	if cdn != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, cdn)
+	}
+
+	expectb := false
+	markDowns := cfg.EnableActiveMarkdowns
+	if markDowns != expectb {
+		t.Fatalf("expected '%v', got %v\n", expectb, markDowns)
+	}
+
+	expect = "active"
+	reasonCode := cfg.ReasonCode
+	if reasonCode != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, reasonCode)
+	}
+
+	expect = "test_files/credentials"
+	creds := cfg.TOCredentialFile
+	if creds != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, creds)
+	}
+
+	readCredentials(&cfg)
+
+	expect = "https://tp.cdn.com:443"
+	tourl := cfg.TOUrl
+	if tourl != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, tourl)
+	}
+
+	expect = "to_user"
+	touser := cfg.TOUser
+	if touser != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, touser)
+	}
+
+	expect = "to_pass"
+	topass := cfg.TOPass
+	if topass != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, topass)
+	}
+
+	expect = "15s"
+	poll := cfg.TmPollIntervalSeconds
+	if poll != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, poll)
+	}
+
+	expect = "5s"
+	rto := cfg.TORequestTimeOutSeconds
+	if rto != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, rto)
+	}
+
+	expect = "./test_files/etc"
+	cfgdir := cfg.TrafficServerConfigDir
+	if cfgdir != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, cfgdir)
+	}
+
+	expect = "./test_files/bin"
+	bindir := cfg.TrafficServerBinDir
+	if bindir != expect {
+		t.Fatalf("expected '%s', got %s\n", expect, bindir)
+	}
+}

--- a/cache-config/tm-health-client/config/test_files/credentials
+++ b/cache-config/tm-health-client/config/test_files/credentials
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+export TO_URL="https://tp.cdn.com:443"
+export TO_USER="to_user"
+export TO_PASS="to_pass"

--- a/cache-config/tm-health-client/config/test_files/tm-health-client.json
+++ b/cache-config/tm-health-client/config/test_files/tm-health-client.json
@@ -1,0 +1,15 @@
+{
+  "cdn-name": "over-the-top",
+  "enable-active-markdowns": false,
+  "reason-code": "active",
+  "to-credential-file": "test_files/credentials",
+  "to-url": "https://tp.cdn.com:443", 
+  "to-request-timeout-seconds": "5s",
+  "tm-poll-interval-seconds": "15s",
+  "trafficserver-config-dir": "./test_files/etc",
+  "trafficserver-bin-dir": "./test_files/bin",
+  "trafficmonitors":{
+    "tm-01.foo.com": true,
+    "tm-02.foo.com": false
+  }
+}

--- a/cache-config/tm-health-client/tm-health-client-logrotate
+++ b/cache-config/tm-health-client/tm-health-client-logrotate
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+/var/log/trafficcontrol-cache-config/tm-health-client.log {
+    compress
+    copytruncate
+    maxage 90
+    missingok
+    nomail
+    notifempty
+    rotate 10
+    size 100M
+}

--- a/cache-config/tm-health-client/tm-health-client.go
+++ b/cache-config/tm-health-client/tm-health-client.go
@@ -1,0 +1,53 @@
+package main
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"os"
+
+	"github.com/apache/trafficcontrol/cache-config/tm-health-client/config"
+	"github.com/apache/trafficcontrol/cache-config/tm-health-client/tmutil"
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+const (
+	Success     = 0
+	ConfigError = 166
+)
+
+func main() {
+	cfg, err, helpflag := config.GetConfig()
+	if err != nil {
+		log.Errorln(err.Error())
+		os.Exit(ConfigError)
+	} else {
+		log.Infoln("startup complete, the config has been loaded")
+	}
+	if helpflag { // user used --help option
+		os.Exit(Success)
+	}
+
+	tmInfo, err := tmutil.NewParentInfo(cfg)
+	if err != nil {
+		log.Errorf("startup could not initialize ATS parent info: %s\n", err.Error())
+	}
+
+	tmInfo.PollAndUpdateCacheStatus()
+}

--- a/cache-config/tm-health-client/tm-health-client.json
+++ b/cache-config/tm-health-client/tm-health-client.json
@@ -1,0 +1,11 @@
+{
+  "cdn-name": "mycdn",
+  "enable-active-markdowns": false,
+  "reason-code": "active",
+  "to-credential-file": "/etc/credentials",
+  "to-url": "https://tp.cdn.com:443", 
+  "to-request-timeout-seconds": "5s",
+  "tm-poll-interval-seconds": "15s",
+  "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
+  "trafficserver-bin-dir": "/opt/trafficserver/bin",
+}

--- a/cache-config/tm-health-client/tm-health-client.service
+++ b/cache-config/tm-health-client/tm-health-client.service
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+[Unit]
+Description=Traffic monitor health service for Trafficserver
+After=trafficserver
+
+[Service]
+ExecStart=/usr/bin/tm-health-client -vv
+RequiredBy=trafficserver
+Restart=always
+ExecStop=/bin/kill -s $MAINPID
+
+[Install]
+

--- a/cache-config/tm-health-client/tmutil/test_files/bin/traffic_ctl
+++ b/cache-config/tm-health-client/tmutil/test_files/bin/traffic_ctl
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if [ "$*" = "metric match host_status" ]; then
+  cat <<HERE
+proxy.process.host_status.cdn-mid-01.cdn.com HOST_STATUS_DOWN,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:DOWN:1628104231:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-02.cdn.com HOST_STATUS_DOWN,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:DOWN:1628173565:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-03.cdn.com HOST_STATUS_DOWN,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:DOWN:1628173713:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-04.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-05.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-06.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-07.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-08.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-09.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-10.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-11.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-12.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-13.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+proxy.process.host_status.cdn-mid-14.cdn.com HOST_STATUS_UP,ACTIVE:UP:0:0,LOCAL:UP:0:0,MANUAL:UP:0:0,SELF_DETECT:UP:0
+HERE
+fi
+
+exit 0

--- a/cache-config/tm-health-client/tmutil/test_files/etc/parent.config
+++ b/cache-config/tm-health-client/tmutil/test_files/etc/parent.config
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+dest_domain=foo.com port=80 parent="cdn-mid-01.bar.net:80|1.0;cdn-mid-02.bar.net:80|1.0;cdn-mid-03.bar.net:80|1.0;cdn-mid-04.bar.net:80|1.0;" round_robin=consistent_hash go_direct=false qstring=consider go_direct=true
+#
+dest_domain=foo.com port=80 parent="cdn-mid-05.foo.net:80|1.0;cdn-mid-06.foo.net:80|1.0;cdn-mid-07.foo.net:80|1.0;cdn-mid-08.foo.net:80|1.0;" round_robin=consistent_hash go_direct=false qstring=ignore go_direct=false

--- a/cache-config/tm-health-client/tmutil/test_files/etc/strategies.yaml
+++ b/cache-config/tm-health-client/tmutil/test_files/etc/strategies.yaml
@@ -1,0 +1,107 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+hosts:
+  - &edge1
+    host: edge-01.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.1.19:80
+      - scheme: https
+        port: 443
+        health_check_url: https://192.168.1.19:443
+  - &edge2
+    host: edge-02.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.2.20:80
+      - scheme: https
+        port: 443
+        health_check_url: https://196.168.2.20:443
+  - &edge3
+    host: edge-03.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.2.30:80
+      - scheme: https
+        port: 443
+        health_check_url: https://192.168.2.30:443
+  - &edge4
+    host: edge-04.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.1.154:80
+      - scheme: https
+        port: 443
+        health_check_url: https://192.168.1.154:443
+  - &mid1
+    host: mid-01.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.1.10:80
+      - scheme: https
+        port: 443
+        health_check_url: https://192.168.1.10:443
+  - &mid2
+    host: mid-02.cdn.com
+    protocol:
+      - scheme: http
+        port: 80
+        health_check_url: http://192.168.3.95:80
+      - scheme: https
+        port: 443
+        health_check_url: https://192.168.3.95:443
+groups:
+  - &edge-tier
+    - <<: *edge1
+      weight: 0.25
+    - <<: *edge2
+      weight: 0.25
+    - <<: *edge3
+      weight: 0.25
+    - <<: *edge4
+      weight: 0.25
+  - &mid-tier
+    - <<: *mid1
+      weight: 0.5
+    - <<: *mid2
+      weight: 0.5
+strategies:
+  - strategy: "peering-g1"
+    policy: consistent_hash
+    go_direct: false
+    parent_is_proxy: true
+    cache_peer_result: false
+    groups: 
+      - *edge-tier
+      - *mid-tier
+    scheme: http 
+    failover:
+      max_simple_retries: 2 
+      ring_mode:
+        peering_ring
+      response_codes:
+        - 404
+      health_check:
+        - passive
+        - active

--- a/cache-config/tm-health-client/tmutil/test_files/tm-health-client.json
+++ b/cache-config/tm-health-client/tmutil/test_files/tm-health-client.json
@@ -1,0 +1,15 @@
+{
+  "cdn-name": "over-the-top",
+  "enable-active-markdowns": false,
+  "reason-code": "active",
+  "to-credential-file": "/etc/credentials",
+  "to-url": "https://tp.cdn.com:443", 
+  "to-request-timeout-seconds": "5s",
+  "tm-poll-interval-seconds": "15s",
+  "trafficserver-config-dir": "./test_files/etc",
+  "trafficserver-bin-dir": "./test_files/bin",
+  "trafficmonitors":{
+    "tm-01.foo.com": true,
+    "tm-02.foo.com": false
+  }
+}

--- a/cache-config/tm-health-client/tmutil/tmutil.go
+++ b/cache-config/tm-health-client/tmutil/tmutil.go
@@ -1,0 +1,676 @@
+package tmutil
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/apache/trafficcontrol/cache-config/tm-health-client/config"
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_monitor/datareq"
+	"github.com/apache/trafficcontrol/traffic_monitor/tmclient"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	serverRequest  = "https://tp.cdn.comcast.net/api/3.0/servers?type=RASCAL"
+	TrafficCtl     = "traffic_ctl"
+	ParentsFile    = "parent.config"
+	StrategiesFile = "strategies.yaml"
+)
+
+type ParentAvailable interface {
+	available() bool
+}
+
+// the necessary fields of a trafficserver parents config file needed to
+// read the file and keep track of it's modification time.
+type ParentConfigFile struct {
+	Filename       string
+	LastModifyTime int64
+}
+
+// the necessary data required to keep track of trafficserver config
+// files, lists of parents a trafficserver instance uses, and directory
+// locations used for configuration and trafficserver executables.
+type ParentInfo struct {
+	ParentDotConfig        ParentConfigFile
+	StrategiesDotYaml      ParentConfigFile
+	TrafficServerBinDir    string
+	TrafficServerConfigDir string
+	Parents                map[string]ParentStatus
+	Cfg                    config.Cfg
+}
+
+// when reading the 'strategies.yaml', these fields are used to help
+// parse out fail_over objects.
+type FailOver struct {
+	MaxSimpleRetries      int      `yaml:"max_simple_retries,omitempty"`
+	MaxUnavailableRetries int      `yaml:"max_unavailable_retries,omitempty"`
+	RingMode              string   `yaml:"ring_mode,omitempty"`
+	ResponseCodes         []int    `yaml:"response_codes,omitempty"`
+	MarkDownCodes         []int    `yaml:"markdown_codes,omitempty"`
+	HealthCheck           []string `yaml:"health_check,omitempty"`
+}
+
+// the trafficserver 'HostStatus' fields that are necessary to interface
+// with the trafficserver 'traffic_ctl' command.
+type ParentStatus struct {
+	Fqdn         string
+	ActiveReason bool
+	LocalReason  bool
+	ManualReason bool
+}
+
+// used to get the overall parent availablity from the
+// HostStatus markdown reasons.  all markdown reasons
+// must be true for a parent to be considered available.
+func (p ParentStatus) available() bool {
+	if !p.ActiveReason {
+		return false
+	} else if !p.LocalReason {
+		return false
+	} else if !p.ManualReason {
+		return false
+	}
+	return true
+}
+
+// used to log that a parent's status is either UP or
+// DOWN based upon the HostStatus reason codes.  to
+// be considered UP, all reason codes must be 'true'.
+func (p ParentStatus) Status() string {
+	if !p.ActiveReason {
+		return "DOWN"
+	} else if !p.LocalReason {
+		return "DOWN"
+	} else if !p.ManualReason {
+		return "DOWN"
+	}
+	return "UP"
+}
+
+type StatusReason int
+
+// these are the HostStatus reason codes used withing
+// trafficserver.
+const (
+	ACTIVE StatusReason = iota
+	LOCAL
+	MANUAL
+)
+
+// used for logging a parent's HostStatus reason code
+// setting.
+func (s StatusReason) String() string {
+	switch s {
+	case ACTIVE:
+		return "ACTIVE"
+	case LOCAL:
+		return "LOCAL"
+	case MANUAL:
+		return "MANUAL"
+	}
+	return "UNDEFINED"
+}
+
+// the fields used from 'strategies.yaml' that describe
+// a parent.
+type Host struct {
+	HostName  string     `yaml:"host"`
+	Protocols []Protocol `yaml:"protocol"`
+}
+
+// the protocol object in 'strategies.yaml' that help to
+// describe a parent.
+type Protocol struct {
+	Scheme           string  `yaml:"scheme"`
+	Port             int     `yaml:"port"`
+	Health_check_url string  `yaml:"health_check_url,omitempty"`
+	Weight           float64 `yaml:"weight,omitempty"`
+}
+
+// a trafficserver strategy object from 'strategies.yaml'.
+type Strategy struct {
+	Strategy        string   `yaml:"strategy"`
+	Policy          string   `yaml:"policy"`
+	HashKey         string   `yaml:"hash_key,omitempty"`
+	GoDirect        bool     `yaml:"go_direct,omitempty"`
+	ParentIsProxy   bool     `yaml:"parent_is_proxy,omitempty"`
+	CachePeerResult bool     `yaml:"cache_peer_result,omitempty"`
+	Scheme          string   `yaml:"scheme"`
+	FailOvers       FailOver `yaml:"failover,omitempty"`
+}
+
+// the top level array defintions in a trafficserver 'strategies.yaml'
+// configuration file.
+type Strategies struct {
+	Strategy []Strategy    `yaml:"strategies"`
+	Hosts    []Host        `yaml:"hosts"`
+	Groups   []interface{} `yaml:"groups"`
+}
+
+// used at startup to load a trafficservers list of parents from
+// it's 'parent.config', 'strategies.yaml' and current parent
+// status from trafficservers HostStatus subsystem.
+func NewParentInfo(cfg config.Cfg) (*ParentInfo, error) {
+
+	parentConfig := filepath.Join(cfg.TrafficServerConfigDir, ParentsFile)
+	modTime, err := getFileModificationTime(parentConfig)
+	if err != nil {
+		return nil, errors.New("error reading " + ParentsFile + ": " + err.Error())
+	}
+	parents := ParentConfigFile{
+		Filename:       parentConfig,
+		LastModifyTime: modTime,
+	}
+
+	stratyaml := filepath.Join(cfg.TrafficServerConfigDir, StrategiesFile)
+	modTime, err = getFileModificationTime(stratyaml)
+	if err != nil {
+		return nil, errors.New("error reading " + StrategiesFile + ": " + err.Error())
+	}
+
+	strategies := ParentConfigFile{
+		Filename:       filepath.Join(cfg.TrafficServerConfigDir, StrategiesFile),
+		LastModifyTime: modTime,
+	}
+
+	parentInfo := ParentInfo{
+		ParentDotConfig:        parents,
+		StrategiesDotYaml:      strategies,
+		TrafficServerBinDir:    cfg.TrafficServerBinDir,
+		TrafficServerConfigDir: cfg.TrafficServerConfigDir,
+	}
+
+	// initialize the trafficserver parents map.
+	parentStatus := make(map[string]ParentStatus)
+
+	// read the 'parent.config'.
+	if err := parentInfo.readParentConfig(parentStatus); err != nil {
+		return nil, errors.New("loading " + ParentsFile + " file: " + err.Error())
+	}
+
+	// read the strategies.yaml.
+	if err := parentInfo.readStrategies(parentStatus); err != nil {
+		return nil, errors.New("loading parent " + StrategiesFile + " file: " + err.Error())
+	}
+
+	// collect the trafficserver parent status from the HostStatus subsystem.
+	if err := parentInfo.readHostStatus(parentStatus); err != nil {
+		return nil, errors.New("reading trafficserver host status: " + err.Error())
+	}
+
+	log.Infof("startup loaded %d parent records\n", len(parentStatus))
+
+	parentInfo.Parents = parentStatus
+	parentInfo.Cfg = cfg
+
+	return &parentInfo, nil
+}
+
+// Queries a traffic monitor that is monitoring the trafficserver instance running on a host to
+// obtain the availability, health, of a parent used by trafficserver.
+func (c *ParentInfo) GetCacheStatuses() (map[tc.CacheName]datareq.CacheStatus, error) {
+
+	tmHostName, err := c.findATrafficMonitor()
+	if err != nil {
+		return nil, errors.New("finding a trafficmonitor: " + err.Error())
+	}
+	tmc := tmclient.New("http://"+tmHostName, config.GetRequestTimeout())
+
+	return tmc.CacheStatuses()
+}
+
+// The main polling function that keeps the parents list current if
+// with any changes to the trafficserver 'parent.config' or 'strategies.yaml'.
+// Also, it keeps parent status current with the the trafficserver HostStatus
+// subsystem.  Finally, on each poll cycle a trafficmonitor is queried to check
+// that all parents used by this trafficserver are available for use based upon
+// the trafficmonitors idea from it's health protocol.  Parents are marked up or
+// down in the trafficserver subsystem based upon that hosts current status and
+// the status that trafficmonitor health protocol has determined for a parent.
+func (c *ParentInfo) PollAndUpdateCacheStatus() {
+	pollingInterval := config.GetTMPollingInterval()
+	log.Infoln("polling started")
+
+	for {
+		if err := c.UpdateParentInfo(); err != nil {
+			log.Errorf("could not load new ATS parent info: %s\n", err.Error())
+		} else {
+			log.Debugf("updated parent info, total number of parents: %d\n", len(c.Parents))
+		}
+
+		// read traffic manager cache statuses.
+		caches, err := c.GetCacheStatuses()
+		if err != nil {
+			log.Errorln(err.Error())
+		}
+
+		for k, v := range caches {
+			hostName := string(k)
+			cs, ok := c.Parents[hostName]
+			if ok {
+				tmAvailable := *v.CombinedAvailable
+				if cs.available() != tmAvailable {
+					if !c.Cfg.EnableActiveMarkdowns {
+						if !tmAvailable {
+							log.Infof("TM reports that %s is not available and should be marked DOWN but, mark downs are disabled by configuration", hostName)
+						} else {
+							log.Infof("TM reports that %s is available and should be marked UP but, mark up is disabled by configuration", hostName)
+						}
+					} else {
+						if err = c.markParent(cs.Fqdn, *v.Status, tmAvailable); err != nil {
+							log.Errorln(err.Error())
+						}
+					}
+				}
+			}
+		}
+
+		time.Sleep(pollingInterval)
+	}
+}
+
+// Used by the polling function to update the parents list from
+// changes to 'parent.config' and 'strategies.yaml'.  The parents
+// availability is also updated to reflect the current state from
+// the trafficserver HostStatus subsystem.
+func (c *ParentInfo) UpdateParentInfo() error {
+	ptime, err := getFileModificationTime(c.ParentDotConfig.Filename)
+	if err != nil {
+		return errors.New("error reading " + ParentsFile + ": " + err.Error())
+	}
+	stime, err := getFileModificationTime(c.StrategiesDotYaml.Filename)
+	if err != nil {
+		return errors.New("error reading " + StrategiesFile + ": " + err.Error())
+	}
+	if c.ParentDotConfig.LastModifyTime < ptime {
+		// read the 'parent.config'.
+		if err := c.readParentConfig(c.Parents); err != nil {
+			return errors.New("updating " + ParentsFile + " file: " + err.Error())
+		} else {
+			log.Infof("updated parents from new %s, total parents: %d\n", ParentsFile, len(c.Parents))
+		}
+	}
+
+	if c.StrategiesDotYaml.LastModifyTime < stime {
+		// read the 'strategies.yaml'.
+		if err := c.readStrategies(c.Parents); err != nil {
+			return errors.New("updating parent " + StrategiesFile + " file: " + err.Error())
+		} else {
+			log.Infof("updated parents from new %s total parents: %d\n", StrategiesFile, len(c.Parents))
+		}
+	}
+
+	// collect the trafficserver current host status.
+	if err := c.readHostStatus(c.Parents); err != nil {
+		return errors.New("reading latest trafficserver host status: " + err.Error())
+	}
+
+	return nil
+}
+
+// choose an available trafficmonitor, returns an error if
+// there are none.
+func (c *ParentInfo) findATrafficMonitor() (string, error) {
+	var tmHostname string
+	lth := len(c.Cfg.TrafficMonitors)
+	if lth == 0 {
+		return "", errors.New("there are no available traffic monitors")
+	}
+
+	// build an array of available traffic monitors.
+	tms := make([]string, 0)
+	for k, v := range c.Cfg.TrafficMonitors {
+		if v == true {
+			log.Debugf("traffic monitor %s is available\n", k)
+			tms = append(tms, k)
+		}
+	}
+
+	// choose one at random.
+	lth = len(tms)
+	if lth > 0 {
+		rand.Seed(time.Now().UnixNano())
+		r := (rand.Intn(lth))
+		tmHostname = tms[r]
+	} else {
+		return "", errors.New("there are no available traffic monitors")
+	}
+
+	log.Infof("polling: %s\n", tmHostname)
+
+	return tmHostname, nil
+}
+
+// get the file modification times for a trafficserver configuration
+// file.
+func getFileModificationTime(fn string) (int64, error) {
+	f, err := os.Open(fn)
+	if err != nil {
+		return 0, errors.New("opening " + fn + ": " + err.Error())
+	}
+	defer f.Close()
+
+	finfo, err := f.Stat()
+	if err != nil {
+		return 0, errors.New("unable to get file status for " + fn + ": " + err.Error())
+	}
+	return finfo.ModTime().UnixNano(), nil
+}
+
+// parse out the hostname of a parent listed in parents.config
+// or 'strategies.yaml'. the hostname can be an IP address.
+func parseFqdn(fqdn string) string {
+	var hostName string
+	if ip := net.ParseIP(fqdn); ip == nil {
+		// not an IP, get the hostname
+		flds := strings.Split(fqdn, ".")
+		hostName = flds[0]
+	} else { // use the IP addr
+		hostName = fqdn
+	}
+	return hostName
+}
+
+// used to mark a parent as up or down in the trafficserver HostStatus
+// subsystem.
+func (c *ParentInfo) markParent(fqdn string, cacheStatus string, available bool) error {
+	hostName := parseFqdn(fqdn)
+	tc := filepath.Join(c.TrafficServerBinDir, TrafficCtl)
+	reason := c.Cfg.ReasonCode
+	var status string
+	if available {
+		status = "up"
+	} else {
+		status = "down"
+	}
+
+	cmd := exec.Command(tc, "host", status, "--reason", reason, fqdn)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.New("marking " + fqdn + " " + status + ": " + TrafficCtl + " error: " + err.Error())
+	}
+	pv, ok := c.Parents[hostName]
+	if ok {
+		switch reason {
+		case "active":
+			pv.ActiveReason = available
+		case "local":
+			pv.LocalReason = available
+		}
+	}
+	c.Parents[hostName] = pv
+
+	if !available {
+		log.Infof("marked parent %s DOWN, cache status was: %s\n", hostName, cacheStatus)
+	} else {
+		log.Infof("marked parent %s UP, cache status was: %s\n", hostName, cacheStatus)
+	}
+	return nil
+}
+
+// reads the current parent statuses from the trafficserver HostStatus
+// subsystem.
+func (c *ParentInfo) readHostStatus(parentStatus map[string]ParentStatus) error {
+	tc := filepath.Join(c.TrafficServerBinDir, TrafficCtl)
+
+	cmd := exec.Command(tc, "metric", "match", "host_status")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.New(TrafficCtl + " error: " + err.Error())
+	}
+
+	if len((stdout.Bytes())) > 0 {
+		var activeReason bool
+		var localReason bool
+		var manualReason bool
+		var hostName string
+		var fqdn string
+		scanner := bufio.NewScanner(bytes.NewReader(stdout.Bytes()))
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(line, "proxy.process.host_status.") {
+				fields := strings.Split(line, " ")
+				if len(fields) > 0 {
+					fqdnField := strings.Split(fields[0], "proxy.process.host_status.")
+					if len(fqdnField) > 0 {
+						fqdn = fqdnField[1]
+					}
+					statField := strings.Split(fields[1], ",")
+					if len(statField) == 5 {
+						if strings.HasPrefix(statField[1], "ACTIVE:UP") {
+							activeReason = true
+						} else if strings.HasPrefix(statField[1], "ACTIVE:DOWN") {
+							activeReason = false
+						}
+						if strings.HasPrefix(statField[2], "LOCAL:UP") {
+							localReason = true
+						} else if strings.HasPrefix(statField[2], "LOCAL:DOWN") {
+							localReason = false
+						}
+						if strings.HasPrefix(statField[3], "MANUAL:UP") {
+							manualReason = true
+						} else if strings.HasPrefix(statField[3], "MANUAL:DOWN") {
+							manualReason = false
+						}
+					}
+					pstat := ParentStatus{
+						Fqdn:         fqdn,
+						ActiveReason: activeReason,
+						LocalReason:  localReason,
+						ManualReason: manualReason,
+					}
+					hostName = parseFqdn(fqdn)
+					pv, ok := parentStatus[hostName]
+					// create the ParentStatus struct and add it to the
+					// Parents map only if an entry in the map does not
+					// already exist.
+					if !ok {
+						parentStatus[hostName] = pstat
+						log.Infof("added Host '%s' from ATS Host Status to the parents map\n", hostName)
+					} else {
+						available := pstat.available()
+						if pv.available() != available {
+							log.Infof("host status for '%s' has changed to %s\n", hostName, pstat.Status())
+							parentStatus[hostName] = pstat
+						}
+					}
+				}
+			}
+		}
+		log.Debugf("processed trafficserver host status results, total parents: %d\n", len(parentStatus))
+	}
+	return nil
+}
+
+// load parents list from the Trafficserver 'parent.config' file.
+func (c *ParentInfo) readParentConfig(parentStatus map[string]ParentStatus) error {
+	fn := c.ParentDotConfig.Filename
+
+	_, err := os.Stat(fn)
+	if err != nil {
+		log.Warnf("skipping 'parents': %s\n", err.Error())
+		return nil
+	}
+
+	log.Debugf("loading %s\n", fn)
+
+	f, err := os.Open(fn)
+
+	if err != nil {
+		return errors.New("failed to open + " + fn + " :" + err.Error())
+	}
+	defer f.Close()
+
+	finfo, err := os.Stat(fn)
+	if err != nil {
+		return errors.New("failed to Stat + " + fn + " :" + err.Error())
+	}
+	c.ParentDotConfig.LastModifyTime = finfo.ModTime().UnixNano()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		sbytes := scanner.Bytes()
+		if sbytes[0] == 35 { // skip comment lines, 35 is a '#'.
+			continue
+		}
+		// search for the parent list.
+		if i := strings.Index(string(sbytes), "parent="); i > 0 {
+			var plist []string
+			res := bytes.Split(sbytes, []byte("\""))
+			// 'parent.config' parent separators are ';' or ','.
+			plist = strings.Split(strings.TrimSpace(string(res[1])), ";")
+			if len(plist) == 1 {
+				plist = strings.Split(strings.TrimSpace(string(res[1])), ",")
+			}
+			// parse the parent list to get each hostName and it's associated
+			// port.
+			if len(plist) > 1 {
+				for _, v := range plist {
+					parent := strings.Split(v, ":")
+					if len(parent) == 2 {
+						fqdn := parent[0]
+						hostName := parseFqdn(fqdn)
+						_, ok := parentStatus[hostName]
+						// create the ParentStatus struct and add it to the
+						// Parents map only if an entry in the map does not
+						// already exist.
+						if !ok {
+							pstat := ParentStatus{
+								Fqdn:         strings.TrimSpace(fqdn),
+								ActiveReason: true,
+								LocalReason:  true,
+								ManualReason: true,
+							}
+							parentStatus[hostName] = pstat
+							log.Debugf("added Host '%s' from %s to the parents map\n", hostName, fn)
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// load the parent hosts from 'strategies.yaml'.
+func (c *ParentInfo) readStrategies(parentStatus map[string]ParentStatus) error {
+	var includes []string
+	fn := c.StrategiesDotYaml.Filename
+
+	_, err := os.Stat(fn)
+	if err != nil {
+		log.Warnf("skipping 'strategies': %s\n", err.Error())
+		return nil
+	}
+
+	log.Debugf("loading %s\n", fn)
+
+	// open the strategies file for scanning.
+	f, err := os.Open(fn)
+	if err != nil {
+		return errors.New("failed to open + " + fn + " :" + err.Error())
+	}
+	defer f.Close()
+
+	finfo, err := os.Stat(fn)
+	if err != nil {
+		return errors.New("failed to Stat + " + fn + " :" + err.Error())
+	}
+	c.StrategiesDotYaml.LastModifyTime = finfo.ModTime().UnixNano()
+
+	scanner := bufio.NewScanner(f)
+
+	// search for any yaml files that should be included in the
+	// yaml stream.
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#include") {
+			fields := strings.Split(line, " ")
+			if len(fields) >= 2 {
+				includeFile := filepath.Join(c.TrafficServerConfigDir, fields[1])
+				includes = append(includes, includeFile)
+			}
+		}
+	}
+
+	includes = append(includes, fn)
+
+	var yamlContent string
+
+	// load all included and 'strategies yaml' files to
+	// the yamlContent.
+	for _, includeFile := range includes {
+		log.Debugf("loading %s\n", includeFile)
+		content, err := ioutil.ReadFile(includeFile)
+		if err != nil {
+			return errors.New(err.Error())
+		}
+
+		yamlContent = yamlContent + string(content)
+	}
+
+	strategies := Strategies{}
+
+	if err := yaml.Unmarshal([]byte(yamlContent), &strategies); err != nil {
+		return errors.New("failed to unmarshall " + fn + ": " + err.Error())
+	}
+
+	for _, host := range strategies.Hosts {
+		fqdn := host.HostName
+		hostName := parseFqdn(fqdn)
+		// create the ParentStatus struct and add it to the
+		// Parents map only if an entry in the map does not
+		// already exist.
+		_, ok := parentStatus[hostName]
+		if !ok {
+			pstat := ParentStatus{
+				Fqdn:         strings.TrimSpace(fqdn),
+				ActiveReason: true,
+				LocalReason:  true,
+				ManualReason: true,
+			}
+			parentStatus[hostName] = pstat
+			log.Debugf("added Host '%s' from %s to the parents map\n", hostName, fn)
+		}
+	}
+	return nil
+}

--- a/cache-config/tm-health-client/tmutil/tmutil_test.go
+++ b/cache-config/tm-health-client/tmutil/tmutil_test.go
@@ -1,0 +1,229 @@
+package tmutil
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"github.com/apache/trafficcontrol/cache-config/tm-health-client/config"
+	"testing"
+)
+
+const (
+	test_config_file = "test_files/tm-health-client.json"
+)
+
+func TestReadParentDotConfig(t *testing.T) {
+	cfg := config.Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	parentDotConfig := ParentConfigFile{
+		Filename:       "test_files/etc/parent.config",
+		LastModifyTime: 1,
+	}
+
+	pi := ParentInfo{
+		ParentDotConfig: parentDotConfig,
+		Cfg:             cfg,
+	}
+
+	err := config.LoadConfig(&cfg, test_config_file)
+	if err != nil {
+		t.Fatalf("failed to load %s: %s\n", test_config_file, err.Error())
+	}
+
+	parentStatus := make(map[string]ParentStatus)
+	if err := pi.readParentConfig(parentStatus); err != nil {
+		t.Fatalf("failed readParentConfig(): %s\n", err.Error())
+	}
+
+	numParents := len(parentStatus)
+	if numParents != 8 {
+		t.Fatalf("failed readParentConfig(): expected 8 parents got %d\n", numParents)
+	}
+}
+
+func TestReadStrategiesDotYaml(t *testing.T) {
+	cfg := config.Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	strategiesDotYaml := ParentConfigFile{
+		Filename:       "test_files/etc/strategies.yaml",
+		LastModifyTime: 1,
+	}
+
+	pi := ParentInfo{
+		StrategiesDotYaml: strategiesDotYaml,
+		Cfg:               cfg,
+	}
+
+	err := config.LoadConfig(&cfg, test_config_file)
+	if err != nil {
+		t.Fatalf("failed to load %s: %s\n", test_config_file, err.Error())
+	}
+
+	parentStatus := make(map[string]ParentStatus)
+	if err := pi.readStrategies(parentStatus); err != nil {
+		t.Fatalf("failed readStrategies(): %s\n", err.Error())
+	}
+
+	numParents := len(parentStatus)
+	if numParents != 6 {
+		t.Fatalf("failed readStrategies(): expected 6 parents got %d\n", numParents)
+	}
+}
+
+func TestReadHostStatus(t *testing.T) {
+	cfg := config.Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	pi := ParentInfo{
+		TrafficServerBinDir: "./test_files/bin",
+		Cfg:                 cfg,
+	}
+
+	err := config.LoadConfig(&cfg, test_config_file)
+	if err != nil {
+		t.Fatalf("failed to load %s: %s\n", test_config_file, err.Error())
+	}
+	fmt.Println(cfg)
+
+	parentStatus := make(map[string]ParentStatus)
+	if err := pi.readHostStatus(parentStatus); err != nil {
+		t.Fatalf("failed readHostStatus(): %s\n", err.Error())
+	}
+
+	numParents := len(parentStatus)
+	if numParents != 14 {
+		t.Fatalf("failed readHostStatus(): expected 14 parents got %d\n", numParents)
+	}
+}
+
+func TestFindATrafficMonitor(t *testing.T) {
+	cfg := config.Cfg{
+		TrafficMonitors: make(map[string]bool, 0),
+	}
+
+	pi := ParentInfo{
+		Cfg: cfg,
+	}
+
+	err := config.LoadConfig(&cfg, test_config_file)
+	if err != nil {
+		t.Fatalf("failed to load %s: %s\n", test_config_file, err.Error())
+	}
+
+	tm, err := pi.findATrafficMonitor()
+	if err != nil {
+		t.Fatalf("unexpected error calling findATrafficMonitor(): %s\n", err.Error())
+	}
+	if tm != "tm-01.foo.com" {
+		t.Fatalf("expected result: 'tm-01.foo.com', got: %s\n", tm)
+	}
+
+	hostName := parseFqdn(tm)
+	if hostName != "tm-01" {
+		t.Fatalf("expected result: 'tm-01', got: %s\n", hostName)
+	}
+}
+
+func TestParentStatus(t *testing.T) {
+	pstat := ParentStatus{
+		Fqdn:         "foo-01.bar.com",
+		ActiveReason: true,
+		LocalReason:  true,
+		ManualReason: false,
+	}
+
+	available := pstat.available()
+	if available {
+		t.Fatalf("expected parent status for %s to be false, got %v\n",
+			pstat.Fqdn, available)
+	}
+	status := pstat.Status()
+	if status != "DOWN" {
+		t.Fatalf("expected status 'DOWN' got %s\n", status)
+	}
+	pstat.ManualReason = true
+	available = pstat.available()
+	if !available {
+		t.Fatalf("expected parent status for %s to be true, got %v\n",
+			pstat.Fqdn, available)
+	}
+	status = pstat.Status()
+	if status != "UP" {
+		t.Fatalf("expected status 'UP' got %s\n", status)
+	}
+	pstat.LocalReason = false
+	available = pstat.available()
+	if available {
+		t.Fatalf("expected parent status for %s to be false, got %v\n",
+			pstat.Fqdn, available)
+	}
+	status = pstat.Status()
+	if status != "DOWN" {
+		t.Fatalf("expected status 'DOWN' got %s\n", status)
+	}
+
+	pstat.LocalReason = true
+	pstat.ActiveReason = false
+	available = pstat.available()
+	if available {
+		t.Fatalf("expected parent status for %s to be false, got %v\n",
+			pstat.Fqdn, available)
+	}
+	status = pstat.Status()
+	if status != "DOWN" {
+		t.Fatalf("expected status 'DOWN' got %s\n", status)
+	}
+	pstat.ActiveReason = true
+	available = pstat.available()
+	if !available {
+		t.Fatalf("expected parent status for %s to be false, got %v\n",
+			pstat.Fqdn, available)
+	}
+	status = pstat.Status()
+	if status != "UP" {
+		t.Fatalf("expected status 'UP' got %s\n", status)
+	}
+}
+
+func TestStatusReason(t *testing.T) {
+	var reason StatusReason
+
+	reason = ACTIVE
+	if reason.String() != "ACTIVE" {
+		t.Fatalf("expected reason 'ACTIVE' got %s\n", reason.String())
+	}
+	reason = LOCAL
+	if reason.String() != "LOCAL" {
+		t.Fatalf("expected reason 'LOCAL' got %s\n", reason.String())
+	}
+	reason = MANUAL
+	if reason.String() != "MANUAL" {
+		t.Fatalf("expected reason 'MANUAL' got %s\n", reason.String())
+	}
+	reason = 9
+	if reason.String() != "UNDEFINED" {
+		t.Fatalf("expected reason 'UNDEFINED' got %s\n", reason.String())
+	}
+}


### PR DESCRIPTION
Adds to the trafficcontrol-cache-config package a client that runs on trafficserver caches to monitor the health status
of it's parent caches as reported by Traffic Monitor.  The client will utilize the Traffic Server traffic_ctl tool to mark 
parents UP or DOWN based upon the health status from Traffic Monitor.

## Which Traffic Control components are affected by this PR?

- Traffic Control Cache Config (T3C, formerly ORT)
- Traffic Monitor

## What is the best way to verify this PR?
Run the unit tests and install on a cache running Trafficserver

Install:
- Build and Install the trafficcontrol-cache-config.rpm
- Rename the sample tm-health-client.json at /etc/trafficcontrol-cache-config/tm-health-client.json.sample to the tm-health-client.json
- Edit the tm-health-client.json per the documentation
- run **systemctl daemon-reload**
- run **systemctl enable tm-health-client**
- run **systemctl start tm-health-client**
- Log file is at /var/log/trafficcontrol-cache-config/tm-health-client.log

It should discover the Traffic Monitors for the relevant CDN from the configured Traffic Ops and begin polling them
with no errors and logging parent cache mark downs when Traffic Monitor determines a parent is un-healthy.

## PR submission checklist
- [x] This PR has tests 
- [x] This PR has documentation 
- [] This PR has a CHANGELOG.md entry 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
