### PR TITLE
 Upgrade CDNs Traffic Portal view to use AG-Grid tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Monitors now peer with other Traffic Monitors of the same status (e.g. ONLINE with ONLINE, OFFLINE with OFFLINE), instead of all peering with ONLINE.
 - Added permissions to the role form in traffic portal
 - Updated the Cache Stats Traffic Portal page to use a more performant AG-Grid-based table.
+- Updated the CDNs Traffic Portal page to use a more performant AG-Grid-based table.
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/traffic_portal/app/src/common/modules/table/cdns/table.cdns.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cdns/table.cdns.tpl.html
@@ -18,34 +18,15 @@ under the License.
 -->
 
 <div class="x_panel">
-    <div class="x_title">
-        <ol class="breadcrumb pull-left">
-            <li class="active">CDNs</li>
-        </ol>
-        <div class="pull-right">
-            <button name="createCdnButton" class="btn btn-primary" title="Create CDN" ng-click="createCDN()"><i class="fa fa-plus"></i></button>
-            <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
-        </div>
-        <div class="clearfix"></div>
-    </div>
-    <div class="x_content">
-        <br>
-        <table id="cdnsTable" class="table responsive-utilities jambo_table">
-            <thead>
-                <tr class="headings">
-                    <th>Name</th>
-                    <th>Domain</th>
-                    <th>DNSSEC Enabled</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr ng-click="editCDN(cdn.id)" ng-repeat="cdn in ::cdns" context-menu="contextMenuItems">
-                    <td name="name" data-search="^{{::cdn.name}}$">{{::cdn.name}}</td>
-                    <td data-search="^{{::cdn.domainName}}$">{{::cdn.domainName}}</td>
-                    <td data-search="^{{::cdn.dnssecEnabled}}$">{{::cdn.dnssecEnabled}}</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
+	<common-grid-controller
+		title="CDNs"
+		table-name="cdns"
+		options="gridOptions"
+		data="cdns"
+		columns="columns"
+		drop-down-options="dropDownOptions"
+		context-menu-options="contextMenuOptions"
+		default-data="defaultData"
+	>
+	</common-grid-controller>
 </div>
-

--- a/traffic_portal/test/integration/Data/cdn.ts
+++ b/traffic_portal/test/integration/Data/cdn.ts
@@ -26,12 +26,6 @@ export const cdns = {
 					password: "pa$$word"
 				}
 			],
-			check: [
-				{
-					description: "check CSV link from CDN page",
-					Name: "Export as CSV"
-				}
-			],
 			add: [
 				{
 					description: "create a CDN",
@@ -98,12 +92,6 @@ export const cdns = {
 					password: "pa$$word"
 				}
 			],
-			check: [
-				{
-					description: "check CSV link from CDN page",
-					Name: "Export as CSV"
-				}
-			],
 			add: [
 				{
 					description: "create a CDN",
@@ -153,12 +141,6 @@ export const cdns = {
 					description: "Operation Role",
 					username: "TPOperator",
 					password: "pa$$word"
-				}
-			],
-			check: [
-				{
-					description: "check CSV link from CDN page",
-					Name: "Export as CSV"
 				}
 			],
 			add: [

--- a/traffic_portal/test/integration/specs/CDNs.spec.ts
+++ b/traffic_portal/test/integration/specs/CDNs.spec.ts
@@ -16,11 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { browser } from 'protractor';
+import { browser } from "protractor";
 
-import { LoginPage } from '../PageObjects/LoginPage.po'
-import { CDNPage } from '../PageObjects/CDNPage.po';
-import { TopNavigationPage } from '../PageObjects/TopNavigationPage.po';
+import { LoginPage } from "../PageObjects/LoginPage.po"
+import { CDNPage } from "../PageObjects/CDNPage.po";
+import { TopNavigationPage } from "../PageObjects/TopNavigationPage.po";
 import { cdns } from "../Data";
 
 
@@ -29,44 +29,37 @@ const topNavigation = new TopNavigationPage();
 const cdnsPage = new CDNPage();
 
 cdns.tests.forEach(async cdnsData =>{
-    cdnsData.logins.forEach(login => {
-        describe('Traffic Portal - CDN - ' + login.description, function(){
-            it('can login', async () => {
-                browser.get(browser.params.baseUrl);
-                await loginPage.Login(login);
-                expect(await loginPage.CheckUserName(login)).toBeTruthy();
-            });
-            it('can open CDN page', async () => {
-                await cdnsPage.OpenCDNsPage();
-            });
-             cdnsData.check.forEach(check => {
-                 it(check.description, async () => {
-                     expect(await cdnsPage.CheckCSV(check.Name)).toBe(true);
-                     await cdnsPage.OpenCDNsPage();
-                 });
-            });
-            cdnsData.add.forEach(add => {
-                it(add.description, async () => {
-                    expect(await cdnsPage.CreateCDN(add)).toBeTruthy();
-                    await cdnsPage.OpenCDNsPage();
-                });
-            });
-            cdnsData.update.forEach(update => {
-                it(update.description, async () => {
-                    await cdnsPage.SearchCDN(update.Name);
-                    expect(await cdnsPage.UpdateCDN(update)).toBeTruthy();
-                });
-            });
-            cdnsData.remove.forEach(remove => {
-                it(remove.description, async () => {
-                    await cdnsPage.SearchCDN(remove.Name);
-                    expect(await cdnsPage.DeleteCDN(remove)).toBeTruthy();
-
-                });
-            });
-            it('can logout', async () => {
-                expect(await topNavigation.Logout()).toBeTruthy();
-            });
-        });
-    });
+	for (const login of cdnsData.logins) {
+		describe(`Traffic Portal - CDN - ${login.description}`, () =>{
+			beforeAll(async () => {
+				browser.get(browser.params.baseUrl);
+				await loginPage.Login(login);
+				expect(await loginPage.CheckUserName(login)).toBeTruthy();
+				await cdnsPage.openCDNsPage();
+			});
+			afterAll(async ()=>{
+				expect(await topNavigation.Logout()).toBeTruthy();
+			});
+			afterEach(async ()=> {
+				await cdnsPage.openCDNsPage();
+			});
+			for (const add of cdnsData.add) {
+				it(add.description, async () => {
+					expect(await cdnsPage.createCDN(add)).toBeTruthy();
+				});
+			}
+			for (const update of cdnsData.update) {
+				it(update.description, async () => {
+					await cdnsPage.searchCDN(update.Name);
+					expect(await cdnsPage.updateCDN(update)).toBeTruthy();
+				});
+			}
+			for (const remove of cdnsData.remove) {
+				it(remove.description, async () => {
+					await cdnsPage.searchCDN(remove.Name);
+					expect(await cdnsPage.deleteCDN(remove.Name, remove.validationMessage)).toBeTruthy();
+				});
+			}
+		});
+	}
 });


### PR DESCRIPTION
This closes #6471.

This updates the "CDNs" Traffic Portal page to use AG-Grid instead of JQuery datatables. It's mostly a drop-in replacement, except for two things.

- A column for CDN ID and another for "Last Updated" have been added - the data was always available but just not shown previously. They're both hidden by default to preserve the old table's structure a bit more.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure all the TP tests pass, make sure the new table looks okay. There are a lot of context menu options, so I checked a few of those out, they seem to all be working okay.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**