### PR TITLE
Fixing tm-health-client stopping trafficserver

### DIFF
--- a/cache-config/tm-health-client/tm-health-client.service
+++ b/cache-config/tm-health-client/tm-health-client.service
@@ -27,5 +27,4 @@ Restart=always
 RestartSec=5
 
 [Install]
-RequiredBy=trafficserver.service
 WantedBy=trafficserver.service


### PR DESCRIPTION
It was found during testing that the fix made to the tm-health-client systemd service file was stopping trafficserver. 


## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?

`systemctl stop tm-health-client` should not stop trafficserver. Although a bit more extensive testing might be required. 

## If this is a bugfix, which Traffic Control versions contained the bug?

- master


## PR submission checklist
- [] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

