### PR TITLE
Print single quote in heredoc in subshell for Bash 3 compatibility

### DIFF
--- a/pkg
+++ b/pkg
@@ -163,7 +163,7 @@ Usage: $SELF [options] [projects]
   -d           Disable compiler optimizations for debugging.
   -f <file>    Use <file> as the docker-compose. Default: $COMPOSE_FILE
   -h           Print help message and exit
-  -L           Don't write logs to files - respects output levels on stderr/stdout as set by -q/-v
+  -L           Don$(echo \')t write logs to files - respects output levels on stderr/stdout as set by -q/-v
   -l           List available projects.
   -o           Build from the optional list. Same as -f "$COMPOSE_FILE_OPT"
   -p           Pull builder Docker images, do not build them (default)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes an issue in the `pkg` script when using Bash 3 (as macOS does, since it is the last major version to use GPL 2 and they don't want to touch GPL 3). In Bash 3, a heredoc containing an unmatched single quote is a syntax error:
```
computer:trafficcontrol user$ ./pkg -v
./pkg: line 157: unexpected EOF while looking for matching `)'
./pkg: line 266: syntax error: unexpected end of file
```
which affects `pkg` because of this single quote: https://github.com/apache/trafficcontrol/blob/9516de39fffa3ddda0346720ef98edabc8efa07e/pkg#L166
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Build system <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Ensure `env bash --version` returns a 3.x.x version
2. Test `pkg` by building a package

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master (9516de39ff)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->