### PR TITLE
Remove Traffic Router Profile name restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Adds updates to the trafficcontrol-health-client to, use new ATS Host status formats, detect and use proper
   traffic_ctl commands, and adds new markup-poll-threshold config.
 - Traffic Monitor now defaults to 100 historical "CRConfig" Snapshots stored internally if not specified in configuration (previous default was 20,000)
+- `TRAFFIC_ROUTER`-type Profiles no longer need to have names that match any kind of pattern (e.g. `CCR_.*`)
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/cache-config/testing/ort-tests/tcdata/profiles.go
+++ b/cache-config/testing/ort-tests/tcdata/profiles.go
@@ -22,27 +22,6 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-// CreateBadProfiles ensures that profiles can't be created with bad values
-func (r *TCData) CreateBadProfiles(t *testing.T) {
-
-	// blank profile
-	prs := []tc.Profile{
-		tc.Profile{Type: "", Name: "", Description: "", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "description", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "", CDNID: 1},
-		tc.Profile{Type: "ATS_PROFILE", Name: "", Description: "description", CDNID: 1},
-		tc.Profile{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
-	}
-
-	for _, pr := range prs {
-		resp, _, err := TOSession.CreateProfile(pr)
-
-		if err == nil {
-			t.Errorf("Creating bad profile %+v succeeded, response: %+v", pr, resp)
-		}
-	}
-}
-
 func (r *TCData) CreateTestProfiles(t *testing.T) {
 
 	for _, pr := range r.TestData.Profiles {

--- a/docs/source/overview/profiles_and_parameters.rst
+++ b/docs/source/overview/profiles_and_parameters.rst
@@ -120,8 +120,6 @@ TP_PROFILE
 TR_PROFILE
 	A Traffic Router Profile.
 
-	.. warning:: For legacy reasons, the names of Profiles of this type *must* begin with ``CCR_`` or ``TR_``. This is **not** enforced by the :ref:`to-api` or Traffic Portal, but certain Traffic Control operations/components expect this and will fail to work otherwise!
-
 	.. seealso:: :ref:`tr-profile`
 
 TS_PROFILE

--- a/grove/grovetccfg/grovetccfg.go
+++ b/grove/grovetccfg/grovetccfg.go
@@ -51,7 +51,6 @@ const GroveConfigFile = "grove.cfg"
 const GroveConfigPath = "/etc/grove/" + GroveConfigFile
 const ConfigHistory = "cfg_history/"
 const RemapHistory = "remap_history/"
-const GroveProfileType = "GROVE_PROFILE"
 
 // Exit codes are defined in the documentation, DO NOT change to iota, to avoid ambiguity.
 const (
@@ -263,7 +262,7 @@ func main() {
 	}
 	// end of API 1.2 stuff
 
-	if hostProfile.Type == GroveProfileType {
+	if hostProfile.Type == tc.GroveProfileType {
 		updateRequired, cfg, err := createGroveCfg(toc, hostServer)
 		if err != nil {
 			fmt.Println(time.Now().Format(time.RFC3339Nano) + " Error getting config rules for '" + GroveConfigPath + "' :" + err.Error())
@@ -286,7 +285,7 @@ func main() {
 			}
 		}
 	} else {
-		fmt.Println(time.Now().Format(time.RFC3339Nano) + " Warning: the profile '" + hostServer.Profile + "' is not a '" + GroveProfileType + "', will not build a config from it.")
+		fmt.Println(time.Now().Format(time.RFC3339Nano) + " Warning: the profile '" + hostServer.Profile + "' is not a '" + tc.GroveProfileType + "', will not build a config from it.")
 	}
 
 	rules := remap.RemapRules{}

--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -236,7 +236,7 @@ to-enroll() {
 			;;
 		"tr" )
 			export MY_TYPE="CCR"
-			export MY_PROFILE="CCR_CIAB"
+			export MY_PROFILE="TRAFFIC_ROUTER"
 			export MY_STATUS="ONLINE"
 			;;
 		"tp" )

--- a/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/trafficops-init.sh
@@ -142,7 +142,7 @@ traffic_router_zonemanager_timeout() {
   fi;
 
   local modified_crconfig crconfig_path zonemanager_timeout;
-  crconfig_path=/traffic_ops_data/profiles/040-CCR_CIAB.json;
+  crconfig_path=/traffic_ops_data/profiles/040-TRAFFIC_ROUTER.json;
   modified_crconfig="$(mktemp)";
   # 5 minutes, which is the default zonemanager.cache.maintenance.interval value
   zonemanager_timeout="$(( 60 * 5 ))";

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-TRAFFIC_ROUTER.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/040-TRAFFIC_ROUTER.json
@@ -1,7 +1,7 @@
 {
   "cdnName": "$CDN_NAME",
   "description": "Traffic Router for CDN-In-A-Box",
-  "name": "CCR_CIAB",
+  "name": "TRAFFIC_ROUTER",
   "routingDisabled": false,
   "type": "TR_PROFILE",
   "params": [

--- a/lib/go-tc/profiles.go
+++ b/lib/go-tc/profiles.go
@@ -34,6 +34,32 @@ import (
 	"github.com/lib/pq"
 )
 
+// These are the valid values for the Type property of a Profile. No other
+// values will be accepted, and these are not configurable.
+const (
+	CacheServerProfileType     = "ATS_PROFILE"
+	DeliveryServiceProfileType = "DS_PROFILE"
+	ElasticSearchProfileType   = "ES_PROFILE"
+	GroveProfileType           = "GROVE_PROFILE"
+	InfluxdbProfileType        = "INFLUXDB_PROFILE"
+	KafkaProfileType           = "KAFKA_PROFILE"
+	LogstashProfileType        = "LOGSTASH_PROFILE"
+	OriginProfileType          = "ORG_PROFILE"
+	// RiakProfileType is the type of a Profile used on the legacy RiakKV system
+	// which used to be used as a back-end for Traffic Vault.
+	//
+	// Deprecated: Support for Riak as a Traffic Vault back-end is being dropped
+	// in the near future. Profiles of type UnknownProfileType should be used on
+	// PostgreSQL database servers instead.
+	RiakProfileType           = "RIAK_PROFILE"
+	SplunkProfileType         = "SPLUNK_PROFILE"
+	TrafficMonitorProfileType = "TM_PROFILE"
+	TrafficPortalProfileType  = "TP_PROFILE"
+	TrafficRouterProfileType  = "TR_PROFILE"
+	TrafficStatsProfileType   = "TS_PROFILE"
+	UnkownProfileType         = "UNK_PROFILE"
+)
+
 // ProfilesResponse is a list of profiles returned by GET requests.
 type ProfilesResponse struct {
 	Response []Profile `json:"response"`
@@ -190,7 +216,7 @@ func (profileImport *ProfileImportRequest) Validate(tx *sql.Tx) error {
 			log.Errorf("%v: %v", errString, err.Error())
 			errs = append(errs, errors.New(errString))
 		} else if ok {
-			errs = append(errs, fmt.Errorf("A profile with the name \"%v\" already exists", *profile.Name))
+			errs = append(errs, fmt.Errorf("a profile with the name \"%s\" already exists", *profile.Name))
 		}
 	}
 

--- a/traffic_ops/testing/api/v2/profiles_test.go
+++ b/traffic_ops/testing/api/v2/profiles_test.go
@@ -39,11 +39,11 @@ func CreateBadProfiles(t *testing.T) {
 
 	// blank profile
 	prs := []tc.Profile{
-		tc.Profile{Type: "", Name: "", Description: "", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "description", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "", CDNID: 1},
-		tc.Profile{Type: "ATS_PROFILE", Name: "", Description: "description", CDNID: 1},
-		tc.Profile{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
+		{Type: "", Name: "", Description: "", CDNID: 0},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "description", CDNID: 0},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "", CDNID: 1},
+		{Type: tc.CacheServerProfileType, Name: "", Description: "description", CDNID: 1},
+		{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
 	}
 
 	for _, pr := range prs {

--- a/traffic_ops/testing/api/v3/profiles_test.go
+++ b/traffic_ops/testing/api/v3/profiles_test.go
@@ -117,11 +117,11 @@ func CreateBadProfiles(t *testing.T) {
 
 	// blank profile
 	prs := []tc.Profile{
-		tc.Profile{Type: "", Name: "", Description: "", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "description", CDNID: 0},
-		tc.Profile{Type: "ATS_PROFILE", Name: "badprofile", Description: "", CDNID: 1},
-		tc.Profile{Type: "ATS_PROFILE", Name: "", Description: "description", CDNID: 1},
-		tc.Profile{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
+		{Type: "", Name: "", Description: "", CDNID: 0},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "description", CDNID: 0},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "", CDNID: 1},
+		{Type: tc.CacheServerProfileType, Name: "", Description: "description", CDNID: 1},
+		{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
 	}
 
 	for _, pr := range prs {

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -235,9 +235,9 @@ func CreateBadProfiles(t *testing.T) {
 	// blank profile
 	prs := []tc.Profile{
 		{Type: "", Name: "", Description: "", CDNID: 0},
-		{Type: "ATS_PROFILE", Name: "badprofile", Description: "description", CDNID: 0},
-		{Type: "ATS_PROFILE", Name: "badprofile", Description: "", CDNID: 1},
-		{Type: "ATS_PROFILE", Name: "", Description: "description", CDNID: 1},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "description", CDNID: 0},
+		{Type: tc.CacheServerProfileType, Name: "badprofile", Description: "", CDNID: 1},
+		{Type: tc.CacheServerProfileType, Name: "", Description: "description", CDNID: 1},
 		{Type: "", Name: "badprofile", Description: "description", CDNID: 1},
 	}
 

--- a/traffic_ops/testing/api/v4/profiles_test.go
+++ b/traffic_ops/testing/api/v4/profiles_test.go
@@ -453,10 +453,9 @@ func UpdateTestProfiles(t *testing.T) {
 	expectedCDNId := cdns.Response[0].ID
 	expectedName := "testing"
 	expectedRoutingDisabled := true
-	expectedType := "TR_PROFILE"
 
 	remoteProfile.Description = expectedProfileDesc
-	remoteProfile.Type = expectedType
+	remoteProfile.Type = tc.TrafficRouterProfileType
 	remoteProfile.CDNID = expectedCDNId
 	remoteProfile.Name = expectedName
 	remoteProfile.RoutingDisabled = expectedRoutingDisabled
@@ -480,8 +479,8 @@ func UpdateTestProfiles(t *testing.T) {
 	if respProfile.Description != expectedProfileDesc {
 		t.Errorf("results do not match actual: %s, expected: %s", respProfile.Description, expectedProfileDesc)
 	}
-	if respProfile.Type != expectedType {
-		t.Errorf("results do not match actual: %s, expected: %s", respProfile.Type, expectedType)
+	if respProfile.Type != tc.TrafficRouterProfileType {
+		t.Errorf("results do not match actual: %s, expected: %s", respProfile.Type, tc.TrafficRouterProfileType)
 	}
 	if respProfile.CDNID != expectedCDNId {
 		t.Errorf("results do not match actual: %d, expected: %d", respProfile.CDNID, expectedCDNId)

--- a/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
@@ -375,7 +375,7 @@ WITH cdn_profile_ids AS (
     MAX(p.id) as profile_id -- We only want 1 profile, so get the probably-newest if there's more than one.
   FROM
     cdn c
-    LEFT JOIN profile p ON c.id = p.cdn AND (p.name like 'CCR%' OR p.name like 'TR%')
+    LEFT JOIN profile p ON c.id = p.cdn AND (p.type = 'TR_PROFILE')
     GROUP BY c.name, c.dnssec_enabled, c.domain_name
 )
 SELECT

--- a/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
+++ b/traffic_ops/traffic_ops_golang/cdn/dnssecrefresh.go
@@ -375,7 +375,7 @@ WITH cdn_profile_ids AS (
     MAX(p.id) as profile_id -- We only want 1 profile, so get the probably-newest if there's more than one.
   FROM
     cdn c
-    LEFT JOIN profile p ON c.id = p.cdn AND (p.type = 'TR_PROFILE')
+    LEFT JOIN profile p ON c.id = p.cdn AND (p.type = '` + tc.TrafficRouterProfileType + `')
     GROUP BY c.name, c.dnssec_enabled, c.domain_name
 )
 SELECT

--- a/traffic_ops/traffic_ops_golang/cdn/domains.go
+++ b/traffic_ops/traffic_ops_golang/cdn/domains.go
@@ -21,23 +21,21 @@ package cdn
 
 import (
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 	"net/http"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
+	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/util/ims"
 
 	"github.com/jmoiron/sqlx"
 )
 
-const RouterProfilePrefix = "CCR"
-
 func selectMaxLastUpdatedQuery() string {
 	return `SELECT max(t) from (
 		SELECT max(profile.last_updated) as t FROM profile
-JOIN cdn ON profile.cdn = cdn.id WHERE profile.name LIKE '` + RouterProfilePrefix + `%'
+JOIN cdn ON profile.cdn = cdn.id WHERE profile.type = 'TR_PROFILE'
 UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='profile') as res`
 }
@@ -48,7 +46,7 @@ func getDomainsList(useIMS bool, header http.Header, tx *sqlx.Tx) ([]tc.Domain, 
 	domains := []tc.Domain{}
 
 	q := `SELECT p.id, p.name, p.description, domain_name FROM profile AS p
-	JOIN cdn ON p.cdn = cdn.id WHERE p.name LIKE '` + RouterProfilePrefix + `%'`
+	JOIN cdn ON p.cdn = cdn.id WHERE p.type = 'TR_PROFILE'`
 
 	if useIMS {
 		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, header, nil, selectMaxLastUpdatedQuery())

--- a/traffic_ops/traffic_ops_golang/cdn/domains.go
+++ b/traffic_ops/traffic_ops_golang/cdn/domains.go
@@ -35,7 +35,7 @@ import (
 func selectMaxLastUpdatedQuery() string {
 	return `SELECT max(t) from (
 		SELECT max(profile.last_updated) as t FROM profile
-JOIN cdn ON profile.cdn = cdn.id WHERE profile.type = 'TR_PROFILE'
+JOIN cdn ON profile.cdn = cdn.id WHERE profile.type = '` + tc.TrafficRouterProfileType + `'
 UNION ALL
 	select max(last_updated) as t from last_deleted l where l.table_name='profile') as res`
 }
@@ -46,7 +46,7 @@ func getDomainsList(useIMS bool, header http.Header, tx *sqlx.Tx) ([]tc.Domain, 
 	domains := []tc.Domain{}
 
 	q := `SELECT p.id, p.name, p.description, domain_name FROM profile AS p
-	JOIN cdn ON p.cdn = cdn.id WHERE p.type = 'TR_PROFILE'`
+	JOIN cdn ON p.cdn = cdn.id WHERE p.type = '` + tc.TrafficRouterProfileType + `'`
 
 	if useIMS {
 		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, header, nil, selectMaxLastUpdatedQuery())

--- a/traffic_ops/traffic_ops_golang/cdn/genksk.go
+++ b/traffic_ops/traffic_ops_golang/cdn/genksk.go
@@ -135,7 +135,7 @@ WITH cdn_profile_id AS (
     JOIN cdn c ON c.id = p.cdn
   WHERE
     c.name = $1
-    AND (p.type = 'TR_PROFILE')
+    AND (p.type = '` + tc.TrafficRouterProfileType + `')
   FETCH FIRST 1 ROWS ONLY
 )
 SELECT

--- a/traffic_ops/traffic_ops_golang/cdn/genksk.go
+++ b/traffic_ops/traffic_ops_golang/cdn/genksk.go
@@ -135,7 +135,7 @@ WITH cdn_profile_id AS (
     JOIN cdn c ON c.id = p.cdn
   WHERE
     c.name = $1
-    AND (p.name like 'CCR%' OR p.name like 'TR%')
+    AND (p.type = 'TR_PROFILE')
   FETCH FIRST 1 ROWS ONLY
 )
 SELECT

--- a/traffic_ops/traffic_ops_golang/profile/profiles_test.go
+++ b/traffic_ops/traffic_ops_golang/profile/profiles_test.go
@@ -42,7 +42,6 @@ func getTestProfiles() []tc.ProfileNullable {
 	ID := 1
 	name := "profile1"
 	description := "desc1"
-	pt := "TR_PROFILE"
 	cdnID := 1
 	cdnName := "cdn1"
 	rd := true
@@ -55,7 +54,7 @@ func getTestProfiles() []tc.ProfileNullable {
 		CDNName:         &cdnName,
 		CDNID:           &cdnID,
 		RoutingDisabled: &rd,
-		Type:            &pt,
+		Type:            util.StrPtr(tc.TrafficRouterProfileType),
 	}
 	profiles = append(profiles, testCase)
 


### PR DESCRIPTION
This PR removes restrictions previously placed on the names of Profiles used by Traffic Routers. From the docs:

> For legacy reasons, the names of Profiles of this type must begin with `CCR_` or `TR_`. This is **not** enforced by the [Traffic Ops API](https://traffic-control-cdn.readthedocs.io/en/latest/api/index.html#to-api) or Traffic Portal, but certain Traffic Control operations/components expect this and will fail to work otherwise!

However, as can been seen in these changes, that's not even actually strictly true. `TR_` prefixes were not supported by the `/cdns/domains` Traffic Ops API endpoint.

After this PR, however, TO only checks for the correct Profile *type* (`TRAFFIC_ROUTER`), **not** pattern-matching on the name at all.

This is potentially breaking, but only in the extremely weird scenario where Traffic Router servers were using a Profile for some other type of server (since Profile types are immutable, it's not conceivable that someone would have e.g. `TRAFFIC_ROUTER_1` as a Profile type, so the Profile type must be some other valid type e.g. `TRAFFIC_PORTAL`). I believe Traffic Portal would disallow such an assignment anyway, but I'm not certain.

This addresses - but doesn't itself close, without #6218 - #2564.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops
- CDN in a Box

## What is the best way to verify this PR?
Make sure that all tests pass - existing tests do exercise these endpoints, which should prove that `CCR_` as a prefix still works. To prove that other things still work, CiaB helps by simply being able to run without the prefix. 

## PR submission checklist
- [x] This PR has tests, of a sort, by affecting CiaB which is itself adequately tested.
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**