### PR TITLE
Remove more unused TM config options

### DIFF
--- a/.github/actions/tm-integration-tests/entrypoint.sh
+++ b/.github/actions/tm-integration-tests/entrypoint.sh
@@ -120,11 +120,8 @@ go build
 
 cat > ./traffic_monitor.cfg <<- EOF
   {
-      "cache_health_polling_interval_ms": 6000,
-      "cache_stat_polling_interval_ms": 6000,
       "monitor_config_polling_interval_ms": 15000,
       "http_timeout_ms": 8000,
-      "peer_polling_interval_ms": 5000,
       "peer_optimistic": true,
       "max_events": 200,
       "health_flush_interval_ms": 20,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 - Removed the unused `backend_max_connections` option from `cdn.conf`.
-- Removed the unused `http_poll_no_sleep`, `max_stat_history`, and `max_health_history` Traffic Monitor config options.
+- Removed the unused `http_poll_no_sleep`, `max_stat_history`, `max_health_history`, `cache_health_polling_interval_ms`, `cache_stat_polling_interval_ms`, and `peer_polling_interval_ms` Traffic Monitor config options.
 - Removed the `Long Description 2` and `Long Description 3` fields of `DeliveryService` from the UI, and changed the backend so that routes corresponding API 4.0 and above no longer accept or return these fields.
 - The Perl implementation of Traffic Ops has been stripped out, along with the Go implementation's "fall-back to Perl" behavior.
 - Traffic Ops no longer includes an `app/public` directory, as the static webserver has been removed along with the Perl Traffic Ops implementation. Traffic Ops also no longer attempts to download MaxMind GeoIP City databases when running the Traffic Ops Postinstall script.

--- a/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-monitor/defaults/main.yml
@@ -24,11 +24,8 @@ tm_user: traffic_monitor
 tm_group: traffic_monitor
 
 # traffic_monitor.cfg
-tm_cache_health_polling_interval_ms: 6000
-tm_cache_stat_polling_interval_ms: 6000
 tm_monitor_config_polling_interval_ms: 5000
 tm_http_timeout_ms: 2000
-tm_peer_polling_interval_ms: 5000
 tm_peer_optimistic: true
 tm_max_events: 200
 tm_health_flush_interval_ms: 20

--- a/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
+++ b/infrastructure/ansible/roles/traffic-monitor/templates/traffic_monitor.cfg.j2
@@ -12,11 +12,8 @@
 # limitations under the License.
 #}
 {
-        "cache_health_polling_interval_ms": {{ tm_cache_health_polling_interval_ms }},
-        "cache_stat_polling_interval_ms": {{ tm_cache_stat_polling_interval_ms }},
         "monitor_config_polling_interval_ms": {{ tm_monitor_config_polling_interval_ms }},
         "http_timeout_ms": {{ tm_http_timeout_ms }},
-        "peer_polling_interval_ms": {{ tm_peer_polling_interval_ms }},
         "peer_optimistic": {{ tm_peer_optimistic | lower }},
         "max_events": {{ tm_max_events }},
         "health_flush_interval_ms": {{ tm_health_flush_interval_ms }},

--- a/infrastructure/cdn-in-a-box/traffic_monitor/traffic_monitor.cfg
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/traffic_monitor.cfg
@@ -1,9 +1,6 @@
 {
-	"cache_health_polling_interval_ms": 6000,
-	"cache_stat_polling_interval_ms": 6000,
 	"monitor_config_polling_interval_ms": 15000,
 	"http_timeout_ms": $HTTP_TIMEOUT_MS,
-	"peer_polling_interval_ms": 5000,
 	"peer_optimistic": true,
 	"peer_optimistic_quorum_min": 0,
 	"max_events": 200,

--- a/infrastructure/docker/traffic_monitor/run.sh
+++ b/infrastructure/docker/traffic_monitor/run.sh
@@ -68,11 +68,8 @@ init() {
 	mkdir -p /opt/traffic_monitor/conf
 	cat > /opt/traffic_monitor/conf/traffic_monitor.cfg <<- ENDOFMESSAGE
 		{
-				"cache_health_polling_interval_ms": 6000,
-				"cache_stat_polling_interval_ms": 6000,
 				"monitor_config_polling_interval_ms": 15000,
 				"http_timeout_ms": 2000,
-				"peer_polling_interval_ms": 5000,
 				"peer_optimistic": true,
 				"max_events": 200,
 				"health_flush_interval_ms": 20,

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -38,7 +38,7 @@ func (h Handler) ResultChan() <-chan Result {
 	return h.resultChan
 }
 
-// NewHandler returns a new cache handler. Note this handler does NOT precomputes stat data before calling ResultChan, and Result.Precomputed will be nil
+// NewHandler returns a new cache handler. Note this handler does NOT precompute stat data before calling ResultChan, and Result.Precomputed will be nil.
 func NewHandler() Handler {
 	return Handler{resultChan: make(chan Result)}
 }
@@ -119,7 +119,7 @@ func (result *Result) HasStat(stat string) bool {
 	return false
 }
 
-// InterfaceNames returns the names of all network interfaces used by the cache
+// InterfacesNames returns the names of all network interfaces used by the cache
 // server that was monitored to obtain the result.
 func (result *Result) InterfacesNames() []string {
 	interfaceNames := make([]string, 0, len(result.Statistics.Interfaces))

--- a/traffic_monitor/conf/traffic_monitor.cfg
+++ b/traffic_monitor/conf/traffic_monitor.cfg
@@ -1,9 +1,6 @@
 {
-	"cache_health_polling_interval_ms": 6000,
-	"cache_stat_polling_interval_ms": 6000,
 	"monitor_config_polling_interval_ms": 5000,
 	"http_timeout_ms": 2000,
-	"peer_polling_interval_ms": 5000,
 	"peer_optimistic": true,
 	"peer_optimistic_quorum_min": 0,
 	"max_events": 200,

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -97,11 +97,8 @@ func (t *PollingProtocol) UnmarshalJSON(b []byte) error {
 
 // Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
 type Config struct {
-	CacheHealthPollingInterval   time.Duration   `json:"-"`
-	CacheStatPollingInterval     time.Duration   `json:"-"`
 	MonitorConfigPollingInterval time.Duration   `json:"-"`
 	HTTPTimeout                  time.Duration   `json:"-"`
-	PeerPollingInterval          time.Duration   `json:"-"`
 	PeerOptimistic               bool            `json:"peer_optimistic"`
 	PeerOptimisticQuorumMin      int             `json:"peer_optimistic_quorum_min"`
 	MaxEvents                    uint64          `json:"max_events"`
@@ -115,7 +112,6 @@ type Config struct {
 	LogLocationEvent             string          `json:"log_location_event"`
 	ServeReadTimeout             time.Duration   `json:"-"`
 	ServeWriteTimeout            time.Duration   `json:"-"`
-	HealthToStatRatio            uint64          `json:"health_to_stat_ratio"`
 	StaticFileDir                string          `json:"static_file_dir"`
 	CRConfigHistoryCount         uint64          `json:"crconfig_history_count"`
 	TrafficOpsMinRetryInterval   time.Duration   `json:"-"`
@@ -136,11 +132,8 @@ func (c Config) EventLog() log.LogLocation   { return log.LogLocation(c.LogLocat
 
 // DefaultConfig is the default configuration for the application, if no configuration file is given, or if a given config setting doesn't exist in the config file.
 var DefaultConfig = Config{
-	CacheHealthPollingInterval:   6 * time.Second,
-	CacheStatPollingInterval:     6 * time.Second,
 	MonitorConfigPollingInterval: 5 * time.Second,
 	HTTPTimeout:                  2 * time.Second,
-	PeerPollingInterval:          5 * time.Second,
 	PeerOptimistic:               true,
 	PeerOptimisticQuorumMin:      0,
 	MaxEvents:                    200,
@@ -154,7 +147,6 @@ var DefaultConfig = Config{
 	LogLocationEvent:             LogLocationStdout,
 	ServeReadTimeout:             10 * time.Second,
 	ServeWriteTimeout:            10 * time.Second,
-	HealthToStatRatio:            4,
 	StaticFileDir:                StaticFileDir,
 	CRConfigHistoryCount:         20000,
 	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
@@ -172,11 +164,8 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 	type Alias Config
 	json := jsoniter.ConfigFastest // TODO make configurable?
 	return json.Marshal(&struct {
-		CacheHealthPollingIntervalMs   uint64 `json:"cache_health_polling_interval_ms"`
-		CacheStatPollingIntervalMs     uint64 `json:"cache_stat_polling_interval_ms"`
 		MonitorConfigPollingIntervalMs uint64 `json:"monitor_config_polling_interval_ms"`
 		HTTPTimeoutMS                  uint64 `json:"http_timeout_ms"`
-		PeerPollingIntervalMs          uint64 `json:"peer_polling_interval_ms"`
 		PeerOptimistic                 bool   `json:"peer_optimistic"`
 		PeerOptimisticQuorumMin        int    `json:"peer_optimistic_quorum_min"`
 		HealthFlushIntervalMs          uint64 `json:"health_flush_interval_ms"`
@@ -186,11 +175,8 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 		ServeWriteTimeoutMs            uint64 `json:"serve_write_timeout_ms"`
 		*Alias
 	}{
-		CacheHealthPollingIntervalMs:   uint64(c.CacheHealthPollingInterval / time.Millisecond),
-		CacheStatPollingIntervalMs:     uint64(c.CacheStatPollingInterval / time.Millisecond),
 		MonitorConfigPollingIntervalMs: uint64(c.MonitorConfigPollingInterval / time.Millisecond),
 		HTTPTimeoutMS:                  uint64(c.HTTPTimeout / time.Millisecond),
-		PeerPollingIntervalMs:          uint64(c.PeerPollingInterval / time.Millisecond),
 		PeerOptimistic:                 bool(true),
 		PeerOptimisticQuorumMin:        int(c.PeerOptimisticQuorumMin),
 		HealthFlushIntervalMs:          uint64(c.HealthFlushInterval / time.Millisecond),
@@ -204,11 +190,8 @@ func (c *Config) MarshalJSON() ([]byte, error) {
 func (c *Config) UnmarshalJSON(data []byte) error {
 	type Alias Config
 	aux := &struct {
-		CacheHealthPollingIntervalMs   *uint64 `json:"cache_health_polling_interval_ms"`
-		CacheStatPollingIntervalMs     *uint64 `json:"cache_stat_polling_interval_ms"`
 		MonitorConfigPollingIntervalMs *uint64 `json:"monitor_config_polling_interval_ms"`
 		HTTPTimeoutMS                  *uint64 `json:"http_timeout_ms"`
-		PeerPollingIntervalMs          *uint64 `json:"peer_polling_interval_ms"`
 		PeerOptimistic                 *bool   `json:"peer_optimistic"`
 		PeerOptimisticQuorumMin        *int    `json:"peer_optimistic_quorum_min"`
 		HealthFlushIntervalMs          *uint64 `json:"health_flush_interval_ms"`
@@ -231,20 +214,11 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if aux.CacheHealthPollingIntervalMs != nil {
-		c.CacheHealthPollingInterval = time.Duration(*aux.CacheHealthPollingIntervalMs) * time.Millisecond
-	}
-	if aux.CacheStatPollingIntervalMs != nil {
-		c.CacheStatPollingInterval = time.Duration(*aux.CacheStatPollingIntervalMs) * time.Millisecond
-	}
 	if aux.MonitorConfigPollingIntervalMs != nil {
 		c.MonitorConfigPollingInterval = time.Duration(*aux.MonitorConfigPollingIntervalMs) * time.Millisecond
 	}
 	if aux.HTTPTimeoutMS != nil {
 		c.HTTPTimeout = time.Duration(*aux.HTTPTimeoutMS) * time.Millisecond
-	}
-	if aux.PeerPollingIntervalMs != nil {
-		c.PeerPollingInterval = time.Duration(*aux.PeerPollingIntervalMs) * time.Millisecond
 	}
 	if aux.HealthFlushIntervalMs != nil {
 		c.HealthFlushInterval = time.Duration(*aux.HealthFlushIntervalMs) * time.Millisecond

--- a/traffic_monitor/config/config_test.go
+++ b/traffic_monitor/config/config_test.go
@@ -25,11 +25,8 @@ import (
 
 const exampleTMConfig = `
 {
-	"cache_health_polling_interval_ms": 120000,
-	"cache_stat_polling_interval_ms": 120000,
 	"monitor_config_polling_interval_ms": 5000,
 	"http_timeout_ms": 30000,
-	"peer_polling_interval_ms": 120000,
 	"peer_optimistic": true,
 	"peer_optimistic_quorum_min": 0,
 	"max_events": 200,

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -54,12 +54,12 @@ func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData
 	toData := todata.NewThreadsafe()
 
 	cacheHealthHandler := cache.NewHandler()
-	cacheHealthPoller := poller.NewCache(cfg.CacheHealthPollingInterval, true, cacheHealthHandler, cfg, appData, cfg.CachePollingProtocol)
+	cacheHealthPoller := poller.NewCache(true, cacheHealthHandler, cfg, appData, cfg.CachePollingProtocol)
 	cacheStatHandler := cache.NewPrecomputeHandler(toData)
-	cacheStatPoller := poller.NewCache(cfg.CacheStatPollingInterval, false, cacheStatHandler, cfg, appData, cfg.CachePollingProtocol)
+	cacheStatPoller := poller.NewCache(false, cacheStatHandler, cfg, appData, cfg.CachePollingProtocol)
 	monitorConfigPoller := poller.NewMonitorConfig(cfg.MonitorConfigPollingInterval)
 	peerHandler := peer.NewHandler()
-	peerPoller := poller.NewCache(cfg.PeerPollingInterval, false, peerHandler, cfg, appData, cfg.PeerPollingProtocol)
+	peerPoller := poller.NewCache(false, peerHandler, cfg, appData, cfg.PeerPollingProtocol)
 
 	go monitorConfigPoller.Poll()
 	go cacheHealthPoller.Poll()
@@ -121,7 +121,7 @@ func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData
 		localCacheStatus,
 	)
 
-	StartOpsConfigManager(
+	if _, err := StartOpsConfigManager(
 		opsConfigFile,
 		toSession,
 		toData,
@@ -147,7 +147,9 @@ func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData
 		unpolledCaches,
 		monitorConfig,
 		cfg,
-	)
+	); err != nil {
+		return fmt.Errorf("starting ops config manager: %v", err)
+	}
 
 	if err := startMonitorConfigFilePoller(trafficMonitorConfigFileName); err != nil {
 		return fmt.Errorf("starting monitor config file poller: %v", err)

--- a/traffic_monitor/manager/stat.go
+++ b/traffic_monitor/manager/stat.go
@@ -83,7 +83,6 @@ func StartStatHistoryManager(
 	precomputedData := map[tc.CacheName]cache.PrecomputedData{}
 
 	lastResults := map[tc.CacheName]cache.Result{}
-	overrideMap := map[tc.CacheName]bool{}
 
 	haveCachesChanged := func() bool {
 		select {
@@ -98,7 +97,7 @@ func StartStatHistoryManager(
 		if haveCachesChanged() {
 			unpolledCaches.SetNewCaches(getNewCaches(localStates, monitorConfig))
 		}
-		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), errorCount, dsStats, lastStatEndTimes, lastStatDurations, unpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, overrideMap, combineState, cfg.CachePollingProtocol)
+		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), errorCount, dsStats, lastStatEndTimes, lastStatDurations, unpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, combineState, cfg.CachePollingProtocol)
 	}
 
 	go func() {
@@ -252,7 +251,6 @@ func processStatResults(
 	localStates peer.CRStatesThreadsafe,
 	events health.ThreadsafeEvents,
 	localCacheStatusThreadsafe threadsafe.CacheAvailableStatus,
-	overrideMap map[tc.CacheName]bool,
 	combineState func(),
 	pollingProtocol config.PollingProtocol,
 ) {
@@ -262,7 +260,6 @@ func processStatResults(
 	combinedStates := combinedStatesThreadsafe.Get()
 	defer func() {
 		for _, r := range results {
-			// log.Debugf("poll %v %v statfinish\n", result.PollID, endTime)
 			r.PollFinished <- r.PollID
 		}
 	}()

--- a/traffic_monitor/peer/peer.go
+++ b/traffic_monitor/peer/peer.go
@@ -65,7 +65,7 @@ func (handler Handler) Handle(id string, r io.Reader, format string, reqTime tim
 	}
 
 	if r != nil {
-		json := jsoniter.ConfigFastest // TODo make configurable?
+		json := jsoniter.ConfigFastest // TODO make configurable?
 		err = json.NewDecoder(r).Decode(&result.PeerStates)
 		if err == nil {
 			result.Available = true

--- a/traffic_monitor/poller/cache.go
+++ b/traffic_monitor/poller/cache.go
@@ -56,11 +56,9 @@ type CachePollerConfig struct {
 	PollingProtocol config.PollingProtocol
 }
 
-// NewHTTP creates and returns a new CachePoller.
+// NewCache creates and returns a new CachePoller.
 // If tick is false, CachePoller.TickChan() will return nil.
-// TODO: rename to not "http", since it's now pluggable
 func NewCache(
-	interval time.Duration,
 	tick bool,
 	handler handler.Handler,
 	cfg config.Config,
@@ -75,7 +73,6 @@ func NewCache(
 		TickChan:      tickChan,
 		ConfigChannel: make(chan CachePollerConfig),
 		Config: CachePollerConfig{
-			Interval:        interval,
 			PollingProtocol: pollingProtocol,
 		},
 		GlobalContexts: GetGlobalContexts(cfg, appData),
@@ -130,15 +127,6 @@ func (p CachePoller) Poll() {
 		}
 		p.Config = newConfig
 	}
-}
-
-func mustDie(die <-chan struct{}) bool {
-	select {
-	case <-die:
-		return true
-	default:
-	}
-	return false
 }
 
 // TODO iterationCount and/or p.TickChan?

--- a/traffic_monitor/poller/monitorconfig.go
+++ b/traffic_monitor/poller/monitorconfig.go
@@ -44,8 +44,7 @@ type MonitorConfigPoller struct {
 	OpsConfig        handler.OpsConfig
 }
 
-// Creates and returns a new CachePoller.
-// If tick is false, CachePoller.TickChan() will return nil
+// NewMonitorConfig Creates and returns a new MonitorConfigPoller.
 func NewMonitorConfig(interval time.Duration) MonitorConfigPoller {
 	return MonitorConfigPoller{
 		Interval:       interval,

--- a/traffic_monitor/tests/_integration/tm/Dockerfile_run.sh
+++ b/traffic_monitor/tests/_integration/tm/Dockerfile_run.sh
@@ -39,11 +39,8 @@ init() {
 	mkdir -p /opt/traffic_monitor/conf
 	cat > /opt/traffic_monitor/conf/traffic_monitor.cfg <<- EOF
 		{
-				"cache_health_polling_interval_ms": 6000,
-				"cache_stat_polling_interval_ms": 6000,
 				"monitor_config_polling_interval_ms": 15000,
 				"http_timeout_ms": 2000,
-				"peer_polling_interval_ms": 5000,
 				"peer_optimistic": true,
 				"max_events": 200,
 				"health_flush_interval_ms": 20,

--- a/traffic_monitor/threadsafe/durationmap.go
+++ b/traffic_monitor/threadsafe/durationmap.go
@@ -32,7 +32,7 @@ type DurationMap struct {
 	m           *sync.RWMutex
 }
 
-// Copy copies this duration map.
+// CopyDurationMap copies this duration map.
 func CopyDurationMap(a map[tc.CacheName]time.Duration) map[tc.CacheName]time.Duration {
 	b := map[tc.CacheName]time.Duration{}
 	for k, v := range a {


### PR DESCRIPTION
Remove the following TM config options which appear to be used but
actually aren't, due to them having a corresponding profile parameter:
- cache_health_polling_interval_ms
- cache_stat_polling_interval_ms
- peer_polling_interval_ms

These are actually unused because the following profile parameters take
precedence as soon as the monitoring.json snapshot is retrieved from TO:
- heartbeat.polling.interval
- health.polling.interval
- peers.polling.interval

Additionally, do some minor cleanup of unused functions, unused
parameters, and comments.

-----------------------------------------------

## Which Traffic Control components are affected by this PR?
- Traffic Monitor
- Automation (Ansible roles)

## What is the best way to verify this PR?
Ensure that TM still starts up and performs its cache health polling using the interval in the `heartbeat.polling.interval` profile parameter, its cache stat polling using the interval in the `health.polling.interval` profile parameter, and its peer polling using the interval in the `peers.polling.interval` profile parameter.

## PR submission checklist
- [x] This PR updates the tests to remove the unused configuration, but it doesn't really make sense to test the removal of config options.
- [x] These config options were not documented
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
