### PR TITLE
Remove t3c unused code

### DIFF
--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -62,13 +62,12 @@ type TrafficOpsReq struct {
 	changedFiles  []string            // list of config files which were changed
 
 	configFiles          map[string]*ConfigFile
-	TrafficCtlReload     bool   // a traffic_ctl_reload is required
-	SysCtlReload         bool   // a reload of the sysctl.conf is required
-	NtpdRestart          bool   // ntpd needs restarting
-	TeakdRestart         bool   // a restart of teakd is required
-	TrafficServerRestart bool   // a trafficserver restart is required
-	RemapConfigReload    bool   // remap.config should be reloaded
-	unixTimeStr          string // unix time string at program startup.
+	TrafficCtlReload     bool // a traffic_ctl_reload is required
+	SysCtlReload         bool // a reload of the sysctl.conf is required
+	NtpdRestart          bool // ntpd needs restarting
+	TeakdRestart         bool // a restart of teakd is required
+	TrafficServerRestart bool // a trafficserver restart is required
+	RemapConfigReload    bool // remap.config should be reloaded
 }
 
 type ShouldReloadRestart struct {
@@ -180,8 +179,6 @@ func (r *TrafficOpsReq) DumpConfigFiles() {
 
 // NewTrafficOpsReq returns a new TrafficOpsReq object.
 func NewTrafficOpsReq(cfg config.Cfg) *TrafficOpsReq {
-	unixTimeString := strconv.FormatInt(time.Now().Unix(), 10)
-
 	return &TrafficOpsReq{
 		Cfg:           cfg,
 		pkgs:          map[string]bool{},
@@ -189,7 +186,6 @@ func NewTrafficOpsReq(cfg config.Cfg) *TrafficOpsReq {
 		configFiles:   map[string]*ConfigFile{},
 		installedPkgs: map[string]struct{}{},
 		pluginPkgs:    map[string]struct{}{},
-		unixTimeStr:   unixTimeString,
 	}
 }
 

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -792,24 +792,17 @@ func (r *TrafficOpsReq) CheckSyncDSState() (UpdateStatus, error) {
 }
 
 // CheckReloadRestart determines the final reload/restart state after all config files are processed.
-func (r *TrafficOpsReq) CheckReloadRestart(data []FileRestartData) (bool, bool, bool, bool, bool, bool) {
-	trafficCtlReload := false
-	sysCtlReload := false
-	ntpdRestart := false
-	teakdRestart := false
-	trafficServerRestart := false
-	remapConfigReload := false
-
+func (r *TrafficOpsReq) CheckReloadRestart(data []FileRestartData) RestartData {
+	rd := RestartData{}
 	for _, changedFile := range data {
-		trafficCtlReload = trafficCtlReload || changedFile.TrafficCtlReload
-		sysCtlReload = sysCtlReload || changedFile.SysCtlReload
-		ntpdRestart = ntpdRestart || changedFile.NtpdRestart
-		teakdRestart = teakdRestart || changedFile.TeakdRestart
-		trafficServerRestart = trafficServerRestart || changedFile.TrafficServerRestart
-		remapConfigReload = remapConfigReload || changedFile.RemapConfigReload
+		rd.TrafficCtlReload = rd.TrafficCtlReload || changedFile.TrafficCtlReload
+		rd.SysCtlReload = rd.SysCtlReload || changedFile.SysCtlReload
+		rd.NtpdRestart = rd.NtpdRestart || changedFile.NtpdRestart
+		rd.TeakdRestart = rd.TeakdRestart || changedFile.TeakdRestart
+		rd.TrafficServerRestart = rd.TrafficServerRestart || changedFile.TrafficServerRestart
+		rd.RemapConfigReload = rd.RemapConfigReload || changedFile.RemapConfigReload
 	}
-
-	return trafficCtlReload, sysCtlReload, ntpdRestart, teakdRestart, trafficServerRestart, remapConfigReload
+	return rd
 }
 
 // ProcessConfigFiles processes all config files retrieved from Traffic Ops.
@@ -881,7 +874,7 @@ func (r *TrafficOpsReq) ProcessConfigFiles() (UpdateStatus, error) {
 		}
 	}
 
-	r.TrafficCtlReload, r.SysCtlReload, r.NtpdRestart, r.TeakdRestart, r.TrafficServerRestart, r.RemapConfigReload = r.CheckReloadRestart(shouldRestartReload.ReloadRestart)
+	r.RestartData = r.CheckReloadRestart(shouldRestartReload.ReloadRestart)
 
 	if 0 < len(r.changedFiles) {
 		log.Infof("Final state: remap.config: %t reload: %t restart: %t ntpd: %t sysctl: %t", r.RemapConfigReload, r.TrafficCtlReload, r.TrafficServerRestart, r.NtpdRestart, r.SysCtlReload)


### PR DESCRIPTION
This is a tech-debt change, removes unused variables and de-duplicates fields. No behavioral change.

No tests, doesn't change behavior, existing behavior is covered by tests.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests, run t3c, verify behavior is unchanged.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist

- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
