### PR TITLE
Traffic Stats logging use lib/go-log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 - Deprecated the endpoints and docs associated with `api_capability`.
+- The use of a seelog configuration file to configure Traffic Stats logging is deprecated, and logging configuration should instead be present in the `logs` property of the Traffic Stats configuration file (refer to documentation for details).
 
 ### Removed
 - Removed the `user_role` table.

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -45,34 +45,38 @@ Configuration
 
 Configuring Traffic Stats
 -------------------------
-Traffic Stats's configuration file can be found in :file:`/opt/traffic_stats/conf/traffic_stats.cfg`. The following values need to be configured:
+Traffic Stats's configuration file can be found in :file:`/opt/traffic_stats/conf/traffic_stats.cfg`. It is a JSON-format file with the following properties.
 
-toUser
-	The user used to connect to Traffic Ops
-toPasswd
-	The password to use when connecting to Traffic Ops
-toUrl
-	The URL of the Traffic Ops server used by Traffic Stats
-influxUser
-	The user to use when connecting to InfluxDB (if configured on InfluxDB, else leave default)
-influxPassword
-	That password to use when connecting to InfluxDB (if configured, else leave blank)
-pollingInterval
-	The interval at which Traffic Monitor is polled and stats are stored in InfluxDB
-statusToMon
-	The status of Traffic Monitor to poll (poll ONLINE or OFFLINE Traffic Monitors)
-seelogConfig
-	The absolute path of the seelog configuration file
-dailySummaryPollingInterval
-	The interval, in seconds, at which Traffic Stats checks to see if daily stats need to be computed and stored.
-cacheRetentionPolicy
-	The default retention policy for cache stats
-dsRetentionPolicy
-	The default retention policy for :term:`Delivery Service` statistics
-dailySummaryRetentionPolicy
-	The retention policy to be used for the daily statistics
-influxUrls
-	An array of InfluxDB hosts for Traffic Stats to write stats to.
+:toUser: The username of the user as whom to connect to Traffic Ops
+:toPasswd: The password to use when authenticating with Traffic Ops
+:toUrl: The URL of the Traffic Ops server used by Traffic Stats
+:influxUser: Optionally specify the user to use when connecting to InfluxDB (if InfluxDB is not configured to require authentication, has no effect)
+:influxPassword: Optionally specify the password to use when connecting to InfluxDB (if InfluxDB is not configured to require authentication, has no effect)
+:pollingInterval: The interval in seconds for which Traffic Monitor will wait between polling for stats and storing them in InfluxDB
+:statusToMon: The name of the :term:`Status` of the Traffic Monitors to poll (e.g. ``ONLINE`` or ``OFFLINE``)
+:seelogConfig: Optionally specify the absolute path to a `seelog <https://github.com/cihub/seelog>`_ configuration file. Has no effect if the ``logs`` property is present.
+
+	.. deprecated:: ATCv6.1
+		This will be removed in the future, configurations should be migrated to the new ``logs`` property.
+
+:logs: This property is an object containing keys that specify locations for different log streams.
+
+	.. versionadded:: ATCv6.1
+
+	:error: The location of error-level logs. If omitted, ``null``, an empty string (``""``), or the special path ``/dev/null`` (even on Windows), error-level logs will not be emitted. The special values "stderr" and "stdout" cause logging to use STDOUT or STDERR, respectively\ [#logfiles]_.
+	:warning: The location of warning-level logs. If omitted, ``null``, an empty string (``""``), or the special path ``/dev/null`` (even on Windows), warning-level logs will not be emitted. The special values "stderr" and "stdout" cause logging to use STDOUT or STDERR, respectively\ [#logfiles]_.
+	:info: The location of info-level logs. If omitted, ``null``, an empty string (``""``), or the special path ``/dev/null`` (even on Windows), info-level logs will not be emitted. The special values "stderr" and "stdout" cause logging to use STDOUT or STDERR, respectively\ [#logfiles]_.
+	:debug: The location of debug-level logs. If omitted, ``null``, an empty string (``""``), or the special path ``/dev/null`` (even on Windows), debug-level logs will not be emitted. The special values "stderr" and "stdout" cause logging to use STDOUT or STDERR, respectively\ [#logfiles]_.
+	:event: The location of event-level logs. If omitted, ``null``, an empty string (``""``), or the special path ``/dev/null`` (even on Windows), event-level logs will not be emitted. The special values "stderr" and "stdout" cause logging to use STDOUT or STDERR, respectively\ [#logfiles]_.
+
+		.. note:: At the time of this writing, Traffic Stats does not make use of the "event" log level.
+
+
+:dailySummaryPollingInterval: The interval, in seconds, on which Traffic Stats checks to see if daily stats need to be computed and stored.
+:cacheRetentionPolicy: The default retention policy for cache stats
+:dsRetentionPolicy: The default retention policy for :term:`Delivery Service` statistics
+:dailySummaryRetentionPolicy: The retention policy to be used for the daily statistics
+:influxUrls: An array of InfluxDB hosts for Traffic Stats to write stats to.
 
 Configuring InfluxDB
 --------------------
@@ -248,3 +252,5 @@ Options and Arguments
 .. option:: --target-user username
 
 	The name of the user as whom the utility will connect to the target InfluxDB instance
+
+.. [#logfiles] To log to files named literally "stdout" or "stderr", use an absolute or relative file path e.g. "./stdout" or "/path/to/stderr".

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -136,58 +136,58 @@ type Timers struct {
 
 func info(args ...interface{}) {
 	if useSeelog {
-		seelog.Info(args)
+		seelog.Info(args...)
 	} else {
-		log.Infoln(args)
+		log.Infoln(args...)
 	}
 }
 func infof(format string, args ...interface{}) {
 	if useSeelog {
-		seelog.Infof(format, args)
+		seelog.Infof(format, args...)
 	} else {
-		log.Infof(format, args)
+		log.Infof(format, args...)
 	}
 }
 func errorln(args ...interface{}) {
 	if useSeelog {
-		seelog.Error(args)
+		seelog.Error(args...)
 	} else {
-		log.Errorln(args)
+		log.Errorln(args...)
 	}
 }
 func errorf(format string, args ...interface{}) {
 	if useSeelog {
-		seelog.Errorf(format, args)
+		seelog.Errorf(format, args...)
 	} else {
-		log.Errorf(format, args)
+		log.Errorf(format, args...)
 	}
 }
 func warn(args ...interface{}) {
 	if useSeelog {
-		seelog.Warn(args)
+		seelog.Warn(args...)
 	} else {
-		log.Warnln(args)
+		log.Warnln(args...)
 	}
 }
 func warnf(format string, args ...interface{}) {
 	if useSeelog {
-		seelog.Warnf(format, args)
+		seelog.Warnf(format, args...)
 	} else {
-		log.Warnf(format, args)
+		log.Warnf(format, args...)
 	}
 }
 func debug(args ...interface{}) {
 	if useSeelog {
-		seelog.Debug(args)
+		seelog.Debug(args...)
 	} else {
-		log.Debugln(args)
+		log.Debugln(args...)
 	}
 }
 func debugf(format string, args ...interface{}) {
 	if useSeelog {
-		seelog.Debugf(format, args)
+		seelog.Debugf(format, args...)
 	} else {
-		log.Debugf(format, args)
+		log.Debugf(format, args...)
 	}
 }
 

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -39,7 +39,7 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-util"
 	client "github.com/apache/trafficcontrol/traffic_ops/v2-client"
 
-	log "github.com/cihub/seelog"
+	"github.com/cihub/seelog"
 	influx "github.com/influxdata/influxdb/client/v2"
 )
 
@@ -115,14 +115,14 @@ func main() {
 
 	if err != nil {
 		err = fmt.Errorf("could not load startup config: %v", err)
-		log.Error(err)
+		seelog.Error(err)
 		panic(err)
 	}
 
 	Bps = make(map[string]influx.BatchPoints)
 	config.BpsChan = make(chan influx.BatchPoints)
 
-	defer log.Flush()
+	defer seelog.Flush()
 
 	configChan := make(chan RunningConfig)
 	go getToData(config, true, configChan)
@@ -139,16 +139,16 @@ func main() {
 	for {
 		select {
 		case <-hupChan:
-			log.Info("HUP Received - reloading config")
+			seelog.Info("HUP Received - reloading config")
 			newConfig, err := loadStartupConfig(*configFile, config)
 			if err != nil {
-				log.Errorf("could not load startup config: %v", err)
+				seelog.Errorf("could not load startup config: %v", err)
 			} else {
 				config = newConfig
 				tickers = setTimers(config)
 			}
 		case <-termChan:
-			log.Info("Shutdown Request Received - Sending stored metrics then quitting")
+			seelog.Info("Shutdown Request Received - Sending stored metrics then quitting")
 			for _, val := range Bps {
 				sendMetrics(config, val, false)
 			}
@@ -164,24 +164,24 @@ func main() {
 		case <-tickers.Poll:
 			for cdnName, urls := range runningConfig.HealthUrls {
 				for _, u := range urls {
-					log.Debug(cdnName, " -> ", u)
+					seelog.Debug(cdnName, " -> ", u)
 					go calcMetrics(cdnName, u, runningConfig.CacheMap, config)
 				}
 			}
 		case now := <-tickers.DailySummary:
 			go calcDailySummary(now, config, runningConfig)
 		case batchPoints := <-config.BpsChan:
-			log.Debug("Received ", len(batchPoints.Points()), " stats")
+			seelog.Debug("Received ", len(batchPoints.Points()), " stats")
 			key := fmt.Sprintf("%s%s", batchPoints.Database(), batchPoints.RetentionPolicy())
 			bp, ok := Bps[key]
 			if ok {
 				for _, p := range batchPoints.Points() {
 					bp.AddPoint(p)
 				}
-				log.Debug("Aggregating ", len(bp.Points()), " stats to ", key)
+				seelog.Debug("Aggregating ", len(bp.Points()), " stats to ", key)
 			} else {
 				Bps[key] = batchPoints
-				log.Debug("Created ", key)
+				seelog.Debug("Created ", key)
 			}
 		}
 	}
@@ -234,12 +234,12 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 		config.MaxPublishSize = defaultMaxPublishSize
 	}
 
-	logger, err := log.LoggerFromConfigAsFile(config.SeelogConfig)
+	logger, err := seelog.LoggerFromConfigAsFile(config.SeelogConfig)
 	if err != nil {
 		return config, fmt.Errorf("error reading Seelog config %s", config.SeelogConfig)
 	}
-	log.ReplaceLogger(logger)
-	log.Info("Replaced logger, see log file according to", config.SeelogConfig)
+	seelog.ReplaceLogger(logger)
+	seelog.Info("Replaced logger, see seelog file according to", config.SeelogConfig)
 
 	if len(config.InfluxURLs) == 0 {
 		return config, fmt.Errorf("No InfluxDB urls provided in influxUrls, please provide at least one valid URL.  e.g. \"influxUrls\": [\"http://localhost:8086\"]")
@@ -262,16 +262,16 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 }
 
 func calcDailySummary(now time.Time, config StartupConfig, runningConfig RunningConfig) {
-	log.Infof("lastSummaryTime is %v", runningConfig.LastSummaryTime)
+	seelog.Infof("lastSummaryTime is %v", runningConfig.LastSummaryTime)
 	if runningConfig.LastSummaryTime.Day() != now.Day() {
 		startTime := now.Truncate(24 * time.Hour).Add(-24 * time.Hour)
 		endTime := startTime.Add(24 * time.Hour)
-		log.Info("Summarizing from ", startTime, " (", startTime.Unix(), ") to ", endTime, " (", endTime.Unix(), ")")
+		seelog.Info("Summarizing from ", startTime, " (", startTime.Unix(), ") to ", endTime, " (", endTime.Unix(), ")")
 
 		// influx connection
 		influxClient, err := influxConnect(config)
 		if err != nil {
-			log.Errorf("could not connect to InfluxDb to get daily summary stats: %v", err)
+			seelog.Errorf("could not connect to InfluxDb to get daily summary stats: %v", err)
 			return
 		}
 
@@ -283,17 +283,17 @@ func calcDailySummary(now time.Time, config StartupConfig, runningConfig Running
 
 		calcDailyMaxGbps(influxClient, bp, startTime, endTime, config)
 		calcDailyBytesServed(influxClient, bp, startTime, endTime, config)
-		log.Info("Collected daily stats @ ", now)
+		seelog.Info("Collected daily stats @ ", now)
 	}
 }
 
 func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime time.Time, endTime time.Time, config StartupConfig) {
 	kilobitsToGigabits := 1000000.00
 	queryString := fmt.Sprintf(`select time, cdn, max(value) from "monthly"."bandwidth.cdn.1min" where time > '%s' and time < '%s' group by cdn`, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-	log.Infof("queryString = %v\n", queryString)
+	seelog.Infof("queryString = %v\n", queryString)
 	res, err := queryDB(client, queryString, "cache_stats")
 	if err != nil {
-		log.Errorf("An error occured getting max bandwidth! %v\n", err)
+		seelog.Errorf("An error occured getting max bandwidth! %v\n", err)
 		return
 	}
 	if res != nil && len(res[0].Series) > 0 {
@@ -304,12 +304,12 @@ func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime tim
 					cdn := record[1].(string)
 					value, err := record[2].(json.Number).Float64()
 					if err != nil {
-						log.Errorf("Couldn't parse value from record %v\n", record)
+						seelog.Errorf("Couldn't parse value from record %v\n", record)
 						continue
 					}
 					value = value / kilobitsToGigabits
 					statTime, _ := time.Parse(time.RFC3339, t)
-					log.Infof("max gbps for cdn %v = %v", cdn, value)
+					seelog.Infof("max gbps for cdn %v = %v", cdn, value)
 					var statsSummary tc.StatsSummary
 					statsSummary.CDNName = util.StrPtr(cdn)
 					statsSummary.DeliveryService = util.StrPtr("all")
@@ -331,7 +331,7 @@ func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime tim
 						statTime,
 					)
 					if err != nil {
-						log.Errorf("error adding data point for max Gbps...%v\n", err)
+						seelog.Errorf("error adding data point for max Gbps...%v\n", err)
 						continue
 					}
 					bp.AddPoint(pt)
@@ -347,10 +347,10 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 	sampleTimeSecs := 60.00
 	bitsTobytes := 8.00
 	queryString := fmt.Sprintf(`select mean(value) from "monthly"."bandwidth.cdn.1min" where time > '%s' and time < '%s' group by time(1m), cdn`, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-	log.Infof("queryString = %v\n", queryString)
+	seelog.Infof("queryString = %v\n", queryString)
 	res, err := queryDB(client, queryString, "cache_stats")
 	if err != nil {
-		log.Error("An error occured getting max bandwidth!\n")
+		seelog.Error("An error occured getting max bandwidth!\n")
 		return
 	}
 	if res != nil && len(res[0].Series) > 0 {
@@ -361,14 +361,14 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 				if record[1] != nil {
 					value, err := record[1].(json.Number).Float64()
 					if err != nil {
-						log.Errorf("Couldn't parse value from record %v\n", record)
+						seelog.Errorf("Couldn't parse value from record %v\n", record)
 						continue
 					}
 					bytesServed += value * sampleTimeSecs / bitsTobytes
 				}
 			}
 			bytesServedTB := bytesServed / bytesToTerabytes
-			log.Infof("TBytes served for cdn %v = %v", cdn, bytesServedTB)
+			seelog.Infof("TBytes served for cdn %v = %v", cdn, bytesServedTB)
 			//write to Traffic Ops
 			var statsSummary tc.StatsSummary
 			statsSummary.CDNName = util.StrPtr(cdn)
@@ -390,7 +390,7 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 				startTime,
 			)
 			if err != nil {
-				log.Errorf("error adding creating data point for max Gbps...%v\n", err)
+				seelog.Errorf("error adding creating data point for max Gbps...%v\n", err)
 				continue
 			}
 			bp.AddPoint(pt)
@@ -417,12 +417,12 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
-		log.Error(newErr)
+		seelog.Error(newErr)
 		return
 	}
 	_, _, err = to.CreateSummaryStats(statsSummary)
 	if err != nil {
-		log.Errorf("could not create summary stats: %v", err)
+		seelog.Errorf("could not create summary stats: %v", err)
 	}
 }
 
@@ -434,7 +434,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		log.Error(msg)
+		seelog.Error(msg)
 		return
 	}
 
@@ -444,7 +444,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		log.Error(msg)
+		seelog.Error(msg)
 		return
 	}
 
@@ -461,7 +461,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		log.Error(msg)
+		seelog.Error(msg)
 		return
 	}
 
@@ -480,9 +480,9 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 
 	lastSummaryTimeResponse, _, err := to.GetSummaryStatsLastUpdated(util.StrPtr("daily_maxgbps"))
 	if err != nil {
-		log.Errorf("unable to get summary stats last updated: %v", err)
+		seelog.Errorf("unable to get summary stats last updated: %v", err)
 	} else if lastSummaryTimeResponse.Response.SummaryTime == nil {
-		log.Warn("unable to get last updated stats summary timestamp: daily_maxgbps stats summary not reported yet")
+		seelog.Warn("unable to get last updated stats summary timestamp: daily_maxgbps stats summary not reported yet")
 	} else {
 		runningConfig.LastSummaryTime = *lastSummaryTimeResponse.Response.SummaryTime
 	}
@@ -494,14 +494,14 @@ func setHealthURLs(config StartupConfig, runningConfig *RunningConfig, cacheStat
 	runningConfig.HealthUrls = make(map[string]map[string][]string)
 	for _, server := range runningConfig.CacheMap {
 		if server.Type == tc.MonitorTypeName && server.Status != config.StatusToMon {
-			log.Debugf("Skipping %s.%s.  Looking for status %s but got status %s", server.HostName, server.DomainName, config.StatusToMon, server.Status)
+			seelog.Debugf("Skipping %s.%s.  Looking for status %s but got status %s", server.HostName, server.DomainName, config.StatusToMon, server.Status)
 			continue
 		}
 
 		if server.Type == tc.MonitorTypeName && server.Status == config.StatusToMon {
 			cdnName := server.CDNName
 			if cdnName == "" {
-				log.Error("Unable to find CDN name for " + server.HostName + ".. skipping")
+				seelog.Error("Unable to find CDN name for " + server.HostName + ".. skipping")
 				continue
 			}
 
@@ -525,30 +525,30 @@ func calcMetrics(cdnName string, urls []string, cacheMap map[string]tc.Server, c
 	for _, u := range urls {
 		trafMonData, err = getURL(u)
 		if err != nil {
-			log.Errorf("error getting %s stats URL %s: %v", cdnName, u, err)
+			seelog.Errorf("error getting %s stats URL %s: %v", cdnName, u, err)
 			continue
 		}
 		healthURL = u
-		log.Infof("successfully got %s stats URL %s", cdnName, u)
+		seelog.Infof("successfully got %s stats URL %s", cdnName, u)
 		break
 	}
 	if healthURL == "" {
-		log.Errorf("unable to get any %s stats URL - skipping timeslot", cdnName)
+		seelog.Errorf("unable to get any %s stats URL - skipping timeslot", cdnName)
 		return
 	}
 
 	if strings.Contains(healthURL, "CacheStats") {
 		err = calcCacheValues(trafMonData, cdnName, sampleTime, cacheMap, config)
 		if err != nil {
-			log.Errorf("error calculating cache metric values for CDN %s: %v", cdnName, err)
+			seelog.Errorf("error calculating cache metric values for CDN %s: %v", cdnName, err)
 		}
 	} else if strings.Contains(healthURL, "DsStats") {
 		err = calcDsValues(trafMonData, cdnName, sampleTime, config)
 		if err != nil {
-			log.Errorf("error calculating delivery service metric values for CDN %s: %v", cdnName, err)
+			seelog.Errorf("error calculating delivery service metric values for CDN %s: %v", cdnName, err)
 		}
 	} else {
-		log.Warn("Don't know what to do with given %s stats URL: ", cdnName, healthURL)
+		seelog.Warn("Don't know what to do with given %s stats URL: ", cdnName, healthURL)
 	}
 }
 
@@ -582,7 +582,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 			validTime := time.Now().AddDate(0, 0, -1).UnixNano() / 1000000
 			timeStamp := int64(dsMetricData[0].Time)
 			if timeStamp < validTime {
-				log.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", dsName, dsMetric, timeStamp))
+				seelog.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", dsName, dsMetric, timeStamp))
 				continue
 			}
 			var cachegroup, statName string
@@ -608,7 +608,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 			statTime := strconv.Itoa(dsMetricData[0].Time)
 			msInt, err := strconv.ParseInt(statTime, 10, 64)
 			if err != nil {
-				log.Errorf("calculating delivery service metric values: error parsing stat time: %v", err)
+				seelog.Errorf("calculating delivery service metric values: error parsing stat time: %v", err)
 			}
 
 			newTime := time.Unix(0, msInt*int64(time.Millisecond))
@@ -628,7 +628,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 				newTime,
 			)
 			if err != nil {
-				log.Errorf("calculating delivery service metric values: error creating new influxDB point: %v", err)
+				seelog.Errorf("calculating delivery service metric values: error creating new influxDB point: %v", err)
 				continue
 			}
 			bps.AddPoint(pt)
@@ -636,7 +636,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 		}
 	}
 	config.BpsChan <- bps
-	log.Info("Collected ", statCount, " deliveryservice stats values for ", cdnName, " @ ", sampleTime)
+	seelog.Info("Collected ", statCount, " deliveryservice stats values for ", cdnName, " @ ", sampleTime)
 	return nil
 }
 
@@ -654,7 +654,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 		RetentionPolicy: config.CacheRetentionPolicy,
 	})
 	if err != nil {
-		log.Errorf("calculating cache metric values: creating new influxDB batch points: %v", err)
+		seelog.Errorf("calculating cache metric values: creating new influxDB batch points: %v", err)
 	}
 
 	for cacheName, cacheData := range jData.Caches {
@@ -667,7 +667,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 			//Get the stat time and make sure it's greater than the time 24 hours ago.  If not, skip it so influxdb doesn't throw retention policy errors.
 			validTime := time.Now().AddDate(0, 0, -1)
 			if statData[0].Time.Before(validTime) {
-				log.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", cacheName, statName, statData[0].Time))
+				seelog.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", cacheName, statName, statData[0].Time))
 				continue
 			}
 			dataKey := statName
@@ -677,11 +677,11 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 			//Get the stat value and convert to float
 			statFloatValue := 0.0
 			if statsValue, ok := statData[0].Val.(string); !ok {
-				log.Warnf("stat data %s with value %v couldn't be converted into string", statName, statData[0].Val)
+				seelog.Warnf("stat data %s with value %v couldn't be converted into string", statName, statData[0].Val)
 			} else {
 				statFloatValue, err = strconv.ParseFloat(statsValue, 64)
 				if err != nil {
-					log.Warnf("stat %s with value %v couldn't be converted into a float", statName, statsValue)
+					seelog.Warnf("stat %s with value %v couldn't be converted into a float", statName, statsValue)
 				}
 			}
 
@@ -702,7 +702,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 				statData[0].Time,
 			)
 			if err != nil {
-				log.Errorf("calculating cache metric values: error creating new influxDB point: %v", err)
+				seelog.Errorf("calculating cache metric values: error creating new influxDB point: %v", err)
 				continue
 			}
 			bps.AddPoint(pt)
@@ -710,7 +710,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 		}
 	}
 	config.BpsChan <- bps
-	log.Info("Collected ", statCount, " cache stats values for ", cdnName, " @ ", sampleTime)
+	seelog.Info("Collected ", statCount, " cache stats values for ", cdnName, " @ ", sampleTime)
 	return nil
 }
 
@@ -740,7 +740,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 			}
 			con, err := influx.NewUDPClient(conf)
 			if err != nil {
-				log.Errorf("An error occurred creating InfluxDB UDP client: %v", err)
+				seelog.Errorf("An error occurred creating InfluxDB UDP client: %v", err)
 				continue
 			}
 			return con, nil
@@ -753,7 +753,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		}
 		con, err := influx.NewHTTPClient(conf)
 		if err != nil {
-			log.Errorf("An error occurred creating InfluxDB HTTP client: %v", err)
+			seelog.Errorf("An error occurred creating InfluxDB HTTP client: %v", err)
 			continue
 		}
 		//Close old connections explicitly
@@ -763,7 +763,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		host.InfluxClient = con
 		_, _, err = con.Ping(10)
 		if err != nil {
-			log.Warnf("pinging InfluxDB: %v", err)
+			seelog.Warnf("pinging InfluxDB: %v", err)
 			continue
 		}
 		return con, nil
@@ -778,7 +778,7 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 		if retry {
 			config.BpsChan <- bps
 		}
-		log.Errorf("sending metrics to InfluxDB: unable to get InfluxDB client: %v", err)
+		seelog.Errorf("sending metrics to InfluxDB: unable to get InfluxDB client: %v", err)
 		return
 	}
 
@@ -793,7 +793,7 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 			if retry {
 				config.BpsChan <- chunkBps
 			}
-			log.Errorf("sending metrics to InfluxDB: error creating new batch points: %v", err)
+			seelog.Errorf("sending metrics to InfluxDB: error creating new batch points: %v", err)
 		}
 		for _, p := range pts[:intMin(config.MaxPublishSize, len(pts))] {
 			chunkBps.AddPoint(p)
@@ -805,9 +805,9 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 			if retry {
 				config.BpsChan <- chunkBps
 			}
-			log.Errorf("sending metrics to InfluxDB: error writing batch points: %v", err)
+			seelog.Errorf("sending metrics to InfluxDB: error writing batch points: %v", err)
 		} else {
-			log.Info(fmt.Sprintf("Sent %v stats for %v", len(chunkBps.Points()), chunkBps.Database()))
+			seelog.Info(fmt.Sprintf("Sent %v stats for %v", len(chunkBps.Points()), chunkBps.Database()))
 		}
 	}
 }

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -458,7 +458,7 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 	infof("queryString = %s", queryString)
 	res, err := queryDB(client, queryString, "cache_stats")
 	if err != nil {
-		errorln("An error occured getting max bandwidth: %v", err)
+		errorln("An error occured getting max bandwidth: ", err)
 		return
 	}
 	if res != nil && len(res[0].Series) > 0 {
@@ -656,7 +656,7 @@ func calcMetrics(cdnName string, urls []string, cacheMap map[string]tc.Server, c
 			errorf("error calculating delivery service metric values for CDN %s: %v", cdnName, err)
 		}
 	} else {
-		warn("Don't know what to do with given %s stats URL: ", cdnName, healthURL)
+		warn("Don't know what to do with given ", cdnName, " stats URL: ", healthURL)
 	}
 }
 

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -131,7 +131,7 @@ func main() {
 	tickers = setTimers(config)
 
 	termChan := make(chan os.Signal, 1)
-	signal.Notify(termChan, syscall.SIGKILL, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(termChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
 
 	hupChan := make(chan os.Signal, 1)
 	signal.Notify(hupChan, syscall.SIGHUP)

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -35,6 +35,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	client "github.com/apache/trafficcontrol/traffic_ops/v2-client"
@@ -54,6 +55,38 @@ const (
 	defaultMaxPublishSize              = 10000
 )
 
+type Logger struct {
+	Error   log.LogLocation `json:"error"`
+	Warning log.LogLocation `json:"warning"`
+	Info    log.LogLocation `json:"info"`
+	Debug   log.LogLocation `json:"debug"`
+	Event   log.LogLocation `json:"event"`
+}
+
+func (l Logger) ErrorLog() log.LogLocation {
+	return l.Error
+}
+func (l Logger) WarningLog() log.LogLocation {
+	return l.Warning
+}
+func (l Logger) InfoLog() log.LogLocation {
+	return l.Info
+}
+func (l Logger) DebugLog() log.LogLocation {
+	return l.Debug
+}
+func (l Logger) EventLog() log.LogLocation {
+	return l.Event
+}
+
+var defaultLogger Logger = Logger{
+	Error:   log.LogLocationStderr,
+	Warning: log.LogLocationStderr,
+	Info:    log.LogLocationStderr,
+	Debug:   log.LogLocationNull,
+	Event:   log.LogLocationStderr,
+}
+
 // StartupConfig contains all fields necessary to create a traffic stats session.
 type StartupConfig struct {
 	ToUser                      string   `json:"toUser"`
@@ -68,13 +101,16 @@ type StartupConfig struct {
 	ConfigInterval              int      `json:"configInterval"`
 	MaxPublishSize              int      `json:"maxPublishSize"`
 	StatusToMon                 string   `json:"statusToMon"`
-	SeelogConfig                string   `json:"seelogConfig"`
+	SeelogConfig                *string  `json:"seelogConfig"`
+	LogConfig                   *Logger  `json:"logs"`
 	CacheRetentionPolicy        string   `json:"cacheRetentionPolicy"`
 	DsRetentionPolicy           string   `json:"dsRetentionPolicy"`
 	DailySummaryRetentionPolicy string   `json:"dailySummaryRetentionPolicy"`
 	BpsChan                     chan influx.BatchPoints
 	InfluxDBs                   []*InfluxDBProps
 }
+
+var useSeelog bool = true
 
 // RunningConfig is used to store runtime configuration for Traffic Stats.  This includes information
 // about caches, cachegroups, and health urls
@@ -98,6 +134,63 @@ type Timers struct {
 	Config       <-chan time.Time
 }
 
+func info(args ...interface{}) {
+	if useSeelog {
+		seelog.Info(args)
+	} else {
+		log.Infoln(args)
+	}
+}
+func infof(format string, args ...interface{}) {
+	if useSeelog {
+		seelog.Infof(format, args)
+	} else {
+		log.Infof(format, args)
+	}
+}
+func errorln(args ...interface{}) {
+	if useSeelog {
+		seelog.Error(args)
+	} else {
+		log.Errorln(args)
+	}
+}
+func errorf(format string, args ...interface{}) {
+	if useSeelog {
+		seelog.Errorf(format, args)
+	} else {
+		log.Errorf(format, args)
+	}
+}
+func warn(args ...interface{}) {
+	if useSeelog {
+		seelog.Warn(args)
+	} else {
+		log.Warnln(args)
+	}
+}
+func warnf(format string, args ...interface{}) {
+	if useSeelog {
+		seelog.Warnf(format, args)
+	} else {
+		log.Warnf(format, args)
+	}
+}
+func debug(args ...interface{}) {
+	if useSeelog {
+		seelog.Debug(args)
+	} else {
+		log.Debugln(args)
+	}
+}
+func debugf(format string, args ...interface{}) {
+	if useSeelog {
+		seelog.Debugf(format, args)
+	} else {
+		log.Debugf(format, args)
+	}
+}
+
 func main() {
 	var Bps map[string]influx.BatchPoints
 	var config StartupConfig
@@ -115,7 +208,7 @@ func main() {
 
 	if err != nil {
 		err = fmt.Errorf("could not load startup config: %v", err)
-		seelog.Error(err)
+		errorln(err)
 		panic(err)
 	}
 
@@ -139,16 +232,16 @@ func main() {
 	for {
 		select {
 		case <-hupChan:
-			seelog.Info("HUP Received - reloading config")
+			info("HUP Received - reloading config")
 			newConfig, err := loadStartupConfig(*configFile, config)
 			if err != nil {
-				seelog.Errorf("could not load startup config: %v", err)
+				errorf("could not load startup config: %v", err)
 			} else {
 				config = newConfig
 				tickers = setTimers(config)
 			}
 		case <-termChan:
-			seelog.Info("Shutdown Request Received - Sending stored metrics then quitting")
+			info("Shutdown Request Received - Sending stored metrics then quitting")
 			for _, val := range Bps {
 				sendMetrics(config, val, false)
 			}
@@ -164,24 +257,24 @@ func main() {
 		case <-tickers.Poll:
 			for cdnName, urls := range runningConfig.HealthUrls {
 				for _, u := range urls {
-					seelog.Debug(cdnName, " -> ", u)
+					debug(cdnName, " -> ", u)
 					go calcMetrics(cdnName, u, runningConfig.CacheMap, config)
 				}
 			}
 		case now := <-tickers.DailySummary:
 			go calcDailySummary(now, config, runningConfig)
 		case batchPoints := <-config.BpsChan:
-			seelog.Debug("Received ", len(batchPoints.Points()), " stats")
+			debug("Received ", len(batchPoints.Points()), " stats")
 			key := fmt.Sprintf("%s%s", batchPoints.Database(), batchPoints.RetentionPolicy())
 			bp, ok := Bps[key]
 			if ok {
 				for _, p := range batchPoints.Points() {
 					bp.AddPoint(p)
 				}
-				seelog.Debug("Aggregating ", len(bp.Points()), " stats to ", key)
+				debug("Aggregating ", len(bp.Points()), " stats to ", key)
 			} else {
 				Bps[key] = batchPoints
-				seelog.Debug("Created ", key)
+				debug("Created ", key)
 			}
 		}
 	}
@@ -234,12 +327,27 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 		config.MaxPublishSize = defaultMaxPublishSize
 	}
 
-	logger, err := seelog.LoggerFromConfigAsFile(config.SeelogConfig)
-	if err != nil {
-		return config, fmt.Errorf("error reading Seelog config %s", config.SeelogConfig)
+	if config.LogConfig != nil {
+		if err = log.InitCfg(config.LogConfig); err != nil {
+			return config, fmt.Errorf("initializing logging configuration: %w", err)
+		}
+		useSeelog = false
+	} else if config.SeelogConfig != nil {
+		logger, err := seelog.LoggerFromConfigAsFile(*config.SeelogConfig)
+		if err != nil {
+			return config, fmt.Errorf("error reading Seelog config '%s': %w", *config.SeelogConfig, err)
+		}
+		seelog.ReplaceLogger(logger)
+		useSeelog = true
+		infof("Replaced logger, see seelog file according to '%s'", *config.SeelogConfig)
+		warn("seelog-based logging is deprecated, please switch to using the 'logs' property")
+	} else {
+		if err = log.InitCfg(defaultLogger); err != nil {
+			return config, fmt.Errorf("initializing default logger: %w", err)
+		}
+		useSeelog = false
+		warn("No logging configuration found in configuration file - default logging to stderr will be used")
 	}
-	seelog.ReplaceLogger(logger)
-	seelog.Info("Replaced logger, see seelog file according to", config.SeelogConfig)
 
 	if len(config.InfluxURLs) == 0 {
 		return config, fmt.Errorf("No InfluxDB urls provided in influxUrls, please provide at least one valid URL.  e.g. \"influxUrls\": [\"http://localhost:8086\"]")
@@ -262,16 +370,16 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 }
 
 func calcDailySummary(now time.Time, config StartupConfig, runningConfig RunningConfig) {
-	seelog.Infof("lastSummaryTime is %v", runningConfig.LastSummaryTime)
+	infof("lastSummaryTime is %v", runningConfig.LastSummaryTime)
 	if runningConfig.LastSummaryTime.Day() != now.Day() {
 		startTime := now.Truncate(24 * time.Hour).Add(-24 * time.Hour)
 		endTime := startTime.Add(24 * time.Hour)
-		seelog.Info("Summarizing from ", startTime, " (", startTime.Unix(), ") to ", endTime, " (", endTime.Unix(), ")")
+		info("Summarizing from ", startTime, " (", startTime.Unix(), ") to ", endTime, " (", endTime.Unix(), ")")
 
 		// influx connection
 		influxClient, err := influxConnect(config)
 		if err != nil {
-			seelog.Errorf("could not connect to InfluxDb to get daily summary stats: %v", err)
+			errorf("could not connect to InfluxDb to get daily summary stats: %v", err)
 			return
 		}
 
@@ -283,17 +391,17 @@ func calcDailySummary(now time.Time, config StartupConfig, runningConfig Running
 
 		calcDailyMaxGbps(influxClient, bp, startTime, endTime, config)
 		calcDailyBytesServed(influxClient, bp, startTime, endTime, config)
-		seelog.Info("Collected daily stats @ ", now)
+		info("Collected daily stats @ ", now)
 	}
 }
 
 func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime time.Time, endTime time.Time, config StartupConfig) {
 	kilobitsToGigabits := 1000000.00
 	queryString := fmt.Sprintf(`select time, cdn, max(value) from "monthly"."bandwidth.cdn.1min" where time > '%s' and time < '%s' group by cdn`, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-	seelog.Infof("queryString = %v\n", queryString)
+	infof("queryString = %v\n", queryString)
 	res, err := queryDB(client, queryString, "cache_stats")
 	if err != nil {
-		seelog.Errorf("An error occured getting max bandwidth! %v\n", err)
+		errorf("An error occured getting max bandwidth! %v\n", err)
 		return
 	}
 	if res != nil && len(res[0].Series) > 0 {
@@ -304,12 +412,12 @@ func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime tim
 					cdn := record[1].(string)
 					value, err := record[2].(json.Number).Float64()
 					if err != nil {
-						seelog.Errorf("Couldn't parse value from record %v\n", record)
+						errorf("Couldn't parse value from record %v\n", record)
 						continue
 					}
 					value = value / kilobitsToGigabits
 					statTime, _ := time.Parse(time.RFC3339, t)
-					seelog.Infof("max gbps for cdn %v = %v", cdn, value)
+					infof("max gbps for cdn %v = %v", cdn, value)
 					var statsSummary tc.StatsSummary
 					statsSummary.CDNName = util.StrPtr(cdn)
 					statsSummary.DeliveryService = util.StrPtr("all")
@@ -331,7 +439,7 @@ func calcDailyMaxGbps(client influx.Client, bp influx.BatchPoints, startTime tim
 						statTime,
 					)
 					if err != nil {
-						seelog.Errorf("error adding data point for max Gbps...%v\n", err)
+						errorf("error adding data point for max Gbps...%v\n", err)
 						continue
 					}
 					bp.AddPoint(pt)
@@ -347,10 +455,10 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 	sampleTimeSecs := 60.00
 	bitsTobytes := 8.00
 	queryString := fmt.Sprintf(`select mean(value) from "monthly"."bandwidth.cdn.1min" where time > '%s' and time < '%s' group by time(1m), cdn`, startTime.Format(time.RFC3339), endTime.Format(time.RFC3339))
-	seelog.Infof("queryString = %v\n", queryString)
+	infof("queryString = %s", queryString)
 	res, err := queryDB(client, queryString, "cache_stats")
 	if err != nil {
-		seelog.Error("An error occured getting max bandwidth!\n")
+		errorln("An error occured getting max bandwidth: %v", err)
 		return
 	}
 	if res != nil && len(res[0].Series) > 0 {
@@ -361,14 +469,14 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 				if record[1] != nil {
 					value, err := record[1].(json.Number).Float64()
 					if err != nil {
-						seelog.Errorf("Couldn't parse value from record %v\n", record)
+						errorf("Couldn't parse value from record %v", record)
 						continue
 					}
 					bytesServed += value * sampleTimeSecs / bitsTobytes
 				}
 			}
 			bytesServedTB := bytesServed / bytesToTerabytes
-			seelog.Infof("TBytes served for cdn %v = %v", cdn, bytesServedTB)
+			infof("TBytes served for cdn %v = %v", cdn, bytesServedTB)
 			//write to Traffic Ops
 			var statsSummary tc.StatsSummary
 			statsSummary.CDNName = util.StrPtr(cdn)
@@ -390,7 +498,7 @@ func calcDailyBytesServed(client influx.Client, bp influx.BatchPoints, startTime
 				startTime,
 			)
 			if err != nil {
-				seelog.Errorf("error adding creating data point for max Gbps...%v\n", err)
+				errorf("error adding creating data point for max Gbps...%v\n", err)
 				continue
 			}
 			bp.AddPoint(pt)
@@ -417,12 +525,12 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
-		seelog.Error(newErr)
+		errorln(newErr)
 		return
 	}
 	_, _, err = to.CreateSummaryStats(statsSummary)
 	if err != nil {
-		seelog.Errorf("could not create summary stats: %v", err)
+		errorf("could not create summary stats: %v", err)
 	}
 }
 
@@ -434,7 +542,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		seelog.Error(msg)
+		errorln(msg)
 		return
 	}
 
@@ -444,7 +552,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		seelog.Error(msg)
+		errorln(msg)
 		return
 	}
 
@@ -461,7 +569,7 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 		if init {
 			panic(msg)
 		}
-		seelog.Error(msg)
+		errorln(msg)
 		return
 	}
 
@@ -480,9 +588,9 @@ func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 
 	lastSummaryTimeResponse, _, err := to.GetSummaryStatsLastUpdated(util.StrPtr("daily_maxgbps"))
 	if err != nil {
-		seelog.Errorf("unable to get summary stats last updated: %v", err)
+		errorf("unable to get summary stats last updated: %v", err)
 	} else if lastSummaryTimeResponse.Response.SummaryTime == nil {
-		seelog.Warn("unable to get last updated stats summary timestamp: daily_maxgbps stats summary not reported yet")
+		warn("unable to get last updated stats summary timestamp: daily_maxgbps stats summary not reported yet")
 	} else {
 		runningConfig.LastSummaryTime = *lastSummaryTimeResponse.Response.SummaryTime
 	}
@@ -494,14 +602,14 @@ func setHealthURLs(config StartupConfig, runningConfig *RunningConfig, cacheStat
 	runningConfig.HealthUrls = make(map[string]map[string][]string)
 	for _, server := range runningConfig.CacheMap {
 		if server.Type == tc.MonitorTypeName && server.Status != config.StatusToMon {
-			seelog.Debugf("Skipping %s.%s.  Looking for status %s but got status %s", server.HostName, server.DomainName, config.StatusToMon, server.Status)
+			debugf("Skipping %s.%s.  Looking for status %s but got status %s", server.HostName, server.DomainName, config.StatusToMon, server.Status)
 			continue
 		}
 
 		if server.Type == tc.MonitorTypeName && server.Status == config.StatusToMon {
 			cdnName := server.CDNName
 			if cdnName == "" {
-				seelog.Error("Unable to find CDN name for " + server.HostName + ".. skipping")
+				errorln("Unable to find CDN name for " + server.HostName + ".. skipping")
 				continue
 			}
 
@@ -525,30 +633,30 @@ func calcMetrics(cdnName string, urls []string, cacheMap map[string]tc.Server, c
 	for _, u := range urls {
 		trafMonData, err = getURL(u)
 		if err != nil {
-			seelog.Errorf("error getting %s stats URL %s: %v", cdnName, u, err)
+			errorf("error getting %s stats URL %s: %v", cdnName, u, err)
 			continue
 		}
 		healthURL = u
-		seelog.Infof("successfully got %s stats URL %s", cdnName, u)
+		infof("successfully got %s stats URL %s", cdnName, u)
 		break
 	}
 	if healthURL == "" {
-		seelog.Errorf("unable to get any %s stats URL - skipping timeslot", cdnName)
+		errorf("unable to get any %s stats URL - skipping timeslot", cdnName)
 		return
 	}
 
 	if strings.Contains(healthURL, "CacheStats") {
 		err = calcCacheValues(trafMonData, cdnName, sampleTime, cacheMap, config)
 		if err != nil {
-			seelog.Errorf("error calculating cache metric values for CDN %s: %v", cdnName, err)
+			errorf("error calculating cache metric values for CDN %s: %v", cdnName, err)
 		}
 	} else if strings.Contains(healthURL, "DsStats") {
 		err = calcDsValues(trafMonData, cdnName, sampleTime, config)
 		if err != nil {
-			seelog.Errorf("error calculating delivery service metric values for CDN %s: %v", cdnName, err)
+			errorf("error calculating delivery service metric values for CDN %s: %v", cdnName, err)
 		}
 	} else {
-		seelog.Warn("Don't know what to do with given %s stats URL: ", cdnName, healthURL)
+		warn("Don't know what to do with given %s stats URL: ", cdnName, healthURL)
 	}
 }
 
@@ -582,7 +690,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 			validTime := time.Now().AddDate(0, 0, -1).UnixNano() / 1000000
 			timeStamp := int64(dsMetricData[0].Time)
 			if timeStamp < validTime {
-				seelog.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", dsName, dsMetric, timeStamp))
+				info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", dsName, dsMetric, timeStamp))
 				continue
 			}
 			var cachegroup, statName string
@@ -608,7 +716,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 			statTime := strconv.Itoa(dsMetricData[0].Time)
 			msInt, err := strconv.ParseInt(statTime, 10, 64)
 			if err != nil {
-				seelog.Errorf("calculating delivery service metric values: error parsing stat time: %v", err)
+				errorf("calculating delivery service metric values: error parsing stat time: %v", err)
 			}
 
 			newTime := time.Unix(0, msInt*int64(time.Millisecond))
@@ -628,7 +736,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 				newTime,
 			)
 			if err != nil {
-				seelog.Errorf("calculating delivery service metric values: error creating new influxDB point: %v", err)
+				errorf("calculating delivery service metric values: error creating new influxDB point: %v", err)
 				continue
 			}
 			bps.AddPoint(pt)
@@ -636,7 +744,7 @@ func calcDsValues(tmData []byte, cdnName string, sampleTime int64, config Startu
 		}
 	}
 	config.BpsChan <- bps
-	seelog.Info("Collected ", statCount, " deliveryservice stats values for ", cdnName, " @ ", sampleTime)
+	info("Collected ", statCount, " deliveryservice stats values for ", cdnName, " @ ", sampleTime)
 	return nil
 }
 
@@ -654,7 +762,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 		RetentionPolicy: config.CacheRetentionPolicy,
 	})
 	if err != nil {
-		seelog.Errorf("calculating cache metric values: creating new influxDB batch points: %v", err)
+		errorf("calculating cache metric values: creating new influxDB batch points: %v", err)
 	}
 
 	for cacheName, cacheData := range jData.Caches {
@@ -667,7 +775,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 			//Get the stat time and make sure it's greater than the time 24 hours ago.  If not, skip it so influxdb doesn't throw retention policy errors.
 			validTime := time.Now().AddDate(0, 0, -1)
 			if statData[0].Time.Before(validTime) {
-				seelog.Info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", cacheName, statName, statData[0].Time))
+				info(fmt.Sprintf("Skipping %v %v: %v is greater than 24 hours old.", cacheName, statName, statData[0].Time))
 				continue
 			}
 			dataKey := statName
@@ -677,11 +785,11 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 			//Get the stat value and convert to float
 			statFloatValue := 0.0
 			if statsValue, ok := statData[0].Val.(string); !ok {
-				seelog.Warnf("stat data %s with value %v couldn't be converted into string", statName, statData[0].Val)
+				warnf("stat data %s with value %v couldn't be converted into string", statName, statData[0].Val)
 			} else {
 				statFloatValue, err = strconv.ParseFloat(statsValue, 64)
 				if err != nil {
-					seelog.Warnf("stat %s with value %v couldn't be converted into a float", statName, statsValue)
+					warnf("stat %s with value %v couldn't be converted into a float", statName, statsValue)
 				}
 			}
 
@@ -702,7 +810,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 				statData[0].Time,
 			)
 			if err != nil {
-				seelog.Errorf("calculating cache metric values: error creating new influxDB point: %v", err)
+				errorf("calculating cache metric values: error creating new influxDB point: %v", err)
 				continue
 			}
 			bps.AddPoint(pt)
@@ -710,7 +818,7 @@ func calcCacheValues(trafmonData []byte, cdnName string, sampleTime int64, cache
 		}
 	}
 	config.BpsChan <- bps
-	seelog.Info("Collected ", statCount, " cache stats values for ", cdnName, " @ ", sampleTime)
+	info("Collected ", statCount, " cache stats values for ", cdnName, " @ ", sampleTime)
 	return nil
 }
 
@@ -740,7 +848,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 			}
 			con, err := influx.NewUDPClient(conf)
 			if err != nil {
-				seelog.Errorf("An error occurred creating InfluxDB UDP client: %v", err)
+				errorf("An error occurred creating InfluxDB UDP client: %v", err)
 				continue
 			}
 			return con, nil
@@ -753,7 +861,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		}
 		con, err := influx.NewHTTPClient(conf)
 		if err != nil {
-			seelog.Errorf("An error occurred creating InfluxDB HTTP client: %v", err)
+			errorf("An error occurred creating InfluxDB HTTP client: %v", err)
 			continue
 		}
 		//Close old connections explicitly
@@ -763,7 +871,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		host.InfluxClient = con
 		_, _, err = con.Ping(10)
 		if err != nil {
-			seelog.Warnf("pinging InfluxDB: %v", err)
+			warnf("pinging InfluxDB: %v", err)
 			continue
 		}
 		return con, nil
@@ -778,7 +886,7 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 		if retry {
 			config.BpsChan <- bps
 		}
-		seelog.Errorf("sending metrics to InfluxDB: unable to get InfluxDB client: %v", err)
+		errorf("sending metrics to InfluxDB: unable to get InfluxDB client: %v", err)
 		return
 	}
 
@@ -793,7 +901,7 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 			if retry {
 				config.BpsChan <- chunkBps
 			}
-			seelog.Errorf("sending metrics to InfluxDB: error creating new batch points: %v", err)
+			errorf("sending metrics to InfluxDB: error creating new batch points: %v", err)
 		}
 		for _, p := range pts[:intMin(config.MaxPublishSize, len(pts))] {
 			chunkBps.AddPoint(p)
@@ -805,9 +913,9 @@ func sendMetrics(config StartupConfig, bps influx.BatchPoints, retry bool) {
 			if retry {
 				config.BpsChan <- chunkBps
 			}
-			seelog.Errorf("sending metrics to InfluxDB: error writing batch points: %v", err)
+			errorf("sending metrics to InfluxDB: error writing batch points: %v", err)
 		} else {
-			seelog.Info(fmt.Sprintf("Sent %v stats for %v", len(chunkBps.Points()), chunkBps.Database()))
+			info(fmt.Sprintf("Sent %v stats for %v", len(chunkBps.Points()), chunkBps.Database()))
 		}
 	}
 }


### PR DESCRIPTION
This is related to #5981 but does not fix it.

This adds the ability to use a standard `lib/go-log`-based configuration for TS logging. It also deprecates the use of a seelog configuration file.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Stats

## What is the best way to verify this PR?
Play around with logging configurations, make sure logging is still taking place appropriately when configured, if the docs don't help figure out what configurations should yield what kind of logging then the docs changes are bad.

## PR submission checklist
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 