### PR TITLE
Fix t3c to invalidate cache if req keys change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6066](https://github.com/apache/trafficcontrol/issues/6066) - Fixed missing/incorrect indices on some tables
 - [#6169](https://github.com/apache/trafficcontrol/issues/6169) - Fixed t3c-update not updating server status when a fallback to a previous Traffic Ops API version occurred
 - [#5576](https://github.com/apache/trafficcontrol/issues/5576) - Inconsistent Profile Name restrictions
+- [#6327](https://github.com/apache/trafficcontrol/issues/6327) - Fixed cache config to invalidate its cache if the Server's Profile or CDN changes
 - [#6174](https://github.com/apache/trafficcontrol/issues/6174) - Fixed t3c-apply with no hostname failing if the OS hostname returns a full FQDN
 - Fixed Federations IMS so TR federations watcher will get updates.
 - [#5129](https://github.com/apache/trafficcontrol/issues/5129) - Updated TM so that it returns a 404 if the endpoint is not supported.

--- a/cache-config/testing/ort-tests/t3c-ims_test.go
+++ b/cache-config/testing/ort-tests/t3c-ims_test.go
@@ -15,12 +15,20 @@ package orttest
 */
 
 import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
 	testutil "github.com/apache/trafficcontrol/cache-config/testing/ort-tests/util"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
 )
 
 func TestIMS(t *testing.T) {
@@ -33,6 +41,7 @@ func TestIMS(t *testing.T) {
 		tcdata.DeliveryServices}, func() {
 
 		doTestIMS(t)
+		doTestIMSChangedCDN(t)
 
 	})
 	t.Logf("------------- End of TestIMS ---------------")
@@ -67,6 +76,111 @@ func doTestIMS(t *testing.T) {
 	t.Logf("------------- End doTestIMS ---------------")
 }
 
+// doTestIMSChangedCDN tests that after caching, requests which use the CDN as a key don't use the invalid cache.
+func doTestIMSChangedCDN(t *testing.T) {
+	t.Logf("------------- Start doTestIMSChangedCDN ---------------")
+	defer func() { t.Logf("------------- End doTestIMSChangedCDN ---------------") }()
+
+	cacheHostName := "atlanta-edge-03"
+
+	t.Logf("doTestIMSChangedCDN calling badass with cache")
+	if stdOut, exitCode := t3cApplyCache(cacheHostName, false); exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	if !testutil.FileExists(t3cutil.ApplyCachePath) {
+		t.Fatalf("expected: cache '%v' to exist after badass, actual: doesn't exist", t3cutil.ApplyCachePath)
+	}
+
+	if stdOut, exitCode := t3cApplyCache(cacheHostName, false); exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	} else if !strings.Contains(stdOut, "not modified, using old config") {
+		t.Errorf("ERROR: expected t3c second badass to have a successful IMS 304, actual: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	cdn1Domain := "test.cdn1.net"
+	cdn2Domain := "test.cdn2.net"
+	cdn2ProfileName := "ATS_EDGE_TIER_CACHE_CDN2"
+
+	{
+		// check that remap.config has the initial cdn1
+
+		remapName := filepath.Join(test_config_dir, "remap.config")
+		remapDotConfig, err := ioutil.ReadFile(remapName)
+		if err != nil {
+			t.Fatalf("reading %v: %v\n", remapName, err)
+		}
+
+		if !bytes.Contains(remapDotConfig, []byte(cdn1Domain)) {
+			t.Errorf("expected remap.config to contain cdn1 domain '%v', actual: '%v'\n", cdn1Domain, string(remapDotConfig))
+		}
+	}
+
+	{
+		// change the server's CDN
+
+		cdn2Name := "cdn2"
+		cdns, _, err := tcdata.TOSession.GetCDNByNameWithHdr(cdn2Name, nil)
+		if err != nil {
+			t.Fatalf("getting cdn: " + err.Error())
+		} else if len(cdns) != 1 {
+			t.Fatalf("getting cdn: expected 1 cdn actual num %v cdns %+v", len(cdns), cdns)
+		}
+
+		// have to change the profile at the same time, or TO will reject the change.
+		profiles, _, err := tcdata.TOSession.GetProfileByNameWithHdr(cdn2ProfileName, nil)
+		if err != nil {
+			t.Fatalf("getting profile: " + err.Error())
+		} else if len(cdns) != 1 {
+			t.Fatalf("getting profile: expected 1 cdn actual num %v objects %+v", len(profiles), profiles)
+		}
+
+		cdn2ID := cdns[0].ID
+		cdn2ProfileID := profiles[0].ID
+
+		sv, _, err := GetServer(tcdata.TOSession, cacheHostName)
+		if err != nil {
+			t.Fatalf("getting server: " + err.Error())
+		}
+
+		sv.CDNID = &cdn2ID
+		sv.CDNName = &cdn2Name
+		sv.ProfileID = &cdn2ProfileID
+		sv.Profile = &cdn2ProfileName
+
+		_, _, err = tcdata.TOSession.UpdateServerByIDWithHdr(*sv.ID, *sv, nil)
+		if err != nil {
+			t.Fatalf("updating server: " + err.Error())
+		}
+	}
+
+	// run t3c after changing the cdn
+
+	stdOut, exitCode := t3cApplyCache(cacheHostName, false)
+	if exitCode != 0 {
+		t.Fatalf("ERROR: t3c badass failed: code '%v' output '%v'\n", exitCode, stdOut)
+	}
+
+	{
+		// check that remap.config has the changed cdn2, and does not have the old cdn1
+
+		remapName := filepath.Join(test_config_dir, "remap.config")
+		remapDotConfig, err := ioutil.ReadFile(remapName)
+		if err != nil {
+			t.Fatalf("reading %v: %v\n", remapName, err)
+		}
+
+		if !bytes.Contains(remapDotConfig, []byte(cdn2Domain)) {
+			t.Errorf("expected after changing server to cdn2 for remap.config to contain cdn2 domain '%v', actual: '%v'\n", cdn2Domain, string(remapDotConfig))
+		}
+
+		if bytes.Contains(remapDotConfig, []byte(cdn1Domain)) {
+			t.Errorf("expected after changing server to cdn2 for remap.config to not contain cdn1 domain '%v', actual: '%v'\n", cdn1Domain, string(remapDotConfig))
+		}
+	}
+
+}
+
 func t3cApplyCache(host string, noCache bool) (string, int) {
 	args := []string{
 		"apply",
@@ -86,4 +200,17 @@ func t3cApplyCache(host string, noCache bool) (string, int) {
 	}
 	_, stdErr, exitCode := t3cutil.Do("t3c", args...) // should be no stdout, we told it to log to stderr
 	return string(stdErr), exitCode
+}
+
+func GetServer(toClient *toclient.Session, hostName string) (*tc.ServerV30, toclientlib.ReqInf, error) {
+	params := url.Values{}
+	params.Add("hostName", hostName)
+	resp, reqInf, err := toClient.GetServersWithHdr(&params, nil)
+	if err != nil {
+		return nil, reqInf, err
+	}
+	if len(resp.Response) == 0 {
+		return nil, reqInf, errors.New("not found")
+	}
+	return &resp.Response[0], reqInf, nil
 }

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -885,6 +885,70 @@
     },
     {
       "active": true,
+      "cdnName": "cdn2",
+      "cacheurl": "",
+      "ccrDnsTtl": 3600,
+      "checkPath": "",
+      "consistentHashQueryParams": [],
+      "deepCachingType": "NEVER",
+      "displayName": "ds-on-cdn2",
+      "dnsBypassCname": null,
+      "dnsBypassIp": "",
+      "dnsBypassIp6": "",
+      "dnsBypassTtl": 30,
+      "dscp": 40,
+      "edgeHeaderRewrite": null,
+      "fqPacingRate": 0,
+      "geoLimit": 0,
+      "geoLimitCountries": "",
+      "geoLimitRedirectURL": null,
+      "geoProvider": 0,
+      "globalMaxMbps": 0,
+      "globalMaxTps": 0,
+      "httpBypassFqdn": "",
+      "infoUrl": "TBD",
+      "initialDispersion": 1,
+      "ipv6RoutingEnabled": true,
+      "lastUpdated": "2018-04-06 16:48:51+00",
+      "logsEnabled": false,
+      "longDesc": "d s top",
+      "longDesc1": "ds top",
+      "longDesc2": "ds-top",
+      "matchList": [
+        {
+          "pattern": ".*\\.ds-cdn2\\..*",
+          "setNumber": 0,
+          "type": "HOST_REGEXP"
+        }
+      ],
+      "maxDnsAnswers": 0,
+      "midHeaderRewrite": null,
+      "missLat": 41.881944,
+      "missLong": -87.627778,
+      "multiSiteOrigin": false,
+      "orgServerFqdn": "http://ds-cdn2-origin.example.net",
+      "originShield": null,
+      "profileDescription": null,
+      "profileName": null,
+      "protocol": 2,
+      "qstringIgnore": 1,
+      "rangeRequestHandling": 0,
+      "regexRemap": null,
+      "regionalGeoBlocking": false,
+      "remapText": null,
+      "routingName": "cdn",
+      "signed": false,
+      "signingAlgorithm": null,
+      "sslKeyVersion": 0,
+      "tenant": "tenant1",
+      "tenantName": "tenant1",
+      "type": "HTTP_LIVE_NATNL",
+      "xmlId": "ds-cdn2",
+      "anonymousBlockingEnabled": false,
+      "topology": "top-for-ds-cdn2"
+    },
+    {
+      "active": true,
       "cdnName": "cdn1",
       "cacheurl": "",
       "ccrDnsTtl": 3600,
@@ -1790,6 +1854,403 @@
       ]
     },
     {
+      "cdnName": "cdn2",
+      "description": "Edge Cache - Apache Traffic Server",
+      "name": "ATS_EDGE_TIER_CACHE_CDN2",
+      "routingDisabled": false,
+      "type": "ATS_PROFILE",
+      "params": [
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.proxy_name",
+          "secure": false,
+          "value": "STRING __HOSTNAME__"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.config_dir",
+          "secure": false,
+          "value": "STRING /opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.admin.user_id",
+          "secure": false,
+          "value": "STRING ats"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.server_ports",
+          "secure": false,
+          "value": "STRING 8080 8080:ipv6"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.insert_response_via_str",
+          "secure": false,
+          "value": "INT 3"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.parent_proxy_routing_enable",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.parent_proxy.retry_time",
+          "secure": false,
+          "value": "INT 60"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.connect_attempts_timeout",
+          "secure": false,
+          "value": "INT 10"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.cache.required_headers",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.enable_http_stats",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.dns.round_robin_nameservers",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.max_space_mb_for_logs",
+          "secure": false,
+          "value": "INT 512"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.max_space_mb_headroom",
+          "secure": false,
+          "value": "INT 50"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.log.logfile_dir",
+          "secure": false,
+          "value": "STRING /opt/trafficserver/var/log/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.reverse_proxy.enabled",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.diags.debug.enabled",
+          "secure": false,
+          "value": "INT 1"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.slow.log.threshold",
+          "secure": false,
+          "value": "INT 10000"
+        },
+        {
+          "configFile": "cache.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "hosting.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "parent.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "plugin.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "records.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "volume.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.url_remap.remap_required",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.threshold.queryTime",
+          "secure": false,
+          "value": "1000"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.polling.url",
+          "secure": false,
+          "value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Disk_Volume",
+          "secure": false,
+          "value": "1"
+        },
+        {
+          "configFile": "rascal.properties",
+          "name": "health.connection.timeout",
+          "secure": false,
+          "value": "2000"
+        },
+        {
+          "configFile": "chkconfig",
+          "name": "trafficserver",
+          "secure": false,
+          "value": "0:off\t1:off\t2:on\t3:on\t4:on\t5:on\t6:off"
+        },
+        {
+          "configFile": "regex_revalidate.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.exec_thread.autoconfig",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "allow_ip",
+          "secure": false,
+          "value": "127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "allow_ip6",
+          "secure": false,
+          "value": "::1/128,fc01:9400:1000:8::/64"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "path",
+          "secure": false,
+          "value": "_astats"
+        },
+        {
+          "configFile": "astats.config",
+          "name": "record_types",
+          "secure": false,
+          "value": "122"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.http.transaction_active_timeout_in",
+          "secure": false,
+          "value": "INT 0"
+        },
+        {
+          "configFile": "records.config",
+          "name": "CONFIG proxy.config.body_factory.template_sets_dir",
+          "secure": false,
+          "value": "STRING /opt/trafficserver/etc/trafficserver/body_factory"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Drive_Letters",
+          "secure": false,
+          "value": "cache"
+        },
+        {
+          "configFile": "ip_allow.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        },
+        {
+          "configFile": "storage.config",
+          "name": "Drive_Prefix",
+          "secure": false,
+          "value": "/var/trafficserver/"
+        },
+        {
+          "configFile": "set_dscp_0.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_10.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_12.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_14.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_18.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_20.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_22.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_26.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_28.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_30.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_34.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_36.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_38.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_8.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_16.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_24.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_32.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_40.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_48.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_56.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "set_dscp_37.config",
+          "name": "location",
+          "value": "/opt/trafficserver/etc/trafficserver/dscp"
+        },
+        {
+          "configFile": "package",
+          "lastUpdated": "2018-01-19T19:01:21.499423+00:00",
+          "name": "trafficserver",
+          "secure": true,
+          "value": "CHANGEME"
+        },
+        {
+          "configFile": "empty-file.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "non-empty-file.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver/"
+        },
+        {
+          "configFile": "non-empty-file.config",
+          "name": "foo",
+          "secure": false,
+          "value": "bar"
+        },
+        {
+          "configFile": "remap.config",
+          "name": "location",
+          "secure": false,
+          "value": "/opt/trafficserver/etc/trafficserver"
+        }
+      ]
+    },
+    {
       "cdnName": "cdn1",
       "description": "edge1 description",
       "lastUpdated": "2018-03-02T17:27:11.818418+00:00",
@@ -2179,6 +2640,106 @@
       "offlineReason": null,
       "physLocation": "Denver",
       "profile": "ATS_EDGE_TIER_CACHE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-03\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup2",
+      "cdnName": "cdn1",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-03-02",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "127.0.0.19/30",
+              "gateway": "127.0.0.19",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:d::10/64",
+              "gateway": "2345:1234:12:d::10",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "ATS_EDGE_TIER_CACHE",
+      "rack": "RR 119.02",
+      "revalPending": false,
+      "routerHostName": "",
+      "routerPortName": "",
+      "status": "REPORTED",
+      "tcpPort": 80,
+      "type": "EDGE",
+      "updPending": false,
+      "xmppId": "atlanta-edge-03\\\\@ocdn.kabletown.net",
+      "xmppPasswd": "X"
+    },
+    {
+      "cachegroup": "cachegroup2",
+      "cdnName": "cdn2",
+      "domainName": "ga.atlanta.kabletown.net",
+      "guid": null,
+      "hostName": "atlanta-edge-03-03",
+      "httpsPort": 443,
+      "iloIpAddress": "",
+      "iloIpGateway": "",
+      "iloIpNetmask": "",
+      "iloPassword": "",
+      "iloUsername": "",
+      "interfaces": [
+        {
+          "ipAddresses": [
+            {
+              "address": "127.0.0.20/30",
+              "gateway": "127.0.0.20",
+              "serviceAddress": true
+            },
+            {
+              "address": "2345:1234:12:d::11/64",
+              "gateway": "2345:1234:12:d::11",
+              "serviceAddress": false
+            }
+          ],
+          "maxBandwidth": null,
+          "monitor": true,
+          "mtu": 9000,
+          "name": "bond0"
+        }
+      ],
+      "lastUpdated": "2018-03-28T17:30:00.220351+00:00",
+      "mgmtIpAddress": "",
+      "mgmtIpGateway": "",
+      "mgmtIpNetmask": "",
+      "offlineReason": null,
+      "physLocation": "Denver",
+      "profile": "ATS_EDGE_TIER_CACHE_CDN2",
       "rack": "RR 119.02",
       "revalPending": false,
       "routerHostName": "",
@@ -4255,6 +4816,16 @@
           "parents": [
             0
           ]
+        }
+      ]
+    },
+    {
+      "name": "top-for-ds-cdn2",
+      "description": "a topology",
+      "nodes": [
+        {
+          "cachegroup": "cachegroup2",
+          "parents": []
         }
       ]
     }


### PR DESCRIPTION
Fixes t3c to invalidate cached objects if the request keys change, for example if a Server's CDN changes.

Without this, IMS requests are being issued, but for example, t3c gets the Server, and then gets the Server's Profile, and doesn't correctly invalidate a cached Profile if the Server's Profile changed (but the old Profile didn't). This resulted in old data being incorrectly used, and config generating incorrectly, which could be subtle (a Profile with a single records.config Parameter) or catastrophic (a server switched to a different CDN).

Includes tests.
Includes changelog.
No docs, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c so it stores a cache, change the server's CDN in Traffic Ops and run t3c again, verify remap.config domains are the new CDN.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0.0


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
