### PR TITLE
Fix t3c-apply default hostname to be short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6066](https://github.com/apache/trafficcontrol/issues/6066) - Fixed missing/incorrect indices on some tables
 - [#6169](https://github.com/apache/trafficcontrol/issues/6169) - Fixed t3c-update not updating server status when a fallback to a previous Traffic Ops API version occurred
 - [#5576](https://github.com/apache/trafficcontrol/issues/5576) - Inconsistent Profile Name restrictions
+- [#6174](https://github.com/apache/trafficcontrol/issues/6174) - Fixed t3c-apply with no hostname failing if the OS hostname returns a full FQDN
 - Fixed Federations IMS so TR federations watcher will get updates.
 
 ### Changed

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -369,6 +369,8 @@ If any of the related flags are also set, they override the mode's default behav
 		if err != nil {
 			return Cfg{}, errors.New("Could not get the hostname from the O.S., please supply a hostname: " + err.Error())
 		}
+		// strings.Split always returns a slice with at least 1 element, so we don't need a len check
+		cacheHostName = strings.Split(cacheHostName, ".")[0]
 	}
 
 	useGit := StrToUseGitFlag(*useGitStr)

--- a/cache-config/testing/docker/docker-compose.yml
+++ b/cache-config/testing/docker/docker-compose.yml
@@ -85,6 +85,7 @@ services:
         RHEL_VERSION: ${RHEL_VERSION:-8}
       context: .
       dockerfile: ort_test/Dockerfile
+    cap_add: ['SYS_ADMIN'] # necessary for hostname tests
     depends_on:
       - yumserver
       - to_server

--- a/cache-config/testing/ort-tests/t3c-os-hostname-short_test.go
+++ b/cache-config/testing/ort-tests/t3c-os-hostname-short_test.go
@@ -1,0 +1,127 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+)
+
+func TestT3cApplyOSHostnameShort(t *testing.T) {
+	t.Log("------------- Starting TestT3cApplyOSHostnameShort tests ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+		doTestT3cApplyOSHostnameShort(t)
+	})
+	t.Log("------------- End of TestT3cApplyOSHostnameShort tests ---------------")
+}
+
+func doTestT3cApplyOSHostnameShort(t *testing.T) {
+	// verifies that when no hostname is passed,
+	// t3c-apply will get the OS hostname,
+	// and use the short name (which is what will be in Traffic Ops),
+	// and not the full FQDN.
+
+	startingHost, errCode := getHostName()
+	if errCode != 0 {
+		t.Fatalf("getting the hostname failed: code %v message %v", errCode, startingHost)
+	}
+
+	t.Logf("original host is " + startingHost)
+
+	cacheHostName := "atlanta-edge-03"
+
+	if msg, code := setHostName(cacheHostName); code != 0 {
+		t.Fatalf("setting the hostname failed: code %v message %v", code, msg)
+	}
+
+	defer func() {
+		if msg, code := setHostName(startingHost); code != 0 {
+			t.Fatalf("setting the hostname back to the original '%v' failed: code %v message %v", startingHost, code, msg)
+		} else {
+			t.Logf("set hostname back to original '" + startingHost + "'")
+		}
+	}()
+
+	// verify the host was really set
+	if newHost, errCode := getHostName(); errCode != 0 {
+		t.Fatalf("getting the hostname failed: code %v message %v", errCode, newHost)
+	} else if newHost != cacheHostName {
+		t.Fatalf("setting hostname claimed it succeeded, but was '%v' expected '%v'", newHost, cacheHostName)
+	} else {
+		t.Logf("set hostname to '" + newHost + "'")
+	}
+
+	t.Logf("calling t3c-apply with no host flag, with a short hostname")
+	if stdOut, exitCode := t3cApplyNoHost(); exitCode != 0 {
+		t.Fatalf("t3c-apply with no hostname arg and and system hostname '%v' failed: code '%v' output '%v'\n", cacheHostName, exitCode, stdOut)
+	}
+
+	fqdnHostName := cacheHostName + ".fqdn.example.test"
+	if msg, code := setHostName(fqdnHostName); code != 0 {
+		t.Fatalf("setting the hostname failed: code %v message %v", code, msg)
+	}
+
+	// verify the host was really set
+	if newHost, errCode := getHostName(); errCode != 0 {
+		t.Fatalf("getting the hostname failed: code %v message %v", errCode, newHost)
+	} else if newHost != fqdnHostName {
+		t.Fatalf("setting hostname claimed it succeeded, but was '%v' expected '%v'", newHost, fqdnHostName)
+	} else {
+		t.Logf("set hostname to '" + newHost + "'")
+	}
+
+	t.Logf("calling t3c-apply with no host flag, with a fqdn hostname")
+	if stdOut, exitCode := t3cApplyNoHost(); exitCode != 0 {
+		t.Fatalf("t3c-apply with no hostname arg and and system hostname '%v' failed: code '%v' output '%v'\n", cacheHostName, exitCode, stdOut)
+	}
+}
+
+func setHostName(host string) (string, int) {
+	stdOut, stdErr, exitCode := t3cutil.Do("hostname", host)
+	return "out: " + string(stdOut) + " err: " + string(stdErr), exitCode
+}
+
+func getHostName() (string, int) {
+	stdOut, stdErr, exitCode := t3cutil.Do("hostname")
+	if exitCode == 0 {
+		return strings.TrimSpace(string(stdOut)), 0
+	}
+	return "out: " + string(stdOut) + " err: " + string(stdErr), exitCode
+}
+
+func t3cApplyNoHost() (string, int) {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"-vv",
+		"--omit-via-string-release=true",
+		"--git=" + "yes",
+		"--run-mode=" + "badass",
+	}
+	_, stdErr, exitCode := t3cutil.Do("t3c", args...)
+	return string(stdErr), exitCode
+}


### PR DESCRIPTION
Fixes #6174 - t3c-apply with no hostname flag works even if the OS hostname returns a full FQDN rather than a short host name.

Includes tests.
Includes changelog.
No docs, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run t3c integration tests. Run t3c-apply without the hostname flag, on a machine which returns a full FQDN for `hostname`, verify t3c-apply runs as-expected and generates config for the short hostname of the machine.


## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0
- 5.1
- 5.0

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
