### PR TITLE
Adds support to the tc-health-client for querying Traffic Monitors via a caching Proxy server.

### DIFF
--- a/tc-health-client/README.md
+++ b/tc-health-client/README.md
@@ -1,9 +1,3 @@
-% tc-health-client(1) tc-health-client 6.1.0 | ATC tc-health-client Manual
-%
-% 2021-09-20
-% tc-health-client(1) tc-health-client 6.1.0 
-%
-% 2021-09-17
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -109,6 +103,7 @@ Sample configuarion file:
     "to-url": "https://tp.cdn.com:443", 
     "to-request-timeout-seconds": "5s",
     "tm-poll-interval-seconds": "60s",
+    "tm-proxy-url", "http://sample-http-proxy.cdn.net:80",
     "tm-update-cycles": 5,
     "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
     "trafficserver-bin-dir": "/opt/trafficserver/bin",
@@ -153,6 +148,13 @@ Sample configuarion file:
 
   The polling interval in seconds used to update **Traffic Server** parent
   status.
+
+### tm-proxy-url
+
+  If not nil, all Traffic Monitor requests will be proxied through this 
+  proxy endpoint.  This is useful when there are large numbers of caches
+  polling a Traffic Monitor and you wish to funnel queries through a caching
+  proxy server to limit direct direct connections to Traffic Monitor.
 
 ### tm-update-cycles
 

--- a/tc-health-client/tc-health-client.json
+++ b/tc-health-client/tc-health-client.json
@@ -5,6 +5,7 @@
   "to-credential-file": "/etc/credentials",
   "to-url": "https://tp.cdn.com:443", 
   "to-request-timeout-seconds": "5s",
+  "tm-proxy-url":, "proxy.net:80",
   "tm-poll-interval-seconds": "15s",
   "tm-update-cycles": 5,
   "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",

--- a/tc-health-client/tmagent/tmagent.go
+++ b/tc-health-client/tmagent/tmagent.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -244,6 +245,11 @@ func (c *ParentInfo) GetCacheStatuses() (map[tc.CacheName]datareq.CacheStatus, e
 		return nil, errors.New("finding a trafficmonitor: " + err.Error())
 	}
 	tmc := tmclient.New("http://"+tmHostName, config.GetRequestTimeout())
+
+	// Use a proxy to query TM if the ProxyURL is set
+	if c.Cfg.ParsedProxyURL != nil {
+		tmc.Transport = &http.Transport{Proxy: http.ProxyURL(c.Cfg.ParsedProxyURL)}
+	}
 
 	return tmc.CacheStatuses()
 }

--- a/traffic_monitor/tmclient/tmclient.go
+++ b/traffic_monitor/tmclient/tmclient.go
@@ -38,8 +38,9 @@ import (
 )
 
 type TMClient struct {
-	url     string
-	timeout time.Duration
+	url       string
+	timeout   time.Duration
+	Transport *http.Transport // optional http Transport
 }
 
 func New(url string, timeout time.Duration) *TMClient {
@@ -198,6 +199,9 @@ func (c *TMClient) ConfigDoc() (handler.OpsConfig, error) {
 func (c *TMClient) getBytes(path string) ([]byte, error) {
 	url := c.url + path
 	httpClient := http.Client{Timeout: c.timeout}
+	if c.Transport != nil {
+		httpClient.Transport = c.Transport
+	}
 	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, errors.New("getting from '" + url + "': " + err.Error())


### PR DESCRIPTION
Adds support to the tc-health-client for querying Traffic Monitors via a caching Proxy server.

- adds a tm-proxy-url config property
- updates the traffic_monitor/tmclient to use an optional http.Transport
  object needed to support an Http Proxy.

## Which Traffic Control components are affected by this PR?

- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?

On an edge cache, configure the tc-health-client to run with the tm-proxy-url set in the /etc/trafficcontrol/tc-health-client.json config file.  With the proxy server configured to proxy traffic monitor requests from the health-client, verify traffic monitor requests are successful, see /var/log/trafficcontrol/tc-health-client.log

## If this is a bugfix, which Traffic Control versions contained the bug?

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
