### PR TITLE
adds note to blueprint regarding lazy consensus option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ list with a short description of your feature plus a link to the blueprint PR.
 1. Wait for feedback to be applied to your blueprint PR. Because it's a PR,
 line-specific feedback can be given.
 1. Just like any PR, once all the concerns have been addressed, the blueprint is
-merged into the blueprints directory (if accepted) or closed (if rejected).
+merged into the blueprints directory (if accepted) or closed (if rejected). Note: Blueprint authors have the option of invoking <a href="https://community.apache.org/committers/lazyConsensus.html" target="_blank">lazy consensus</a> to facilitate the merge of the blueprint if community feedback is not being provided or feedback has stalled. To invoke lazy consensus, please make the community aware via an email to the dev mailing list that you intend to invoke lazy consensus after X hours with no feedback.
 1. Start work on the feature. Optionally, you can open a draft PR if you want
 feedback during development.
 1. Submit your PR for review and reference the blueprint in the PR description.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ list with a short description of your feature plus a link to the blueprint PR.
 1. Wait for feedback to be applied to your blueprint PR. Because it's a PR,
 line-specific feedback can be given.
 1. Just like any PR, once all the concerns have been addressed, the blueprint is
-merged into the blueprints directory (if accepted) or closed (if rejected). Note: Blueprint authors have the option of invoking <a href="https://community.apache.org/committers/lazyConsensus.html" target="_blank">lazy consensus</a> to facilitate the merge of the blueprint if community feedback is not being provided or feedback has stalled. To invoke lazy consensus, please make the community aware via an email to the dev mailing list that you intend to invoke lazy consensus after X hours with no feedback.
+merged into the blueprints directory (if accepted) or closed (if rejected). Note: Blueprint authors have the option of invoking [lazy consensus](https://community.apache.org/committers/lazyConsensus.html) to facilitate the merge of the blueprint if community feedback is not being provided or feedback has stalled. To invoke lazy consensus, please make the community aware via an email to the [dev@trafficcontrol.apache.org](mailto:dev@trafficcontrol.apache.org) mailing list that you intend to invoke lazy consensus after X hours with no feedback.
 1. Start work on the feature. Optionally, you can open a draft PR if you want
 feedback during development.
 1. Submit your PR for review and reference the blueprint in the PR description.


### PR DESCRIPTION
This PR adds a note to the blueprint section of CONTRIBUTING.md regarding the option to invoke [lazy consensus](https://community.apache.org/committers/lazyConsensus.html) on blueprints if needed.

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation

## What is the best way to verify this PR?
Read Contributing.md file, blueprint section


## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
