### PR TITLE
Fix GHA that checks db migration filenames to properly check timestamp digits

### DIFF
--- a/.github/actions/todb-tests/entrypoint.sh
+++ b/.github/actions/todb-tests/entrypoint.sh
@@ -85,7 +85,7 @@ for migration_dir in ${migration_dirs[@]}; do
 
 	set +e;
 	# All new migrations must use 16-digit timestamps.
-	VIOLATING_FILES="$(ls | sort | cut -d _ -f 1 | sed -n -e '/2020061622101648/,$p' | tr '[:space:]' '\n' | grep -vE '^[0-9]{16}$')";
+	VIOLATING_FILES="$(ls | sort | cut -d _ -f 1 | grep -vE '^[0-9]{16}$' | grep -vE '^00000000000000$')";
 	set -e;
 
 	if [[ ! -z "$VIOLATING_FILES" ]]; then


### PR DESCRIPTION
At some point our GHA that is supposed to ensure the proper number of digits for database migration file name timestamps broke and allowed in something that should've been invalid in #6307. This PR fixes the GHA to properly mark those files as in violation of the naming scheme.

<hr>

## Which Traffic Control components are affected by this PR?
- Automation (GitHub Actions)

## What is the best way to verify this PR?
This PR _should_ fail that check, because our master branch currently _should_ fail that check but doesn't - that's the bug this fixes. If you create a new branch on your fork based on this branch, delete the migration files added in #6307, then push, the check should pass (though others may fail).

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR fixes tests
- [x] This PR has no documentation
- [x] This PR has no CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**