### PR TITLE
Remove t3c unused plugin symbols

### DIFF
--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -334,11 +334,10 @@ func checkRefs(cfg config.Cfg, cfgFile []byte, filesAdding []string) error {
 }
 
 // checkReload is a helper for the sub-command t3c-check-reload.
-func checkReload(pluginPackagesInstalled []string, changedConfigFiles []string) (t3cutil.ServiceNeeds, error) {
-	log.Infof("t3c-check-reload calling with pluginPackagesInstalled '%v' changedConfigFiles '%v'\n", pluginPackagesInstalled, changedConfigFiles)
+func checkReload(changedConfigFiles []string) (t3cutil.ServiceNeeds, error) {
+	log.Infof("t3c-check-reload calling with changedConfigFiles '%v'\n", changedConfigFiles)
 
 	changedFiles := []byte(strings.Join(changedConfigFiles, ","))
-	installedPlugins := []byte(strings.Join(pluginPackagesInstalled, ","))
 
 	cmd := exec.Command(`t3c-check-reload`)
 	outBuf := bytes.Buffer{}
@@ -359,10 +358,6 @@ func checkReload(pluginPackagesInstalled []string, changedConfigFiles []string) 
 		return t3cutil.ServiceNeedsInvalid, errors.New("writing opening json to input: " + err.Error())
 	} else if _, err := stdinPipe.Write(changedFiles); err != nil {
 		return t3cutil.ServiceNeedsInvalid, errors.New("writing changed files to input: " + err.Error())
-	} else if _, err := stdinPipe.Write([]byte(`","installed_plugins":"`)); err != nil {
-		return t3cutil.ServiceNeedsInvalid, errors.New("writing installed_plugins key to input: " + err.Error())
-	} else if _, err := stdinPipe.Write(installedPlugins); err != nil {
-		return t3cutil.ServiceNeedsInvalid, errors.New("writing plugins to input: " + err.Error())
 	} else if _, err := stdinPipe.Write([]byte(`"}`)); err != nil {
 		return t3cutil.ServiceNeedsInvalid, errors.New("writing closing json input: " + err.Error())
 	} else if err := stdinPipe.Close(); err != nil {

--- a/cache-config/t3c-check-reload/t3c-check-reload.go
+++ b/cache-config/t3c-check-reload/t3c-check-reload.go
@@ -65,29 +65,16 @@ func main() {
 	changedConfigFiles = StrMap(changedConfigFiles, strings.TrimSpace)
 	changedConfigFiles = StrRemoveIf(changedConfigFiles, StrIsEmpty)
 
-	// TODO determine if determining which installed packages were plugins should be part of this app's job?
-	// Probably not, because whatever told the installer to install them already knew that,
-	// we shouldn't re-calculate it.
-
-	pluginPackagesInstalled := strings.Split(changedCfg.InstalledPlugins, ",")
-	pluginPackagesInstalled = StrMap(pluginPackagesInstalled, strings.TrimSpace)
-	pluginPackagesInstalled = StrRemoveIf(pluginPackagesInstalled, StrIsEmpty)
-
 	// ATS restart is needed if:
 	// [x] 1. mode was badass
-	// [x] 2. any ATS Plugin was installed
-	// [x] 3. plugin.config or 50-ats.rules was changed
-	// [ ] 4. package 'trafficserver' was installed
+	// [x] 2. plugin.config or 50-ats.rules was changed
+	// [ ] 3. package 'trafficserver' was installed
 
 	// ATS reload is needed if:
 	// [ ] 1. new SSL keys were installed AND ssl_multicert.config was changed
 	// [ ] 2. any of the following were changed: url_sig*, uri_signing*, hdr_rw*, (plugin.config), (50-ats.rules),
 	//        ssl/*.cer, ssl/*.key, anything else in /trafficserver,
 	//
-
-	if len(pluginPackagesInstalled) > 0 {
-		ExitRestart()
-	}
 
 	for _, fileRequiringRestart := range configFilesRequiringRestart {
 		for _, changedPath := range changedConfigFiles {
@@ -118,8 +105,7 @@ func main() {
 }
 
 type ChangedCfg struct {
-	ChangedFiles     string `json:"changed_files"`
-	InstalledPlugins string `json:"installed_plugins"`
+	ChangedFiles string `json:"changed_files"`
 }
 
 // ExitRestart returns the "needs restart" message and exits.
@@ -168,5 +154,6 @@ func StrIsEmpty(str string) bool { return str == "" }
 func usageStr() string {
 	return `usage: t3c-check-reload [--help]
 Accepts json data from stdin in in the following format:
-{"changed_files":"<comma separated list of files>","installed_plugins":"<comma separated list of plugins>"}`
+{"changed_files":"<comma separated list of files>"}
+`
 }


### PR DESCRIPTION
t3c wasn't sending the list of installed plugins to t3c-check-reload
like it's designed to take, but that was actually unnecessary,
because installed plugins always require a restart, but syncds
never installs plugins, and badass always restarts. So the entire
check served no purpose.

No new tests, existing tests cover the behavior, and this doesn't change behavior, just removes unused code.
No docs, no interface change.
No changelog, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify behavior is unchanged.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix

## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
