### PR TITLE
Fix t3c version in build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - cache config t3c-apply retrying when another t3c-apply is running.
 - IMS warnings to Content Invalidation requests in Traffic Portal and documentation.
 - [#6032](https://github.com/apache/trafficcontrol/issues/6032) Add t3c setting mode 0600 for secure files
+- [#6405](https://github.com/apache/trafficcontrol/issues/6405) Added cache config version to all t3c apps and config file headers
 - Traffic Vault: Added additional flag to TV Riak (Deprecated) Util
 
 ### Fixed

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -42,6 +42,8 @@ t3c-apply [-2AbceFhIknopsSvW] [-a service-action] [-f \<all|reval|none\>] [-g \<
 
 [\-\-help]
 
+[\-\-version]
+
 # DESCRIPTION
 
 The t3c-apply command is a transliteration of traffic_ops_ort.pl script to the go language. It is designed to replace the traffic_ops_ort.pl perl script and it is used to apply configuration from Traffic Control, stored in Traffic Ops, to the cache.
@@ -93,6 +95,10 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
                     Whether to set the records.config via header to the ATS
                     release from the RPM. Default true.
+
+-E, -\-version
+
+                    Print version information and exit.
 
 -f, -\-files=value  [all | reval]
 

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -31,6 +31,14 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 // exit codes
 const (
 	Success           = 0
@@ -66,7 +74,7 @@ const LockFileRetryTimeout = time.Minute
 func main() {
 	var syncdsUpdate torequest.UpdateStatus
 	var lock util.FileLock
-	cfg, err := config.GetCfg()
+	cfg, err := config.GetCfg(Version, GitRevision)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(ConfigError)

--- a/cache-config/t3c-check-refs/README.md
+++ b/cache-config/t3c-check-refs/README.md
@@ -43,6 +43,8 @@ t3c-check-refs [-c directory] [-d location] [-e location] [-f files] [-i locatio
 
 [\-\-help]
 
+[\-\-version]
+
 ## DESCRIPTION
 
 The t3c-check-refs app will read an ATS formatted plugin.config or remap.config
@@ -89,6 +91,10 @@ supplied, t3c-check-refs reads its config file input from stdin.
     Log verbosity. Logging is output to stderr. By default,
     errors are logged. To log warnings, pass '-v'. To log info,
     pass '-vv'. To omit error logging, see '-s'.
+
+-V, -\-version
+
+    Print version information and exit.
 
 ## EXIT CODES
 

--- a/cache-config/t3c-check-refs/t3c-check-refs.go
+++ b/cache-config/t3c-check-refs/t3c-check-refs.go
@@ -33,6 +33,14 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 var (
 	cfg          config.Cfg
 	atsPlugins   = make(map[string]int)
@@ -241,7 +249,7 @@ func main() {
 	pluginErrorCount := 0
 
 	var err error
-	cfg, err = config.InitConfig()
+	cfg, err = config.InitConfig(Version, GitRevision)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		os.Exit(1)

--- a/cache-config/t3c-check-reload/README.md
+++ b/cache-config/t3c-check-reload/README.md
@@ -43,6 +43,8 @@ t3c-check-reload
 
 [\-\-help]
 
+[\-\-version]
+
 # DESCRIPTION
 
 The t3c-check-reload app takes json input from stdin.
@@ -62,11 +64,16 @@ Possible return values are:
 # JSON Format
 
     {"changed_files":"<list of files>","installed_plugins":"<list of plugins>"}
+
 # OPTIONS
--h, --help
+
+-h, -\-help
 
     Print usage information and exit
 
+-V, -\-version
+
+    Print version information and exit.
 
 # AUTHORS
 

--- a/cache-config/t3c-check-reload/t3c-check-reload.go
+++ b/cache-config/t3c-check-reload/t3c-check-reload.go
@@ -30,15 +30,29 @@ import (
 	"github.com/pborman/getopt/v2"
 )
 
+const AppName = "t3c-check-reload"
+
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 func main() {
 	// presumably calculated by by t3c-check-refs
 	// TODO remove? The blueprint says t3c/ORT will no longer install packages
 
+	version := getopt.BoolLong("version", 'V', "Print version information and exit.")
 	help := getopt.BoolLong("help", 'h', "Print usage information and exit")
 	getopt.Parse()
 
 	if *help {
 		fmt.Println(usageStr())
+		os.Exit(0)
+	} else if *version {
+		fmt.Println(t3cutil.VersionStr(AppName, Version, GitRevision))
 		os.Exit(0)
 	}
 

--- a/cache-config/t3c-check/README.md
+++ b/cache-config/t3c-check/README.md
@@ -42,6 +42,8 @@ t3c-check \<command\> [\<args\>]
 
 [\-\-help]
 
+[\-\-version]
+
 # DESCRIPTION
 
 The t3c-check application has commands for checking things about new config files, such as
@@ -60,6 +62,15 @@ t3c-check-reload
 t3c-check-refs
 
     Check if a config file's referenced plugins and files are valid
+
+# OPTIONS
+-h, -\-help
+
+    Print usage information and exit
+
+-V, -\-version
+
+    Print version information and exit.
 
 # AUTHORS
 

--- a/cache-config/t3c-check/t3c-check.go
+++ b/cache-config/t3c-check/t3c-check.go
@@ -20,13 +20,26 @@ package main
  */
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-log"
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall" // TODO change to x/unix ?
 
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/lib/go-log"
+
 	"github.com/pborman/getopt/v2"
 )
+
+const AppName = "t3c-check"
+
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
 
 var commands = map[string]struct{}{
 	"refs":   {},
@@ -42,10 +55,14 @@ const ExitCodeCommandLookupErr = 5
 
 func main() {
 	flagHelp := getopt.BoolLong("help", 'h', "Print usage information and exit")
+	flagVersion := getopt.BoolLong("version", 'V', "Print version information and exit.")
 	getopt.Parse()
 	log.Init(os.Stderr, os.Stderr, os.Stderr, os.Stderr, os.Stderr)
 	if *flagHelp {
 		log.Errorln(usageStr())
+		os.Exit(ExitCodeSuccess)
+	} else if *flagVersion {
+		fmt.Println(t3cutil.VersionStr(AppName, Version, GitRevision))
 		os.Exit(ExitCodeSuccess)
 	}
 

--- a/cache-config/t3c-diff/README.md
+++ b/cache-config/t3c-diff/README.md
@@ -42,6 +42,8 @@ t3c-diff \<file-a\> \<file-a\>
 
 [\-\-help]
 
+[\-\-version]
+
 # DESCRIPTION
 
 The t3c-diff application compares configuration files with semantic context, omitting comments and other semantically irrelevant text.
@@ -58,9 +60,13 @@ if the file being created or deleted is semantically empty.
 
 # OPTIONS
 
--h, --help
+-h, -\-help
 
     Print usage info and exit.
+
+-V, -\-version
+
+    Print version information and exit.
 
 # AUTHORS
 

--- a/cache-config/t3c-diff/t3c-diff.go
+++ b/cache-config/t3c-diff/t3c-diff.go
@@ -34,8 +34,19 @@ import (
 	"github.com/pborman/getopt/v2"
 )
 
+const AppName = "t3c-diff"
+
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 func main() {
 	help := getopt.BoolLong("help", 'h', "Print usage info and exit")
+	version := getopt.BoolLong("version", 'V', "Print version information and exit")
 	lineComment := getopt.StringLong("line_comment", 'l', "#", "Comment symbol")
 	mode := getopt.IntLong("file-mode", 'm', 0644, "file mode default is 644")
 	fa := getopt.StringLong("file-a", 'a', "", "first diff file")
@@ -46,6 +57,9 @@ func main() {
 
 	if *help {
 		log.Errorln(usageStr)
+		os.Exit(0)
+	} else if *version {
+		fmt.Println(t3cutil.VersionStr(AppName, Version, GitRevision))
 		os.Exit(0)
 	}
 

--- a/cache-config/t3c-generate/cfgfile/all.go
+++ b/cache-config/t3c-generate/cfgfile/all.go
@@ -36,7 +36,6 @@ import (
 // GetAllConfigs gets all config files for cfg.CacheHostName.
 func GetAllConfigs(
 	toData *t3cutil.ConfigData,
-	appVersion string,
 	cfg config.Cfg,
 ) ([]t3cutil.ATSConfigFile, error) {
 	if toData.Server.HostName == nil {
@@ -50,7 +49,7 @@ func GetAllConfigs(
 	}
 
 	genTime := time.Now()
-	hdrCommentTxt := makeHeaderComment(*toData.Server.HostName, appVersion, toData.TrafficOpsURL, toData.TrafficOpsAddresses, genTime)
+	hdrCommentTxt := makeHeaderComment(*toData.Server.HostName, cfg.AppVersion(), toData.TrafficOpsURL, toData.TrafficOpsAddresses, genTime)
 
 	hasSSLMultiCertConfig := false
 	configs := []t3cutil.ATSConfigFile{}

--- a/cache-config/t3c-generate/cfgfile/cfgfile_test.go
+++ b/cache-config/t3c-generate/cfgfile/cfgfile_test.go
@@ -91,7 +91,7 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 	cfg.Dir = cfgPath
 	cfg.RevalOnly = revalOnly
 
-	configs, err := GetAllConfigs(toData, "", cfg)
+	configs, err := GetAllConfigs(toData, cfg)
 	if err != nil {
 		t.Fatalf("error getting configs: " + err.Error())
 	}
@@ -103,7 +103,7 @@ func TestGetAllConfigsWriteConfigsDeterministic(t *testing.T) {
 	configStr = removeComments(configStr)
 
 	for i := 0; i < 10; i++ {
-		configs2, err := GetAllConfigs(toData, "", cfg)
+		configs2, err := GetAllConfigs(toData, cfg)
 		if err != nil {
 			t.Fatalf("error getting configs2: " + err.Error())
 		}

--- a/cache-config/t3c-generate/t3c-generate.go
+++ b/cache-config/t3c-generate/t3c-generate.go
@@ -35,8 +35,16 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 func main() {
-	cfg, err := config.GetCfg()
+	cfg, err := config.GetCfg(Version, GitRevision)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Getting config: "+err.Error()+"\n")
 		os.Exit(config.ExitCodeErrGeneric)
@@ -80,7 +88,7 @@ func main() {
 	// 	os.Exit(config.ExitCodeErrGeneric)
 	// }
 
-	configs, err := cfgfile.GetAllConfigs(toData, config.AppVersion, cfg)
+	configs, err := cfgfile.GetAllConfigs(toData, cfg)
 	if err != nil {
 		log.Errorln("Getting config for'" + *toData.Server.HostName + "': " + err.Error())
 		os.Exit(config.ExitCodeErrGeneric)

--- a/cache-config/t3c-preprocess/README.md
+++ b/cache-config/t3c-preprocess/README.md
@@ -40,6 +40,10 @@ t3c-preprocess - Traffic Control Cache Configuration preprocessor
 
 t3c-preprocess
 
+[\-\-help]
+
+[\-\-version]
+
 # DESCRIPTION
 
 The 't3c-preprocess' app preprocesses generated config files, replacing directives with relevant data.
@@ -63,6 +67,16 @@ The following directives will be replaced. These directives may be placed anywhe
 
     __RETURN__          is replaced with a newline character, and any whitespace before or after
                         it is removed.
+
+# OPTIONS
+
+-h, -\-help
+
+    Print usage information and exit
+
+-V, -\-version
+
+    Print version information and exit.
 
 # AUTHORS
 

--- a/cache-config/t3c-request/README.md
+++ b/cache-config/t3c-request/README.md
@@ -42,6 +42,8 @@ t3c-request [-hIprv] [-D \<config|update-status|packages|chkconfig|system-info|s
 
 [\-\-help]
 
+[\-\-version]
+
 # DESCRIPTION
 
   The t3c-request app is used get update status, package information, linux

--- a/cache-config/t3c-request/t3c-request.go
+++ b/cache-config/t3c-request/t3c-request.go
@@ -29,8 +29,16 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
+
 func main() {
-	cfg, err := config.InitConfig()
+	cfg, err := config.InitConfig(Version, GitRevision)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		os.Exit(1)
@@ -44,7 +52,7 @@ func main() {
 		cfg.TOPass,
 		cfg.TOInsecure,
 		cfg.TOTimeoutMS,
-		cfg.UserAgent,
+		cfg.UserAgent(),
 	)
 	if err != nil {
 		log.Errorf("%s\n", err)

--- a/cache-config/t3c-update/README.md
+++ b/cache-config/t3c-update/README.md
@@ -53,34 +53,34 @@ t3c-update [-ahIqv] [-d value] [-e value] [-H value] [-i value] [-l value] [-P v
 
 # OPTIONS
 
--a, --set-reval-status
+-a, -\-set-reval-status
 
     [true | false] sets the servers revalidate status (required)
 
--H, --cache-host-name=value
+-H, -\-cache-host-name=value
 
     Host name of the cache to generate config for. Must be the
     server host name in Traffic Ops, not a URL, and not the FQDN
 
--h, --help
+-h, -\-help
 
     Print usage information and exit
 
--I, --traffic-ops-insecure
+-I, -\-traffic-ops-insecure
 
     [true | false] ignore certificate errors from Traffic Ops
 
--l, --login-dispersion=value
+-l, -\-login-dispersion=value
 
     [seconds] wait a random number of seconds between 0 and
     [seconds] before login to traffic ops, default 0
 
--P, --traffic-ops-password=value
+-P, -\-traffic-ops-password=value
 
     Traffic Ops password. Required. May also be set with the
     environment variable TO_PASS
 
--q, --set-update-status
+-q, -\-set-update-status
 
     [true | false] sets the servers update status (required)
 
@@ -90,18 +90,18 @@ t3c-update [-ahIqv] [-d value] [-e value] [-H value] [-i value] [-l value] [-P v
     ignored. If a fatal error occurs, the return code will be
     non-zero but no text will be output to stderr
 
--t, --traffic-ops-timeout-milliseconds=value
+-t, -\-traffic-ops-timeout-milliseconds=value
 
     Timeout in milli-seconds for Traffic Ops requests, default
     is 30000 [30000]
 
--u, --traffic-ops-url=value
+-u, -\-traffic-ops-url=value
 
     Traffic Ops URL. Must be the full URL, including the scheme.
     Required. May also be set with     the environment variable
     TO_URL
 
--U, --traffic-ops-user=value
+-U, -\-traffic-ops-user=value
 
     Traffic Ops username. Required. May also be set with the
     environment variable TO_USER
@@ -112,7 +112,7 @@ t3c-update [-ahIqv] [-d value] [-e value] [-H value] [-i value] [-l value] [-P v
     errors are logged. To log warnings, pass '-v'. To log info,
     pass '-vv'. To omit error logging, see '-s'.
 
--V, --version
+-V, -\-version
 
     Print the version and exit
 

--- a/cache-config/t3c-update/t3c-update.go
+++ b/cache-config/t3c-update/t3c-update.go
@@ -30,14 +30,16 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
-var (
-	cfg config.Cfg
-)
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
 
 func main() {
-	var err error
-
-	cfg, err = config.InitConfig()
+	cfg, err := config.InitConfig(Version, GitRevision)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "ERROR: %s\n", err.Error())
 		os.Exit(1)
@@ -51,7 +53,7 @@ func main() {
 		cfg.TOPass,
 		cfg.TOInsecure,
 		cfg.TOTimeoutMS,
-		cfg.UserAgent,
+		cfg.UserAgent(),
 	)
 	if err != nil {
 		log.Errorf("%s\n", err)

--- a/cache-config/t3c/README.md
+++ b/cache-config/t3c/README.md
@@ -38,8 +38,11 @@ t3c - Traffic Control Cache Configuration tools
 
 # SYNOPSIS
 
-t3c [\-\-help]
-    \<command\> [\<args\>]
+t3c \<command\> [\<args\>]
+
+[\-\-help]
+
+[\-\-version]
 
 # DESCRIPTION
 
@@ -51,8 +54,13 @@ The latest version and documentation can be found at https://github.com/apache/t
 
 # OPTIONS
 
-\-\-help
+-h, -\-help
+
     Prints the synopsis and usage information.
+
+-V, -\-version
+
+    Print the version and exit
 
 # COMMANDS
 

--- a/cache-config/t3c/t3c.go
+++ b/cache-config/t3c/t3c.go
@@ -20,13 +20,26 @@ package main
  */
 
 import (
-	"github.com/apache/trafficcontrol/lib/go-log"
+	"fmt"
 	"os"
 	"os/exec"
 	"syscall" // TODO change to x/unix ?
 
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/lib/go-log"
+
 	"github.com/pborman/getopt/v2"
 )
+
+const AppName = "t3c-check"
+
+// Version is the application version.
+// This is overwritten by the build with the current project version.
+var Version = "0.4"
+
+// GitRevision is the git revision the application was built from.
+// This is overwritten by the build with the current project version.
+var GitRevision = "nogit"
 
 var commands = map[string]struct{}{
 	"apply":      struct{}{},
@@ -47,10 +60,14 @@ const ExitCodeCommandLookupErr = 5
 
 func main() {
 	flagHelp := getopt.BoolLong("help", 'h', "Print usage information and exit")
+	flagVersion := getopt.BoolLong("version", 'V', "Print version information and exit.")
 	getopt.Parse()
 	log.Init(os.Stderr, os.Stderr, os.Stderr, os.Stderr, os.Stderr)
 	if *flagHelp {
 		log.Errorln(usageStr())
+		os.Exit(ExitCodeSuccess)
+	} else if *flagVersion {
+		fmt.Println(t3cutil.VersionStr(AppName, Version, GitRevision))
 		os.Exit(ExitCodeSuccess)
 	}
 

--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -196,3 +196,20 @@ func ValidateURL(u *url.URL) error {
 	}
 	return nil
 }
+
+// VersionStr returns a common version string format for all t3c apps.
+// The appName is the command itself, e.g. t3c-apply.
+// The versionNum is the version number from the build system. It should include the major, minor, git revision, and a monotonically increasing number, e.g. '4.2.1234.abc123'.
+func VersionStr(appName string, versionNum string, gitRevision string) string {
+	if len(gitRevision) > 8 {
+		gitRevision = gitRevision[:8]
+	}
+	return appName + " " + versionNum + ".." + gitRevision
+}
+
+func UserAgentStr(appName string, versionNum string, gitRevision string) string {
+	if len(gitRevision) > 8 {
+		gitRevision = gitRevision[:8]
+	}
+	return appName + "/" + versionNum + ".." + gitRevision
+}


### PR DESCRIPTION
Fixes the t3c build to properly add the ATC version, changeset,
and monotonic version to the t3c version commands,
as well as to t3c-generate generated files.

Also adds the version flag to apps that were missing it.

I see this as a pretty big win for operations. Every time I install a new t3c version, the first thing I do is run it, and look at how the config files changed. Because production runs are on a schedule, it's difficult or impossible to figure out which exact git commit was the first new version run. This makes it easy to see in the file headers.

Includes changelog
Includes docs
Includes tests

Labelling `improvement` rather than `bug`, because even though some code existed the feature has never worked.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Install `trafficcontrol-cache-config`, run `t3c-* --version`, verify version matches ATC version and includes git changeset.
Run t3c, verify config file comment headers include ATC/RPM version and changeset.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
