### PR TITLE
Make `t3c` request less unnecessary DSS and jobs data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - [#5674](https://github.com/apache/trafficcontrol/issues/5674) Added new query parameters `cdn` and `maxRevalDurationDays` to the `GET /api/x/jobs` Traffic Ops API to filter by CDN name and within the start_time window defined by the `maxRevalDurationDays` GLOBAL profile parameter, respectively.
 
+### Changed
+- Updated `t3c` to request less unnecessary deliveryservice-server assignment and invalidation jobs data via new query params supported by Traffic Ops
+
 ## unreleased
 ### Added
 - [#4982](https://github.com/apache/trafficcontrol/issues/4982) Added the ability to support queueing updates by server type and profile

--- a/cache-config/t3cutil/toreq/clienthlp.go
+++ b/cache-config/t3cutil/toreq/clienthlp.go
@@ -119,5 +119,7 @@ func GetDeliveryServiceURLSigKeys(toClient *toclient.Session, dsName string, opt
 // ReqOpts takes an http.Header and returns a traffic_ops/v4-client.RequestOptions with that header.
 // This is a helper function, for brevity.
 func ReqOpts(hdr http.Header) *toclient.RequestOptions {
-	return &toclient.RequestOptions{Header: hdr}
+	opts := toclient.NewRequestOptions()
+	opts.Header = hdr
+	return &opts
 }

--- a/infrastructure/cdn-in-a-box/cache/traffic_ops_ort.crontab
+++ b/infrastructure/cdn-in-a-box/cache/traffic_ops_ort.crontab
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-*/1 * * * * t3c apply --run-mode=syncds --traffic-ops-url=$TO_URL --traffic-ops-user=$TO_USER --traffic-ops-password=$TO_PASSWORD --git=yes -vv 2>&1 >> /var/log/ort.log
+*/1 * * * * root t3c apply --run-mode=syncds --traffic-ops-url=$TO_URL --traffic-ops-user=$TO_USER --traffic-ops-password=$TO_PASSWORD --git=yes -vv --cache-host-name=$(hostname -s) >> /var/log/ort.log 2>&1


### PR DESCRIPTION
Use the new query parameters supported by Traffic Ops to reduce the
amount of unnecessary data requested from the /deliveryserviceserver and
/jobs APIs.

Also, fix the CIAB `t3c` cron job to actually run and send output to `/var/log/ort.log`.

Closes: #5674
Closes: #6034

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (T3C, formerly ORT)
- CDN in a Box

## What is the best way to verify this PR?
Ensure the GHA CI passes, build CIAB and `docker exec -it <edge/mid-01/mid-02 container> bash` to view the generated ATS config files in `/opt/trafficserver/etc/trafficserver`, submit an invalidation for the demo1 DS via TP, wait for `regex_revalidate.config` to be updated, and ensure it contains the submitted invalidation (it will first update on mid-02, mid-01, then edge). This will indicate that `t3c`'s `GET /jobs` request is working properly. Create a new DS w/ type `HTTP_NO_CACHE`, assign it to the `edge` server, and queue updates. In the `edge` container, check `remap.config` to ensure there is a new entry for the DS. This will indicate that `t3c`'s `GET /deliveryserviceserver` request is working properly.

## PR submission checklist
- [x] This PR does not add any tests because there don't appear to be any unit tests around how t3c makes requests to TO, and I assume the cache-config integration tests pretty much cover `t3c` making requests to TO. Additionally, I performed manual testing in CIAB.
- [x] Performance enhancement, no docs necessary
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
