### PR TITLE
TO DB Tests: Always run db downgrades

### DIFF
--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -38,13 +38,13 @@ postgresql_package="$(<<<"postgresql${POSTGRES_VERSION}" sed 's/\.//g' |
 )"
 pg_isready=$(rpm -ql "$postgresql_package" | grep bin/pg_isready)
 if [[ ! -x "$pg_isready" ]] ; then
-    echo "Can't find pg_ready in ${postgresql_package}"
-    exit 1
+	echo "Can't find pg_ready in ${postgresql_package}"
+	exit 1
 fi
 
 while ! $pg_isready -h"$DB_SERVER" -p"$DB_PORT" -d "$DB_NAME"; do
-        echo "waiting for db on $DB_SERVER $DB_PORT"
-        sleep 3
+	echo "waiting for db on $DB_SERVER $DB_PORT"
+	sleep 3
 done
 
 echo "*:*:*:postgres:$DB_USER_PASS" > "${HOME}/.pgpass"
@@ -58,29 +58,29 @@ export GOPATH=/opt/traffic_ops/go
 
 # gets the current DB version. On success, output the version number. On failure, output a failure message starting with 'failed'.
 get_current_db_version() {
-    local dbversion_output
-    if ! dbversion_output="$(./db/admin --env=production dbversion 2>&1)"; then
-        echo "failed to get dbversion: $dbversion_output"
-        return
-    fi
-    local version=$(echo "$dbversion_output" | egrep '^dbversion [[:digit:]]+$' | awk '{print $2}')
-    if [[ -z "$version" ]]; then
-        echo "failed to get dbversion from output: $db_version_output"
-        return
-    fi
-    echo "$version"
+	local dbversion_output
+	if ! dbversion_output="$(./db/admin --env=production dbversion 2>&1)"; then
+		echo "failed to get dbversion: $dbversion_output"
+		return
+	fi
+	local version=$(echo "$dbversion_output" | egrep '^dbversion [[:digit:]]+$' | awk '{print $2}')
+	if [[ -z "$version" ]]; then
+		echo "failed to get dbversion from output: $db_version_output"
+		return
+	fi
+	echo "$version"
 }
 
 get_db_dumps() {
-    find /db_dumps -name '*.dump'
+	find /db_dumps -name '*.dump'
 }
 
 db_is_empty=true
 
 for d in $(get_db_dumps); do
-    db_is_empty=false
-    echo "checking integrity of DB dump: $d"
-    pg_restore -l "$d" > /dev/null || { echo "invalid DB dump: $d. Unable to list contents"; exit 1; }
+	db_is_empty=false
+	echo "checking integrity of DB dump: $d"
+	pg_restore -l "$d" > /dev/null || { echo "invalid DB dump: $d. Unable to list contents"; exit 1; }
 done
 
 cd "$TO_DIR"
@@ -93,8 +93,8 @@ fi
 
 # reset the DB if it is empty (i.e. no db.dump was provided)
 if [[ "$old_db_version" -eq 0 ]]; then
-    db_is_empty=true
-    ./db/admin --env=production reset || { echo "DB reset failed!"; exit 1; }
+	db_is_empty=true
+	./db/admin --env=production reset || { echo "DB reset failed!"; exit 1; }
 fi
 
 # applies migrations then performs seeding and patching
@@ -106,29 +106,28 @@ new_db_version=$(get_current_db_version)
 run_db_downgrades=true
 
 if [[ "$old_db_version" = "$new_db_version" ]]; then
-    echo "new DB version matches old DB version, no downgrade migrations to test"
-    run_db_downgrades=false
+	echo "new DB version matches old DB version, no downgrade migrations to test"
+	run_db_downgrades=false
 fi
 
 if [[ "$db_is_empty" = true ]]; then
-    echo "starting DB was empty, skipping DB downgrades"
-    run_db_downgrades=false
+	echo "starting DB was empty, skipping DB downgrades"
+	run_db_downgrades=false
 fi
 
 if [[ "$run_db_downgrades" = true ]]; then
-    # downgrade the DB until the initial DB version
-    while [[ "$new_db_version" != "$old_db_version" ]]; do
-        ./db/admin --env=production down || { echo "DB downgrade failed!"; exit 1; }
-        new_db_version=$(get_current_db_version)
-        [[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
-    done
+	# downgrade the DB until the initial DB version
+	while [[ "$new_db_version" != "$old_db_version" ]]; do
+		./db/admin --env=production down || { echo "DB downgrade failed!"; exit 1; }
+		new_db_version=$(get_current_db_version)
+		[[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
+	done
 fi
 
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do
-    echo "testing restoration of DB dump: $d"
-    dropdb --echo --if-exists "$DB_NAME" < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
-    createdb --echo < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
-    pg_restore --verbose --clean --if-exists --exit-on-error -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
+	echo "testing restoration of DB dump: $d"
+	dropdb --echo --if-exists "$DB_NAME" < "$d" > /dev/null || echo "Dropping DB ${DB_NAME} failed: $d"
+	createdb --echo < "$d" > /dev/null || echo "Creating DB ${DB_NAME} failed: $d"
+	pg_restore --verbose --clean --if-exists --exit-on-error -d "$DB_NAME" < "$d" > /dev/null || { echo "DB restoration failed: $d"; exit 1; }
 done
-

--- a/traffic_ops_db/test/docker/run-db-test.sh
+++ b/traffic_ops_db/test/docker/run-db-test.sh
@@ -103,26 +103,12 @@ fi
 new_db_version=$(get_current_db_version)
 [[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
 
-run_db_downgrades=true
-
-if [[ "$old_db_version" = "$new_db_version" ]]; then
-	echo "new DB version matches old DB version, no downgrade migrations to test"
-	run_db_downgrades=false
-fi
-
-if [[ "$db_is_empty" = true ]]; then
-	echo "starting DB was empty, skipping DB downgrades"
-	run_db_downgrades=false
-fi
-
-if [[ "$run_db_downgrades" = true ]]; then
-	# downgrade the DB until the initial DB version
-	while [[ "$new_db_version" != "$old_db_version" ]]; do
-		./db/admin --env=production down || { echo "DB downgrade failed!"; exit 1; }
-		new_db_version=$(get_current_db_version)
-		[[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
-	done
-fi
+# downgrade the DB until the initial DB version
+while [[ "$new_db_version" != "$old_db_version" ]]; do
+	./db/admin --env=production down || { echo "DB downgrade failed!"; exit 1; }
+	new_db_version=$(get_current_db_version)
+	[[ "$new_db_version" =~ ^failed ]] && { echo "get_current_db_version failed: $new_db_version"; exit 1; }
+done
 
 # test full restoration of the initial DB dump
 for d in $(get_db_dumps); do


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR makes it so that the Traffic Ops Database tests always test downgrading, even if no database dump is provided.
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops Database

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run the TO DB tests with no dump and verify that
- they pass
- they downgrade

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->