### PR TITLE
Add flags to TV Riak util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `Invalidation Type` (REFRESH or REFETCH) for invalidating content to Traffic Portal.
 - IMS warnings to Content Invalidation requests in Traffic Portal and documentation.
 - [#6032](https://github.com/apache/trafficcontrol/issues/6032) Add t3c setting mode 0600 for secure files
+- Traffic Vault: Added additional flag to TV Riak (Deprecated) Util
 
 ### Fixed
 - [#6197](https://github.com/apache/trafficcontrol/issues/6197) - TO `/deliveryservices/:id/routing` makes requests to all TRs instead of by CDN.

--- a/docs/source/tools/traffic_vault_util.rst
+++ b/docs/source/tools/traffic_vault_util.rst
@@ -28,7 +28,7 @@ The ``traffic_vault_util`` tool - located at :file:`tools/traffic_vault_util.go`
 
 Usage
 =====
-``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT] [--skip_tls] [--server_name SERVER_NAME]``
+``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT] [--insecure] [--server_name SERVER_NAME]``
 
 .. option:: --dry_run
 
@@ -69,7 +69,7 @@ Usage
 
 	.. warning:: Although this flag is optional, the utility will not work without it. It will try, but it will fail\ [1]_.
 
-.. option:: --skip_tls
+.. option:: --insecure
 
 	An optional flag which, if given, specifies whether to utilize TLS certificate checks when establishing a connection. Defaults to false.
 

--- a/docs/source/tools/traffic_vault_util.rst
+++ b/docs/source/tools/traffic_vault_util.rst
@@ -28,7 +28,7 @@ The ``traffic_vault_util`` tool - located at :file:`tools/traffic_vault_util.go`
 
 Usage
 =====
-``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT] [--insecure] [--server_name SERVER_NAME]``
+``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT] [--insecure]``
 
 .. option:: --dry_run
 
@@ -72,9 +72,5 @@ Usage
 .. option:: --insecure
 
 	An optional flag which, if given, specifies whether to utilize TLS certificate checks when establishing a connection. Defaults to false.
-
-.. option:: --server_name
-
-	A dependent flag which is required if :option:`--skip_tls` is ``false``, otherwise optional. The server name is used to verify against TLS certificates.
 
 .. [1] These problems are all tracked by `GitHub Issue #3261 <https://github.com/apache/trafficcontrol/issues/3261>`_.

--- a/docs/source/tools/traffic_vault_util.rst
+++ b/docs/source/tools/traffic_vault_util.rst
@@ -28,7 +28,7 @@ The ``traffic_vault_util`` tool - located at :file:`tools/traffic_vault_util.go`
 
 Usage
 =====
-``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT]``
+``traffic_vault_util [--dry_run] --vault_ip IP --vault_action ACTION [--vault_user USER] [--vault_password PASSWD] [--vault_port PORT] [--skip_tls] [--server_name SERVER_NAME]``
 
 .. option:: --dry_run
 
@@ -68,5 +68,13 @@ Usage
 	An optional flag which, if given, specifies the name of the user as whom to connect to Riak.
 
 	.. warning:: Although this flag is optional, the utility will not work without it. It will try, but it will fail\ [1]_.
+
+.. option:: --skip_tls
+
+	An optional flag which, if given, specifies whether to utilize TLS certificate checks when establishing a connection. Defaults to false.
+
+.. option:: --server_name
+
+	A dependent flag which is required if :option:`--skip_tls` is ``false``, otherwise optional. The server name is used to verify against TLS certificates.
 
 .. [1] These problems are all tracked by `GitHub Issue #3261 <https://github.com/apache/trafficcontrol/issues/3261>`_.

--- a/tools/traffic_vault_util.go
+++ b/tools/traffic_vault_util.go
@@ -37,14 +37,14 @@ var vault_user string
 var vault_pass string
 var vault_action string
 var dry_run bool
-var skip_tls bool
+var insecure bool
 var server_name string
 
-func connectToRiak(vault_ip string, vault_port uint, skip_tls bool, server_name string) *riak.Cluster {
+func connectToRiak(vault_ip string, vault_port uint, insecure bool, server_name string) *riak.Cluster {
 
 	tlsConfig := tls.Config{
 		ServerName:         server_name,
-		InsecureSkipVerify: skip_tls,
+		InsecureSkipVerify: insecure,
 	}
 
 	authOptions := riak.AuthOptions{
@@ -220,7 +220,7 @@ func init() {
 	flag.StringVar(&vault_pass, "vault_password", "", "Riak Password")
 	flag.StringVar(&vault_action, "vault_action", "", "Action: list_buckets|list_keys|list_values|convert_ssl_to_xmlid")
 	flag.BoolVar(&dry_run, "dry_run", false, "Do not perform writes")
-	flag.BoolVar(&skip_tls, "skip_tls", false, "Disable TLS certificate checks when connecting to cluster. Defaults to false")
+	flag.BoolVar(&insecure, "skip_tls", false, "Disable TLS certificate checks when connecting to cluster. Defaults to false")
 	flag.StringVar(&server_name, "server_name", "", "Name of server. Required and must match TLS configuration if 'skip_tls' is false.")
 }
 
@@ -236,11 +236,11 @@ func main() {
 		log.Fatal("Must provide Traffic Vault IP or host")
 	}
 
-	if !skip_tls && len(server_name) == 0 {
+	if !insecure && len(server_name) == 0 {
 		log.Fatal("Must provide valid Server Name if requiring TLS. To skip TLS verification, utilize 'skip_tls' flag.")
 	}
 
-	cluster := connectToRiak(vault_ip, vault_port, skip_tls, server_name)
+	cluster := connectToRiak(vault_ip, vault_port, insecure, server_name)
 	defer func() {
 		if err := cluster.Stop(); err != nil {
 			log.Fatal(err.Error())

--- a/tools/traffic_vault_util.go
+++ b/tools/traffic_vault_util.go
@@ -38,12 +38,11 @@ var vault_pass string
 var vault_action string
 var dry_run bool
 var insecure bool
-var server_name string
 
-func connectToRiak(vault_ip string, vault_port uint, insecure bool, server_name string) *riak.Cluster {
+func connectToRiak(vault_ip string, vault_port uint, insecure bool) *riak.Cluster {
 
 	tlsConfig := tls.Config{
-		ServerName:         server_name,
+		ServerName:         vault_ip,
 		InsecureSkipVerify: insecure,
 	}
 
@@ -220,8 +219,7 @@ func init() {
 	flag.StringVar(&vault_pass, "vault_password", "", "Riak Password")
 	flag.StringVar(&vault_action, "vault_action", "", "Action: list_buckets|list_keys|list_values|convert_ssl_to_xmlid")
 	flag.BoolVar(&dry_run, "dry_run", false, "Do not perform writes")
-	flag.BoolVar(&insecure, "skip_tls", false, "Disable TLS certificate checks when connecting to cluster. Defaults to false")
-	flag.StringVar(&server_name, "server_name", "", "Name of server. Required and must match TLS configuration if 'skip_tls' is false.")
+	flag.BoolVar(&insecure, "insecure", false, "Disable TLS certificate checks when connecting to cluster. Defaults to false")
 }
 
 func main() {
@@ -236,11 +234,7 @@ func main() {
 		log.Fatal("Must provide Traffic Vault IP or host")
 	}
 
-	if !insecure && len(server_name) == 0 {
-		log.Fatal("Must provide valid Server Name if requiring TLS. To skip TLS verification, utilize 'skip_tls' flag.")
-	}
-
-	cluster := connectToRiak(vault_ip, vault_port, insecure, server_name)
+	cluster := connectToRiak(vault_ip, vault_port, insecure)
 	defer func() {
 		if err := cluster.Stop(); err != nil {
 			log.Fatal(err.Error())


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Tools - Traffic Vault Util

## What is the best way to verify this PR?
Attempt to connect to an instance of Riak with appropriate parameters. If, when used previously, the connection was to ignore TLS configuration, then pass the new `skip_tls=true` flag as a program argument. If TLS is required, then `server_name SERVER_NAME` will be also required to validate the TLS certificates.

Verify the documentation (Tools -> Traffic Vault Util) has the correct and appropriate changes.

## PR submission checklist
- [x] This PR has tests - No tests available against the tool.
- [x] This PR has documentation - Documentation was updated to reflect the changes
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
