### PR TITLE
Remove unused `deliveryservice_tmuser` table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated the CDNs Traffic Portal page to use a more performant AG-Grid-based table.
 - Updated the Profiles Traffic Portal page to use a more performant AG-Grid-based table.
 - Updated Go version to 1.18
+- Removed the unused `deliveryservice_tmuser` table from Traffic Ops database
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/cache-config/testing/ort-tests/tcdata/todb.go
+++ b/cache-config/testing/ort-tests/tcdata/todb.go
@@ -198,19 +198,6 @@ INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('badtenant', 
 	return nil
 }
 
-// SetupDeliveryServiceTmUsers ...
-func SetupDeliveryServiceTmUsers(db *sql.DB) error {
-
-	sqlStmt := `
-INSERT INTO deliveryservice_tmuser (deliveryservice, tm_user_id, last_updated) VALUES (100, (SELECT id FROM tm_user where username = 'admin') , '2018-01-19 21:19:32.372969');
-`
-	err := execSQL(db, sqlStmt)
-	if err != nil {
-		return execError(sqlStmt, err)
-	}
-	return nil
-}
-
 // SetupJobs ...
 func SetupJobs(db *sql.DB) error {
 
@@ -268,7 +255,6 @@ func (r *TCData) Teardown(db *sql.DB) error {
 	DELETE FROM job;
 	DELETE FROM log;
 	DELETE FROM asn;
-	DELETE FROM deliveryservice_tmuser;
 	DELETE FROM tm_user;
 	DELETE FROM role;
 	DELETE FROM capability;

--- a/traffic_ops/app/db/migrations/2022031612431414_remove_unused_ds_tmuser_table.down.sql
+++ b/traffic_ops/app/db/migrations/2022031612431414_remove_unused_ds_tmuser_table.down.sql
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+CREATE TABLE public.deliveryservice_tmuser (
+	deliveryservice bigint NOT NULL,
+	tm_user_id bigint NOT NULL,
+	last_updated timestamp with time zone NOT NULL DEFAULT now(),
+	CONSTRAINT idx_89525_primary PRIMARY KEY (deliveryservice, tm_user_id)
+);
+
+CREATE INDEX idx_89525_fk_tm_userid
+ON public.deliveryservice_tmuser
+USING btree (tm_user_id);
+
+CREATE TRIGGER on_delete_current_timestamp
+AFTER DELETE ON public.deliveryservice_tmuser
+FOR EACH ROW EXECUTE PROCEDURE on_delete_current_timestamp_last_updated('public.deliveryservice_tmuser');
+
+CREATE TRIGGER on_update_current_timestamp
+BEFORE UPDATE ON public.deliveryservice_tmuser
+FOR EACH ROW EXECUTE PROCEDURE on_update_current_timestamp_last_updated('public.deliveryservice_tmuser');
+
+ALTER TABLE ONLY public.deliveryservice_tmuser
+ADD CONSTRAINT fk_tm_user_ds
+FOREIGN KEY (deliveryservice)
+REFERENCES deliveryservice(id)
+ON UPDATE CASCADE
+ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.deliveryservice_tmuser
+ADD CONSTRAINT fk_tm_user_id
+FOREIGN KEY (tm_user_id)
+REFERENCES tm_user(id)
+ON UPDATE CASCADE
+ON DELETE CASCADE;

--- a/traffic_ops/app/db/migrations/2022031612431414_remove_unused_ds_tmuser_table.up.sql
+++ b/traffic_ops/app/db/migrations/2022031612431414_remove_unused_ds_tmuser_table.up.sql
@@ -1,0 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+DROP TABLE public.deliveryservice_tmuser CASCADE;

--- a/traffic_ops/app/db/seeds.sql
+++ b/traffic_ops/app/db/seeds.sql
@@ -399,7 +399,6 @@ INSERT INTO public.last_deleted (table_name) VALUES ('deliveryservice_regex') ON
 INSERT INTO public.last_deleted (table_name) VALUES ('deliveryservice_request') ON CONFLICT (table_name) DO NOTHING;
 INSERT INTO public.last_deleted (table_name) VALUES ('deliveryservice_request_comment') ON CONFLICT (table_name) DO NOTHING;
 INSERT INTO public.last_deleted (table_name) VALUES ('deliveryservice_server') ON CONFLICT (table_name) DO NOTHING;
-INSERT INTO public.last_deleted (table_name) VALUES ('deliveryservice_tmuser') ON CONFLICT (table_name) DO NOTHING;
 INSERT INTO public.last_deleted (table_name) VALUES ('division') ON CONFLICT (table_name) DO NOTHING;
 INSERT INTO public.last_deleted (table_name) VALUES ('federation') ON CONFLICT (table_name) DO NOTHING;
 INSERT INTO public.last_deleted (table_name) VALUES ('federation_deliveryservice') ON CONFLICT (table_name) DO NOTHING;

--- a/traffic_ops/testing/api/v2/todb_test.go
+++ b/traffic_ops/testing/api/v2/todb_test.go
@@ -204,19 +204,6 @@ INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('badtenant', 
 	return nil
 }
 
-// SetupDeliveryServiceTmUsers ...
-func SetupDeliveryServiceTmUsers(db *sql.DB) error {
-
-	sqlStmt := `
-INSERT INTO deliveryservice_tmuser (deliveryservice, tm_user_id, last_updated) VALUES (100, (SELECT id FROM tm_user where username = 'admin') , '2018-01-19 21:19:32.372969');
-`
-	err := execSQL(db, sqlStmt)
-	if err != nil {
-		return fmt.Errorf("exec failed %v", err)
-	}
-	return nil
-}
-
 // SetupJobs ...
 func SetupJobs(db *sql.DB) error {
 
@@ -274,7 +261,6 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM job;
 	DELETE FROM log;
 	DELETE FROM asn;
-	DELETE FROM deliveryservice_tmuser;
 	DELETE FROM tm_user;
 	DELETE FROM role;
 	DELETE FROM capability;

--- a/traffic_ops/testing/api/v3/todb_test.go
+++ b/traffic_ops/testing/api/v3/todb_test.go
@@ -204,19 +204,6 @@ INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('badtenant', 
 	return nil
 }
 
-// SetupDeliveryServiceTmUsers ...
-func SetupDeliveryServiceTmUsers(db *sql.DB) error {
-
-	sqlStmt := `
-INSERT INTO deliveryservice_tmuser (deliveryservice, tm_user_id, last_updated) VALUES (100, (SELECT id FROM tm_user where username = 'admin') , '2018-01-19 21:19:32.372969');
-`
-	err := execSQL(db, sqlStmt)
-	if err != nil {
-		return fmt.Errorf("exec failed %v", err)
-	}
-	return nil
-}
-
 // SetupJobs ...
 func SetupJobs(db *sql.DB) error {
 
@@ -274,7 +261,6 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM job;
 	DELETE FROM log;
 	DELETE FROM asn;
-	DELETE FROM deliveryservice_tmuser;
 	DELETE FROM tm_user;
 	DELETE FROM role;
 	DELETE FROM capability;

--- a/traffic_ops/testing/api/v4/todb_test.go
+++ b/traffic_ops/testing/api/v4/todb_test.go
@@ -336,19 +336,6 @@ INSERT INTO tenant (name, active, parent_id, last_updated) VALUES ('badtenant', 
 	return nil
 }
 
-// SetupDeliveryServiceTmUsers ...
-func SetupDeliveryServiceTmUsers(db *sql.DB) error {
-
-	sqlStmt := `
-INSERT INTO deliveryservice_tmuser (deliveryservice, tm_user_id, last_updated) VALUES (100, (SELECT id FROM tm_user where username = 'admin') , '2018-01-19 21:19:32.372969');
-`
-	err := execSQL(db, sqlStmt)
-	if err != nil {
-		return fmt.Errorf("exec failed %v", err)
-	}
-	return nil
-}
-
 // SetupJobs ...
 func SetupJobs(db *sql.DB) error {
 
@@ -406,7 +393,6 @@ func Teardown(db *sql.DB) error {
 	DELETE FROM job;
 	DELETE FROM log;
 	DELETE FROM asn;
-	DELETE FROM deliveryservice_tmuser;
 	DELETE FROM tm_user;
 	DELETE FROM role;
 	DELETE FROM capability;


### PR DESCRIPTION
This PR closes #2910 by removing the now-unused `deliveryservice_tmuser` table from the TO database.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops (database)
- Traffic Ops client (Go, tests)
- t3c (tests)

## What is the best way to verify this PR?
No known functionality depended on this table, so just ensure existing functionality continues to work.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**