### PR TITLE
Add the ability to close idle connections to TO Go client (all versions)

### DIFF
--- a/traffic_ops/toclientlib/endpoints.go
+++ b/traffic_ops/toclientlib/endpoints.go
@@ -18,22 +18,22 @@ package toclientlib
 const apiBaseStr = "/api/"
 
 // APIBase returns the base API string for HTTP requests, such as /api/3.1.
-func (sn *TOClient) APIBase() string {
-	return apiBaseStr + sn.APIVersion()
+func (to *TOClient) APIBase() string {
+	return apiBaseStr + to.APIVersion()
 }
 
 // APIVersion is the version of the Traffic Ops API this client will use for requests.
 // If the client was created with any function except Login, or with UseLatestSupportedAPI false,
 // this will be LatestAPIVersion().
 // Otherwise, it will be the version dynamically determined to be the latest the Traffic Ops Server supports.
-func (sn *TOClient) APIVersion() string {
-	if sn.latestSupportedAPI != "" {
-		return sn.latestSupportedAPI
+func (to *TOClient) APIVersion() string {
+	if to.latestSupportedAPI != "" {
+		return to.latestSupportedAPI
 	}
-	return sn.LatestAPIVersion()
+	return to.LatestAPIVersion()
 }
 
 // LatestAPIVersion returns the latest Traffic Ops API version this client supports.
-func (sn *TOClient) LatestAPIVersion() string {
-	return sn.apiVersions[0]
+func (to *TOClient) LatestAPIVersion() string {
+	return to.apiVersions[0]
 }

--- a/traffic_ops/toclientlib/toclientlib.go
+++ b/traffic_ops/toclientlib/toclientlib.go
@@ -481,6 +481,21 @@ func NewNoAuthClient(
 	}, apiVersions)
 }
 
+// Close closes all idle "kept-alive" connections in the client's connection
+// pool. Note that connections in use are unaffected by this call, so it's not
+// necessarily true that calling this method will leave the client with no open
+// connections.
+//
+// This will always return a nil error, the signature is just meant to conform
+// to io.Closer.
+func (to *TOClient) Close() error {
+	if to == nil {
+		return nil
+	}
+	to.Client.CloseIdleConnections()
+	return nil
+}
+
 // ErrIsNotImplemented checks that the given error stems from
 // ErrNotImplemented.
 // Caution: This method does not unwrap errors, and relies on the common


### PR DESCRIPTION
This fixes #4182 by making TO clients into `io.Closer`s that can close their idle connections.

I didn't add a test because it seems really difficult to test. I looked at the tests used for `net/http.Client.CloseIdleConnections` and it seems like they're really just testing that calling `CloseIdleConnections`... calls `CloseIdleConnections`. That's probably a lot more useful when you're writing a compiler for the language, but for us merely _using_ that language, I vote we trust the basic precepts of its grammar and its standard library. 

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops Client (Go)

## What is the best way to verify this PR?
Make sure nothing breaks.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**