### PR TITLE
Fix TM stats_over_http parsing to sum DS data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6259](https://github.com/apache/trafficcontrol/issues/6259) - Traffic Portal No Longer Allows Spaces in Server Object "Router Port Name"
 - [#6392](https://github.com/apache/trafficcontrol/issues/6392) - Traffic Ops prevents assigning ORG servers to topology-based delivery services (as well as a number of other valid operations being prohibited by "last server assigned to DS" validations which don't apply to topology-based delivery services)
 - [#6175](https://github.com/apache/trafficcontrol/issues/6175) - POST request to /api/4.0/phys_locations accepts mismatch values for regionName.
+- Fixed Traffic Monitor parsing stats_over_http output so that multiple stats for the same underlying delivery service (when the delivery service has more than 1 regex) are properly summed together. This makes the resulting data more accurate in addition to fixing the "new stat is lower than last stat" warnings.
 - [#6285](https://github.com/apache/trafficcontrol/issues/6285) - The Traffic Ops Postinstall script will work in CentOS 7, even if Python 3 is installed
 - [#5373](https://github.com/apache/trafficcontrol/issues/5373) - Traffic Monitor logs not consistent
 - Traffic Ops: Sanitize username before executing LDAP query

--- a/traffic_monitor/cache/astats.go
+++ b/traffic_monitor/cache/astats.go
@@ -139,7 +139,7 @@ func astatsPrecompute(cacheName string, data todata.TOData, stats Statistics, mi
 
 	var err error
 	for stat, value := range miscStats {
-		dsStats, err = astatsProcessStat(cacheName, dsStats, data, stat, value)
+		dsStats, err = astatsProcessStat(dsStats, data, stat, value)
 		if err != nil && err != dsdata.ErrNotProcessedStat {
 			log.Infof("precomputing cache %s stat %s value %v error %v", cacheName, stat, value, err)
 			precomputed.Errors = append(precomputed.Errors, err)
@@ -153,7 +153,7 @@ func astatsPrecompute(cacheName string, data todata.TOData, stats Statistics, mi
 
 // astatsProcessStat and its subsidiary functions act as a State Machine,
 // flowing the stat through states for each "." component of the stat name.
-func astatsProcessStat(server string, stats map[string]*DSStat, toData todata.TOData, stat string, value interface{}) (map[string]*DSStat, error) {
+func astatsProcessStat(stats map[string]*DSStat, toData todata.TOData, stat string, value interface{}) (map[string]*DSStat, error) {
 	parts := strings.Split(stat, ".")
 	if len(parts) < 1 {
 		return stats, fmt.Errorf("stat has no initial part")
@@ -161,7 +161,7 @@ func astatsProcessStat(server string, stats map[string]*DSStat, toData todata.TO
 
 	switch parts[0] {
 	case "plugin":
-		return astatsProcessStatPlugin(server, stats, toData, stat, parts[1:], value)
+		return astatsProcessStatPlugin(stats, toData, parts[1:], value)
 	case "proxy":
 		fallthrough
 	case "server":
@@ -173,19 +173,19 @@ func astatsProcessStat(server string, stats map[string]*DSStat, toData todata.TO
 	}
 }
 
-func astatsProcessStatPlugin(server string, stats map[string]*DSStat, toData todata.TOData, stat string, statParts []string, value interface{}) (map[string]*DSStat, error) {
+func astatsProcessStatPlugin(stats map[string]*DSStat, toData todata.TOData, statParts []string, value interface{}) (map[string]*DSStat, error) {
 	if len(statParts) < 1 {
 		return stats, fmt.Errorf("stat has no plugin part")
 	}
 	switch statParts[0] {
 	case "remap_stats":
-		return astatsProcessStatPluginRemapStats(server, stats, toData, stat, statParts[1:], value)
+		return astatsProcessStatPluginRemapStats(stats, toData, statParts[1:], value)
 	default:
 		return stats, fmt.Errorf("stat has unknown plugin part '%s'", statParts[0])
 	}
 }
 
-func astatsProcessStatPluginRemapStats(server string, stats map[string]*DSStat, toData todata.TOData, stat string, statParts []string, value interface{}) (map[string]*DSStat, error) {
+func astatsProcessStatPluginRemapStats(stats map[string]*DSStat, toData todata.TOData, statParts []string, value interface{}) (map[string]*DSStat, error) {
 	if len(statParts) < 3 {
 		return stats, fmt.Errorf("stat has no remap_stats deliveryservice and name parts")
 	}

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -280,7 +280,7 @@ func (handler Handler) Handle(id string, rdr io.Reader, format string, reqTime t
 	}
 
 	if reqErr != nil {
-		log.Warnf("%v handler given error '%v'\n", id, reqErr) // error here, in case the thing that called Handle didn't error
+		log.Warnf("%s handler given error: %s", id, reqErr.Error()) // error here, in case the thing that called Handle didn't error
 		result.Error = reqErr
 		handler.resultChan <- result
 		return

--- a/traffic_monitor/cache/stats_over_http.go
+++ b/traffic_monitor/cache/stats_over_http.go
@@ -343,7 +343,7 @@ func parseNumericStat(value interface{}) (uint64, error) {
 		if value.(int64) < 0 {
 			return 0, errors.New("value was negative")
 		}
-		return uint64(value.(uint64)), nil
+		return value.(uint64), nil
 	case float64:
 		if value.(float64) > math.MaxUint64 || value.(float64) < 0 {
 			return 0, errors.New("value out of range for uint64")
@@ -356,7 +356,7 @@ func parseNumericStat(value interface{}) (uint64, error) {
 		return uint64(value.(float64)), nil
 	case string:
 		if statVal, err := strconv.ParseUint(value.(string), 10, 64); err != nil {
-			return 0, fmt.Errorf("Could not parse '%v' to uint64: %v", value, err)
+			return 0, fmt.Errorf("could not parse '%v' to uint64: %v", value, err)
 		} else {
 			return statVal, nil
 		}
@@ -421,17 +421,17 @@ func statsOverHTTPPrecompute(cacheName string, data todata.TOData, stats Statist
 
 			switch statParts[len(statParts)-1] {
 			case "status_2xx":
-				dsStat.Status2xx = parsedStat
+				dsStat.Status2xx += parsedStat
 			case "status_3xx":
-				dsStat.Status3xx = parsedStat
+				dsStat.Status3xx += parsedStat
 			case "status_4xx":
-				dsStat.Status4xx = parsedStat
+				dsStat.Status4xx += parsedStat
 			case "status_5xx":
-				dsStat.Status5xx = parsedStat
+				dsStat.Status5xx += parsedStat
 			case "out_bytes":
-				dsStat.OutBytes = parsedStat
+				dsStat.OutBytes += parsedStat
 			case "in_bytes":
-				dsStat.InBytes = parsedStat
+				dsStat.InBytes += parsedStat
 			default:
 				err = fmt.Errorf("Unknown stat '%s'", statParts[len(statParts)-1])
 				log.Infof("precomputing cache %s stat %s value %v error %v", cacheName, stat, value, err)

--- a/traffic_monitor/ds/stat_test.go
+++ b/traffic_monitor/ds/stat_test.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"regexp"
 	"testing"
-	"time"
 
 	tc_log "github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
@@ -60,7 +59,6 @@ func TestCreateStats(t *testing.T) {
 	toData := getMockTOData()
 	combinedCRStates := peer.NewCRStatesThreadsafe()
 	lastStatsThs := threadsafe.NewLastStats()
-	now := time.Now()
 	maxEvents := uint64(4)
 	events := health.NewThreadsafeEvents(maxEvents)
 	localCRStates := peer.NewCRStatesThreadsafe()
@@ -87,20 +85,13 @@ func TestCreateStats(t *testing.T) {
 	lastStatsVal := lastStatsThs.Get()
 	lastStatsCopy := lastStatsVal.Copy()
 
-	dsStats, err := CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, now, monitorConfig, events, localCRStates)
-
-	if err != nil {
-		t.Fatalf("CreateStats err expected: nil, actual: " + err.Error())
-	}
+	dsStats := CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, monitorConfig, events, localCRStates)
 
 	serverDeliveryServices := toData.ServerDeliveryServices
 	toData.ServerDeliveryServices = map[tc.CacheName][]tc.DeliveryServiceName{} // temporarily unassign servers to generate warnings about caches not assigned to delivery services
 	buffer := bytes.NewBuffer(make([]byte, 0, 10000))
 	tc_log.Info = log.New(buffer, "TestAddAvailabilityDataNotFoundInDeliveryService", log.Lshortfile)
-	_, err = CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, now, monitorConfig, events, localCRStates)
-	if err != nil {
-		t.Fatalf("CreateStats err expected: nil, actual: " + err.Error())
-	}
+	_ = CreateStats(precomputeds, toData, combinedCRStates.Get(), lastStatsCopy, monitorConfig, events, localCRStates)
 	checkLogOutput(t, buffer, toData, caches)
 	toData.ServerDeliveryServices = serverDeliveryServices
 

--- a/traffic_monitor/manager/manager.go
+++ b/traffic_monitor/manager/manager.go
@@ -112,7 +112,6 @@ func Start(opsConfigFile string, cfg config.Config, appData config.StaticAppData
 		combinedStates,
 		toData,
 		cachesChangedForStatMgr,
-		errorCount,
 		cfg,
 		monitorConfig,
 		events,

--- a/traffic_monitor/manager/stat.go
+++ b/traffic_monitor/manager/stat.go
@@ -64,7 +64,6 @@ func StartStatHistoryManager(
 	combinedStates peer.CRStatesThreadsafe,
 	toData todata.TODataThreadsafe,
 	cachesChanged <-chan struct{},
-	errorCount threadsafe.Uint,
 	cfg config.Config,
 	monitorConfig threadsafe.TrafficMonitorConfigMap,
 	events health.ThreadsafeEvents,
@@ -97,7 +96,7 @@ func StartStatHistoryManager(
 		if haveCachesChanged() {
 			statUnpolledCaches.SetNewCaches(getNewCaches(localStates, monitorConfig))
 		}
-		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), errorCount, dsStats, lastStatEndTimes, lastStatDurations, statUnpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, combineState, cfg.CachePollingProtocol)
+		processStatResults(results, statInfoHistory, statResultHistory, statMaxKbpses, combinedStates, lastStats, toData.Get(), dsStats, lastStatEndTimes, lastStatDurations, statUnpolledCaches, monitorConfig.Get(), precomputedData, lastResults, localStates, events, localCacheStatus, combineState, cfg.CachePollingProtocol)
 	}
 
 	go func() {
@@ -241,7 +240,6 @@ func processStatResults(
 	combinedStatesThreadsafe peer.CRStatesThreadsafe,
 	lastStats threadsafe.LastStats,
 	toData todata.TOData,
-	errorCount threadsafe.Uint,
 	dsStats threadsafe.DSStats,
 	lastStatEndTimes map[tc.CacheName]time.Time,
 	lastStatDurationsThreadsafe threadsafe.DurationMap,
@@ -307,15 +305,10 @@ func processStatResults(
 
 	lastStatsVal := lastStats.Get()
 	lastStatsCopy := lastStatsVal.Copy()
-	newDsStats, err := ds.CreateStats(precomputedData, toData, combinedStates, lastStatsCopy, time.Now(), mc, events, localStates)
+	newDsStats := ds.CreateStats(precomputedData, toData, combinedStates, lastStatsCopy, mc, events, localStates)
 
-	if err != nil {
-		errorCount.Inc()
-		log.Errorf("getting deliveryservice: %v\n", err)
-	} else {
-		dsStats.Set(*newDsStats)
-		lastStats.Set(*lastStatsCopy)
-	}
+	dsStats.Set(*newDsStats)
+	lastStats.Set(*lastStatsCopy)
 
 	pollerName := "stat"
 	health.CalcAvailability(results, pollerName, &statResultHistoryThreadsafe, mc, toData, localCacheStatusThreadsafe, localStates, events, pollingProtocol)


### PR DESCRIPTION
The stats_over_http parsing was replacing stat values instead of summing
them for delivery services with multiple regexes. Since stats_over_http
response output can change order from request to request, this was
causing TM to report "new stat is lower than last stat" warnings when
the response order changed (which happens quite frequently). By properly
summing together the stats that match the same underlying delivery
service, these warnings disappear, and the reported data from TM is more
accurate.

Additionally, some things like unused parameters were cleaned up while
trying to find the underlying cause of these warnings.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
In an environment that contains delivery services with multiple regexes in use and servers that use the stats_over_http plugin (instead of astats), run TM prior to this version. You will likely see many "new stat is less than last stat" warnings. Then run this version of TM, and you shouldn't see any of those warnings anymore.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 5.x
- 6.x

## PR submission checklist
- [x] This PR updates some tests but doesn't really add a new test for this particular case
- [x] Bug fix, no docs necessary
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
