### PR TITLE
Truncate DNSSEC refresh cron job log file before runs

### DIFF
--- a/traffic_ops/etc/cron.d/trafops_dnssec_refresh
+++ b/traffic_ops/etc/cron.d/trafops_dnssec_refresh
@@ -15,5 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-*/5 * * * * trafops /opt/traffic_ops/app/bin/checks/DnssecRefresh/ToDnssecRefresh --traffic-ops-url https://localhost --traffic-ops-user admin --traffic-ops-password twelve --log-location-error /var/log/traffic_ops/trafops_dnssec_refresh.log --log-location-warning /var/log/traffic_ops/trafops_dnssec_refresh.log --log-location-info /var/log/traffic_ops/trafops_dnssec_refresh.log
+*/5 * * * * trafops > /var/log/traffic_ops/trafops_dnssec_refresh.log && /opt/traffic_ops/app/bin/checks/DnssecRefresh/ToDnssecRefresh --traffic-ops-url https://localhost --traffic-ops-user admin --traffic-ops-password twelve --log-location-error /var/log/traffic_ops/trafops_dnssec_refresh.log --log-location-warning /var/log/traffic_ops/trafops_dnssec_refresh.log --log-location-info /var/log/traffic_ops/trafops_dnssec_refresh.log
 


### PR DESCRIPTION
In an environment where this cron job is not overwritten with valid
credentials, it will slowly fill up the TO disk. Plus, we really only
care about logs from the most recent run. Without valid credentials, an
error is logged.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
Let the cron job run, ensure it truncates the log file each time but still logs the error.


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
6.0

## PR submission checklist
- [x] cron job fix, no test <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] cron job fix, no docs <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] minor cron job fix, no changelog necessary <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
