### PR TITLE
Skip check for the past dbversion's migration existing if it is squashed

### DIFF
--- a/traffic_ops/app/db/admin.go
+++ b/traffic_ops/app/db/admin.go
@@ -331,6 +331,7 @@ func maybeMigrateFromGoose() bool {
 	if err := Migrate.Steps(1); err != nil {
 		die("Error migrating to Migrate from Goose: " + err.Error())
 	}
+	DBVersion, DBVersionDirty, _ = Migrate.Version()
 	return true
 }
 

--- a/traffic_ops/app/db/admin.go
+++ b/traffic_ops/app/db/admin.go
@@ -129,16 +129,17 @@ var (
 	DBVersionDirty bool
 
 	// globals that are parsed out of DBConfigFile and used in commands
-	DBDriver      string
-	DBName        string
-	DBSuperUser   = DefaultDBSuperUser
-	DBUser        string
-	DBPassword    string
-	HostIP        string
-	HostPort      string
-	SSLMode       string
-	Migrate       *migrate.Migrate
-	MigrationName string
+	ConnectionString string
+	DBDriver         string
+	DBName           string
+	DBSuperUser      = DefaultDBSuperUser
+	DBUser           string
+	DBPassword       string
+	HostIP           string
+	HostPort         string
+	SSLMode          string
+	Migrate          *migrate.Migrate
+	MigrationName    string
 )
 
 func parseDBConfig() error {
@@ -569,11 +570,11 @@ func main() {
 
 func initMigrate() bool {
 	var err error
-	connectionString := fmt.Sprintf("%s://%s:%s@%s:%s/%s?sslmode=%s", DBDriver, DBUser, DBPassword, HostIP, HostPort, DBName, SSLMode)
+	ConnectionString = fmt.Sprintf("%s://%s:%s@%s:%s/%s?sslmode=%s", DBDriver, DBUser, DBPassword, HostIP, HostPort, DBName, SSLMode)
 	if TrafficVault {
-		Migrate, err = migrate.New(TrafficVaultMigrationsSource, connectionString)
+		Migrate, err = migrate.New(TrafficVaultMigrationsSource, ConnectionString)
 	} else {
-		Migrate, err = migrate.New(DBMigrationsSource, connectionString)
+		Migrate, err = migrate.New(DBMigrationsSource, ConnectionString)
 	}
 	if err != nil {
 		die("Starting Migrate: " + err.Error())

--- a/traffic_ops_db/test/docker/Dockerfile-db-admin
+++ b/traffic_ops_db/test/docker/Dockerfile-db-admin
@@ -23,25 +23,43 @@ FROM centos:7
 ARG POSTGRES_VERSION=13.2
 ENV POSTGRES_VERSION=$POSTGRES_VERSION
 
-# NOTE: temporary workaround for removal of golang packages from CentOS 7 base repo
 RUN yum install -y \
-    epel-release \
-    centos-release-scl-rh \
-    https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
+		epel-release \
+		centos-release-scl-rh \
+		https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     git && \
-    yum -y install golang
+    yum -y install           \
+        cpanminus            \
+        expat-devel          \
+        libcap               \
+        libcurl-devel        \
+        libidn-devel         \
+        libpcap-devel        \
+        mkisofs              \
+        openssl-devel        \
+        perl-core            \
+        perl-Crypt-ScryptKDF \
+        perl-DBD-Pg          \
+        perl-DBI             \
+        perl-Digest-SHA1     \
+        perl-JSON            \
+        perl-libwww-perl     \
+        perl-TermReadKey     \
+        perl-Test-CPAN-Meta  \
+        perl-WWW-Curl        \
+        postgresql13         \
+        postgresql13-devel &&\
+    yum clean all
 
 # Override TRAFFIC_OPS_RPM arg to use a different one using --build-arg TRAFFIC_OPS_RPM=...  Can be local file or http://...
 ARG TRAFFIC_OPS_RPM=traffic_ops.rpm
 ADD $TRAFFIC_OPS_RPM /
-RUN yum install -y \
-        /$(basename $TRAFFIC_OPS_RPM) && \
-        rm /$(basename $TRAFFIC_OPS_RPM) && \
-    yum clean all
+RUN rpm -Uvh $(basename $TRAFFIC_OPS_RPM) && \
+    rm $(basename $TRAFFIC_OPS_RPM)
 
 WORKDIR /opt/traffic_ops/app
 
-ADD run-db-test.sh \
+COPY run-db-test.sh \
     db-config.sh \
     /
 

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -132,7 +132,7 @@ fi
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
     echo "testing restoration of DB dump: $d"
-    dropdb --echo --if-exists < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
+    dropdb --echo --if-exists "$DB_NAME" < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
     createdb --echo < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
     pg_restore --verbose --clean --if-exists --exit-on-error -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR
- Fixes an issue introduced by #6096 where, where when migrating from Goose, `db/admin dbversion` would return `0` instead of Goose migration version (e080781e61)
- Fixes the issue that #6096 was supposed to fix: Running the first unsquashed migration without checking whether the past migration exists if migrating from the last squashed migration (f102c654ff).
- Fixes a bug in the Traffic Ops DB tests where `dropdb` did not specify the database to drop


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Delete the `2021080408053529_fix_indices` migrations (unnecessary once #6127 is fixed)
2. Migrate the Traffic Ops database at [ATC 5.1.2](https://github.com/apache/trafficcontrol/commits/RELEASE-5.1.2)
3. Dump the database, move the dump to `traffic_ops_db/test/docker/initdb.d`, and rebuild the `db` service
4. Build a Traffic Ops RPM, move it to `traffic_ops_db/test/docker/traffic_ops.rpm` and rebuild the `trafficops-db-admin` service
5. Run the Traffic Ops DB tests

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 6.0.x release branch

## PR submission checklist
- [x] This PR modifies existing tests<!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->