### PR TITLE
Changes the t3c process locking so that no two simultaneous t3c instances run.

### DIFF
--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -69,6 +69,9 @@ func main() {
 	} else if cfg == (config.Cfg{}) { // user used the --help option
 		os.Exit(Success)
 	}
+	if !lock.GetLock("/var/run/t3c.lock") {
+		os.Exit(AlreadyRunning)
+	}
 
 	if cfg.UseGit == config.UseGitYes {
 		err := util.EnsureConfigDirIsGitRepo(cfg)
@@ -103,11 +106,6 @@ func main() {
 	} else if !util.CleanTmpDir(cfg) {
 		log.Errorln("CleanTmpDir failed, cannot continue")
 		os.Exit(GeneralFailure)
-	}
-	if !cfg.ReportOnly {
-		if !lock.GetLock(config.TmpBase + "/to_ort.lock") {
-			os.Exit(AlreadyRunning)
-		}
 	}
 
 	log.Infoln(time.Now().Format(time.RFC3339))


### PR DESCRIPTION
Changes the t3c process locking so that no two simultaneous t3c instances run. The locking now occurs before t3c attempts logging into traffic ops.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?

- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?

Try to start two or more t3c-apply processes on the same machine.  Only one will run, the others should
exit with a log message indicating another t3c-apply process is already running.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
