### PR TITLE
Walk back deprecation of TO APIv3, add instability warnings for 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added ORT flag to set local.dns bind address from server service addresses
 - Added an endpoint for statuses on asynchronous jobs and applied it to the ACME renewal endpoint.
 - Added two new cdn.conf options to make Traffic Vault configuration more backend-agnostic: `traffic_vault_backend` and `traffic_vault_config`
-- Traffic Ops API version 4.0
+- Traffic Ops API version 4.0 - This version is **unstable** meaning that breaking changes can occur at any time - use at your own peril!
 - `GET` request method for `/deliveryservices/{{ID}}/assign`
 - `GET` request method for `/deliveryservices/{{ID}}/status`
 - [#5644](https://github.com/apache/trafficcontrol/issues/5644) ORT config generation: Added ATS9 ip_allow.yaml support, and automatic generation if the server's package Parameter is 9.\*
@@ -151,7 +151,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The Traffic Ops API routes `GET /api/{version}/cachegroupparameters`, `POST /api/{version}/cachegroupparameters`, `GET /api/{version}/cachegroups/{id}/parameters`, and `DELETE /api/{version}/cachegroupparameters/{cachegroupID}/{parameterId}` have been deprecated and will no longer be available as of Traffic Ops API v4
 - The `riak_port` option in cdn.conf is now deprecated. Please use the `"port"` field in `traffic_vault_config` instead.
 - The `traffic_ops_ort.pl` tool has been deprecated in favor of `t3c`, and will be removed in the next major version.
-- With the release of Traffic Ops API version 4.0, major API versions 2 and 3 are now deprecated, subject to removal with the next ATC major version release, at the earliest.
+- With the release of ATC v6.0, major API version 2 is now deprecated, subject to removal with the next ATC major version release, at the earliest.
 
 ### Removed
 - Removed the unused `backend_max_connections` option from `cdn.conf`.

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -309,7 +309,7 @@ API V2 Routes
 API routes available in version 2.
 
 .. deprecated:: ATCv6
-	Traffic Ops API version 2 is deprecated in favor of version 4.
+	Traffic Ops API version 2 is deprecated in favor of version 3.
 
 .. toctree::
 	:maxdepth: 4
@@ -321,9 +321,6 @@ API V3 Routes
 =============
 API routes available in version 3.
 
-.. deprecated:: ATCv6
-	Traffic Ops API version 3 is deprecated in favor of version 4.
-
 .. toctree::
 	:maxdepth: 4
 	:glob:
@@ -333,6 +330,8 @@ API routes available in version 3.
 API V4 Routes
 =============
 API routes available in version 4.
+
+.. danger:: API version 4 is *unstable*, meaning that breaking changes can occur at any time. Use at your own peril!
 
 .. toctree::
 	:maxdepth: 4

--- a/traffic_ops/v2-client/README.md
+++ b/traffic_ops/v2-client/README.md
@@ -2,13 +2,13 @@
 
 ## Deprecated
 The version of the Traffic Ops API supported by this client is deprecated.
-Please switch to the `github.com/apache/trafficcontrol/traffic_ops/v4-client`
+Please switch to the `github.com/apache/trafficcontrol/traffic_ops/v3-client`
 package.
 
 ## Getting Started
 1. Obtain the latest version of the library
 
-`go get github.com/apache/trafficcontrol/traffic_ops/client`
+`go get github.com/apache/trafficcontrol/traffic_ops/v2-client`
 
 2. Get a basic TO session started and fetch a list of CDNs
 ```go

--- a/traffic_ops/v3-client/README.md
+++ b/traffic_ops/v3-client/README.md
@@ -1,14 +1,9 @@
 # Traffic Ops Go Client
 
-## Deprecated
-The version of the Traffic Ops API supported by this client is deprecated.
-Please switch to the `github.com/apache/trafficcontrol/traffic_ops/v4-client`
-package.
-
 ## Getting Started
 1. Obtain the latest version of the library
 
-`go get github.com/apache/trafficcontrol/traffic_ops/client`
+`go get github.com/apache/trafficcontrol/traffic_ops/v3-client`
 
 2. Get a basic TO session started and fetch a list of CDNs
 ```go

--- a/traffic_ops/v4-client/README.md
+++ b/traffic_ops/v4-client/README.md
@@ -1,9 +1,14 @@
 # Traffic Ops Go Client
 
+## Unstable
+The version of the Traffic Ops API for which this client was made is
+*unstable*, meaning that breaking changes to it - and to this client - can
+occur at any time. Use at your own peril!
+
 ## Getting Started
 1. Obtain the latest version of the library
 
-`go get github.com/apache/trafficcontrol/traffic_ops/client`
+`go get github.com/apache/trafficcontrol/traffic_ops/v4-client`
 
 2. Get a basic TO session started and fetch a list of CDNs
 ```go


### PR DESCRIPTION
With [the recent discussion on the mailing list](https://lists.apache.org/thread.html/rdf09f89d935597367cd2b5bbdeac20929066b5e2f286e7757cee39a0%40%3Cdev.trafficcontrol.apache.org%3E) we've decided to move forward with TO APIv4 being "unstable", which means that APIv3 - being the latest stable version - cannot be deprecated. This PR walks back changes made to deprecate it, and adds a couple of warnings about the instability of TO API v4. 

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Read the warnings, make sure docs build correctly, etc.

## PR submission checklist
- Docs don't have tests
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**