### PR TITLE
Fix a null pointer exception when delivery service doesn't exist

### DIFF
--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -701,10 +701,10 @@ public class ZoneManager extends Resolver {
 						ttl = ZoneUtils.getLong(ds.getTtls(), type, 60);
 					}
 					switch(type) {
-						case "A": 
+						case "A":
 							list.add(new ARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
 							break;
-						case "AAAA": 
+						case "AAAA":
 							list.add(new AAAARecord(name, DClass.IN, ttl, InetAddress.getByName(value)));
 							break;
 						case "CNAME":
@@ -741,7 +741,7 @@ public class ZoneManager extends Resolver {
 			// NSRecords will be replaced later if tr.isEdgeDNSRouting() is true; we need these to allow stub zones to be signed, etc
 			list.add(new NSRecord(name, DClass.IN, ZoneUtils.getLong(ttl, "NS", 60), getGlueName(ds, trJo, name, key)));
 			list.add(new ARecord(trName,
-					DClass.IN, ZoneUtils.getLong(ttl, "A", 60), 
+					DClass.IN, ZoneUtils.getLong(ttl, "A", 60),
 					InetAddress.getByName(JsonUtils.optString(trJo, IP))));
 
 			String ip6 = trJo.get("ip6").asText();
@@ -866,7 +866,7 @@ public class ZoneManager extends Resolver {
 
 	/**
 	 * Gets trafficRouter.
-	 * 
+	 *
 	 * @return the trafficRouter
 	 */
 	public TrafficRouter getTrafficRouter() {
@@ -875,7 +875,7 @@ public class ZoneManager extends Resolver {
 
 	/**
 	 * Attempts to find a {@link Zone} that would contain the specified {@link Name}.
-	 * 
+	 *
 	 * @param name
 	 *            the Name to use to attempt to find the Zone
 	 * @return the Zone to use to resolve the specified Name
@@ -922,7 +922,7 @@ public class ZoneManager extends Resolver {
 	/**
 	 * Creates a dynamic zone that serves a set of A and AAAA records for the specified {@link Name}
 	 * .
-	 * 
+	 *
 	 * @param staticZone
 	 *            The Zone that would normally serve this request
 	 * @param builder
@@ -940,7 +940,11 @@ public class ZoneManager extends Resolver {
 			if (result != null) {
 				final Zone dynamicZone = fillDynamicZone(dynamicZoneCache, staticZone, request, result);
 				track.setResultCode(dynamicZone, request.getName(), request.getQueryType());
-				builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
+				if (result.getDeliveryService() == null) {
+					builder.deliveryServiceXmlIds(null);
+        } else {
+          builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
+        }
 				return dynamicZone;
 			} else {
 				return null;

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -944,9 +944,9 @@ public class ZoneManager extends Resolver {
 					builder.deliveryServiceXmlIds(null);
         } else {
           builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
-        }
-				return dynamicZone;
-			} else {
+      }
+        return dynamicZone;
+      } else {
 				return null;
 			}
 		} catch (final Exception e) {

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -942,11 +942,11 @@ public class ZoneManager extends Resolver {
 				track.setResultCode(dynamicZone, request.getName(), request.getQueryType());
 				if (result.getDeliveryService() == null) {
 					builder.deliveryServiceXmlIds(null);
-        } else {
-          builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
-      }
-        return dynamicZone;
-      } else {
+        			} else {
+				        builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
+			        }
+        			return dynamicZone;
+      			} else {
 				return null;
 			}
 		} catch (final Exception e) {

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -946,7 +946,7 @@ public class ZoneManager extends Resolver {
 				        builder.deliveryServiceXmlIds(result.getDeliveryService().getId());
 			        }
         			return dynamicZone;
-      			} else {
+			} else {
 				return null;
 			}
 		} catch (final Exception e) {


### PR DESCRIPTION
This fixes a null pointer exception when the targeted delivery service doesn't exist.

- Traffic Router

## What is the best way to verify this PR?

The way it was discovered by trying to get a delivery service that doesn't exist

```
dig @tr.domain.tld tata.cdn.tld A
```

## If this is a bugfix, which Traffic Control versions contained the bug?

- master
- 6.0.0 (RC0)


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)


