### PR TITLE
Fix email content injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - lib/go-atscfg Make funcs to take Opts, to reduce future breaking changes.
 - CDN in a Box now uses `t3c` for cache configuration.
 - CDN in a Box now uses Apache Traffic Server 8.1.
+- Customer names in payloads sent to the `/deliveryservices/request` Traffic Ops API endpoint can no longer contain characters besides alphanumerics, @, !, #, $, %, ^, &amp;, *, (, ), [, ], '.', ' ', and '-'. This fixes a vulnerability that allowed email content injection.
 
 ### Deprecated
 - The Riak Traffic Vault backend is now deprecated and its support may be removed in a future release. It is highly recommended to use the new PostgreSQL backend instead.

--- a/docs/source/api/v2/deliveryservices_request.rst
+++ b/docs/source/api/v2/deliveryservices_request.rst
@@ -36,7 +36,11 @@ Request Structure
 -----------------
 :details: An object describing the actual parameters for the Delivery Service request
 
-	:customer:        Name of the customer associated with the :term:`Delivery Service`
+	:customer: Name of the customer associated with the :term:`Delivery Service` - must only contain alphanumeric characters and the characters :kbd:`@`, :kbd:`!`, :kbd:`#`, :kbd:`$`, :kbd:`%`, :kbd:`^`, :kbd:`&`, :kbd:`*`, :kbd:`(`, :kbd:`)`, :kbd:`[`, :kbd:`]`, :kbd:`.`, :kbd:` `, and :kbd:`-`
+
+		.. versionchanged:: ATCv6
+			Prior to ATC version 6, this field had no restrictions.
+
 	:deepCachingType: An optional string describing when to do Deep Caching for this :term:`Delivery Service` - one of:
 
 		NEVER
@@ -115,8 +119,8 @@ Request Structure
 		"hasNegativeCachingCustomization": false,
 		"negativeCachingCustomizationNote": "",
 		"serviceAliases": [],
-		"rateLimitingGBPS": "less than 50",
-		"rateLimitingTPS": "no more than 5000",
+		"rateLimitingGBPS": 50,
+		"rateLimitingTPS": 5000,
 		"overflowService": null,
 		"headerRewriteEdge": "",
 		"headerRewriteMid": "",

--- a/docs/source/api/v3/deliveryservices_request.rst
+++ b/docs/source/api/v3/deliveryservices_request.rst
@@ -36,7 +36,11 @@ Request Structure
 -----------------
 :details: An object describing the actual parameters for the Delivery Service request
 
-	:customer:        Name of the customer associated with the :term:`Delivery Service`
+	:customer: Name of the customer associated with the :term:`Delivery Service` - must only contain alphanumeric characters and the characters :kbd:`@`, :kbd:`!`, :kbd:`#`, :kbd:`$`, :kbd:`%`, :kbd:`^`, :kbd:`&`, :kbd:`*`, :kbd:`(`, :kbd:`)`, :kbd:`[`, :kbd:`]`, :kbd:`.`, :kbd:` `, and :kbd:`-`
+
+	.. versionchanged:: ATCv6
+		Prior to ATC version 6, this field had no restrictions.
+
 	:deepCachingType: An optional string describing when to do Deep Caching for this :term:`Delivery Service` - one of:
 
 		NEVER
@@ -115,8 +119,8 @@ Request Structure
 		"hasNegativeCachingCustomization": false,
 		"negativeCachingCustomizationNote": "",
 		"serviceAliases": [],
-		"rateLimitingGBPS": "less than 50",
-		"rateLimitingTPS": "no more than 5000",
+		"rateLimitingGBPS": 50,
+		"rateLimitingTPS": 5000,
 		"overflowService": null,
 		"headerRewriteEdge": "",
 		"headerRewriteMid": "",

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -36,6 +37,10 @@ import (
 // EmailTemplate is an html/template.Template for formatting DeliveryServiceRequestRequests into
 // text/html email bodies. Its direct use is discouraged, instead use
 // DeliveryServiceRequestRequest.Format.
+//
+// Deprecated: Delivery Services Requests have been deprecated in favor of
+// Delivery Service Requests, and will be removed from the Traffic Ops API at
+// some point in the future.
 var EmailTemplate = template.Must(template.New("Email Template").Parse(`<!DOCTYPE html>
 <html lang="en-US">
 <head>
@@ -159,6 +164,10 @@ pre {
 type IDNoMod int
 
 // DeliveryServiceRequestRequest is a literal request to make a Delivery Service.
+//
+// Deprecated: Delivery Services Requests have been deprecated in favor of
+// Delivery Service Requests, and will be removed from the Traffic Ops API at
+// some point in the future.
 type DeliveryServiceRequestRequest struct {
 	// EmailTo is the email address that is ultimately the destination of a formatted DeliveryServiceRequestRequest.
 	EmailTo string `json:"emailTo"`
@@ -168,6 +177,10 @@ type DeliveryServiceRequestRequest struct {
 
 // DeliveryServiceRequestDetails holds information about what a user is trying
 // to change, with respect to a delivery service.
+//
+// Deprecated: Delivery Services Requests have been deprecated in favor of
+// Delivery Service Requests, and will be removed from the Traffic Ops API at
+// some point in the future.
 type DeliveryServiceRequestDetails struct {
 	// ContentType is the type of content to be delivered, e.g. "static", "VOD" etc.
 	ContentType string `json:"contentType"`
@@ -255,7 +268,7 @@ func (d DeliveryServiceRequestDetails) Format() (string, error) {
 	b := &strings.Builder{}
 
 	if err := EmailTemplate.Execute(b, d); err != nil {
-		return "", fmt.Errorf("Failed to apply template: %v", err)
+		return "", fmt.Errorf("Failed to apply template: %w", err)
 	}
 	return b.String(), nil
 }
@@ -275,7 +288,7 @@ func (d *DeliveryServiceRequestRequest) Validate() error {
 	details := d.Details
 	err = validation.ValidateStruct(&details,
 		validation.Field(&details.ContentType, validation.Required),
-		validation.Field(&details.Customer, validation.Required),
+		validation.Field(&details.Customer, validation.Required, validation.Match(regexp.MustCompile(`^[\w@!#$%^&\*\(\)\[\]\. -]+$`))),
 		validation.Field(&details.DeepCachingType, validation.By(
 			func(t interface{}) error {
 				if t != (*DeepCachingType)(nil) && *t.(*DeepCachingType) == DeepCachingTypeInvalid {


### PR DESCRIPTION
This PR restricts the character set for customer names in the `/deliveryservices/request` Traffic Ops API endpoint to alphanumeric and @, !, #, $, %, ^, &amp;, *, (, ), [, ], '.', ' ', and '-'.
-----------------------------------------------

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Make a request to `/deliveryservices/request` with a customer name that includes newline characters, e.g.
```json
{
	"emailTo": "foo@bar.com",
	"details": {
		"customer": "XYZ Corporation \nThis string has newlines.\n",
		"contentType": "static",
		"deepCachingType": "NEVER",
		"deliveryProtocol": "http",
		"routingType": "http",
		"routingName": "demo1",
		"serviceDesc": "service description goes here",
		"peakBPSEstimate": "less-than-5-Gbps",
		"peakTPSEstimate": "less-than-1000-TPS",
		"maxLibrarySizeEstimate": "less-than-200-GB",
		"originURL": "http://myorigin.com",
		"hasOriginDynamicRemap": false,
		"originTestFile": "http://origin.infra.ciab.test",
		"hasOriginACLWhitelist": false,
		"originHeaders": "",
		"otherOriginSecurity": "",
		"queryStringHandling": "ignore-in-cache-key-and-pass-up",
		"rangeRequestHandling": "range-requests-not-used",
		"hasSignedURLs": false,
		"hasNegativeCachingCustomization": false,
		"negativeCachingCustomizationNote": "",
		"serviceAliases": [],
		"rateLimitingGBPS": 50,
		"rateLimitingTPS": 5000,
		"overflowService": null,
		"headerRewriteEdge": "",
		"headerRewriteMid": "",
		"headerRewriteRedirectRouter": "",
		"notes": ""
	}
}
```
and observe that it is rejected by the API

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- 5.x
- 4.x

## PR submission checklist
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 