### PR TITLE
Update PUT user/current to work with v4 User Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6285](https://github.com/apache/trafficcontrol/issues/6285) - The Traffic Ops Postinstall script will work in CentOS 7, even if Python 3 is installed
 - [#5373](https://github.com/apache/trafficcontrol/issues/5373) - Traffic Monitor logs not consistent
 - Traffic Ops: Sanitize username before executing LDAP query
+- [#6367](https://github.com/apache/trafficcontrol/issues/6367) - Fix PUT `user/current` to work with v4 User Roles and Permissions
 
 ### Changed
 - Updated `t3c` to request less unnecessary deliveryservice-server assignment and invalidation jobs data via new query params supported by Traffic Ops

--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -317,7 +317,7 @@ type UserResponseV4 struct {
 // "undefined" values.
 type CurrentUserUpdateRequest struct {
 	// User, for whatever reason, contains all of the actual data.
-	User CurrentUserUpdateRequestUser `json:"user"`
+	User *CurrentUserUpdateRequestUser `json:"user"`
 }
 
 // CurrentUserUpdateRequestUser holds all of the actual data in a request to update the current user.

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -33,8 +33,6 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
-
-	"github.com/jmoiron/sqlx"
 )
 
 const replacePasswordQuery = `
@@ -169,7 +167,6 @@ WHERE u.id=$1
 
 func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 	var useV4User bool
-	var userV4 tc.UserV4
 	inf, userErr, sysErr, errCode := api.NewInfo(r, nil, nil)
 	tx := inf.Tx.Tx
 	if userErr != nil || sysErr != nil {
@@ -316,16 +313,7 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if useV4User {
-		userV4 = user.Upgrade()
-	}
-
-	if useV4User {
-		err = updateUserV4(userV4, inf.Tx)
-	} else {
-		err = updateUser(&user, tx, changePasswd, changeConfirmPasswd)
-	}
-	if err != nil {
+	if err = updateUser(&user, tx, changePasswd, changeConfirmPasswd); err != nil {
 		errCode = http.StatusInternalServerError
 		sysErr = fmt.Errorf("updating user: %v", err)
 		api.HandleErr(w, r, tx, errCode, nil, sysErr)
@@ -333,26 +321,10 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if useV4User {
-		api.WriteRespAlertObj(w, r, tc.SuccessLevel, "User profile was successfully updated", userV4)
+		api.WriteRespAlertObj(w, r, tc.SuccessLevel, "User profile was successfully updated", user.Upgrade())
 	} else {
 		api.WriteRespAlertObj(w, r, tc.SuccessLevel, "User profile was successfully updated", user)
 	}
-}
-
-func updateUserV4(u tc.UserV4, tx *sqlx.Tx) error {
-	resultRows, err := tx.NamedQuery(UpdateQueryV40(), u)
-	if err != nil {
-		return err
-	}
-	defer resultRows.Close()
-
-	for resultRows.Next() {
-		if err := resultRows.Scan(&u.LastUpdated, &u.Tenant, &u.Role); err != nil {
-			return err
-		}
-	}
-
-	return nil
 }
 
 func updateUser(u *tc.User, tx *sql.Tx, changePassword bool, changeConfirmPasswd bool) error {

--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -28,13 +28,13 @@ import (
 
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
-	"github.com/jmoiron/sqlx"
 
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/auth"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/dbhelpers"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/tenant"
-	//"github.com/jmoiron/sqlx"
+
+	"github.com/jmoiron/sqlx"
 )
 
 const replacePasswordQuery = `


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #6367

The `user/current` PUT requests appeared to be failing on v4 API calls. However after testing I was able to successfully change a current user's information, but the response did not display said information. This will fix the response to ensure the correct information is returned.

Additionally, a check was added to ensure the request was wrapped in a legacy `user{}` object.

Lastly, the API integration tests were checking for values to update by issuing an _update_ (PUT) request then performing a _read_ (GET) request. This appears to work as intended for all API versions, it was only the API response for v4.0 that was incorrect.

<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Ensure a valid user is created via the API with appropriate role (say _operations_):
````bash
curl --request POST \
  --url https://<traffic_ops_host>/api/4.0/users \
  --header 'Content-Type: application/json' \
  --data '{
	"addressLine1":"1234 Somewhere ln",
	"city":"Manhattan",
	"company":"Stihl",
	"confirmLocalPasswd":"passwdops",
	"country":"USA",
	"email":"john.frank@local.tld",
	"fullName":"John",
	"localPasswd":"passwdops",
	"phoneNumber":"555-123-4567",
	"postalCode":"10002",
	"role":"operations",
	"stateOrProvince":"New York",
	"username":"operations",
	"tenantId":1
}'
````

Then log in with said user:
````bash
curl --request POST \
  --url https://<traffic_ops_host>/api/4.0/user/login \
  --header 'Content-Type: application/json' \
  --data '{"u":"operations","p":"passwdops"}'
````

Send GET request to `user/current` to ensure correct user is returned

_Request_:
````bash
curl --request GET \
  --url https://<traffic_ops_host>/api/4.0/user/current/
````
_Response_:
````json
{
  "response": {
    "username": "operations",
    "localUser": true,
    "addressLine1": "1234 Somewhere ln",
    "addressLine2": null,
    "city": "Manhattan",
    "company": "Stihl",
    "country": "USA",
    "email": "john.frank@local.tld",
    "fullName": "John",
    "gid": null,
    "id": 89,
    "newUser": false,
    "phoneNumber": "555-123-4567",
    "postalCode": "10002",
    "publicSshKey": null,
    "role": "operations",
    "stateOrProvince": "New York",
    "tenant": "root",
    "tenantId": 1,
    "uid": null,
    "lastUpdated": "2021-12-01T14:13:14.261472-07:00",
    "lastAuthenticated": "2021-12-01T14:13:14.261472-07:00"
  }
}
````

Send PUT request to `user/current` with editable fields modified (say `addressLine1`, `city`, `country`, `postalCode` for example):
````bash
curl --request PUT \
  --url https://<traffic_ops_host>/api/4.0/user/current \
  --header 'Content-Type: application/json' \
  --data '{
	"user": {
		"username": "operations",
		"addressLine1": "5432 Somewhere ln",
		"addressLine2": null,
		"city": "Denver",
		"company": "Stihl",
		"country": "US",
		"email": "john.frank@local.tld",
		"fullName": "John",
		"id": 89,
		"phoneNumber": "555-123-4567",
		"postalCode": "80221",
		"publicSshKey": null,
		"role": "operations",
		"stateOrProvince": "New York",
		"tenant": "root",
		"tenantId": 1
	}
}'
````

Verify fields were updated correctly in the response:
````json
{
  "alerts": [
    {
      "text": "User profile was successfully updated",
      "level": "success"
    }
  ],
  "response": {
    "addressLine1": "5432 Somewhere ln",
    "addressLine2": null,
    "changeLogCount": null,
    "city": "Denver",
    "company": "Stihl",
    "country": "US",
    "email": "john.frank@local.tld",
    "fullName": "John",
    "gid": null,
    "id": 89,
    "lastAuthenticated": null,
    "lastUpdated": "2021-12-01T14:13:14.261472-07:00",
    "newUser": false,
    "phoneNumber": "555-123-4567",
    "postalCode": "80221",
    "publicSshKey": null,
    "registrationSent": null,
    "role": "operations",
    "stateOrProvince": "New York",
    "tenant": "root",
    "tenantId": 1,
    "uid": null,
    "username": "operations"
  }
}
````

Verify updated fields are also returned in GET `user/current` as well as GET `users/:id`

Perform the same above tests for API 3.0, *BUT* be aware that the `role` field must be a valid ID, not a string with API 3.0.

Lastly, attempt to send the body for a PUT request to `user/current` _without_ the `user` containing object. This can be done with either v4.0 or v3.x of the API. An appropriate error message should be returned.

_Request_:
````bash
curl --request PUT \
  --url https://<traffic_ops_host>/api/3.0/user/current \
  --header 'Content-Type: application/json' \
  --data '{
		"username": "operations",
		"addressLine1": "5432 Somewhere ln",
		"addressLine2": null,
		"city": "Denver",
		"company": "Stihl",
		"country": "US",
		"email": "john.frank@local.tld",
		"fullName": "John",
		"id": 89,
		"phoneNumber": "555-123-4567",
		"postalCode": "80212",
		"publicSshKey": null,
		"role": 2,
		"stateOrProvince": "Colorado",
		"tenant": "root",
		"tenantId": 1
}'
````

_Response_:
````json
{
  "alerts": [
    {
      "text": "missing required 'user' object",
      "level": "error"
    }
  ]
}
````

## PR submission checklist
- [X] This PR has tests - API tests exist and do validate functionality, only the v4.0 API response was invalid.
- [ ] This PR has documentation - No changes to documentation were necessary
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
