### PR TITLE
Change a chatty log message from Info to Debug.

### DIFF
--- a/cache-config/tm-health-client/tmagent/tmagent.go
+++ b/cache-config/tm-health-client/tmagent/tmagent.go
@@ -405,7 +405,7 @@ func (c *ParentInfo) findATrafficMonitor() (string, error) {
 		return "", errors.New("there are no available traffic monitors")
 	}
 
-	log.Infof("polling: %s\n", tmHostname)
+	log.Debugf("polling: %s\n", tmHostname)
 
 	return tmHostname, nil
 }


### PR DESCRIPTION
Change a chatty log message from Info to Debug.  The message just logs that it is polling a traffic monitor.
Change requested by @smalenfant 

## Which Traffic Control components are affected by this PR?

- Traffic Control Cache Config (T3C, formerly ORT)


## What is the best way to verify this PR?

Run the unit tests.


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
