### PR TITLE
Fix nil panic from using var when err exists

### DIFF
--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -675,11 +675,11 @@ func (r *TrafficOpsReq) CheckRevalidateState(sleepOverride bool) (UpdateStatus, 
 	updateStatus := UpdateTropsNotNeeded
 
 	serverStatus, err := getUpdateStatus(r.Cfg)
-	log.Infof("my status: %s\n", serverStatus.Status)
 	if err != nil {
 		log.Errorln("getting update status: " + err.Error())
 		return UpdateTropsNotNeeded, errors.New("getting update status: " + err.Error())
 	}
+	log.Infof("my status: %s\n", serverStatus.Status)
 	if serverStatus.UseRevalPending == false {
 		log.Errorln("Update URL: Instant invalidate is not enabled.  Separated revalidation requires upgrading to Traffic Ops version 2.2 and enabling this feature.")
 		return UpdateTropsNotNeeded, nil


### PR DESCRIPTION
Fixes a t3c nil reference panic and crash when a Traffic Ops request fails. 

This is a very minor issue, because t3c is about to fail anyway, because it can't do anything if it can't get the data it needs from TO.

No tests, there's no reasonable way to test this with unit or integration tests. The existing tests ensure normal usage still works.
No docs, no interface change.
No changelog, this is so minor it'd just clutter the changelog, and it didn't cause an actual failure.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run t3c pointed to a TO that fails to connect, verify t3c logs and exits the failure without a panic.


## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0.0


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
