### PR TITLE
Fix t3c update when fallback occurs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6027](https://github.com/apache/trafficcontrol/issues/6027) - Collapsed DB migrations
 - [#6091](https://github.com/apache/trafficcontrol/issues/6091) - Fixed cache config of internal cache communication for https origins
 - [#6066](https://github.com/apache/trafficcontrol/issues/6066) - Fixed missing/incorrect indices on some tables
+- [#6169](https://github.com/apache/trafficcontrol/issues/6169) - Fixed t3c-update not updating server status when a fallback to a previous Traffic Ops API version occurred
 - [#5576](https://github.com/apache/trafficcontrol/issues/5576) - Inconsistent Profile Name restrictions
 - Fixed Federations IMS so TR federations watcher will get updates.
 

--- a/cache-config/t3cutil/toreq/client.go
+++ b/cache-config/t3cutil/toreq/client.go
@@ -104,6 +104,11 @@ func New(url *url.URL, user string, pass string, insecure bool, timeout time.Dur
 		}
 		client.c = nil
 		client.old = oldClient
+
+		{
+			newClient := toclient.NewNoAuthSession("", false, "", false, 0) // only used for the version, because toClient could be nil if it had an error
+			log.Infof("cache-config Traffic Ops client: %v not supported, falling back to %v\n", newClient.APIVersion(), oldClient.APIVersion())
+		}
 	}
 
 	return client, nil

--- a/cache-config/t3cutil/toreq/toreqold/client.go
+++ b/cache-config/t3cutil/toreq/toreqold/client.go
@@ -49,6 +49,10 @@ func (cl *TOClient) SetURL(newURL string) {
 	cl.c.URL = newURL
 }
 
+func (cl *TOClient) APIVersion() string {
+	return cl.c.APIVersion()
+}
+
 // New logs into Traffic Ops, returning the TOClient which contains the logged-in client.
 func New(url *url.URL, user string, pass string, insecure bool, timeout time.Duration, userAgent string) (*TOClient, error) {
 	log.Infoln("URL: '" + url.String() + "' User: '" + user + "' Pass len: '" + strconv.Itoa(len(pass)) + "'")

--- a/cache-config/t3cutil/toreq/toreqold/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/toreqold/clientfuncs.go
@@ -570,7 +570,7 @@ func (cl *TOClient) GetServerUpdateStatus(cacheHostName tc.CacheName) (tc.Server
 func (cl *TOClient) SetServerUpdateStatus(cacheHostName tc.CacheName, updateStatus *bool, revalStatus *bool) (toclientlib.ReqInf, error) {
 	reqInf := toclientlib.ReqInf{}
 	err := torequtil.GetRetry(cl.NumRetries, "server_update_status_"+string(cacheHostName), nil, func(obj interface{}) error {
-		_, toReqInf, err := cl.c.GetServerUpdateStatus(string(cacheHostName))
+		toReqInf, err := cl.c.SetUpdateServerStatuses(string(cacheHostName), updateStatus, revalStatus)
 		if err != nil {
 			return errors.New("setting server update status from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}


### PR DESCRIPTION
Fixed t3c-update when a fallback to a previous Traffic Ops API version occurs.

The bug was that when a fallback occurred, the "old" client was doing a Get instead of a Set.

This also adds a log message of exactly the client's latest version and the version being fallen back to, e.g. `INFO: client.go:112: 2021-09-07T19:56:59.82297Z: cache-config Traffic Ops client: 4.0 not supported, falling back to 3.1`, which should be helpful in debugging, and in manually testing this fix.

No automated tests, unfortunately this can't be reasonably unit-tested since it's the TO request function itself, and the t3c Integration Test Framework doesn't yet have the ability to use multiple TO versions and fall back between them, and that'd be a pretty big feature to add. FWIW I manually tested and verified it's fixed, and sets the update flags in TO appropriately on a TO without the latest major in the client.
Includes changelog.
No docs, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run t3c-update against a TO without the latest major version in the client, verify flags are set and unset as specified.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- ~~[x] This PR has tests~~ explained above, can't be tested without a significant test framework enhancement
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
