### PR TITLE
Remove deprecated error handler and references

### DIFF
--- a/lib/go-tc/alerts.go
+++ b/lib/go-tc/alerts.go
@@ -20,14 +20,7 @@ package tc
  */
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"net/http"
 	"strings"
-
-	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/lib/go-rfc"
 )
 
 // Alert represents an informational message, typically returned through the Traffic Ops API.
@@ -65,32 +58,6 @@ func CreateAlerts(level AlertLevel, messages ...string) Alerts {
 		alerts = append(alerts, Alert{message, level.String()})
 	}
 	return Alerts{alerts}
-}
-
-// GetHandleErrorsFunc is used to provide an error-handling function. The error handler provides a
-// response to an HTTP request made to the Traffic Ops API and accepts a response code and a set of
-// errors to display as alerts.
-//
-// Deprecated: Traffic Ops API handlers should use
-// github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/api.HandleErr instead.
-func GetHandleErrorsFunc(w http.ResponseWriter, r *http.Request) func(status int, errs ...error) {
-	return func(status int, errs ...error) {
-		log.Errorf("%v %v\n", r.RemoteAddr, errs)
-		errBytes, jsonErr := json.Marshal(CreateErrorAlerts(errs...))
-		if jsonErr != nil {
-			log.Errorf("failed to marshal error: %s\n", jsonErr)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprintf(w, http.StatusText(http.StatusInternalServerError))
-			return
-		}
-		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
-
-		ctx := r.Context()
-		ctx = context.WithValue(ctx, StatusKey, status)
-		*r = *r.WithContext(ctx)
-
-		fmt.Fprintf(w, "%s", errBytes)
-	}
 }
 
 // ToStrings converts Alerts to a slice of strings that are their messages. Note that this return

--- a/lib/go-tc/alerts_test.go
+++ b/lib/go-tc/alerts_test.go
@@ -22,8 +22,6 @@ package tc
 import (
 	"errors"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"reflect"
 	"testing"
 )
@@ -120,30 +118,6 @@ func ExampleAlerts_ErrorString() {
 
 	// Output: foo; bar
 	//
-}
-
-func TestGetHandleErrorFunc(t *testing.T) {
-	w := httptest.NewRecorder()
-	r, err := http.NewRequest("", ".", nil)
-	if err != nil {
-		t.Error("Error creating new request")
-	}
-	body := `{"alerts":[{"text":"this is an error","level":"error"}]}`
-
-	errHandler := GetHandleErrorsFunc(w, r)
-	errHandler(http.StatusBadRequest, fmt.Errorf("this is an error"))
-	if w.Body.String() != body {
-		t.Error("Expected body", body, "got", w.Body.String())
-	}
-
-	w = httptest.NewRecorder()
-	body = `{"alerts":[]}`
-
-	errHandler = GetHandleErrorsFunc(w, r)
-	errHandler(http.StatusBadRequest, nil)
-	if w.Body.String() != body {
-		t.Error("Expected body", body, "got", w.Body.String())
-	}
 }
 
 func TestCreateAlerts(t *testing.T) {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -121,8 +121,11 @@ func WriteAndLogErr(w http.ResponseWriter, r *http.Request, bts []byte) {
 	}
 }
 
-// WriteResp takes any object, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
-// This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
+// WriteResp takes any object, serializes it as JSON, and writes that to w.
+//
+// Any errors are logged and written to w as alerts (if applicable). This is a
+// helper for the common case; not using this in unusual cases is perfectly
+// acceptable.
 func WriteResp(w http.ResponseWriter, r *http.Request, v interface{}) {
 	resp := APIResponse{v}
 	WriteRespRaw(w, r, resp)
@@ -139,7 +142,7 @@ func WriteRespRaw(w http.ResponseWriter, r *http.Request, v interface{}) {
 	respBts, err := json.Marshal(v)
 	if err != nil {
 		log.Errorf("marshalling JSON (raw) for %T: %v", v, err)
-		tc.GetHandleErrorsFunc(w, r)(http.StatusInternalServerError, errors.New(http.StatusText(http.StatusInternalServerError)))
+		handleSimpleErr(w, r, http.StatusInternalServerError, nil, nil)
 		return
 	}
 	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
@@ -171,7 +174,7 @@ func WriteRespVals(w http.ResponseWriter, r *http.Request, v interface{}, vals m
 	respBts, err := json.Marshal(vals)
 	if err != nil {
 		log.Errorf("marshalling JSON for %T: %v", v, err)
-		tc.GetHandleErrorsFunc(w, r)(http.StatusInternalServerError, errors.New(http.StatusText(http.StatusInternalServerError)))
+		handleSimpleErr(w, r, http.StatusInternalServerError, nil, nil)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -299,8 +302,11 @@ func RespWriterVals(w http.ResponseWriter, r *http.Request, tx *sql.Tx, vals map
 	}
 }
 
-// WriteRespAlert creates an alert, serializes it as JSON, and writes that to w. Any errors are logged and written to w via tc.GetHandleErrorsFunc.
-// This is a helper for the common case; not using this in unusual cases is perfectly acceptable.
+// WriteRespAlert creates an alert, serializes it as JSON, and writes that to w.
+//
+// Any errors are logged and written to w as alerts (if applicable). This is a
+// helper for the common case; not using this in unusual cases is perfectly
+// acceptable.
 func WriteRespAlert(w http.ResponseWriter, r *http.Request, level tc.AlertLevel, msg string) {
 	if respWritten(r) {
 		log.Errorf("WriteRespAlert called after a write already occurred! Not double-writing! Path %s", r.URL.Path)

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -107,12 +107,11 @@ Subject: {{.InstanceName}} Password Reset Request` + "\r\n\r" + `
 
 func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		defer r.Body.Close()
 		authenticated := false
 		form := auth.PasswordForm{}
 		if err := json.NewDecoder(r.Body).Decode(&form); err != nil {
-			handleErrs(http.StatusBadRequest, err)
+			api.HandleErr(w, r, nil, http.StatusBadRequest, err, nil)
 			return
 		}
 		if form.Username == "" || form.Password == "" {
@@ -189,7 +188,7 @@ func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 		}
 		respBts, err := json.Marshal(resp)
 		if err != nil {
-			handleErrs(http.StatusInternalServerError, err)
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, err)
 			return
 		}
 		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
@@ -365,7 +364,7 @@ func OauthLoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 			return selectedKey, nil
 		})
 		if err != nil {
-			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, errors.New("Error decoding token with message: "+err.Error()))
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, fmt.Errorf("Error decoding token with message: %w", err))
 			return
 		}
 
@@ -405,7 +404,7 @@ func OauthLoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 
 		respBts, err := json.Marshal(resp)
 		if err != nil {
-			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, err)
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, fmt.Errorf("encoding response: %w", err))
 			return
 		}
 		w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)

--- a/traffic_ops/traffic_ops_golang/routing/routes.go
+++ b/traffic_ops/traffic_ops_golang/routing/routes.go
@@ -1314,14 +1314,12 @@ func Routes(d ServerData) ([]Route, http.Handler, error) {
 
 func MemoryStatsHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := runtime.MemStats{}
 		runtime.ReadMemStats(&stats)
 
 		bytes, err := json.Marshal(stats)
 		if err != nil {
-			log.Errorln("unable to marshal stats: " + err.Error())
-			handleErrs(http.StatusInternalServerError, errors.New("marshalling error"))
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, fmt.Errorf("unable to marshal stats: %w", err))
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -1331,13 +1329,11 @@ func MemoryStatsHandler() http.HandlerFunc {
 
 func DBStatsHandler(db *sqlx.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		handleErrs := tc.GetHandleErrorsFunc(w, r)
 		stats := db.DB.Stats()
 
 		bytes, err := json.Marshal(stats)
 		if err != nil {
-			log.Errorln("unable to marshal stats: " + err.Error())
-			handleErrs(http.StatusInternalServerError, errors.New("marshalling error"))
+			api.HandleErr(w, r, nil, http.StatusInternalServerError, nil, fmt.Errorf("unable to marshal stats: %w", err))
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
This removes an error handler from `lib/go-tc` that was meant for use by Traffic Ops - Traffic Ops has its own mechanism for handling errors internal to its package that should be used instead, so the error handler in question was deprecated 2 years ago.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make sure all existing functionality still works.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**