### PR TITLE
Add warnings for Content Invalidation creation and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added definition for `heartbeat.polling.interval` for CDN Traffic Monitor config in API documentation.
 - New `pkg` script options, `-h`, `-s`, `-S`, and `-L`.
 - Added `Invalidation Type` (REFRESH or REFETCH) for invalidating content to Traffic Portal.
+- IMS warnings to Content Invalidation requests in Traffic Portal and documentation.
 
 ### Fixed
 - [#6197](https://github.com/apache/trafficcontrol/issues/6197) - TO `/deliveryservices/:id/routing` makes requests to all TRs instead of by CDN.

--- a/docs/source/admin/quick_howto/content_invalidation.rst
+++ b/docs/source/admin/quick_howto/content_invalidation.rst
@@ -22,7 +22,7 @@ Invalidating content on the CDN is sometimes necessary when the :term:`Origin` w
 
 .. impl-detail:: Given the size of a typical Traffic Control CDN and the amount of content that can be cached in it, removing the content from all the caches may take a long time. To speed up content invalidation, Traffic Control does not try to remove the content from the caches, but it makes the content inaccessible using the `regex_revalidate plugin for Apache Traffic Server <https://docs.trafficserver.apache.org/en/8.0.x/admin-guide/plugins/regex_revalidate.en.html>`_. This forces a "re-validation" of the content.
 
-.. Note:: This method forces :term:`cache servers` to "re-validate" content, so in order to work properly the :term:`Origin` needs to support revalidation according to section 13 of :rfc:`2616`.
+.. Warning:: This method forces :term:`cache servers` to "re-validate" content, so in order to work properly the :term:`Origin` needs to support revalidation according to section 4.3.2 of :rfc:`7234`.
 
 To invalidate content for a specific :term:`Delivery Service`, follow these steps:
 

--- a/docs/source/admin/traffic_portal/usingtrafficportal.rst
+++ b/docs/source/admin/traffic_portal/usingtrafficportal.rst
@@ -645,7 +645,11 @@ Tools
 
 Invalidate Content
 ------------------
-Here, specific assets can be invalidated in all caches of a :term:`Delivery Service`, forcing content to be updated from the origin. Specifically, this *doesn't* mean that :term:`cache servers` will immediately remove items from their caches, but rather will fetch new copies whenever a request is made matching the 'Asset URL' regular expression. This behavior persists until the Invalidate Content Job's :abbr:`TTL (Time To Live)` expires. Each entry in the table on this page has the following fields:
+Here, specific assets can be invalidated in all caches of a :term:`Delivery Service`, forcing content to be updated from the origin. Specifically, this *doesn't* mean that :term:`cache servers` will immediately remove items from their caches, but rather will fetch new copies whenever a request is made matching the 'Asset URL' regular expression. This behavior persists until the Invalidate Content Job's :abbr:`TTL (Time To Live)` expires.
+
+.. Warning:: This method forces :term:`cache servers` to "re-validate" content, so in order to work properly the :term:`Origin` needs to support revalidation according to section 4.3.2 of :rfc:`7234`.
+
+Each entry in the table on this page has the following fields:
 
 :term:`Delivery Service`: The :term:`Delivery Service` to which to apply this Invalidate Content Job
 :Asset URL:        A URL or regular expression which describes the asset(s) to be invalidated

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceJob/form.deliveryServiceJob.tpl.html
@@ -28,6 +28,12 @@ under the License.
         <div class="clearfix"></div>
     </div>
     <div class="x_content">
+        <div class="helptext">
+            <aside class="warning">
+                <h6>Warning</h6>
+                <p>Delivery service origin(s) must support IMS in order to safely invalidate content</p>
+            </aside>
+        </div>
         <br>
         <form name="jobForm" class="form-horizontal form-label-left" novalidate>
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.regex), 'has-feedback': hasError(jobForm.regex)}">

--- a/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/job/form.job.tpl.html
@@ -26,6 +26,12 @@ under the License.
         <div class="clearfix"></div>
     </div>
     <div class="x_content">
+        <div class="helptext">
+            <aside class="warning">
+                <h6>Warning</h6>
+                <p>Delivery service origin(s) must support IMS in order to safely invalidate content</p>
+            </aside>
+        </div>
         <br>
         <form name="jobForm" class="form-horizontal form-label-left" novalidate>
             <div class="form-group" ng-class="{'has-error': hasError(jobForm.deliveryservice), 'has-feedback': hasError(jobForm.deliveryservice)}">


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #5698

This is an aesthetic change to add information warnings related to Content Invalidation. Specifically, this is to notify a person using this feature that the Origin(s) for the Delivery Service should support IMS and other proper cache invalidation requirements as specified in RFC 7234, Section 4.3.2.

If an origin server were to be misconfigured and only return 200s, disregarding IMS headers, then a Content Invdalidation request may have unintended load consequences.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Portal

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Launch and run Traffic Ops and Traffic Portal. Manually verify there is a warning, of appropriate visual representation, when attempting to create a Content Invalidation job at:

`host.domain.tld/#!/jobs/new` endpoint

(Navigate _Tools_ -> _Invalidate Content_ -> _More_ dropdown -> _Create Invalidation Request_)

`host.domain.tld/#!/delivery-services/<id>/jobs/new` endpoint

(Navigate _Services_ -> _Delivery Services_ -> Select a DS -> _More_ dropdown -> _Manage Invalidation Requests_ -> _More_ downdown -> _Create Invalidation Request_)

Documentation for content invalidation was also updated to reference RFC 7234 in both content invalidation locations

[Using Traffic Portal - Invalidate Content](https://traffic-control-cdn.readthedocs.io/en/latest/admin/traffic_portal/usingtrafficportal.html#invalidate-content)

[Quick How-To - Content Invalidation](https://traffic-control-cdn.readthedocs.io/en/latest/admin/quick_howto/content_invalidation.html)


## PR submission checklist
- [ ] This PR has tests - Aesthetic changes only
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
