### PR TITLE
Fix admin_all_permission down script invalid column

### DIFF
--- a/traffic_ops/app/db/migrations/2021111212042120_admin_all_permission.down.sql
+++ b/traffic_ops/app/db/migrations/2021111212042120_admin_all_permission.down.sql
@@ -41,5 +41,5 @@ WHERE "name" = 'admin'
 ON CONFLICT DO NOTHING;
 
 UPDATE public.role
-SET "description" = "Has access to everything."
+SET "description" = 'Has access to everything.'
 WHERE "name" = 'admin';


### PR DESCRIPTION
In #6324 the "down" script for the added migration has a bug where it specifies a (non-existent) column name instead of a string literal. This fixes that.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
1. Run all migrations
2. Roll back at least to before the admin_all_permission migration.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**