### PR TITLE
Add ability to disable TM stats polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a new Traffic Ops cdn.conf option -- `disable_auto_cert_deletion` -- in order to optionally prevent the automatic deletion of certificates for delivery services that no longer exist whenever a CDN snapshot is taken.
 - [#6034](https://github.com/apache/trafficcontrol/issues/6034) Added new query parameter `cdn` to the `GET /api/x/deliveryserviceserver` Traffic Ops API to filter by CDN name
 - Added a new Traffic Monitor configuration option -- `short_hostname_override` -- to traffic_monitor.cfg to allow overriding the system hostname that Traffic Monitor uses.
-- Added a new Traffic Monitor configuration option -- `stat_polling` (default: false) -- to traffic_monitor.cfg to disable stat polling.
+- Added a new Traffic Monitor configuration option -- `stat_polling` (default: true) -- to traffic_monitor.cfg to disable stat polling.
 - A new Traffic Portal server command-line option `-c` to specify a configuration file, and the ability to set `log: null` to log to stdout (consult documentation for details).
 - SANs information to the SSL key endpoint and Traffic Portal page.
 - Added definition for `heartbeat.polling.interval` for CDN Traffic Monitor config in API documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a new Traffic Ops cdn.conf option -- `disable_auto_cert_deletion` -- in order to optionally prevent the automatic deletion of certificates for delivery services that no longer exist whenever a CDN snapshot is taken.
 - [#6034](https://github.com/apache/trafficcontrol/issues/6034) Added new query parameter `cdn` to the `GET /api/x/deliveryserviceserver` Traffic Ops API to filter by CDN name
 - Added a new Traffic Monitor configuration option -- `short_hostname_override` -- to traffic_monitor.cfg to allow overriding the system hostname that Traffic Monitor uses.
+- Added a new Traffic Monitor configuration option -- `stat_polling` (default: false) -- to traffic_monitor.cfg to disable stat polling.
 - A new Traffic Portal server command-line option `-c` to specify a configuration file, and the ability to set `log: null` to log to stdout (consult documentation for details).
 - SANs information to the SSL key endpoint and Traffic Portal page.
 - Added definition for `heartbeat.polling.interval` for CDN Traffic Monitor config in API documentation.

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -60,6 +60,10 @@ Polling protocol can be set for peers and caches and has 3 options:
 
 .. Note:: ``both`` will poll IPv4 and IPv6 and report on availability based on if the respective IP addresses are defined on the server.  So if only an IPv4 address is defined and the protocol is set to ``both`` then it will only show the availability over IPv4, but if both addresses are defined then it will show availability based on IPv4 and IPv6.
 
+Optional Stat Polling
+---------------------
+Traffic Monitor has the option to disable stat polling via the ``stat_polling`` (default: ``true``) option in :file:`traffic_monitor.cfg`. If set to ``false``, Traffic Monitor will not poll caches for stats; it will only poll caches for health. This can be useful in lowering the amount of resources (CPU, bandwidth) used by Traffic Monitor while still allowing it to retain its core functionality (determining cache availability) via health polling alone. However, disabling stat polling also prevents some other ATC features from working properly (basically anything that requires stats data from caches, e.g. Traffic Stats data), so it should only be disabled when absolutely necessary.
+
 Peering and Optimistic Quorum
 -----------------------------
 As mentioned in the :ref:`health-proto` section of the :ref:`tm-overview` overview, peering a Traffic Monitor with one or more other Traffic Monitors enables the optimistic health protocol. In order to leverage the optimistic quorum feature along with the optimistic health protocol, a minimum of three Traffic Monitors are required. The optimistic quorum feature allows a Traffic Monitor to withdraw itself from the optimistic health protocol when it loses connectivity to a number of its peers.

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -101,6 +101,8 @@ type Config struct {
 	HTTPTimeout                  time.Duration   `json:"-"`
 	PeerOptimistic               bool            `json:"peer_optimistic"`
 	PeerOptimisticQuorumMin      int             `json:"peer_optimistic_quorum_min"`
+	DistributedPolling           bool            `json:"distributed_polling"`
+	StatPolling                  bool            `json:"stat_polling"`
 	MaxEvents                    uint64          `json:"max_events"`
 	HealthFlushInterval          time.Duration   `json:"-"`
 	StatFlushInterval            time.Duration   `json:"-"`
@@ -138,6 +140,7 @@ var DefaultConfig = Config{
 	HTTPTimeout:                  2 * time.Second,
 	PeerOptimistic:               true,
 	PeerOptimisticQuorumMin:      0,
+	StatPolling:                  true,
 	MaxEvents:                    200,
 	HealthFlushInterval:          200 * time.Millisecond,
 	StatFlushInterval:            200 * time.Millisecond,

--- a/traffic_monitor/config/config_test.go
+++ b/traffic_monitor/config/config_test.go
@@ -32,6 +32,8 @@ const exampleTMConfig = `
 	"max_events": 200,
 	"health_flush_interval_ms": 1000,
 	"stat_flush_interval_ms": 1000,
+	"stat_polling": false,
+	"distributed_polling": true,
 	"log_location_event": "event.log",
 	"log_location_error": "error.log",
 	"log_location_warning": "warning.log",
@@ -49,10 +51,16 @@ const exampleTMConfig = `
 }
 `
 
-func TestLoggingConfig(t *testing.T) {
+func TestConfigLoad(t *testing.T) {
 	c, err := LoadBytes([]byte(exampleTMConfig))
 	if err != nil {
 		t.Fatalf("loading config bytes - expected: no error, actual: %v", err)
+	}
+	if c.StatPolling != false {
+		t.Errorf("StatPolling - expected: false, actual: %t", c.StatPolling)
+	}
+	if c.DistributedPolling != true {
+		t.Errorf("DistributedPolling - expected: true, actual: %t", c.DistributedPolling)
 	}
 	if string(c.WarningLog()) != c.LogLocationWarning {
 		t.Errorf("warning log location - expected: %s, actual: %s\n", c.LogLocationWarning, string(c.WarningLog()))
@@ -89,5 +97,21 @@ func TestLoggingConfig(t *testing.T) {
 	}
 	if c.HTTPPollingFormat != "thisformatdoesnotexist" {
 		t.Errorf("HTTPPollingFormat - expected: thisformatdoesnotexist, actual: %s", c.HTTPPollingFormat)
+	}
+}
+
+func TestConfigLoadDefaults(t *testing.T) {
+	c, err := LoadBytes([]byte(`{}`))
+	if err != nil {
+		t.Fatalf("loading empty config bytes - expected: no error, actual: %v", err)
+	}
+	if c.PeerOptimistic != true {
+		t.Errorf("PeerOptimistic default - expected: true, actual: %t", c.PeerOptimistic)
+	}
+	if c.StatPolling != true {
+		t.Errorf("StatPolling default - expected: true, actual: %t", c.StatPolling)
+	}
+	if c.DistributedPolling != false {
+		t.Errorf("DistributedPolling default - expected: false, actual: %t", c.DistributedPolling)
 	}
 }

--- a/traffic_monitor/datareq/datareq.go
+++ b/traffic_monitor/datareq/datareq.go
@@ -61,13 +61,19 @@ func MakeDispatchMap(
 	toData todata.TODataThreadsafe,
 	localCacheStatus threadsafe.CacheAvailableStatus,
 	lastStats threadsafe.LastStats,
-	unpolledCaches threadsafe.UnpolledCaches,
+	statUnpolledCaches threadsafe.UnpolledCaches,
+	healthUnpolledCaches threadsafe.UnpolledCaches,
 	monitorConfig threadsafe.TrafficMonitorConfigMap,
+	statPollingEnabled bool,
 ) map[string]http.HandlerFunc {
 
 	// wrap composes all universal wrapper functions. Right now, it's only the UnpolledCheck, but there may be others later. For example, security headers.
 	wrap := func(f http.HandlerFunc) http.HandlerFunc {
-		return wrapUnpolledCheck(unpolledCaches, errorCount, f)
+		if statPollingEnabled {
+			return wrapUnpolledCheck(statUnpolledCaches, errorCount, f)
+		} else {
+			return wrapUnpolledCheck(healthUnpolledCaches, errorCount, f)
+		}
 	}
 
 	dispatchMap := map[string]http.HandlerFunc{

--- a/traffic_monitor/manager/monitorconfig.go
+++ b/traffic_monitor/manager/monitorconfig.go
@@ -223,6 +223,7 @@ func monitorConfigListen(
 
 		healthURLs := map[string]poller.PollConfig{}
 		statURLs := map[string]poller.PollConfig{}
+		// TODO: if distributed = true, peers are only the TMs in the same cachegroup, while remotePeers will be peers from other cachegroups
 		peerURLs := map[string]poller.PollConfig{}
 		caches := map[string]string{}
 
@@ -299,7 +300,9 @@ func monitorConfigListen(
 			peerSet[tc.TrafficMonitorName(srv.HostName)] = struct{}{}
 		}
 
-		statURLSubscriber <- poller.CachePollerConfig{Urls: statURLs, PollingProtocol: cfg.CachePollingProtocol, Interval: intervals.Stat, NoKeepAlive: intervals.StatNoKeepAlive}
+		if cfg.StatPolling {
+			statURLSubscriber <- poller.CachePollerConfig{Urls: statURLs, PollingProtocol: cfg.CachePollingProtocol, Interval: intervals.Stat, NoKeepAlive: intervals.StatNoKeepAlive}
+		}
 		healthURLSubscriber <- poller.CachePollerConfig{Urls: healthURLs, PollingProtocol: cfg.CachePollingProtocol, Interval: intervals.Health, NoKeepAlive: intervals.HealthNoKeepAlive}
 		peerURLSubscriber <- poller.CachePollerConfig{Urls: peerURLs, PollingProtocol: cfg.PeerPollingProtocol, Interval: intervals.Peer, NoKeepAlive: intervals.PeerNoKeepAlive}
 		toIntervalSubscriber <- intervals.TO

--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -67,7 +67,8 @@ func StartOpsConfigManager(
 	healthIteration threadsafe.Uint,
 	errorCount threadsafe.Uint,
 	localCacheStatus threadsafe.CacheAvailableStatus,
-	unpolledCaches threadsafe.UnpolledCaches,
+	statUnpolledCaches threadsafe.UnpolledCaches,
+	healthUnpolledCaches threadsafe.UnpolledCaches,
 	monitorConfig threadsafe.TrafficMonitorConfigMap,
 	cfg config.Config,
 ) (threadsafe.OpsConfig, error) {
@@ -124,8 +125,10 @@ func StartOpsConfigManager(
 			toData,
 			localCacheStatus,
 			lastStats,
-			unpolledCaches,
+			statUnpolledCaches,
+			healthUnpolledCaches,
 			monitorConfig,
+			cfg.StatPolling,
 		)
 
 		// If the HTTPS Listener is defined in the traffic_ops.cfg file then it creates the HTTPS endpoint and the corresponding HTTP endpoint as a redirect


### PR DESCRIPTION
For distributed traffic monitoring, we would like to disable TM stats
polling in order to reduce CPU usage and incoming bandwidth.

This PR allows TM to disable stats polling, so that it only does health polling. Similar to how TM's APIs are disabled until it has successfully _stat_ polled every cache, if stat polling is disabled, TM will disable its APIs until every cache has been successfully _health_ polled. In addition to adding a new `stat_polling` config option (default is true), this PR also adds a `distributed_polling` config option which will be implemented in a future PR.
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run TM with stat polling disabled (`"stat_polling": false` in traffic_monitor.cfg) while requesting its `/publish/CrStates` API every second. Observe that the API is disabled (returns a 503) until it has health polled the caches in the CDN (usually happens within 30 seconds or so, depending on the CDN).

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] TM config not currently documented <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
