### PR TITLE
Remove t3c debug print

### DIFF
--- a/cache-config/t3cutil/toreq/client.go
+++ b/cache-config/t3cutil/toreq/client.go
@@ -76,7 +76,6 @@ func New(url *url.URL, user string, pass string, insecure bool, timeout time.Dur
 	opts.UserAgent = userAgent
 	opts.RequestTimeout = timeout
 	toClient, inf, err := toclient.Login(toURLStr, user, pass, opts)
-	log.Errorf("DEBUG toreq.New reqInf %+v\n", inf)
 	latestSupported := inf.StatusCode != 404 && inf.StatusCode != 501
 	if err != nil && latestSupported {
 		return nil, fmt.Errorf("Logging in to Traffic Ops '%v' code %v: %v", torequtil.MaybeIPStr(inf.RemoteAddr), inf.StatusCode, err)


### PR DESCRIPTION
Fixes #6202

No tests, only removes an accidental debug print, doesn't add anything, nothing to test.
No changelog, bug is not in a release.
No docs, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Verify only code change removes a debug print. Run t3c, verify "DEBUG toreq.New reqInf" is not logged.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release.

## PR submission checklist
- ~~[x] This PR has tests~~ no tests, nothing added to test
- ~~[x] This PR has documentation~~ no docs, no interface change
- ~~[x] This PR has a CHANGELOG.md entry~~ no changelog, not in a release
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
