### PR TITLE
Fix possible overflow in DNSSEC key parsing

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
@@ -242,7 +242,7 @@ func MakeDSRecordText(ksk tc.DNSSECKeyV11, ttl time.Duration) (string, error) {
 	publicKeyBts := make([]byte, publicKeyBtsLen)
 	publicKeyBtsLen, err := base64.StdEncoding.Decode(publicKeyBts, kskPublicBts)
 	if err != nil {
-		return "", errors.New("decoding ksk public key base64: " + err.Error())
+		return "", fmt.Errorf("decoding ksk public key base64: %w", err)
 	}
 	publicKeyBts = publicKeyBts[:publicKeyBtsLen]
 

--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec.go
@@ -253,13 +253,13 @@ func MakeDSRecordText(ksk tc.DNSSECKeyV11, ttl time.Duration) (string, error) {
 	}
 	flagsStr := fields[4]
 	protocolStr := fields[5]
-	flags, err := strconv.Atoi(flagsStr)
+	flags, err := strconv.ParseUint(flagsStr, 10, 16)
 	if err != nil {
-		return "", errors.New("malformed ksk public key: flags '" + flagsStr + "' not a number")
+		return "", fmt.Errorf("malformed ksk public key: can't parse flags '%s' as uint16: %w", flagsStr, err)
 	}
-	protocol, err := strconv.Atoi(protocolStr)
+	protocol, err := strconv.ParseUint(protocolStr, 10, 8)
 	if err != nil {
-		return "", errors.New("malformed ksk public key: protocol '" + protocolStr + "' not a number")
+		return "", fmt.Errorf("malformed ksk public key: can't parse protocol '%s' as uint8: %w", protocolStr, err)
 	}
 
 	realPublicKey := fields[7] // the Riak ksk.Public key is actually the RFC1035 single-line zone file format. For which the 7th field from 0 is the actual public key.

--- a/traffic_ops/traffic_ops_golang/deliveryservice/dnssec_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/dnssec_test.go
@@ -1,0 +1,85 @@
+package deliveryservice
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestMakeDSRecordText(t *testing.T) {
+	ksk := tc.DNSSECKeyV11{
+		DSRecord: &tc.DNSSECKeyDSRecordV11{
+			Algorithm:  7,
+			DigestType: 1,
+		},
+		Public: "",
+	}
+	_, err := MakeDSRecordText(ksk, 0)
+	if err == nil {
+		t.Error("Expected a blank 'Public' field to yield an error")
+	} else {
+		t.Logf("Got expected error from blank 'Public': %v", err)
+	}
+
+	ksk.Public = "not a base64 string"
+	_, err = MakeDSRecordText(ksk, 0)
+	if err == nil {
+		t.Error("Expected an invalid (non-base64-encoded-string) 'Public' field to yield an error")
+	} else {
+		t.Logf("Got expected error from non-base64 'Public': %v", err)
+	}
+
+	ksk.Public = base64.RawStdEncoding.EncodeToString([]byte("x x x x 4 5 x invalid! x"))
+	_, err = MakeDSRecordText(ksk, 0)
+	if err == nil {
+		t.Error("Expected an invalid (bad public key) 'Public' field to yield an error")
+	} else {
+		t.Logf("Got expected error from 'Public' with invalid public key: %v", err)
+	}
+
+	key := base64.StdEncoding.EncodeToString([]byte("This is a public key, I swear"))
+
+	ksk.Public = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("x x x x %d 5 x %s x", uint64(math.Pow(2, 16)+1), key)))
+	_, err = MakeDSRecordText(ksk, 0)
+	if err == nil {
+		t.Error("Expected a 'Public' field with a 'flags' too wide to fit in a uint16 to yield an error")
+	} else {
+		t.Logf("Got expected error from 'flags' too wide: %v", err)
+	}
+
+	ksk.Public = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("x x x x 4 %d x %s x", uint64(math.Pow(2, 8)+1), key)))
+	_, err = MakeDSRecordText(ksk, 0)
+	if err == nil {
+		t.Error("Expected a 'Public' field with a 'protocol' too wide to fit in a uint8 to yield an error")
+	} else {
+		t.Logf("Got expected error from 'protocol' too wide: %v", err)
+	}
+
+	ksk.Public = base64.StdEncoding.EncodeToString([]byte("x x x x 4 5 x " + key + " x"))
+	_, err = MakeDSRecordText(ksk, 0)
+	if err != nil {
+		t.Errorf("Unexpected error for a valid 'Public' field: %v", err)
+	}
+}


### PR DESCRIPTION
This adds checks to the parsing of DNSSEC keys that certain numbers are of the expected widths instead of truncating potentially overflowing values to smaller bit sizes.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make sure the tests pass

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**