### PR TITLE
Removed default limits values in logs API

### DIFF
--- a/docs/source/api/v2/logs.rst
+++ b/docs/source/api/v2/logs.rst
@@ -35,9 +35,9 @@ Request Structure
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| Name      | Required | Description                                                                                                                         |
 	+===========+==========+=====================================================================================================================================+
-	| days      | no       | An integer number of days of change logs to return                                                                                  |
+	| days      | no       | An integer number of days of change logs to return, by default there is no limit applied                                            |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
-	| limit     | no       | The number of records to which to limit the response                                                                                |
+	| limit     | no       | The number of records to which to limit the response, if there is no limit query params, it limits to 1000                          |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/source/api/v3/logs.rst
+++ b/docs/source/api/v3/logs.rst
@@ -35,9 +35,9 @@ Request Structure
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| Name      | Required | Description                                                                                                                         |
 	+===========+==========+=====================================================================================================================================+
-	| days      | no       | An integer number of days of change logs to return                                                                                  |
+	| days      | no       | An integer number of days of change logs to return, by default there is no limit applied                                            |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
-	| limit     | no       | The number of records to which to limit the response                                                                                |
+	| limit     | no       | The number of records to which to limit the response, if there is no limit query params, it limits to 1000                          |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/source/api/v4/logs.rst
+++ b/docs/source/api/v4/logs.rst
@@ -37,7 +37,7 @@ Request Structure
 	+===========+==========+=====================================================================================================================================+
 	| days      | no       | An integer number of days of change logs to return                                                                                  |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
-	| limit     | no       | The number of records to which to limit the response, by default it will display all the response                                                                               |
+	| limit     | no       | The number of records to which to limit the response, by default there is no limit applied                                          |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+

--- a/docs/source/api/v4/logs.rst
+++ b/docs/source/api/v4/logs.rst
@@ -37,7 +37,7 @@ Request Structure
 	+===========+==========+=====================================================================================================================================+
 	| days      | no       | An integer number of days of change logs to return                                                                                  |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
-	| limit     | no       | The number of records to which to limit the response                                                                                |
+	| limit     | no       | The number of records to which to limit the response, by default it will display all the response                                                                               |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+
 	| offset    | no       | The number of results to skip before beginning to return results. Must use in conjunction with limit                                |
 	+-----------+----------+-------------------------------------------------------------------------------------------------------------------------------------+

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -188,26 +188,26 @@ func getLogV40(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
 	queryCount := countQuery + whereCount
 	rowCount, err := inf.Tx.NamedQuery(queryCount, queryValues)
 	if err != nil {
-		return nil, count, errors.New("querying log count for a given user: " + err.Error())
+		return nil, count, fmt.Errorf("querying log count for a given user: %w", err)
 	}
 	defer rowCount.Close()
 	for rowCount.Next() {
 		if err = rowCount.Scan(&count); err != nil {
-			return nil, count, errors.New("scanning logs: " + err.Error())
+			return nil, count, fmt.Errorf("scanning logs: %w", err)
 		}
 	}
 
 	query := selectFromQuery + where + "\n ORDER BY last_updated DESC" + pagination
 	rows, err := inf.Tx.NamedQuery(query, queryValues)
 	if err != nil {
-		return nil, count, errors.New("querying logs: " + err.Error())
+		return nil, count, fmt.Errorf("querying logs: %w", err)
 	}
 	defer rows.Close()
 	ls := []tc.Log{}
 	for rows.Next() {
 		l := tc.Log{}
 		if err = rows.Scan(&l.ID, &l.Level, &l.Message, &l.User, &l.TicketNum, &l.LastUpdated); err != nil {
-			return nil, count, errors.New("scanning logs: " + err.Error())
+			return nil, count, fmt.Errorf("scanning logs: %w", err)
 		}
 		ls = append(ls, l)
 	}

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -38,9 +38,9 @@ import (
 // These are the default values for query string parameters if not provided.
 const (
 	// For the 'limit' parameter.
-	DefaultLogLimit = 1000
+	//DefaultLogLimit = 1000
 	// For the 'limit' parameter when 'days' is given and 'limit' is not.
-	DefaultLogLimitForDays = 1000000
+	//DefaultLogLimitForDays = 1000000
 	// For the 'days' parameter.
 	DefaultLogDays = 30
 )
@@ -54,11 +54,10 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	}
 	defer inf.Close()
 
-	limit := DefaultLogLimit
+	var limit int
 	days := DefaultLogDays
 	if pDays, ok := inf.IntParams["days"]; ok {
 		days = pDays
-		limit = DefaultLogLimitForDays
 	}
 	if pLimit, ok := inf.IntParams["limit"]; ok {
 		limit = pLimit
@@ -67,6 +66,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	a := tc.Alerts{}
 	setLastSeenCookie(w)
 	logs, count, err := getLog(inf, days, limit)
+
 	if err != nil {
 		a.AddNewAlert(tc.ErrorLevel, err.Error())
 		api.WriteAlerts(w, r, http.StatusInternalServerError, a)
@@ -138,12 +138,13 @@ const countQuery = `SELECT count(l.tm_user) FROM log as l`
 func getLog(inf *api.APIInfo, days int, limit int) ([]tc.Log, uint64, error) {
 	var count = uint64(0)
 	var whereCount string
-	if _, ok := inf.Params["limit"]; !ok {
+	/*if _, ok := inf.Params["limit"]; !ok {
 		inf.Params["limit"] = strconv.Itoa(DefaultLogLimit)
 	} else {
 		inf.Params["limit"] = strconv.Itoa(limit)
-	}
+	}*/
 
+	inf.Params["limit"] = strconv.Itoa(limit)
 	queryParamsToQueryCols := map[string]dbhelpers.WhereColumnInfo{
 		"username": {Column: "u.username", Checker: nil},
 	}

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -53,7 +53,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer inf.Close()
-
+	fmt.Println("adding test comments")
 	var limit int
 	days := DefaultLogDays
 	if pDays, ok := inf.IntParams["days"]; ok {

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -45,6 +45,7 @@ const (
 	DefaultLogDays = 30
 )
 
+// Get is the handler for GET requests to /logs.
 func Get(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
 	if userErr != nil || sysErr != nil {
@@ -62,7 +63,6 @@ func Get(w http.ResponseWriter, r *http.Request) {
 	if pLimit, ok := inf.IntParams["limit"]; ok {
 		limit = pLimit
 	}
-
 	a := tc.Alerts{}
 	setLastSeenCookie(w)
 	logs, count, err := getLog(inf, days, limit)
@@ -218,7 +218,9 @@ func getLog(inf *api.APIInfo, days int, limit int) ([]tc.Log, uint64, error) {
 	var count = uint64(0)
 	var whereCount string
 	if _, ok := inf.Params["limit"]; !ok {
-		inf.Params["limit"] = strconv.Itoa(DefaultLogLimit)
+		if _, ok := inf.Params["days"]; !ok {
+			inf.Params["limit"] = strconv.Itoa(DefaultLogLimit)
+		}
 	} else {
 		inf.Params["limit"] = strconv.Itoa(limit)
 	}

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -36,12 +37,49 @@ import (
 
 // These are the default values for query string parameters if not provided.
 const (
+	// For the 'limit' parameter.
+	DefaultLogLimit = 1000
+	// For the 'limit' parameter when 'days' is given and 'limit' is not.
+	DefaultLogLimitForDays = 1000000
 	// For the 'days' parameter.
 	DefaultLogDays = 30
 )
 
-// Get is the handler for GET requests to /logs.
 func Get(w http.ResponseWriter, r *http.Request) {
+	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
+	if userErr != nil || sysErr != nil {
+		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
+		return
+	}
+	defer inf.Close()
+
+	limit := DefaultLogLimit
+	days := DefaultLogDays
+	if pDays, ok := inf.IntParams["days"]; ok {
+		days = pDays
+		limit = DefaultLogLimitForDays
+	}
+	if pLimit, ok := inf.IntParams["limit"]; ok {
+		limit = pLimit
+	}
+
+	a := tc.Alerts{}
+	setLastSeenCookie(w)
+	logs, count, err := getLog(inf, days, limit)
+	if err != nil {
+		a.AddNewAlert(tc.ErrorLevel, err.Error())
+		api.WriteAlerts(w, r, http.StatusInternalServerError, a)
+		return
+	}
+	if a.HasAlerts() {
+		api.WriteAlertsObj(w, r, 200, a, logs)
+	} else {
+		api.WriteRespWithSummary(w, r, logs, count)
+	}
+}
+
+// Get is the handler for GET requests to /logs V4.0.
+func Getv40(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, []string{"days", "limit"})
 	if userErr != nil || sysErr != nil {
 		api.HandleErr(w, r, inf.Tx.Tx, errCode, userErr, sysErr)
@@ -55,7 +93,7 @@ func Get(w http.ResponseWriter, r *http.Request) {
 
 	a := tc.Alerts{}
 	setLastSeenCookie(w)
-	logs, count, err := getLog(inf, days)
+	logs, count, err := getLogV40(inf, days)
 
 	if err != nil {
 		a.AddNewAlert(tc.ErrorLevel, err.Error())
@@ -125,7 +163,7 @@ FROM "log" as l JOIN tm_user as u ON l.tm_user = u.id`
 
 const countQuery = `SELECT count(l.tm_user) FROM log as l`
 
-func getLog(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
+func getLogV40(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
 	var count = uint64(0)
 	var whereCount string
 
@@ -147,6 +185,62 @@ func getLog(inf *api.APIInfo, days int) ([]tc.Log, uint64, error) {
 		whereCount = where
 		where = "\nWHERE " + timeInterval
 	}
+	queryCount := countQuery + whereCount
+	rowCount, err := inf.Tx.NamedQuery(queryCount, queryValues)
+	if err != nil {
+		return nil, count, errors.New("querying log count for a given user: " + err.Error())
+	}
+	defer rowCount.Close()
+	for rowCount.Next() {
+		if err = rowCount.Scan(&count); err != nil {
+			return nil, count, errors.New("scanning logs: " + err.Error())
+		}
+	}
+
+	query := selectFromQuery + where + "\n ORDER BY last_updated DESC" + pagination
+	rows, err := inf.Tx.NamedQuery(query, queryValues)
+	if err != nil {
+		return nil, count, errors.New("querying logs: " + err.Error())
+	}
+	defer rows.Close()
+	ls := []tc.Log{}
+	for rows.Next() {
+		l := tc.Log{}
+		if err = rows.Scan(&l.ID, &l.Level, &l.Message, &l.User, &l.TicketNum, &l.LastUpdated); err != nil {
+			return nil, count, errors.New("scanning logs: " + err.Error())
+		}
+		ls = append(ls, l)
+	}
+	return ls, count, nil
+}
+
+func getLog(inf *api.APIInfo, days int, limit int) ([]tc.Log, uint64, error) {
+	var count = uint64(0)
+	var whereCount string
+	if _, ok := inf.Params["limit"]; !ok {
+		inf.Params["limit"] = strconv.Itoa(DefaultLogLimit)
+	} else {
+		inf.Params["limit"] = strconv.Itoa(limit)
+	}
+
+	queryParamsToQueryCols := map[string]dbhelpers.WhereColumnInfo{
+		"username": {Column: "u.username", Checker: nil},
+	}
+	where, _, pagination, queryValues, errs :=
+		dbhelpers.BuildWhereAndOrderByAndPagination(inf.Params, queryParamsToQueryCols)
+	if len(errs) > 0 {
+		return nil, 0, util.JoinErrs(errs)
+	}
+
+	timeInterval := fmt.Sprintf("l.last_updated > now() - INTERVAL '%v' DAY", days)
+	if where != "" {
+		whereCount = ", tm_user as u\n" + where + " AND l.tm_user = u.id"
+		where = where + " AND " + timeInterval
+	} else {
+		whereCount = where
+		where = "\nWHERE " + timeInterval
+	}
+
 	queryCount := countQuery + whereCount
 	rowCount, err := inf.Tx.NamedQuery(queryCount, queryValues)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -216,7 +216,7 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `divisions/?$`, api.CreateHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 4537138003},
 		{api.Version{Major: 4, Minor: 0}, http.MethodDelete, `divisions/{id}$`, api.DeleteHandler(&division.TODivision{}), auth.PrivLevelOperations, nil, Authenticated, nil, 43253822373},
 
-		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `logs/?$`, logs.Get, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4483405503},
+		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `logs/?$`, logs.Getv40, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4483405503},
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `logs/newcount/?$`, logs.GetNewCount, auth.PrivLevelReadOnly, nil, Authenticated, nil, 44058330123},
 
 		//Content invalidation jobs


### PR DESCRIPTION
## What does this PR (Pull Request) do?

- [x] This PR fixes #6228   <!-- You can check for an issue here: https://github.com/apache/trafficcontrol/issues -->

This removed the logs api which has default limit value.
POST  /logs
## Which Traffic Control components are affected by this PR?

- CDN in a Box
- Traffic Control Client <!-- Please specify which; e.g. 'Python', 'Go', 'Java' -->
- Traffic Ops
- CI tests

## What is the best way to verify this PR?
Execute all the Integration tests and make sure the tests are passed.

## If this is a bug fix, what versions of Traffic Control are affected?
* Master

## The following criteria are ALL met by this PR
<!-- Check the boxes to signify that the associated statement is true. To
"check a box", replace the space inside of the square brackets with an 'x'.
e.g.

- [ x] <- Wrong
- [x ] <- Wrong
- [] <- Wrong
- [*] <- Wrong
- [x] <- Correct!

-->

- [x] This PR includes tests OR I have explained why tests are unnecessary
- [x] This PR includes documentation OR I have explained why documentation is unnecessary
- [x] This PR includes an update to CHANGELOG.md OR such an update is not necessary
- [x] This PR includes any and all required license headers
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://www.apache.org/security/) for details)