### PR TITLE
Re-enable accidentally disabled features

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,3 +26,5 @@ github:
   - hacktoberfest
   features:
     wiki: true
+    issues: true
+    projects: true


### PR DESCRIPTION
PR #6149 accidentally disabled a couple of repository features - this fixes that.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
None.

## What is the best way to verify this PR?
You can't.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**