### PR TITLE
t3c-apply report mode. Ignore update server flag

### DIFF
--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -157,6 +157,7 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
                                     --ignore-update-flag=true
                                     --update-ipallow=true
                     report     sets --report-only=true
+                                    --ignore-update-flag=true
 
                     Note the 'syncds' settings are all the flag defaults. Hence, if no mode is set, the default is effectively 'syncds'.
 

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -331,6 +331,10 @@ If any of the related flags are also set, they override the mode's default behav
 				modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+reportOnlyFlagName+"="+"true")
 				*reportOnlyPtr = true
 			}
+			if !getopt.IsSet(ignoreUpdateFlagName) {
+                                modeLogStrs = append(modeLogStrs, runMode.String()+" setting --"+ignoreUpdateFlagName+"="+"true")
+                                *ignoreUpdateFlagPtr = true
+                        }
 		}
 	}
 

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -281,6 +281,7 @@ badass     sets --install-packages=true
                 --ignore-update-flag=true
                 --update-ipallow=true
 report     sets --report-only=true
+                --ignore-update-flag=true
 
 Note the 'syncds' settings are all the flag defaults. Hence, if no mode is set, the default is effectively 'syncds'.
 

--- a/cache-config/traffic_ops_ort.pl
+++ b/cache-config/traffic_ops_ort.pl
@@ -16,6 +16,7 @@
 use strict;
 use warnings;
 use Getopt::Long;
+use feature qw(switch);
 
 my $dispersion = undef;
 my $retries = 5;
@@ -50,7 +51,7 @@ GetOptions( "dispersion=i"       => \$dispersion, # dispersion (in seconds)
             "disable_parent_config_comments=i" => \$disable_parent_config_comments,
           );
 
-my $cmd = 't3c apply -vv';
+my $cmd = 't3c apply';
 
 if ( defined $dispersion ) {
 	my $sleeptime = rand($dispersion);
@@ -102,6 +103,23 @@ my $mode = $ARGV[0];
 if ( defined $mode ) {
 	$cmd .= ' --run-mode=' . $mode;
 }
+
+if ( defined( $ARGV[1] ) ) {
+	my $log_level = "";
+        my $ort_log_level = uc($ARGV[1]);
+	given ( $ort_log_level ) {
+                when ("ALL")   { $log_level = "-vv"; }
+                when ("TRACE") { $log_level = "-vv"; }
+                when ("DEBUG") { $log_level = "-vv"; }
+                when ("INFO")  { $log_level = "-v"; }
+                when ("WARN")  { $log_level = ""; }
+                when ("ERROR") { $log_level = ""; }
+                when ("FATAL") { $log_level = ""; }
+                when ("NONE")  { $log_level = ""; }
+	}
+	$cmd .= ' ' . $log_level;
+}
+
 if ( defined( $ARGV[2] ) ) {
 	my $to_url = $ARGV[2];
 	$to_url =~ s/\/*$//g;


### PR DESCRIPTION
This update makes a few things more inline with what it was before.

It's adding the `--ignore-update-flag` to `-m report`.
It is also updating the traffic_ops_ort wrapper to set the default verbosity of t3c-apply. It also enables the different logging mode.


- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?

Compare functionality to previous version. There is nothing much changed here.

## If this is a bugfix, which Traffic Control versions contained the bug?

- master
- 6.0.0


## PR submission checklist
- [] This PR has tests - Looking into the test
- [] This PR has documentation - Working on documentation
- [] This PR has a CHANGELOG.md entry - Doesn't warrant a changelog entry (new feature)
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)


