### PR TITLE
Make t3c jobs work with previous TO 4.0

### DIFF
--- a/cache-config/t3c-request/config/config.go
+++ b/cache-config/t3c-request/config/config.go
@@ -170,9 +170,11 @@ func InitConfig() (Cfg, error) {
 	// load old config after initializing the loggers, because we want to log how long it takes
 	oldCfg, err := LoadOldCfg(*oldCfgPtr)
 	if err != nil {
-		return Cfg{}, errors.New("loading old config: " + err.Error())
+		log.Warnf("loading old config failed, old config will not be used! Error: %v\n", err)
+	} else {
+		log.Infof("using old config for IMS requests")
+		cfg.OldCfg = oldCfg
 	}
-	cfg.OldCfg = oldCfg
 
 	return cfg, nil
 }

--- a/cache-config/t3cutil/toreq/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/clientfuncs.go
@@ -531,6 +531,8 @@ func (cl *TOClient) GetJobs(reqHdr http.Header, cdnName string) ([]atscfg.Invali
 		opts := *ReqOpts(reqHdr)
 		opts.QueryParameters.Set("maxRevalDurationDays", "") // only get jobs with a start time within the window defined by the GLOBAL parameter 'maxRevalDurationDays'
 		opts.QueryParameters.Set("cdn", cdnName)             // only get jobs for delivery services in this server's CDN
+		// GetJobsCompat can be changed back to 'cl.c.GetInvalidationJobs' when backwards compatibility
+		// with Traffic Ops from previous ATS 'master' changesets is no longer desired, presumably after the next major ATC release.
 		toJobs, toReqInf, err := cl.GetJobsCompat(opts)
 		if err != nil {
 			return errors.New("getting jobs from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())

--- a/cache-config/t3cutil/toreq/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/clientfuncs.go
@@ -531,7 +531,7 @@ func (cl *TOClient) GetJobs(reqHdr http.Header, cdnName string) ([]atscfg.Invali
 		opts := *ReqOpts(reqHdr)
 		opts.QueryParameters.Set("maxRevalDurationDays", "") // only get jobs with a start time within the window defined by the GLOBAL parameter 'maxRevalDurationDays'
 		opts.QueryParameters.Set("cdn", cdnName)             // only get jobs for delivery services in this server's CDN
-		toJobs, toReqInf, err := cl.c.GetInvalidationJobs(opts)
+		toJobs, toReqInf, err := cl.GetJobsCompat(opts)
 		if err != nil {
 			return errors.New("getting jobs from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}

--- a/cache-config/t3cutil/toreq/conversions.go
+++ b/cache-config/t3cutil/toreq/conversions.go
@@ -20,8 +20,16 @@ package toreq
  */
 
 import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+	toclient "github.com/apache/trafficcontrol/traffic_ops/v4-client"
 )
 
 func serversToLatest(svs tc.ServersV4Response) ([]atscfg.Server, error) {
@@ -39,4 +47,94 @@ func dsesToLatest(dses []tc.DeliveryServiceV40) []atscfg.DeliveryService {
 
 func jobsToLatest(jobs []tc.InvalidationJobV4) []atscfg.InvalidationJob {
 	return atscfg.ToInvalidationJobs(jobs)
+}
+
+// GetJobsCompat gets jobs from any Traffic Ops built from the ATC `master` branch, and converts the different formats to the latest.
+// This makes t3c work with old or new Traffic Ops deployed from `master`,
+// though it doesn't make a version of t3c older than this work with a new TO,
+// which isn't logically possible from the client.
+func (cl *TOClient) GetJobsCompat(opts toclient.RequestOptions) (tc.InvalidationJobsResponseV4, toclientlib.ReqInf, error) {
+	path := "/jobs"
+
+	objs := struct {
+		Response []InvalidationJobV4PlusLegacy `json:"response"`
+		tc.Alerts
+	}{}
+
+	if len(opts.QueryParameters) > 0 {
+		path += "?" + opts.QueryParameters.Encode()
+	}
+	reqInf, err := cl.c.TOClient.Req(http.MethodGet, path, nil, opts.Header, &objs)
+	if err != nil {
+		return tc.InvalidationJobsResponseV4{}, reqInf, errors.New("request: " + err.Error())
+	}
+
+	resp := tc.InvalidationJobsResponseV4{Alerts: objs.Alerts}
+	for _, job := range objs.Response {
+		newJob, err := InvalidationJobV4FromLegacy(job) // (InvalidationJobV4, error) {
+		if err != nil {
+			return tc.InvalidationJobsResponseV4{}, reqInf, errors.New("converting job from possible legacy format: " + err.Error())
+		}
+		resp.Response = append(resp.Response, newJob)
+	}
+	return resp, reqInf, nil
+}
+
+// InvalidationJobV4ForLegacy is a type alias to prevent MarshalJSON recursion.
+type InvalidationJobV4ForLegacy tc.InvalidationJobV4
+
+// InvalidationJobV4PlusLegacy has the data to deserialize both the latest and older versions that Traffic Ops could return.
+type InvalidationJobV4PlusLegacy struct {
+	StartTime *string `json:"startTime"`
+	InvalidationJobV4ForLegacy
+	InvalidationJobV4Legacy
+}
+
+type InvalidationJobV4Legacy struct {
+	Keyword    *string `json:"keyword"`
+	Parameters *string `json:"parameters"`
+}
+
+func InvalidationJobV4FromLegacy(job InvalidationJobV4PlusLegacy) (tc.InvalidationJobV4, error) {
+	if job.StartTime != nil {
+		err := error(nil)
+		job.InvalidationJobV4ForLegacy.StartTime, err = time.Parse(atscfg.JobV4TimeFormat, *job.StartTime)
+		if err != nil {
+			job.InvalidationJobV4ForLegacy.StartTime, err = time.Parse(atscfg.JobLegacyTimeFormat, *job.StartTime)
+			if err != nil {
+				return tc.InvalidationJobV4{}, errors.New("malformed startTime")
+			}
+		}
+	}
+
+	if job.TTLHours == 0 && job.Parameters != nil {
+		params := *job.Parameters
+		params = strings.TrimSpace(params)
+		params = strings.ToLower(params)
+		params = strings.Replace(params, " ", "", -1)
+
+		paramPrefix := strings.ToLower(atscfg.JobLegacyParamPrefix)
+		paramSuffix := strings.ToLower(atscfg.JobLegacyParamSuffix)
+		if !strings.HasPrefix(params, paramPrefix) || !strings.HasSuffix(params, paramSuffix) {
+			return tc.InvalidationJobV4{}, errors.New("legacy job.Parameters was not nil, but unexpected format '" + params + "'")
+		}
+
+		hoursStr := params[len(paramPrefix) : len(params)-len(paramSuffix)]
+		hours, err := strconv.Atoi(hoursStr)
+		if err != nil {
+			return tc.InvalidationJobV4{}, errors.New("legacy job.Parameters was not nil, but hours not an integer: '" + params + "'")
+		}
+		job.TTLHours = uint(hours)
+	}
+
+	if job.InvalidationType == "" && job.Parameters != nil {
+		job.InvalidationType = tc.REFRESH
+	}
+	if strings.HasSuffix(job.AssetURL, atscfg.JobLegacyRefetchSuffix) {
+		job.InvalidationType = tc.REFETCH
+	}
+	job.AssetURL = strings.TrimSuffix(job.AssetURL, atscfg.JobLegacyRefreshSuffix)
+	job.AssetURL = strings.TrimSuffix(job.AssetURL, atscfg.JobLegacyRefetchSuffix)
+
+	return tc.InvalidationJobV4(job.InvalidationJobV4ForLegacy), nil
 }

--- a/cache-config/t3cutil/toreq/conversions.go
+++ b/cache-config/t3cutil/toreq/conversions.go
@@ -85,6 +85,13 @@ type InvalidationJobV4ForLegacy tc.InvalidationJobV4
 
 // InvalidationJobV4PlusLegacy has the data to deserialize both the latest and older versions that Traffic Ops could return.
 type InvalidationJobV4PlusLegacy struct {
+	// StartTime overrides the StartTime in InvalidationJobV4 in order to unmarshal any string format.
+	//
+	// A json.Unmarshal will place a 'startTime' value in this field,
+	// rather than the anonymous embedded InvalidationJobV4ForLegacy (tc.InvalidationJobV4).
+	//
+	// InvalidationJobV4FromLegacy will then parse multiple time formats that different Traffic Ops servers may return,
+	// and put the parsed time in tc.InvalidationJobV4.StartTime.
 	StartTime *string `json:"startTime"`
 	InvalidationJobV4ForLegacy
 	InvalidationJobV4Legacy

--- a/cache-config/testing/ort-tests/t3c-jobs_test.go
+++ b/cache-config/testing/ort-tests/t3c-jobs_test.go
@@ -1,0 +1,96 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+)
+
+func TestT3CJobs(t *testing.T) {
+	t.Logf("------------- Starting TestT3CJobs ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		now := tc.Time{Time: time.Now().Add(time.Minute)}
+		dsi := (interface{})("ds1")
+		ttli := (interface{})(72.0)
+		job := tc.InvalidationJobInput{
+			DeliveryService: &dsi,
+			Regex:           util.StrPtr(`/refetch-test\.png##REFETCH##`),
+			StartTime:       &now,
+			TTL:             &ttli,
+		}
+		if _, _, err := tcdata.TOSession.CreateInvalidationJob(job); err != nil {
+			t.Fatalf("ERROR: create refetch job failed: %v\n", err)
+		}
+		job.Regex = util.StrPtr(`/refresh-test\.png`)
+		if _, _, err := tcdata.TOSession.CreateInvalidationJob(job); err != nil {
+			t.Fatalf("ERROR: create refresh job failed: %v\n", err)
+		}
+
+		out, err := t3cUpdateWaitForParents("atlanta-edge-03", "badass", util.StrPtr("false"))
+		if err != nil {
+			t.Fatalf("ERROR: t3c badass failed: %v\n", err)
+		}
+		t.Log("TestT3CJobs t3c output: '''" + out + "'''")
+
+		fileName := filepath.Join(test_config_dir, "regex_revalidate.config")
+		revalFileBts, err := ioutil.ReadFile(fileName)
+		if err != nil {
+			t.Fatalf("reading %v: %v\n", fileName, err)
+		}
+		revalFile := string(revalFileBts)
+		lines := strings.Split(revalFile, "\n")
+		sawRefresh := false
+		sawRefetch := false
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue // blank lines are ok
+			}
+			if strings.Contains(line, "refresh-test") {
+				sawRefresh = true
+				if !strings.HasSuffix(line, "STALE") {
+					t.Errorf("expected regex_revalidate.config refresh-test line to contain 'STALE', actual '''%v'''", revalFile)
+				}
+			}
+			if strings.Contains(line, "refetch-test") {
+				sawRefetch = true
+				if !strings.HasSuffix(line, "MISS") {
+					t.Errorf("expected regex_revalidate.config refetch-test line to contain 'MISS', actual '''%v'''", revalFile)
+				}
+			}
+		}
+		if !sawRefresh {
+			t.Errorf("expected regex_revalidate.config to contain refresh-test, actual '''%v'''", revalFile)
+		}
+		if !sawRefetch {
+			t.Errorf("expected regex_revalidate.config to contain refetch-test, actual '''%v'''", revalFile)
+		}
+	})
+	t.Logf("------------- End of TestT3CJobs ---------------")
+}


### PR DESCRIPTION
Makes t3c apply invalidations from any Traffic Ops `master` changeset. 

Includes tests.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c against a TO with refresh and refetch invalidations from the old and new 4.0 endpoint changes, verify invalidation config files are created as expected. 

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
