### PR TITLE
Feature/tp refetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - SANs information to the SSL key endpoint and Traffic Portal page.
 - Added definition for `heartbeat.polling.interval` for CDN Traffic Monitor config in API documentation.
 - New `pkg` script options, `-h`, `-s`, `-S`, and `-L`.
+- Added `Invalidation Type` (REFRESH or REFETCH) for invalidating content to Traffic Portal.
 
 ### Fixed
 - [#6197](https://github.com/apache/trafficcontrol/issues/6197) - TO `/deliveryservices/:id/routing` makes requests to all TRs instead of by CDN.

--- a/cache-config/testing/ort-tests/tcdata/todb.go
+++ b/cache-config/testing/ort-tests/tcdata/todb.go
@@ -107,7 +107,7 @@ func SetupRoles(db *sql.DB) error {
 
 	sqlStmt := `
 INSERT INTO role (name, description, priv_level) VALUES ('disallowed','Block all access',0) ON CONFLICT DO NOTHING;
-INSERT INTO role (name, description, priv_level) VALUES ('read-only user','Block all access', 10) ON CONFLICT DO NOTHING;
+INSERT INTO role (name, description, priv_level) VALUES ('read-only','Block all access', 10) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('operations','Block all access', 20) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('admin','super-user', 30) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('portal','Portal User', 2) ON CONFLICT DO NOTHING;

--- a/traffic_ops/testing/api/v2/todb_test.go
+++ b/traffic_ops/testing/api/v2/todb_test.go
@@ -106,7 +106,7 @@ func SetupRoles(db *sql.DB) error {
 
 	sqlStmt := `
 INSERT INTO role (name, description, priv_level) VALUES ('disallowed','Block all access',0) ON CONFLICT DO NOTHING;
-INSERT INTO role (name, description, priv_level) VALUES ('read-only user','Block all access', 10) ON CONFLICT DO NOTHING;
+INSERT INTO role (name, description, priv_level) VALUES ('read-only','Block all access', 10) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('operations','Block all access', 20) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('admin','super-user', 30) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('portal','Portal User', 2) ON CONFLICT DO NOTHING;

--- a/traffic_ops/testing/api/v3/todb_test.go
+++ b/traffic_ops/testing/api/v3/todb_test.go
@@ -106,7 +106,7 @@ func SetupRoles(db *sql.DB) error {
 
 	sqlStmt := `
 INSERT INTO role (name, description, priv_level) VALUES ('disallowed','Block all access',0) ON CONFLICT DO NOTHING;
-INSERT INTO role (name, description, priv_level) VALUES ('read-only user','Block all access', 10) ON CONFLICT DO NOTHING;
+INSERT INTO role (name, description, priv_level) VALUES ('read-only','Block all access', 10) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('operations','Block all access', 20) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('admin','super-user', 30) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('portal','Portal User', 2) ON CONFLICT DO NOTHING;

--- a/traffic_ops/testing/api/v4/crconfig_test.go
+++ b/traffic_ops/testing/api/v4/crconfig_test.go
@@ -61,7 +61,7 @@ func SnapshotWithReadOnlyUser(t *testing.T) {
 		RegistrationSent:     new(time.Time),
 		LocalPassword:        util.StrPtr("test_pa$$word"),
 		ConfirmLocalPassword: util.StrPtr("test_pa$$word"),
-		Role:                 "read-only user",
+		Role:                 "read-only",
 	}
 	user.Email = util.StrPtr("email_tm@domain.com")
 	user.TenantID = resp.Response[0].ID

--- a/traffic_ops/testing/api/v4/tc-fixtures.json
+++ b/traffic_ops/testing/api/v4/tc-fixtures.json
@@ -5541,7 +5541,7 @@
             "phoneNumber": "",
             "postalCode": "",
             "publicSshKey": "",
-            "role": "read-only user",
+            "role": "read-only",
             "stateOrProvince": "",
             "tenant": "tenant1",
             "uid": 0,

--- a/traffic_ops/testing/api/v4/todb_test.go
+++ b/traffic_ops/testing/api/v4/todb_test.go
@@ -100,7 +100,7 @@ func SetupRoles(db *sql.DB) error {
 
 	sqlStmt := `
 INSERT INTO role (name, description, priv_level) VALUES ('disallowed','Block all access',0) ON CONFLICT DO NOTHING;
-INSERT INTO role (name, description, priv_level) VALUES ('read-only user','Block all access', 10) ON CONFLICT DO NOTHING;
+INSERT INTO role (name, description, priv_level) VALUES ('read-only','Block all access', 10) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('operations','Block all access', 20) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('admin','super-user', 30) ON CONFLICT DO NOTHING;
 INSERT INTO role (name, description, priv_level) VALUES ('portal','Portal User', 2) ON CONFLICT DO NOTHING;

--- a/traffic_ops/testing/api/v4/topologies_test.go
+++ b/traffic_ops/testing/api/v4/topologies_test.go
@@ -996,7 +996,7 @@ func CRUDTopologyReadOnlyUser(t *testing.T) {
 		RegistrationSent:     new(time.Time),
 		LocalPassword:        util.StrPtr("test_pa$$word"),
 		ConfirmLocalPassword: util.StrPtr("test_pa$$word"),
-		Role:                 "read-only user",
+		Role:                 "read-only",
 	}
 	user.Email = util.StrPtr("email@domain.com")
 	user.TenantID = resp.Response[0].ID

--- a/traffic_portal/app/src/common/api/JobService.js
+++ b/traffic_portal/app/src/common/api/JobService.js
@@ -20,7 +20,7 @@
 var JobService = function($http, ENV) {
 
 	this.getJobs = function(queryParams) {
-		return $http.get(ENV.api.stable + 'jobs', {params: queryParams}).then(
+		return $http.get(ENV.api.unstable + 'jobs', {params: queryParams}).then(
 			function(result) {
 				return result.data.response;
 			},
@@ -31,7 +31,7 @@ var JobService = function($http, ENV) {
 	};
 
 	this.createJob = function(job) {
-		return $http.post(ENV.api.stable + 'jobs', job).then(
+		return $http.post(ENV.api.unstable + 'jobs', job).then(
 			function (result) {
 				return result;
 			},
@@ -42,7 +42,7 @@ var JobService = function($http, ENV) {
 	};
 
 	this.deleteJob = function(id) {
-		return $http.delete(ENV.api.stable + 'jobs', {params: {id: id}}).then(
+		return $http.delete(ENV.api.unstable + 'jobs', {params: {id: id}}).then(
 			function(result) {
 				return result;
 			},

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
@@ -40,14 +40,22 @@ under the License.
                     <span ng-show="hasError(jobForm.regex)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
-            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttl), 'has-feedback': hasError(jobForm.ttl)}">
+            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlhours), 'has-feedback': hasError(jobForm.ttlhours)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'required')">Required Whole Number</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'pattern')">Whole Number</small>
-                    <span ng-show="hasError(jobForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'required')">Required Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'maxlength')">Too Long</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'pattern')">Whole Number</small>
+                    <span ng-show="hasError(jobForm.ttlhours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group" ng-class="{'has-error': hasError(jobForm.invalidationtype), 'has-feedback': hasError(jobForm.invalidationtype)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Invalidation Type *</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <select name="invalidationtype" class="form-control" ng-model="job.invalidationType" ng-options="invalidationtype as invalidationtype for invalidationtype in invalidationtypes" required>
+                    </select>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.invalidationtype, 'required')">Required</small>
                 </div>
             </div>
             <div class="modal-footer">

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
@@ -43,10 +43,8 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlhours), 'has-feedback': hasError(jobForm.ttlhours)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" min="1" max="999" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'required')">Required Whole Number</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(jobForm.ttlhours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/new/FormNewDeliveryServiceJobController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/new/FormNewDeliveryServiceJobController.js
@@ -22,6 +22,14 @@ var FormNewDeliveryServiceJobController = function(deliveryService, job, $scope,
 	// extends the FormDeliveryServiceJobController to inherit common methods
 	angular.extend(this, $controller('FormDeliveryServiceJobController', { deliveryService: deliveryService, job: job, $scope: $scope }));
 
+	// define invalidation types
+	$scope.invalidationtypes = [
+		'REFRESH',
+		'REFETCH'
+	];
+	// set default invalidation type
+	$scope.job.invalidationType = $scope.invalidationtypes[0];
+	
 	$scope.jobName = 'New';
 
 	$scope.settings = {

--- a/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
@@ -50,10 +50,8 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlhours), 'has-feedback': hasError(jobForm.ttlhours)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" min="1" max="999" required autofocus>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'required')">Required Whole Number</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'pattern')">Whole Number</small>
                     <span ng-show="hasError(jobForm.ttlhours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>

--- a/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
@@ -31,7 +31,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.deliveryservice), 'has-feedback': hasError(jobForm.deliveryservice)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Delivery Service *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <select name="deliveryservice" class="form-control" ng-model="job.deliveryService" ng-options="deliveryservice.id as deliveryservice.xmlId for deliveryservice in deliveryservices" required>
+                    <select name="deliveryservice" class="form-control" ng-model="job.deliveryService" ng-options="deliveryservice.xmlId as deliveryservice.xmlId for deliveryservice in deliveryservices" required>
                         <option value="">Select...</option>
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.deliveryservice, 'required')">Required</small>
@@ -47,14 +47,23 @@ under the License.
                     <span ng-show="hasError(jobForm.regex)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
-            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttl), 'has-feedback': hasError(jobForm.ttl)}">
+            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlHours), 'has-feedback': hasError(jobForm.ttlHours)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttl" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttl" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'required')">Required Whole Number</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttl, 'pattern')">Whole Number</small>
-                    <span ng-show="hasError(jobForm.ttl)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlHours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'required')">Required Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'maxlength')">Too Long</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'pattern')">Whole Number</small>
+                    <span ng-show="hasError(jobForm.ttlHours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group" ng-class="{'has-error': hasError(jobForm.invalidationtype), 'has-feedback': hasError(jobForm.invalidationtype)}">
+                <label class="control-label col-md-2 col-sm-2 col-xs-12">Invalidation Type *</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <select name="invalidationtype" class="form-control" ng-model="job.invalidationType" ng-options="invalidationtype as invalidationtype for invalidationtype in invalidationtypes" required>
+                        <!-- <option value="">Select...</option> -->
+                    </select>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.invalidationtype, 'required')">Required</small>
                 </div>
             </div>
             <div class="modal-footer">

--- a/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
@@ -47,21 +47,20 @@ under the License.
                     <span ng-show="hasError(jobForm.regex)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
-            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlHours), 'has-feedback': hasError(jobForm.ttlHours)}">
+            <div class="form-group" ng-class="{'has-error': hasError(jobForm.ttlhours), 'has-feedback': hasError(jobForm.ttlhours)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">TTL (hours) *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlHours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'required')">Required Whole Number</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'maxlength')">Too Long</small>
-                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlHours, 'pattern')">Whole Number</small>
-                    <span ng-show="hasError(jobForm.ttlHours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                    <input name="ttlhours" type="number" class="form-control" placeholder="Number of hours until the invalidation request expires" ng-model="job.ttlhours" ng-maxlength="3" ng-pattern="/^\d+$/" required autofocus>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'required')">Required Whole Number</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'maxlength')">Too Long</small>
+                    <small class="input-error" ng-show="hasPropertyError(jobForm.ttlhours, 'pattern')">Whole Number</small>
+                    <span ng-show="hasError(jobForm.ttlhours)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
             </div>
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.invalidationtype), 'has-feedback': hasError(jobForm.invalidationtype)}">
                 <label class="control-label col-md-2 col-sm-2 col-xs-12">Invalidation Type *</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
                     <select name="invalidationtype" class="form-control" ng-model="job.invalidationType" ng-options="invalidationtype as invalidationtype for invalidationtype in invalidationtypes" required>
-                        <!-- <option value="">Select...</option> -->
                     </select>
                     <small class="input-error" ng-show="hasPropertyError(jobForm.invalidationtype, 'required')">Required</small>
                 </div>

--- a/traffic_portal/app/src/common/modules/form/job/new/FormNewJobController.js
+++ b/traffic_portal/app/src/common/modules/form/job/new/FormNewJobController.js
@@ -22,6 +22,14 @@ var FormNewJobController = function(job, $scope, $controller, jobService, messag
 	// extends the FormJobController to inherit common methods
 	angular.extend(this, $controller('FormJobController', { job: job, $scope: $scope }));
 
+	// define invalidation types
+	$scope.invalidationtypes = [
+		'REFRESH',
+		'REFETCH'
+	];
+	// set default invalidation type
+	$scope.job.invalidationType = $scope.invalidationtypes[0];
+
 	$scope.jobName = 'New';
 
 	$scope.settings = {

--- a/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
+++ b/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
@@ -68,8 +68,7 @@ var TableJobsController = function(tableName, jobs, $document, $scope, $state, $
 			// need to convert this to a date object for ag-grid filter to work properly
 			x.startTime = new Date(x.startTime.replace("+00", "Z"));
 
-			let ttl = parseInt(x.ttlHours, 10);
-			x.expires = new Date(x.startTime.getTime() + ttl*3600*1000);
+			x.expires = new Date(x.startTime.getTime() + x.ttlHours*3600*1000);
 			return x;
 		});
 

--- a/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
+++ b/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
@@ -34,8 +34,8 @@ var TableJobsController = function(tableName, jobs, $document, $scope, $state, $
 			hide: false
 		},
 		{
-			headerName: "Parameters",
-			field: "parameters",
+			headerName: "TTL (Hours)",
+			field: "ttlHours",
 			hide: false
 		},
 		{
@@ -63,8 +63,7 @@ var TableJobsController = function(tableName, jobs, $document, $scope, $state, $
 			// need to convert this to a date object for ag-grid filter to work properly
 			x.startTime = new Date(x.startTime.replace("+00", "Z"));
 
-			// going to derive the expires date from start + TTL (hours). Format: TTL:24h
-			let ttl = parseInt(x.parameters.slice('TTL:'.length, x.parameters.length-1), 10);
+			let ttl = parseInt(x.ttlHours, 10);
 			x.expires = new Date(x.startTime.getTime() + ttl*3600*1000);
 			return x;
 		});

--- a/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
+++ b/traffic_portal/app/src/common/modules/table/jobs/TableJobsController.js
@@ -54,6 +54,11 @@ var TableJobsController = function(tableName, jobs, $document, $scope, $state, $
 			headerName: "Created By",
 			field: "createdBy",
 			hide: false
+		},
+		{
+			headerName: "Invalidation Type",
+			field: "invalidationType",
+			hide: false
 		}
 	];
 

--- a/traffic_portal/package-lock.json
+++ b/traffic_portal/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "traffic_portal",
       "version": "6.1.0",
       "dependencies": {
         "@uirouter/angularjs": "0.4.2",
@@ -43,7 +44,7 @@
         "grunt-contrib-jshint": "2.1.0",
         "grunt-contrib-uglify": "4.0.1",
         "grunt-contrib-watch": "1.1.0",
-        "grunt-dart-sass": "^2.0.1",
+        "grunt-dart-sass": "2.0.1",
         "grunt-express-server": "0.5.4",
         "grunt-html2js": "0.7.1",
         "grunt-install-dependencies": "0.2.0",
@@ -54,7 +55,7 @@
         "load-grunt-tasks": "5.1.0",
         "morgan": "1.9.1",
         "requirejs": "2.3.6",
-        "sass": "^1.42.1",
+        "sass": "1.42.1",
         "ssl-root-cas": "1.3.1",
         "time-grunt": "1.3.0"
       }

--- a/traffic_portal/test/integration/Data/jobs.ts
+++ b/traffic_portal/test/integration/Data/jobs.ts
@@ -98,7 +98,7 @@ export const jobs = {
                     Regex: "/test",
                     TtlHours: "1",
                     InvalidationType: "REFRESH",
-					validationMessage: "Invalidation request created"
+					validationMessage: "Invalidation (REFRESH) request created"
 				}
 			],
 		}

--- a/traffic_portal/test/integration/Data/jobs.ts
+++ b/traffic_portal/test/integration/Data/jobs.ts
@@ -96,7 +96,8 @@ export const jobs = {
 					description: "create an invalidation request",
                     DeliveryService: "dstestjob1",
                     Regex: "/test",
-                    Ttl: "1",
+                    TtlHours: "1",
+                    InvalidationType: "REFRESH",
 					validationMessage: "Invalidation request created"
 				}
 			],

--- a/traffic_portal/test/integration/PageObjects/Jobs.po.ts
+++ b/traffic_portal/test/integration/PageObjects/Jobs.po.ts
@@ -25,14 +25,16 @@ import { SideNavigationPage } from './SideNavigationPage.po';
 interface Job {
     DeliveryService: string;
     Regex: string;
-    Ttl: string;
+    TtlHours: string;
+    InvalidationType: string;
     validationMessage: string;
 }
 export class JobsPage extends BasePage {
     private moreBtn = element(by.name('moreBtn'));
     private createJobMenuItem = element(by.name('createJobMenuItem'));
     private txtRegex = element(by.name('regex'));
-    private txtTtl = element(by.name('ttl'));
+    private txtTtl = element(by.name('ttlhours'));
+    private txtInvalidationType = element(by.name('invalidationtype'));
     private txtDeliveryservice = element(by.name('deliveryservice'));
     private randomize = randomize;
 
@@ -55,7 +57,8 @@ export class JobsPage extends BasePage {
         await this.createJobMenuItem.click();
         await this.txtDeliveryservice.sendKeys(jobs.DeliveryService + this.randomize)
         await this.txtRegex.sendKeys(jobs.Regex);
-        await this.txtTtl.sendKeys(jobs.Ttl);
+        await this.txtTtl.sendKeys(jobs.TtlHours);
+        await this.txtInvalidationType.sendKeys(jobs.InvalidationType);
         await basePage.ClickCreate();
         result = await basePage.GetOutputMessage().then(value => value.includes(jobs.validationMessage));
         return result;


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This is a continuation of the work in ([PR 6118](https://github.com/apache/trafficcontrol/pull/6118)) as defined in the ([Refetch Blueprint](https://github.com/apache/trafficcontrol/pull/5910)). These changes allow Traffic Portal to take advantage of the changes to the Traffic Ops API and Invalidation Jobs.

The table listing invalidation jobs has been modified to show the TTL explicitly (rather than Parameters) and the create form has been modified to account for the new Invalidation Type field. Traffic Portal integration test was updated to account for these changes as well.

There was also a minor change cleaning up the _roles_ that were defined in some tests that may have been conflicting (`read-only user` should be `read-only`).

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Portal

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Manually, to launch and run Traffic Ops and Traffic Portal. Navigate to the Invalidation Content page under the Tools menu in Traffic Portal. Note the `Parameters` column is now titled `TTL (Hours)` as well as the addition of the `Invalidation Type`.

Manually, create an Invalidation Request. Note the new required field for `Invalidation Type`, which defaults to _REFRESH_.

Repeat the same observation and test as above, however navigate to Delivery Services. Select a Delivery Service. In the upper right drop down menu _More_ -> _Manage Invalidation Requests_. The difference here is that the table and create form are specific to this particular DS.

Automatic integration tests must pass.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation - Documentation will be addressed in a separate PR 
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
