### PR TITLE
Fix json response for invalid invalidation job. Moved CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the DNSSEC refresh Traffic Ops API to only create a new change log entry if any keys were actually refreshed or an error occurred (in order to reduce changelog noise)
 - [#5927](https://github.com/apache/trafficcontrol/issues/5927) Updated CDN-in-a-Box to not run a Riak container by default but instead only run it if the optional flag is provided.
 - Traffic Portal no longer uses `ruby compass` to compile sass and now uses `dart-sass`.
+- Changed Invalidation Jobs throughout (TO, TP, T3C, etc.) to account for the ability to do both REFRESH and REFETCH requests for resources.
 
 ### Deprecated
 - Deprecated the endpoints and docs associated with `api_capability`.
@@ -172,7 +173,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - CDN in a Box now uses Apache Traffic Server 8.1.
 - Customer names in payloads sent to the `/deliveryservices/request` Traffic Ops API endpoint can no longer contain characters besides alphanumerics, @, !, #, $, %, ^, &amp;, *, (, ), [, ], '.', ' ', and '-'. This fixes a vulnerability that allowed email content injection.
 - Go version 1.17 is used to compile Traffic Ops, T3C, Traffic Monitor, Traffic Stats, and Grove.
-- Changed Invalidation Jobs throughout (TO, TP, T3C, etc.) to account for the ability to do both REFRESH and REFETCH requests for resources.
 
 ### Deprecated
 - The Riak Traffic Vault backend is now deprecated and its support may be removed in a future release. It is highly recommended to use the new PostgreSQL backend instead.

--- a/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
+++ b/traffic_ops/traffic_ops_golang/invalidationjobs/invalidationjobs.go
@@ -561,7 +561,8 @@ func CreateV40(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		api.HandleErr(w, r, inf.Tx.Tx, http.StatusBadRequest, errors.New(string(append(resp, '\n'))), fmt.Errorf("error validating job: %v", err))
+		w.WriteHeader(http.StatusBadRequest)
+		api.WriteAndLogErr(w, r, append(resp, '\n'))
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Addresses an issue discovered in testing the TO v4.0 `/jobs` endpoint. The validation of the incoming job was wrapping the alert and error response inside another alert and error response.

Incorrect response:
```json
{
  "alerts": [
    {
      "text": "{\"alerts\":[{\"text\":\"deliveryService: cannot be blank.\",\"level\":\"error\"}]}\n",
      "level": "error"
    }
  ]
}
```

Fixed response:
```json
{
  "alerts": [
    {
      "text": "deliveryService: cannot be blank.",
      "level": "error"
    }
  ]
}
```

Also moved a CHANGELOG entry for the _REFETCH_ feature into the correct location for the CHANGELOG.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Run Traffic Ops and attempt to *POST* a new invalidation request to the `/jobs` endpoint. The following json will trigger a validation error, alert response:
```json
{
	"startTime": "2021-11-05T16:24:00.370Z",
	"regex": "/path/to/some/content\\.jpg",
	"ttlHours": 24,
	"invalidationType": "REFRESH"
}
```

## PR submission checklist
- [ ] This PR has tests - Does not have a functional aspect, only asthetic.
- [ ] This PR has documentation - No documented logic is changed, added, or deleted.
- [x] This PR has a CHANGELOG.md entry 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
