### PR TITLE
allow spaces in server interface router port name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Traffic Router crs/stats to prevent overflow and to correctly record the time used in averages.
 - [#5893](https://github.com/apache/trafficcontrol/issues/5893) - A self signed certificate is created when an HTTPS delivery service is created or an HTTP delivery service is updated to HTTPS.
 - [#6255](https://github.com/apache/trafficcontrol/issues/6255) - Unreadable Prod Mode CDN Notifications in Traffic Portal
+- [#6259](https://github.com/apache/trafficcontrol/issues/6259) - Traffic Portal No Longer Allows Spaces in Server Object "Router Port Name"
 
 ### Changed
 - Updated `t3c` to request less unnecessary deliveryservice-server assignment and invalidation jobs data via new query params supported by Traffic Ops

--- a/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/server/form.server.tpl.html
@@ -258,10 +258,8 @@ under the License.
                         <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-router-hostname'], 'maxlength')">Too long</small>
                         <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-router-hostname'], 'pattern')">No Spaces</small>
                         <label for="{{inf.name}}-router-portname" ng-class="{'has-error': hasError(serverForm[inf.name+'-router-portname'])}">Router Port Name</label>
-                        <input id="{{inf.name}}-router-portname" ng-model="inf.routerPortName" ng-class="{'has-error': hasError(serverForm[inf.name+'-router-portname'])}" type="text" name="{{inf.name}}-router-portname" maxlength="256" pattern="\S*"/>
+                        <input id="{{inf.name}}-router-portname" ng-model="inf.routerPortName" ng-class="{'has-error': hasError(serverForm[inf.name+'-router-portname'])}" type="text" name="{{inf.name}}-router-portname" maxlength="256"/>
                         <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-router-portname'], 'maxlength')">Too long</small>
-                        <small class="input-error" ng-show="hasPropertyError(serverForm[inf.name+'-router-portname'], 'pattern')">No Spaces</small>
-
                     </div>
 
                     <fieldset>


### PR DESCRIPTION
Fixes #6259 


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Start Traffic Portal, make sure you can create a server with a space in its router port name for one or more server interfaces

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- 6.0.0 RC4

## PR submission checklist
- [x] This PR does not have tests
- [x] This PR does not have documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**