### PR TITLE
added defer tx.Commit() to autorenewal to close db connections

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/acme_renew.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/acme_renew.go
@@ -97,6 +97,7 @@ func renewAcmeCerts(cfg *config.Config, dsName string, ctx context.Context, http
 		log.Errorf(dsName+": Error getting tx: %s", err.Error())
 		return nil, err, http.StatusInternalServerError
 	}
+	defer tx.Commit()
 
 	userTx, err := db.Begin()
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/autorenewcerts.go
@@ -157,6 +157,7 @@ func RunAutorenewal(existingCerts []ExistingCerts, cfg *config.Config, ctx conte
 		}
 		return
 	}
+	defer tx.Commit()
 
 	logTx, err := db.Begin()
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #6094 
This PR adds defer tx.Commit() to the certificate autorenewal code to commit db transactions and minimize db connections

-----------------------------------------------
<!-- **^ Add meaningful description above** -->

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Run CiaB off of master with Riak configured for TV
In cdn.conf set acme_renewal / renew_days_before_expiration to 1 or generate a cert for a DS that is expiring within 30 days (openssl req -x509 -nodes -days 3 -newkey rsa:2048 -keyout testprivateKey.key -out testcertificate.crt)
POST to the /api/4.0/acme_autorenew endpoint
Log into the db container and into postgres. Run `select datname,query from pg_stat_activity where datname = 'traffic_ops';` and notice that every time you POST to that autorenew endpoint, a new query shows up searching for RIAK servers, causing a lot of open connections

Do those same steps again but from this branch instead of master and verify that those connections do not show up.

Verify that the autorenewal process is not impacted

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
No tests, docs, or changelog updates since this is a bugfix

- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
