### PR TITLE
Generate a self signed cert on ds creation/update (#6024)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#5129](https://github.com/apache/trafficcontrol/issues/5129) - Updated TM so that it returns a 404 if the endpoint is not supported.
 - Fixed Traffic Router crs/stats to prevent overflow and to correctly record the time used in averages.
 - [#6093](https://github.com/apache/trafficcontrol/issues/6093) - Fixed Let's Encrypt to work for delivery services where the domain does not contain the XMLID.
+- [#5893](https://github.com/apache/trafficcontrol/issues/5893) - A self signed certificate is created when an HTTPS delivery service is created or an HTTP delivery service is updated to HTTPS.
 
 ### Changed
 - Migrated completely off of bower in favor of npm

--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -315,6 +315,14 @@ This file deals with the configuration parameters of running Traffic Ops itself.
 	:renew_days_before_expiration: Set the number of days before expiration date to renew certificates.
 	:summary_email: The email address to use for summarizing certificate expiration and renewal status. If it is blank, no email will be sent.
 
+:default_certificate_info: This is an optional object to define default values when generating a self signed certificate when an HTTPS delivery service is created or updated. If this is an empty object or not present in the :ref:`cdn.conf` then the term "Placeholder" will be used for all fields.
+
+ 	:business_unit: An optional field which, if present, will represent the business unit for which the SSL certificate was generated
+	:city: An optional field which, if present, will represent the resident city of the generated SSL certificate
+	:organization: An optional field which, if present, will represent the organization for which the SSL certificate was generated
+	:country: An optional field which, if present, will represent the resident country of the generated SSL certificate
+	:state: An optional field which, if present, will represent the resident state or province of the generated SSL certificate
+
 :geniso: This object contains configuration options for system ISO generation.
 
 	:iso_root_path: Sets the filesystem path to the root of the ISO generation directory. For default installations, this should usually be set to :file:`/opt/traffic_ops/app/public`.

--- a/traffic_ops/app/conf/cdn.conf
+++ b/traffic_ops/app/conf/cdn.conf
@@ -89,5 +89,12 @@
             "kid" : "",
             "hmac_encoded" : ""
         }
-    ]
+    ],
+    "default_certificate_info" : {
+        "business_unit" : "",
+        "city" : "",
+        "organization" : "",
+        "country" : "",
+        "state" : ""
+    }
 }

--- a/traffic_ops/testing/api/v4/deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/deliveryservices_test.go
@@ -42,6 +42,7 @@ func TestDeliveryServices(t *testing.T) {
 		header.Set(rfc.IfModifiedSince, ti)
 		header.Set(rfc.IfUnmodifiedSince, ti)
 		if includeSystemTests {
+			t.Run("Verify SSL key generation on DS creation", VerifySSLKeysOnDsCreationTest)
 			t.Run("Update CDN for a Delivery Service with SSL keys", SSLDeliveryServiceCDNUpdateTest)
 			t.Run("Create URL Signature keys for a Delivery Service", CreateTestDeliveryServicesURLSignatureKeys)
 			t.Run("Retrieve URL Signature keys for a Delivery Service", GetTestDeliveryServicesURLSignatureKeys)
@@ -135,7 +136,7 @@ func CUDDeliveryServiceWithLocks(t *testing.T) {
 	if len(types.Response) < 1 {
 		t.Fatal("expected at least one type")
 	}
-	customDS := getCustomDS(cdn.ID, types.Response[0].ID, "cdn_locks_test_ds_name", "routingName", "https://test_cdn_locks.com", "cdn_locks_test_ds_xml_id")
+	customDS := getCustomDS(cdn.ID, types.Response[0].ID, "cdn-locks-test-ds-name", "edge", "https://test-cdn-locks.com", "cdn-locks-test-ds-xml-id")
 
 	// Create a lock for this user
 	_, _, err = userSession.CreateCDNLock(tc.CDNLock{
@@ -701,6 +702,43 @@ func DeliveryServiceSSLKeys(t *testing.T) {
 	}
 	if dsSSLKey.Certificate.CSR == "" {
 		t.Errorf("expected a valid CSR, but got nothing")
+	}
+}
+
+func VerifySSLKeysOnDsCreationTest(t *testing.T) {
+	for _, ds := range testData.DeliveryServices {
+		if !(*ds.Protocol == tc.DSProtocolHTTPS || *ds.Protocol == tc.DSProtocolHTTPAndHTTPS || *ds.Protocol == tc.DSProtocolHTTPToHTTPS) {
+			continue
+		}
+		var err error
+		dsSSLKey := new(tc.DeliveryServiceSSLKeys)
+		for tries := 0; tries < 5; tries++ {
+			time.Sleep(time.Second)
+			var sslKeysResp tc.DeliveryServiceSSLKeysResponse
+			sslKeysResp, _, err = TOSession.GetDeliveryServiceSSLKeys(*ds.XMLID, client.RequestOptions{})
+			*dsSSLKey = sslKeysResp.Response
+			if err == nil && dsSSLKey != nil {
+				break
+			}
+		}
+
+		if err != nil || dsSSLKey == nil {
+			t.Fatalf("unable to get DS %s SSL key: %v", *ds.XMLID, err)
+		}
+		if dsSSLKey.Certificate.Key == "" {
+			t.Errorf("expected a valid key but got nothing")
+		}
+		if dsSSLKey.Certificate.Crt == "" {
+			t.Errorf("expected a valid certificate, but got nothing")
+		}
+		if dsSSLKey.Certificate.CSR == "" {
+			t.Errorf("expected a valid CSR, but got nothing")
+		}
+
+		err = deliveryservice.Base64DecodeCertificate(&dsSSLKey.Certificate)
+		if err != nil {
+			t.Fatalf("couldn't decode certificate: %v", err)
+		}
 	}
 }
 

--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@ -58,7 +58,9 @@ type Config struct {
 	InfluxEnabled          bool
 	InfluxDBConfPath       string `json:"influxdb_conf_path"`
 	Version                string
-	UseIMS                 bool `json:"use_ims"`
+	UseIMS                 bool                    `json:"use_ims"`
+	RoleBasedPermissions   bool                    `json:"role_based_permissions"`
+	DefaultCertificateInfo *DefaultCertificateInfo `json:"default_certificate_info"`
 }
 
 // ConfigHypnotoad carries http setting for hypnotoad (mojolicious) server
@@ -170,6 +172,38 @@ type ConfigAcmeAccount struct {
 	AcmeUrl      string `json:"acme_url"`
 	Kid          string `json:"kid"`
 	HmacEncoded  string `json:"hmac_encoded"`
+}
+
+type DefaultCertificateInfo struct {
+	BusinessUnit string `json:"business_unit"`
+	City         string `json:"city"`
+	Organization string `json:"organization"`
+	Country      string `json:"country"`
+	State        string `json:"state"`
+}
+
+func (d *DefaultCertificateInfo) Validate() (error, bool) {
+	missingList := []string{}
+	if d.BusinessUnit == "" {
+		missingList = append(missingList, "BusinessUnit")
+	}
+	if d.City == "" {
+		missingList = append(missingList, "City")
+	}
+	if d.Organization == "" {
+		missingList = append(missingList, "Organization")
+	}
+	if d.Country == "" {
+		missingList = append(missingList, "Country")
+	}
+	if d.State == "" {
+		missingList = append(missingList, "State")
+	}
+
+	if len(missingList) != 0 {
+		return fmt.Errorf("default certificate information is missing: %s", missingList), false
+	}
+	return nil, true
 }
 
 // ConfigDatabase reflects the structure of the database.conf file

--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -1603,3 +1603,14 @@ func GetDSIDFromStaticDNSEntry(tx *sql.Tx, staticDNSEntryID int) (int, error) {
 	}
 	return dsID, nil
 }
+
+// GetCDNNameDomain returns the name and domain for a given CDN ID.
+func GetCDNNameDomain(cdnID int, tx *sql.Tx) (string, string, error) {
+	q := `SELECT cdn.name, cdn.domain_name from cdn where cdn.id = $1`
+	cdnName := ""
+	cdnDomain := ""
+	if err := tx.QueryRow(q, cdnID).Scan(&cdnName, &cdnDomain); err != nil {
+		return "", "", fmt.Errorf("getting cdn name and domain for cdn '%v': "+err.Error(), cdnID)
+	}
+	return cdnName, cdnDomain, nil
+}


### PR DESCRIPTION
Backport of #6024 for 6.0.x

Resolved conflict:

```diff
diff --cc traffic_ops/traffic_ops_golang/config/config.go
index 3041441aec,b7be58ae24..0000000000
--- a/traffic_ops/traffic_ops_golang/config/config.go
+++ b/traffic_ops/traffic_ops_golang/config/config.go
@@@ -58,7 -58,9 +58,13 @@@ type Config struct 
  	InfluxEnabled          bool
  	InfluxDBConfPath       string `json:"influxdb_conf_path"`
  	Version                string
++<<<<<<< HEAD
 +	UseIMS                 bool `json:"use_ims"`
++=======
+ 	UseIMS                 bool                    `json:"use_ims"`
+ 	RoleBasedPermissions   bool                    `json:"role_based_permissions"`
+ 	DefaultCertificateInfo *DefaultCertificateInfo `json:"default_certificate_info"`
++>>>>>>> 7d0472dc25 (Generate a self signed cert on ds creation/update (#6024))
  }
  
  // ConfigHypnotoad carries http setting for hypnotoad (mojolicious) server
```