### PR TITLE
Make TM recover from TO being unavailable at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#5690](https://github.com/apache/trafficcontrol/issues/5690) - Fixed github action for added/modified db migration file.
 - [#2471](https://github.com/apache/trafficcontrol/issues/2471) - A PR check to ensure added db migration file is the latest.
+- [#6129](https://github.com/apache/trafficcontrol/issues/6129) - Traffic Monitor start doesn't recover when Traffic Ops is unavailable
 - [#5609](https://github.com/apache/trafficcontrol/issues/5609) - Fixed GET /servercheck filter for an extra query param.
 - [#5954](https://github.com/apache/trafficcontrol/issues/5954) - Traffic Ops HTTP response write errors are ignored
 - [#6048](https://github.com/apache/trafficcontrol/issues/6048) - TM sometimes sets cachegroups to unavailable even though all caches are online

--- a/traffic_monitor/handler/handler.go
+++ b/traffic_monitor/handler/handler.go
@@ -40,6 +40,7 @@ type OpsConfig struct {
 	HttpsListener string `json:"httpsListener"`
 	CertFile      string `json:"certFile"`
 	KeyFile       string `json:"keyFile"`
+	UsingDummyTO  bool   `json:"usingDummyTO"` // only used in the TM UI to indicate if TM started up with on-disk backup snapshots
 }
 
 type Handler interface {

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -39,7 +39,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_monitor/todata"
 	"github.com/apache/trafficcontrol/traffic_monitor/towrap"
 
-	"github.com/json-iterator/go"
+	jsoniter "github.com/json-iterator/go"
 )
 
 // StartOpsConfigManager starts the ops config manager goroutine, returning the (threadsafe) variables which it sets.
@@ -172,15 +172,13 @@ func StartOpsConfigManager(
 				time.Sleep(duration)
 
 				if toSession.BackupFileExists() && (toLoginCount >= cfg.TrafficOpsDiskRetryMax) {
-					log.Errorf("error instantiating Session with traffic_ops, backup disk files exist, creating empty traffic_ops session to read")
-					newOpsConfig.UsingDummyTO = true
+					log.Errorf("error instantiating authenticated session with Traffic Ops, backup disk files exist, continuing with unauthenticated session")
 					break
 				}
 
 				toLoginCount++
 				continue
 			} else {
-				newOpsConfig.UsingDummyTO = false
 				break
 			}
 		}

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -172,6 +172,7 @@ func StartOpsConfigManager(
 				time.Sleep(duration)
 
 				if toSession.BackupFileExists() && (toLoginCount >= cfg.TrafficOpsDiskRetryMax) {
+					newOpsConfig.UsingDummyTO = true
 					log.Errorf("error instantiating authenticated session with Traffic Ops, backup disk files exist, continuing with unauthenticated session")
 					break
 				}
@@ -179,6 +180,7 @@ func StartOpsConfigManager(
 				toLoginCount++
 				continue
 			} else {
+				newOpsConfig.UsingDummyTO = false
 				break
 			}
 		}

--- a/traffic_monitor/towrap/towrap.go
+++ b/traffic_monitor/towrap/towrap.go
@@ -39,9 +39,9 @@ import (
 	"github.com/apache/trafficcontrol/traffic_monitor/config"
 	legacyClient "github.com/apache/trafficcontrol/traffic_ops/v2-client"
 	client "github.com/apache/trafficcontrol/traffic_ops/v3-client"
-	"golang.org/x/net/publicsuffix"
 
 	jsoniter "github.com/json-iterator/go"
+	"golang.org/x/net/publicsuffix"
 )
 
 const localHostIP = "127.0.0.1"

--- a/traffic_monitor/towrap/towrap_test.go
+++ b/traffic_monitor/towrap/towrap_test.go
@@ -1,4 +1,4 @@
-package handler
+package towrap
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -20,28 +20,18 @@ package handler
  */
 
 import (
-	"io"
+	"testing"
 	"time"
+
+	"github.com/apache/trafficcontrol/traffic_monitor/config"
 )
 
-const (
-	NOTIFY_NEVER = iota
-	NOTIFY_CHANGE
-	NOTIFY_ALWAYS
-)
-
-type OpsConfig struct {
-	Username      string `json:"username"`
-	Password      string `json:"password"`
-	Url           string `json:"url"`
-	Insecure      bool   `json:"insecure"`
-	CdnName       string `json:"cdnName"`
-	HttpListener  string `json:"httpListener"`
-	HttpsListener string `json:"httpsListener"`
-	CertFile      string `json:"certFile"`
-	KeyFile       string `json:"keyFile"`
-}
-
-type Handler interface {
-	Handle(string, io.Reader, string, time.Duration, time.Time, error, uint64, bool, interface{}, chan<- uint64)
+func TestTrafficOpsSessionThreadsafeUpdateSetsNonNilSessions(t *testing.T) {
+	s := NewTrafficOpsSessionThreadsafe(nil, nil, 5, config.Config{})
+	err := s.Update("", "", "", true, "", false, 10*time.Second)
+	if err == nil {
+		t.Error("expected an error, got nil")
+	} else if s.session == nil || *s.session == nil || s.legacySession == nil || *s.legacySession == nil {
+		t.Errorf("expected non-nil sessions after getting error from Update()")
+	}
 }


### PR DESCRIPTION
Always set non-nil TO sessions that can eventually authenticate
themselves when TO recovers. Additionally, instead of exclusively using
one major client version after starting up and logging in, always
attempt the latest major version and fall back to the legacy version in
case of error. This will allow TM to seamlessly transition between using
either major version no matter which order TM and TO are upgraded in.

Closes: #6129

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Ensure the added TM unit test passes.

1. Start up TM while TO is also running/available.
2. Once TM has successfully written its backup files to disk, stop TM.
3. In TP, add a new parameter to the TM profile (name = this.is.a.test, config_file = rascal-config.txt, value = test)
4. snapshot the CDN.
5. Shut down TO.
6. Start up TM while TO is still stopped/unavailable.
7. View the log files and observe that TM uses the backup files, continues to operate, and starts polling caches.
8. Start up TO.
9. After one `tm.polling.interval` amount of time (usually 1 minute), TM should successfully poll TO and write the new snapshot backup files. This can be verified by checking the tmconfig.backup file for the parameter created in step 3 (it will be in the `"config": {...}` section).


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 5.x
- 6.0.x

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] Bug fix, no docs needed
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
