### PR TITLE
Updates the trafficcontrol-health-client RPM spec file.

### DIFF
--- a/tc-health-client/build/trafficcontrol-health-client.spec
+++ b/tc-health-client/build/trafficcontrol-health-client.spec
@@ -88,6 +88,9 @@ if [[ ! -d /var/log/trafficcontrol ]]; then
   touch /var/log/trafficcontrol/tc-health-client.log
 fi
 
+# make sure the service unit file is loaded
+systemctl daemon-reload
+
 if [[ ${was_active} = "yes" ]]; then
   systemctl start tc-health-client
 fi


### PR DESCRIPTION
Ensures** the systemd unit service file for the health-client is read following RPM installation by
running **systemctl daemon-reload** so that a restart may be done.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?

- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?

After loading the trafficcontrol-health-client RPM, the health client may be stopped, started, and restarted.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
