### PR TITLE
Update link to join #traffic-control on the ASF slack

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -26,7 +26,7 @@ If this issue identifies a security vulnerability, DO NOT submit it! Instead, co
 the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
 guidelines at https://apache.org/security regarding vulnerability disclosure.
 
-- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/slack-invite)
+- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/tc-slack-request)
 or the Traffic Control Users mailing list (send an email to users-subscribe@trafficcontrol.apache.org to subscribe).
 - Before submitting, please **SEARCH GITHUB** for a similar issue or PR
     * https://github.com/apache/trafficcontrol/issues

--- a/.github/ISSUE_TEMPLATE/2-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.md
@@ -26,7 +26,7 @@ If this issue identifies a security vulnerability, DO NOT submit it! Instead, co
 the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
 guidelines at https://apache.org/security regarding vulnerability disclosure.
 
-- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/slack-invite)
+- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/tc-slack-request)
 or the Traffic Control Users mailing list (send an email to users-subscribe@trafficcontrol.apache.org to subscribe).
 - Before submitting, please **SEARCH GITHUB** for a similar issue or PR
     * https://github.com/apache/trafficcontrol/issues

--- a/.github/ISSUE_TEMPLATE/3-improvement-request.md
+++ b/.github/ISSUE_TEMPLATE/3-improvement-request.md
@@ -26,7 +26,7 @@ If this issue identifies a security vulnerability, DO NOT submit it! Instead, co
 the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
 guidelines at https://apache.org/security regarding vulnerability disclosure.
 
-- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/slack-invite)
+- For *SUPPORT QUESTIONS*, use the #traffic-control channel on the ASF slack (https://s.apache.org/tc-slack-request)
 or the Traffic Control Users mailing list (send an email to users-subscribe@trafficcontrol.apache.org to subscribe).
 - Before submitting, please **SEARCH GITHUB** for a similar issue or PR
     * https://github.com/apache/trafficcontrol/issues

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -17,5 +17,5 @@ contact_links:
     url: http://trafficcontrol.apache.org/mailing_lists
     about: Reach out to one of the Traffic Control mailing lists for discussion.
   - name: Support questions
-    url: https://s.apache.org/slack-invite
+    url: https://s.apache.org/tc-slack-request
     about: Visit us at ‌#traffic-control on Slack to ask a question.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -30,7 +30,7 @@ Who is using Traffic Control?
 
 How do I get help with Traffic Control?
 =======================================
-Join us at ``#traffic-control`` on the `ASF Slack <https://s.apache.org/slack-invite>`_ or send your questions to our `mailing list <mailto:users@trafficcontrol.apache.org>`_.  Slack is usually the best forum for quick Q&A type issues -- like when you are getting a Traffic Control CDN up and running or if you have a question about configuration. Any discussions that could potentially lead to decisions being made about the project -- like a new feature -- should happen on `the developer mailing list <mailto:dev@trafficcontrol.apache.org>`_-.
+Join us at ``#traffic-control`` on the `ASF Slack <https://s.apache.org/tc-slack-request>`_ or send your questions to our `mailing list <mailto:users@trafficcontrol.apache.org>`_.  Slack is usually the best forum for quick Q&A type issues -- like when you are getting a Traffic Control CDN up and running or if you have a question about configuration. Any discussions that could potentially lead to decisions being made about the project -- like a new feature -- should happen on `the developer mailing list <mailto:dev@trafficcontrol.apache.org>`_-.
 
 How do I get involved with the development of Traffic Control?
 ==============================================================


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

The previous short URL to join the ASF slack, https://s.apache.org/slack-invite , is no longer an invite and now redirects to instructions for how to ASF Slack users on how they 

Reason: <blockquote>Infra has disabled the option that would let you provide a link to the workspace to anyone who wanted it, as spammers were taking advantage of it.</blockquote>

This PR updates the repo to instead use a separate short URL that redirects users to a `mailto:` URI that prefills an email asking users@trafficcontrol.apache.org for access to the ASF Slack: https://s.apache.org/tc-slack-request

Subject: Slack Invite request
Body: Will someone please invite me to the ASF Slack so I can join the #traffic-control channel?
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- GitHub templates

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Visit the new short URL and verify that the *to*, *subjects*, and *body* fields are prefilled in your email client

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->