### PR TITLE
Add missing fields to PUT /topologies docs (v3 and v4)

### DIFF
--- a/docs/source/api/v3/topologies.rst
+++ b/docs/source/api/v3/topologies.rst
@@ -348,7 +348,11 @@ Response Structure
 
 ``PUT``
 =======
-Updates a specific :term:`Topology`
+Updates a specific :term:`Topology`.
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Response Type:  Object
 
 Request Structure
 -----------------

--- a/docs/source/api/v4/topologies.rst
+++ b/docs/source/api/v4/topologies.rst
@@ -350,7 +350,12 @@ Response Structure
 
 ``PUT``
 =======
-Updates a specific :term:`Topology`
+Updates a specific :term:`Topology`.
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Permissions Required: TOPOLOGY:UPDATE, TOPOLOGY:READ, CACHE-GROUP:READ
+:Response Type:  Object
 
 Request Structure
 -----------------


### PR DESCRIPTION
The documentation for the `/topologies` TO API endpoint is missing a couple of fields that describe the PUT method. This PR adds them.

<hr>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build, and are correct.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 5.x
- 6.x

## PR submission checklist
- [x] This PR has no tests
- [x] This PR has no documentation
- [x] This PR has no CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**