### PR TITLE
`pr-to-update-go` GHA: Do not hard-code branch name

### DIFF
--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -112,7 +112,7 @@ class GoPRMaker:
 			commit = self.set_go_version(self.latest_go_version, commit_message,
 				source_branch_name)
 		if commit is None:
-			source_branch_ref: GitRef = self.repo.get_git_ref('heads/go-1.15.15')
+			source_branch_ref: GitRef = self.repo.get_git_ref(f'heads/{source_branch_name}')
 			commit = self.repo.get_commit(source_branch_ref.object.sha)
 		subprocess.run(['git', 'fetch', 'origin'], check=True)
 		subprocess.run(['git', 'checkout', commit.sha], check=True)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR changes a place in the *pr-to-update-go* GitHub Action from #6111 where the branch name is hard-coded:
https://github.com/apache/trafficcontrol/blob/ce9d1920771ff054c4cebe36128a0d1bad852950/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py#L115

to instead use the `source_branch_name` variable.
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation (*pr-to-update-go* GitHub Action)<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
On your own fork:
1. Create a label named `go version`
2. Update your `master` branch to match https://github.com/zrhoffman/trafficcontrol/commits/no-hardcode-branch
3. Run the *Is it time to update Go?* GHA workflow manually:
    1. Go to https://github.com/my_username/trafficcontrol/actions/workflows/pr-to-update-go.yml
    2. Choose *Run workflow* -> *Branch: master* -> *Run workflow*

and verify that a PR for updating the repo's Go version to 1.17.1 is opened at https://github.com/my_username/trafficcontrol/pulls

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 6.0.0 (RC3)
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] Buygfix, no documentation necessary<!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] No CHANGELOG.md entry necessary <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->