### PR TITLE
Fix DSRs not showing TLS version restrictions in TP

### DIFF
--- a/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
@@ -26,6 +26,8 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 
 	$scope.changeType = $scope.dsRequest.changeType;
 
+	$scope.restrictTLS = ((dsr)=>dsr.tlsVersions instanceof Array && dsr.tlsVersions.length > 0)($scope.dsRequest.requested ?? $scope.dsRequest.original);
+
 	$scope.requestStatus = $scope.dsRequest.status;
 
 	$scope.deliveryServiceName = angular.copy(($scope.dsRequest.requested) ? $scope.dsRequest.requested.xmlId : $scope.dsRequest.original.xmlId);


### PR DESCRIPTION
Fixes #6168

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make a DSR with TLS version restrictions, make sure the restrictions show up in the DSR

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- all 6.0.0 RCs

## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**