### PR TITLE
Fix for tm-health-client systemd service

### DIFF
--- a/cache-config/tm-health-client/tm-health-client.service
+++ b/cache-config/tm-health-client/tm-health-client.service
@@ -18,13 +18,14 @@
 #
 [Unit]
 Description=Traffic monitor health service for Trafficserver
-After=trafficserver
+After=trafficserver.service
+Requires=trafficserver.service
 
 [Service]
 ExecStart=/usr/bin/tm-health-client -vv
-RequiredBy=trafficserver
 Restart=always
-ExecStop=/bin/kill -s $MAINPID
+ExecStop=/bin/kill -p $MAINPID
 
 [Install]
-
+RequiredBy=trafficserver.service
+WantedBy=trafficserver.service

--- a/cache-config/tm-health-client/tm-health-client.service
+++ b/cache-config/tm-health-client/tm-health-client.service
@@ -24,7 +24,7 @@ Requires=trafficserver.service
 [Service]
 ExecStart=/usr/bin/tm-health-client -vv
 Restart=always
-ExecStop=/bin/kill -p $MAINPID
+RestartSec=5
 
 [Install]
 RequiredBy=trafficserver.service


### PR DESCRIPTION
- Stop and start automatically when trafficserver stop/start
- stopping service now works (changed the kill switch)

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?

Traffic Monitor Health should stop and start depending on the state of trafficserver
It should start without warnings and should also stop without warnings.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- 6.0.0 (RC)

## PR submission checklist
- [] This PR has tests. The changes are system level tests, can't be added to PR
- [] This PR has documentation. This is fix.
- [] This PR has a CHANGELOG.md entry. Doesn't need a CHANGELOG, simple fix to make it work
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

