### PR TITLE
Handle `-` correctly in `traffic_vault_migrate`

### DIFF
--- a/traffic_ops/app/db/traffic_vault_migrate/riak.go
+++ b/traffic_ops/app/db/traffic_vault_migrate/riak.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/basho/riak-go-client"
 
+	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -281,7 +282,7 @@ func (tbl *riakSSLKeyTable) gatherKeys(cluster *riak.Cluster, timeout int) error
 		}
 		tbl.Records[i] = riakSSLKeyRecord{
 			DeliveryServiceSSLKeys: obj,
-			Version:                strings.Split(objs[0].Key, "-")[1],
+			Version:                objs[0].Key[strings.LastIndex(objs[0].Key, "-")+1:],
 		}
 	}
 	return nil
@@ -574,7 +575,9 @@ func getObjects(cluster *riak.Cluster, bucket string, timeout int) ([]*riak.Obje
 		if err != nil {
 			return nil, err
 		}
-		if len(objects) > 1 {
+		if len(objects) == 0 {
+			continue
+		} else if len(objects) > 1 {
 			return nil, fmt.Errorf("Unexpected number of objects %d\n", len(objects))
 		}
 
@@ -601,7 +604,7 @@ func getObject(cluster *riak.Cluster, bucket string, key string, timeout int) ([
 	rsp := fvc.Response
 
 	if rsp.IsNotFound {
-		return nil, fmt.Errorf("errors executing riak fetch value command; key not found: %s:%s", bucket, key)
+		log.Warnf("got no object for bucket: %v, key: %v\n", bucket, key)
 	}
 
 	return rsp.Values, nil


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Closes: #6348
Also changes it so when a orphaned key is found in Riak, a warning is output instead of halting with an error.


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Tools

## What is the best way to verify this PR?
Using Riak TV, create a CDN with a `-` in the name. Create child DS with SSL keys. Run the `traffic_vault_migrate` tool and either the version in postgres will be incorrect, or the insert query will fail due to duplicate inserts.

<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 6.0.1
- master


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
