### PR TITLE
Add t3c retrying app lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added definition for `heartbeat.polling.interval` for CDN Traffic Monitor config in API documentation.
 - New `pkg` script options, `-h`, `-s`, `-S`, and `-L`.
 - Added `Invalidation Type` (REFRESH or REFETCH) for invalidating content to Traffic Portal.
+- cache config t3c-apply retrying when another t3c-apply is running.
 - IMS warnings to Content Invalidation requests in Traffic Portal and documentation.
 - [#6032](https://github.com/apache/trafficcontrol/issues/6032) Add t3c setting mode 0600 for secure files
 

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -59,6 +59,10 @@ func runSysctl(cfg config.Cfg) {
 	}
 }
 
+const LockFilePath = "/var/run/t3c.lock"
+const LockFileRetryInterval = time.Second
+const LockFileRetryTimeout = time.Minute
+
 func main() {
 	var syncdsUpdate torequest.UpdateStatus
 	var lock util.FileLock
@@ -69,9 +73,16 @@ func main() {
 	} else if cfg == (config.Cfg{}) { // user used the --help option
 		os.Exit(Success)
 	}
-	if !lock.GetLock("/var/run/t3c.lock") {
-		os.Exit(AlreadyRunning)
+
+	log.Infoln("Trying to acquire app lock")
+	for lockStart := time.Now(); !lock.GetLock(LockFilePath); {
+		if time.Since(lockStart) > LockFileRetryTimeout {
+			log.Errorf("Failed to get app lock after %v seconds, another instance is running, exiting without running\n", int(LockFileRetryTimeout/time.Second))
+			os.Exit(AlreadyRunning)
+		}
+		time.Sleep(LockFileRetryInterval)
 	}
+	log.Infoln("Acquired app lock")
 
 	if cfg.UseGit == config.UseGitYes {
 		err := util.EnsureConfigDirIsGitRepo(cfg)

--- a/cache-config/t3c-apply/util/util.go
+++ b/cache-config/t3c-apply/util/util.go
@@ -81,7 +81,6 @@ func (f *FileLock) GetLock(lockFile string) bool {
 		return false
 	}
 	if !f.is_locked { // another process is running.
-		log.Errorf("Another t3c process is already running, try again later\n")
 		return false
 	}
 

--- a/cache-config/testing/ort-tests/t3c-lockfile_test.go
+++ b/cache-config/testing/ort-tests/t3c-lockfile_test.go
@@ -33,7 +33,7 @@ func TestLockfile(t *testing.T) {
 		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
 		tcdata.DeliveryServices}, func() {
 
-		hostName := "atlanta-edge-03"
+		const hostName = `atlanta-edge-03`
 		const fileName = `records.config`
 
 		firstOut := ""

--- a/cache-config/testing/ort-tests/t3c-lockfile_test.go
+++ b/cache-config/testing/ort-tests/t3c-lockfile_test.go
@@ -52,12 +52,12 @@ func TestLockfile(t *testing.T) {
 		out, code := t3cUpdateReload(hostName, "badass")
 		t.Logf("TestLockFile second t3c finished %v", time.Now())
 		if code != 0 {
-			t.Fatalf("second t3c apply badass failed: output '''%v''' code %v\n", out, code)
+			t.Fatalf("second t3c apply badass failed: output '''%v''' code %v", out, code)
 		}
 
 		wg.Wait()
 		if firstCode != 0 {
-			t.Fatalf("first t3c apply badass failed: output '''%v''' code %v\n", firstOut, firstCode)
+			t.Fatalf("first t3c apply badass failed: output '''%v''' code %v", firstOut, firstCode)
 		}
 
 		outStr := string(out)

--- a/cache-config/testing/ort-tests/t3c-lockfile_test.go
+++ b/cache-config/testing/ort-tests/t3c-lockfile_test.go
@@ -42,22 +42,22 @@ func TestLockfile(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			t.Logf("TestLockFile first t3c starting %v", time.Now())
+			t.Logf("TestLockFile first t3c starting %s", time.Now())
 			firstOut, firstCode = t3cUpdateReload(hostName, "badass")
-			t.Logf("TestLockFile first t3c finished %v", time.Now())
+			t.Logf("TestLockFile first t3c finished %s", time.Now())
 		}()
 
 		time.Sleep(time.Millisecond * 100) // sleep long enough to ensure the concurrent t3c starts
-		t.Logf("TestLockFile second t3c starting %v", time.Now())
+		t.Logf("TestLockFile second t3c starting %s", time.Now())
 		out, code := t3cUpdateReload(hostName, "badass")
-		t.Logf("TestLockFile second t3c finished %v", time.Now())
+		t.Logf("TestLockFile second t3c finished %s", time.Now())
 		if code != 0 {
-			t.Fatalf("second t3c apply badass failed: output '''%v''' code %v", out, code)
+			t.Fatalf("second t3c apply badass failed: output '''%s''' code %d", out, code)
 		}
 
 		wg.Wait()
 		if firstCode != 0 {
-			t.Fatalf("first t3c apply badass failed: output '''%v''' code %v", firstOut, firstCode)
+			t.Fatalf("first t3c apply badass failed: output '''%s''' code %d", firstOut, firstCode)
 		}
 
 		outStr := string(out)
@@ -76,7 +76,7 @@ func TestLockfile(t *testing.T) {
 		}
 
 		if acquireStartLine == "" || acquireEndLine == "" {
-			t.Fatalf("t3c apply output expected to contain 'Trying to acquire app lock' and 'Acquired app lock', actual: '''%v'''", out)
+			t.Fatalf("t3c apply output expected to contain 'Trying to acquire app lock' and 'Acquired app lock', actual: '''%s'''", out)
 		}
 
 		acquireStart := parseLogLineTime(acquireStartLine)
@@ -90,7 +90,7 @@ func TestLockfile(t *testing.T) {
 
 		minDiff := time.Second * 1 // checking the file lock should never take 1s, so that's enough to verify it was hit
 		if diff := acquireEnd.Sub(*acquireStart); diff < minDiff {
-			t.Fatalf("t3c apply expected time to acquire while another t3c is running to be at least %v, actual %v start line '%v' end line '%v'", minDiff, diff, acquireStartLine, acquireEndLine)
+			t.Fatalf("t3c apply expected time to acquire while another t3c is running to be at least %s, actual %s start line '%s' end line '%s'", minDiff, diff, acquireStartLine, acquireEndLine)
 		}
 
 		t.Logf(testName + " succeeded")

--- a/cache-config/testing/ort-tests/t3c-lockfile_test.go
+++ b/cache-config/testing/ort-tests/t3c-lockfile_test.go
@@ -1,0 +1,113 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+)
+
+func TestLockfile(t *testing.T) {
+	testName := "TestLockfile"
+	t.Logf("------------- Starting " + testName + " ---------------")
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters, tcdata.Statuses,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		hostName := "atlanta-edge-03"
+		const fileName = `records.config`
+
+		firstOut := ""
+		firstCode := 0
+		wg := sync.WaitGroup{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			t.Logf("TestLockFile first t3c starting %v", time.Now())
+			firstOut, firstCode = t3cUpdateReload(hostName, "badass")
+			t.Logf("TestLockFile first t3c finished %v", time.Now())
+		}()
+
+		time.Sleep(time.Millisecond * 100) // sleep long enough to ensure the concurrent t3c starts
+		t.Logf("TestLockFile second t3c starting %v", time.Now())
+		out, code := t3cUpdateReload(hostName, "badass")
+		t.Logf("TestLockFile second t3c finished %v", time.Now())
+		if code != 0 {
+			t.Fatalf("second t3c apply badass failed: output '''%v''' code %v\n", out, code)
+		}
+
+		wg.Wait()
+		if firstCode != 0 {
+			t.Fatalf("first t3c apply badass failed: output '''%v''' code %v\n", firstOut, firstCode)
+		}
+
+		outStr := string(out)
+		outLines := strings.Split(outStr, "\n")
+		acquireStartLine := ""
+		acquireEndLine := ""
+		for _, line := range outLines {
+			if strings.Contains(line, "Trying to acquire app lock") {
+				acquireStartLine = line
+			} else if strings.Contains(line, "Acquired app lock") {
+				acquireEndLine = line
+			}
+			if acquireStartLine != "" && acquireEndLine != "" {
+				break
+			}
+		}
+
+		if acquireStartLine == "" || acquireEndLine == "" {
+			t.Fatalf("t3c apply output expected to contain 'Trying to acquire app lock' and 'Acquired app lock', actual: '''%v'''", out)
+		}
+
+		acquireStart := parseLogLineTime(acquireStartLine)
+		if acquireStart == nil {
+			t.Fatalf("t3c apply acquire line failed to parse time, line '" + acquireStartLine + "'")
+		}
+		acquireEnd := parseLogLineTime(acquireEndLine)
+		if acquireEnd == nil {
+			t.Fatalf("t3c apply acquire line failed to parse time, line '" + acquireEndLine + "'")
+		}
+
+		minDiff := time.Second * 1 // checking the file lock should never take 1s, so that's enough to verify it was hit
+		if diff := acquireEnd.Sub(*acquireStart); diff < minDiff {
+			t.Fatalf("t3c apply expected time to acquire while another t3c is running to be at least %v, actual %v start line '%v' end line '%v'", minDiff, diff, acquireStartLine, acquireEndLine)
+		}
+
+		t.Logf(testName + " succeeded")
+	})
+	t.Logf("------------- End of " + testName + " ---------------")
+}
+
+func parseLogLineTime(line string) *time.Time {
+	fields := strings.Fields(line)
+	if len(fields) < 3 {
+		return nil
+	}
+	timeStr := fields[2]
+	timeStr = strings.TrimSuffix(timeStr, ":")
+	tm, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		return nil
+	}
+	return &tm
+}


### PR DESCRIPTION
Adds t3c retrying the app lock.

This allows operators to run multiple t3c instances on timers, such as for syncds and reval modes, and have them succeed when run around the same time.

It retries the lock every second for a minute. We can make that configurable in the future, but there are already a lot of config options, and if checking a file every second is a performance issue, or if t3c-apply takes more than a minute to run on even a very large CDN, the system is almost certainly in a very bad state. At this point we have so many options, I'd prefer to avoid adding new ones until necessary.

Includes tests.
Includes changelog.
No docs, no interface change, lockfile behavior isn't documented.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run multiple t3c-apply instances, verify the second runs after the first finishes.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
