### PR TITLE
Fix docs for api_capabilities endpoint

### DIFF
--- a/docs/source/api/v2/api_capabilities.rst
+++ b/docs/source/api/v2/api_capabilities.rst
@@ -18,7 +18,7 @@
 ********************
 ``api_capabilities``
 ********************
-.. deprecated:: ATCv7.0
+.. deprecated:: 3.1
 
 Deals with the capabilities that may be associated with API endpoints and methods. These capabilities are assigned to :term:`Roles`, of which a user may have one or more. Capabilities support "wildcarding" or "globbing" using asterisks to group multiple routes into a single capability
 

--- a/docs/source/api/v3/api_capabilities.rst
+++ b/docs/source/api/v3/api_capabilities.rst
@@ -18,7 +18,7 @@
 ********************
 ``api_capabilities``
 ********************
-.. deprecated:: ATCv7.0
+.. deprecated:: 3.1
 
 Deals with the capabilities that may be associated with API endpoints and methods. These capabilities are assigned to :term:`Roles`, of which a user may have one or more. Capabilities support "wildcarding" or "globbing" using asterisks to group multiple routes into a single capability
 

--- a/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
+++ b/traffic_ops/traffic_ops_golang/apicapability/api_capabilities.go
@@ -39,6 +39,7 @@ import (
 // GetAPICapabilitiesHandler implements an http handler that returns
 // API Capabilities. In the event a capability parameter is supplied,
 // it will return only those with an exact match.
+// Deprecated: This API endpoint is deprecated, and will be removed in api v4 and above.
 func GetAPICapabilitiesHandler(w http.ResponseWriter, r *http.Request) {
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	if userErr != nil || sysErr != nil {


### PR DESCRIPTION
This PR only fixes the documentation on the `api_capabilities` endpoint.
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [x] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**