### PR TITLE
Update Compose file versions to 3.8

### DIFF
--- a/cache-config/testing/docker/docker-compose-ats-build.yml
+++ b/cache-config/testing/docker/docker-compose-ats-build.yml
@@ -18,7 +18,7 @@
 #
 
 ---
-version: '2.1'
+version: '3.8'
 
 volumes:
   trafficcontrol:

--- a/cache-config/testing/docker/docker-compose.yml
+++ b/cache-config/testing/docker/docker-compose.yml
@@ -27,7 +27,7 @@
 #
 
 ---
-version: '2.1'
+version: '3.8'
 
 volumes:
   trafficcontrol:

--- a/experimental/graphql.sample/docker-compose.yml
+++ b/experimental/graphql.sample/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   pg-db:

--- a/infrastructure/ansible/sample.lab/docker-compose.yaml
+++ b/infrastructure/ansible/sample.lab/docker-compose.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-version: '2.1'
+version: '3.8'
 
 services:
   sample.driver.playbook:

--- a/infrastructure/cdn-in-a-box/docker-compose.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.expose-ports.yml
@@ -21,7 +21,7 @@
 #
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   db:

--- a/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.readiness.yml
@@ -30,7 +30,7 @@
 #     docker-compose -f docker-compose.readiness.yml up
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   readiness:

--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-ops-test.yml
@@ -24,7 +24,7 @@
 # docker-compose -f docker-compose.traffic-ops-test.yml logs -f integration
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   integration:

--- a/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.traffic-portal-test.yml
@@ -24,7 +24,7 @@
 # docker-compose -f docker-compose.traffic-portal-test.yml logs -f portal-integration-test
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   portal-integration-test:

--- a/infrastructure/cdn-in-a-box/docker-compose.yml
+++ b/infrastructure/cdn-in-a-box/docker-compose.yml
@@ -31,7 +31,7 @@
 # Note that this setup is intended for testing and not for production use.
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   # db is the Traffic Ops database running in postgresql.  Only trafficops needs to have access to it.

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
@@ -18,7 +18,7 @@
 # Exposes debugging ports
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   enroller:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.grafana.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.grafana.expose-ports.yml
@@ -18,7 +18,7 @@
 # Expose the Grafana container on the host on port 3000
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   grafana:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.grafana.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.grafana.yml
@@ -37,7 +37,7 @@
 
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   grafana:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.expose-ports.yml
@@ -31,7 +31,7 @@
 # Note that this setup is intended for testing and not for production use.
 #
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   socksproxy:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.socksproxy.yml
@@ -36,7 +36,7 @@
 # Note that this setup is intended for testing and not for production use.
 #
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   # Optional Socks Proxy for docker hosts that have limited bridge/ipforwarding support.

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.static-subnet.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.static-subnet.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 ---
-version: '2.1'
+version: '3.8'
 
 networks:
   default:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-vault.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-vault.expose-ports.yml
@@ -18,7 +18,7 @@
 # Expose the trafficvault container on the host on ports 8087, 8088, and 8098
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   trafficvault:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-vault.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-vault.yml
@@ -24,7 +24,7 @@
 #
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   trafficvault:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.expose-ports.yml
@@ -31,7 +31,7 @@
 # Note that this setup is intended for testing and not for production use.
 #
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   vnc:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vnc.yml
@@ -37,7 +37,7 @@
 # Note that this setup is intended for testing and not for production use.
 #
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   # TestClient is a VNC/Proxy container for development/testing CDN-In-A-Box 

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vpn.expose-ports.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vpn.expose-ports.yml
@@ -27,7 +27,7 @@
 # connect to this OpenVPN server by it.
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   vpn:

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.vpn.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.vpn.yml
@@ -36,7 +36,7 @@
 # connect to this OpenVPN server by it.
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   vpn:

--- a/infrastructure/docker/build/docker-compose-opt.yml
+++ b/infrastructure/docker/build/docker-compose-opt.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   ats:

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   weasel:

--- a/infrastructure/docker/traffic_ops/docker-compose.yml
+++ b/infrastructure/docker/traffic_ops/docker-compose.yml
@@ -30,7 +30,7 @@
 #
 
 ---
-version: '2'
+version: '3.8'
 
 volumes:
   trafficcontrol:

--- a/test/fakeOrigin/docker-compose.yml
+++ b/test/fakeOrigin/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-version: '2'
+version: '3.8'
 
 services:
   fake_origin:

--- a/tools/golang/docker-compose.yml
+++ b/tools/golang/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2.3'
+version: '3.8'
 
 services:
   lint:

--- a/traffic_monitor/tests/_integration/docker-compose.yml
+++ b/traffic_monitor/tests/_integration/docker-compose.yml
@@ -33,7 +33,7 @@
 #
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   testto:

--- a/traffic_monitor/tests/docker-compose.yml
+++ b/traffic_monitor/tests/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2'
+version: '3.8'
 
 volumes:
   junit:

--- a/traffic_ops/app/bin/tests/docker-compose.yml
+++ b/traffic_ops/app/bin/tests/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2'
+version: '3.8'
 
 volumes:
   traffic_ops_golang:

--- a/traffic_ops/app/db/trafficvault/test/docker-compose.yml
+++ b/traffic_ops/app/db/trafficvault/test/docker-compose.yml
@@ -25,7 +25,7 @@
 #      docker-compose up --exit-code-from trafficvault-db-admin
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   tvdb:

--- a/traffic_ops/traffic_ops_golang/swaggerdocs/v13/docker-compose.yml
+++ b/traffic_ops/traffic_ops_golang/swaggerdocs/v13/docker-compose.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
  
-version: '3.6'
+version: '3.8'
 
 services:
    swagger-spec-server:

--- a/traffic_ops/traffic_ops_golang/swaggerdocs/v13/swaggerspec/docker-compose.yml
+++ b/traffic_ops/traffic_ops_golang/swaggerdocs/v13/swaggerspec/docker-compose.yml
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
  
-version: '3.6'
+version: '3.8'
 
 services:
    to-rst:

--- a/traffic_ops_db/docker/docker-compose.dev.yml
+++ b/traffic_ops_db/docker/docker-compose.dev.yml
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-version: '2'
+version: '3.8'
 
 services:
   db:

--- a/traffic_ops_db/docker/docker-compose.yml
+++ b/traffic_ops_db/docker/docker-compose.yml
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-version: '2'
+version: '3.8'
 
 services:
   db:

--- a/traffic_ops_db/test/docker/docker-compose.yml
+++ b/traffic_ops_db/test/docker/docker-compose.yml
@@ -25,7 +25,7 @@
 #      docker-compose up --exit-code-from trafficops-db-admin
 
 ---
-version: '2.1'
+version: '3.8'
 
 services:
   db:

--- a/traffic_portal/docker/docker-compose.yml
+++ b/traffic_portal/docker/docker-compose.yml
@@ -11,7 +11,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-version: '2'
+version: '3.8'
 
 services:
   portal:

--- a/traffic_router/tests/docker-compose.yml
+++ b/traffic_router/tests/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: '2'
+version: '3.8'
 
 volumes:
   junit:

--- a/traffic_server/_tsb/docker-compose.yml
+++ b/traffic_server/_tsb/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-version: "2.1"
+version: '3.8'
 services:
   ats_build:
     build:


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR updates all of the Compose file versions in the project to version 3.8, which fixes #6276 because 3.8 is greater than the minimum compose file version necessary to support the `target` option (2.3).
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (T3C, formerly ORT)
- Traffic Monitor
- Traffic Ops
- Traffic Portal
- Traffic Router
- CDN in a Box
- Automation - build system, Ansible<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Test the various Compose files whose versions were updated to 3.8 in this PR:

- cache-config/testing/docker/docker-compose.yml
- experimental/graphql.sample/docker-compose.yml
- infrastructure/ansible/sample.lab/docker-compose.yaml
- infrastructure/cdn-in-a-box/docker-compose.yml
- infrastructure/docker/build/docker-compose.yml
- infrastructure/docker/traffic_ops/docker-compose.yml
- test/fakeOrigin/docker-compose.yml
- tools/golang/docker-compose.yml
- traffic_monitor/tests/_integration/docker-compose.yml
- traffic_ops/app/bin/tests/docker-compose.yml
- traffic_ops_db/test/docker/docker-compose.yml
- traffic_portal/docker/docker-compose.yml
- traffic_router/tests/docker-compose.yml


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 5.1.3
- 6.0.0
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] Bugfix, no documentation necessary <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] No CHANGELOG.md entry necessary <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->