### PR TITLE
Prepare database for Roles and Permissions

### DIFF
--- a/traffic_ops/app/db/migrations/2021081800000000_roles_and_permissions.down.sql
+++ b/traffic_ops/app/db/migrations/2021081800000000_roles_and_permissions.down.sql
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ALTER TABLE ONLY public.role
+ALTER COLUMN "description"
+DROP NOT NULL;
+
+DELETE FROM public.role_capability
+WHERE cap_name NOT IN (
+	SELECT DISTINCT "name"
+	FROM public.capability
+);
+
+ALTER TABLE ONLY public.role_capability
+ADD CONSTRAINT fk_cap_name
+FOREIGN KEY (cap_name)
+REFERENCES public.capability (name) ON DELETE RESTRICT;

--- a/traffic_ops/app/db/migrations/2021081800000000_roles_and_permissions.up.sql
+++ b/traffic_ops/app/db/migrations/2021081800000000_roles_and_permissions.up.sql
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+UPDATE public.role
+SET "description"=''
+WHERE "description" IS NULL;
+
+ALTER TABLE public.role
+ALTER COLUMN "description"
+SET NOT NULL;
+
+ALTER TABLE public.role_capability
+DROP CONSTRAINT fk_cap_name;
+
+INSERT INTO public.role("name", "description", priv_level)
+VALUES ('admin', 'Has access to everything.', 30)
+ON CONFLICT ("name") DO NOTHING;

--- a/traffic_ops/app/db/migrations/2021081800000001_no_null_username.down.sql
+++ b/traffic_ops/app/db/migrations/2021081800000001_no_null_username.down.sql
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ALTER TABLE ONLY public.tm_user
+ALTER COLUMN username
+DROP NOT NULL;

--- a/traffic_ops/app/db/migrations/2021081800000001_no_null_username.up.sql
+++ b/traffic_ops/app/db/migrations/2021081800000001_no_null_username.up.sql
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+ALTER TABLE ONLY public.tm_user
+ALTER COLUMN username
+SET NOT NULL;


### PR DESCRIPTION
This PR removes a foreign key constraint that mandated that a Permission on a Role belong to a row in the `capability` table - this will allow adding arbitrary Permissions to Roles. It also disallows null descriptions as specified in the blueprint (NULLs coalesced to empty strings), and adds the `admin` Role if it does not already exist.

This also includes a migration to ensure that usernames are not NULL, because I found it alarming that they were allowed to be when that would break so much.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Ensure CiaB tests, Traffic Ops API/Go client integration tests, and database tests all pass.

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**