### PR TITLE
Remove the addition of the 4.1 TO API version

### DIFF
--- a/docs/source/api/v4/deliveryservices_xmlid_xmlid_sslkeys.rst
+++ b/docs/source/api/v4/deliveryservices_xmlid_xmlid_sslkeys.rst
@@ -73,7 +73,7 @@ Response Structure
 :expiration:      The expiration date of the certificate for the :term:`Delivery Service` in :rfc:`3339` format
 :sans:            The :abbr:`SANs (Subject Alternate Names)` from the SSL certificate.
 
-	.. versionadded:: 4.1
+	.. versionadded:: 4.0
 
 .. code-block:: http
 	:caption: Response Example

--- a/lib/go-tc/deliveryservice_ssl_keys.go
+++ b/lib/go-tc/deliveryservice_ssl_keys.go
@@ -67,14 +67,14 @@ type DeliveryServiceSSLKeys struct {
 
 // DeliveryServiceSSLKeysV4 is the representation of a DeliveryServiceSSLKeys in the latest minor version of
 // version 4 of the Traffic Ops API.
-type DeliveryServiceSSLKeysV4 = DeliveryServiceSSLKeysV41
+type DeliveryServiceSSLKeysV4 = DeliveryServiceSSLKeysV40
 
 // DeliveryServiceSSLKeysV41 structures contain information about an SSL key
 // certificate pair used by a Delivery Service.
 //
 // "V41" is used because this structure was first introduced in version 4.1 of
 // the Traffic Ops API.
-type DeliveryServiceSSLKeysV41 struct {
+type DeliveryServiceSSLKeysV40 struct {
 	DeliveryServiceSSLKeysV15
 	Sans []string `json:"sans,omitempty"`
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/keys.go
@@ -166,7 +166,7 @@ func GetSSLKeysByXMLID(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var keyObj interface{}
-	if inf.Version.Major < 4 || (inf.Version.Major == 4 && inf.Version.Minor < 1) {
+	if inf.Version.Major < 4 {
 		keyObj = keyObjV4.DeliveryServiceSSLKeysV15
 	} else {
 		keyObj = keyObjV4

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -130,9 +130,6 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 		 * 4.x API
 		 */
 
-		// SSL Keys
-		{api.Version{Major: 4, Minor: 1}, http.MethodGet, `deliveryservices/xmlId/{xmlid}/sslkeys$`, deliveryservice.GetSSLKeysByXMLID, auth.PrivLevelAdmin, nil, Authenticated, nil, 41357729074},
-
 		// CDN lock
 		{api.Version{Major: 4, Minor: 0}, http.MethodGet, `cdn_locks/?$`, cdn_lock.Read, auth.PrivLevelReadOnly, nil, Authenticated, nil, 4134390561},
 		{api.Version{Major: 4, Minor: 0}, http.MethodPost, `cdn_locks/?$`, cdn_lock.Create, auth.PrivLevelOperations, nil, Authenticated, nil, 4134390562},

--- a/traffic_portal/app/src/scripts/config.js
+++ b/traffic_portal/app/src/scripts/config.js
@@ -23,4 +23,4 @@
 
 angular.module('config', [])
 
-.constant('ENV', { api: { root:'/api/4.1/', stable: "/api/3.1/" } });
+.constant('ENV', { api: { root:'/api/4.0/', stable: "/api/3.1/" } });


### PR DESCRIPTION
The 4.0 TO API version is currently considered unstable and under
development, so the addition of a 4.1 TO API version was unnecessary.
New TO API changes can currently be made to 4.0.

This is a follow-up to #6282 which included the addition of 4.1.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Ops
- Traffic Portal

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Mostly taken from #6282:
Create a certificate that has SANs and add it to a delivery service (or use one that already exists)
Verify that on the certificate page in TP there is a field for the SANs and that it is filled in appropriately.
Verify that the deliveryservices/xmlId/{xmlid}/sslkeys endpoint returns the SANs for API version ~4.1~ 4.0 but does not for any previous version
Verify that the TO tests pass

## PR submission checklist
- [x] Tests unnecessary for this removal
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] Changelog unnecessary for this removal
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
