### PR TITLE
Tpv2/password reset

### DIFF
--- a/experimental/traffic-portal/angular.json
+++ b/experimental/traffic-portal/angular.json
@@ -23,6 +23,12 @@
 						"allowedCommonJsDependencies": [
 							"chart.js"
 						],
+						"optimization": true,
+						"sourceMap": true,
+						"namedChunks": false,
+						"extractLicenses": true,
+						"vendorChunk": true,
+						"buildOptimizer": true,
 						"outputPath": "dist/traffic-portal/browser",
 						"index": "src/index.html",
 						"main": "src/main.ts",

--- a/experimental/traffic-portal/src/app/app.module.ts
+++ b/experimental/traffic-portal/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { LoginComponent } from "./login/login.component";
 import {AppUIModule} from "./app.ui.module";
 import {SharedModule} from "./shared/shared.module";
 import {AuthenticatedGuard} from "./guards/authenticated-guard.service";
+import { ResetPasswordDialogComponent } from "./login/reset-password-dialog/reset-password-dialog.component";
 
 // TODO: Figure out the actual typing here.
 Chart.plugins.register({
@@ -59,7 +60,8 @@ Chart.plugins.register({
 	bootstrap: [AppComponent],
 	declarations: [
 		AppComponent,
-		LoginComponent
+		LoginComponent,
+		ResetPasswordDialogComponent
 	],
 	imports: [
 		BrowserModule.withServerTransition({ appId: "serverApp" }),

--- a/experimental/traffic-portal/src/app/login/login.component.html
+++ b/experimental/traffic-portal/src/app/login/login.component.html
@@ -19,6 +19,7 @@ limitations under the License.
 	<label for="p">Password</label><input required autocomplete="current-password" type="password" [formControl]="p" name="p" id="p"/>
 	<div>
 		<button mat-raised-button>Login</button>
+		<button mat-button color="accent" type="button" (click)="resetPassword()">Forgot Password</button>
 		<button mat-raised-button color="warn" type="reset">Clear</button>
 	</div>
 </form>

--- a/experimental/traffic-portal/src/app/login/login.component.scss
+++ b/experimental/traffic-portal/src/app/login/login.component.scss
@@ -51,8 +51,10 @@ form {
 	div {
 		grid-column: span 2;
 		display: grid;
-		grid-template-columns: 1fr 1fr;
-		justify-content: space-between;
-		grid-column-gap: 60%;
+		grid-template-columns: auto auto 1fr;
+
+		button:last-child {
+			justify-self: end;
+		}
 	}
 }

--- a/experimental/traffic-portal/src/app/login/login.component.spec.ts
+++ b/experimental/traffic-portal/src/app/login/login.component.spec.ts
@@ -14,6 +14,7 @@
 import { HttpClientModule } from "@angular/common/http";
 import { waitForAsync, ComponentFixture, TestBed } from "@angular/core/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatDialogModule } from "@angular/material/dialog";
 import { RouterTestingModule } from "@angular/router/testing";
 
 import {CurrentUserService} from "src/app/shared/currentUser/current-user.service";
@@ -29,9 +30,10 @@ describe("LoginComponent", () => {
 			declarations: [ LoginComponent ],
 			imports: [
 				FormsModule,
+				MatDialogModule,
 				HttpClientModule,
 				ReactiveFormsModule,
-				RouterTestingModule
+				RouterTestingModule,
 			],
 			providers: [ { provide: CurrentUserService, useValue: mockCurrentUserService }]
 		})

--- a/experimental/traffic-portal/src/app/login/login.component.ts
+++ b/experimental/traffic-portal/src/app/login/login.component.ts
@@ -48,8 +48,9 @@ export class LoginComponent implements OnInit {
 	 * string parameters.
 	 */
 	public ngOnInit(): void {
-		this.returnURL = this.route.snapshot.queryParams.returnUrl || "/core";
-		const token = this.route.snapshot.queryParams.token;
+		const params = this.route.snapshot.queryParamMap;
+		this.returnURL = params.get("returnUrl") ?? "core";
+		const token = params.get("token");
 		if (token) {
 			this.auth.login(token).then(
 				response => {

--- a/experimental/traffic-portal/src/app/login/login.component.ts
+++ b/experimental/traffic-portal/src/app/login/login.component.ts
@@ -13,8 +13,10 @@
 */
 import { Component, OnInit } from "@angular/core";
 import { FormControl } from "@angular/forms";
+import { MatDialog } from "@angular/material/dialog";
 import { Router, ActivatedRoute } from "@angular/router";
 import {CurrentUserService} from "src/app/shared/currentUser/current-user.service";
+import { ResetPasswordDialogComponent } from "./reset-password-dialog/reset-password-dialog.component";
 
 
 /**
@@ -34,13 +36,12 @@ export class LoginComponent implements OnInit {
 	/** The user-entered password. */
 	public p = new FormControl("");
 
-	/**
-	 * Constructor.
-	 */
 	constructor(
 		private readonly route: ActivatedRoute,
 		private readonly router: Router,
-		private readonly auth: CurrentUserService) { }
+		private readonly auth: CurrentUserService,
+		private readonly dialog: MatDialog
+	) { }
 
 	/**
 	 * Runs initialization, setting up the post-login redirection from the query
@@ -79,6 +80,11 @@ export class LoginComponent implements OnInit {
 				console.error("login failed:", err);
 			}
 		);
+	}
+
+	/** Opens the "reset password" dialog. */
+	public resetPassword(): void {
+		this.dialog.open(ResetPasswordDialogComponent, {width: "30%"});
 	}
 
 }

--- a/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.html
+++ b/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.html
@@ -1,0 +1,26 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<h1 mat-dialog-title>Reset Password</h1>
+<form method="dialog" ngNativeValidate (ngSubmit)="submit($event)">
+	<mat-dialog-content>
+		<mat-form-field>
+			<mat-label>Email Address</mat-label>
+			<input matInput type="email" autocomplete="email" [(ngModel)]="email"/>
+		</mat-form-field>
+	</mat-dialog-content>
+	<mat-dialog-actions>
+		<button mat-raised-button color="warn" type="button" mat-dialog-close>Cancel</button>
+		<button mat-raised-button>Submit</button>
+	</mat-dialog-actions>
+</form>

--- a/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.scss
+++ b/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.scss
@@ -1,0 +1,29 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+mat-dialog-content, mat-form-field {
+	width: 100%;
+}
+
+// input {
+// 	width: 100%;
+// }
+
+mat-dialog-actions {
+	display: grid;
+	grid-template-columns: auto auto;
+	justify-content: space-between;
+	button {
+		min-width: 7em;
+	}
+}

--- a/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.spec.ts
+++ b/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.spec.ts
@@ -1,0 +1,40 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { HttpClientModule } from "@angular/common/http";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { ResetPasswordDialogComponent } from "./reset-password-dialog.component";
+
+describe("ResetPasswordDialogComponent", () => {
+	let component: ResetPasswordDialogComponent;
+	let fixture: ComponentFixture<ResetPasswordDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [ ResetPasswordDialogComponent ],
+			imports: [HttpClientModule]
+		})
+			.compileComponents();
+	});
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(ResetPasswordDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.spec.ts
+++ b/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.spec.ts
@@ -13,6 +13,9 @@
 */
 import { HttpClientModule } from "@angular/common/http";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialogRef } from "@angular/material/dialog";
+
+import { UserService } from "src/app/shared/api/UserService";
 
 import { ResetPasswordDialogComponent } from "./reset-password-dialog.component";
 
@@ -21,9 +24,18 @@ describe("ResetPasswordDialogComponent", () => {
 	let fixture: ComponentFixture<ResetPasswordDialogComponent>;
 
 	beforeEach(async () => {
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
 		await TestBed.configureTestingModule({
 			declarations: [ ResetPasswordDialogComponent ],
-			imports: [HttpClientModule]
+			imports: [HttpClientModule],
+			providers: [
+				// The controller doesn't pass any arguments or check the return
+				// value of `close` - this literally needs to do nothing but be
+				// callable.
+				// eslint-disable-next-line @typescript-eslint/no-empty-function
+				{ provide: MatDialogRef, useValue: {close: (): void => {}} },
+				{ provide: UserService, useValue: mockCurrentUserService }
+			]
 		})
 			.compileComponents();
 	});

--- a/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.ts
+++ b/experimental/traffic-portal/src/app/login/reset-password-dialog/reset-password-dialog.component.ts
@@ -1,0 +1,45 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Component } from "@angular/core";
+import { MatDialogRef } from "@angular/material/dialog";
+import { UserService } from "src/app/shared/api";
+
+/**
+ * The controller for the "reset password" dialog.
+ */
+@Component({
+	selector: "tp-reset-password-dialog",
+	styleUrls: ["./reset-password-dialog.component.scss"],
+	templateUrl: "./reset-password-dialog.component.html"
+})
+export class ResetPasswordDialogComponent {
+
+	/** The email address used for password recovery. */
+	public email = "";
+
+	constructor(private readonly api: UserService, private readonly dialogRef: MatDialogRef<ResetPasswordDialogComponent>) { }
+
+	/**
+	 * Handles submission of the dialog's form.
+	 *
+	 * @param event The form submission event.
+	 */
+	public submit(event: Event): void {
+		event.preventDefault();
+		event.stopPropagation();
+		this.api.resetPassword(this.email);
+		this.dialogRef.close();
+	}
+
+}

--- a/experimental/traffic-portal/src/app/shared/api/UserService.ts
+++ b/experimental/traffic-portal/src/app/shared/api/UserService.ts
@@ -237,4 +237,13 @@ export class UserService extends APIService {
 		);
 	}
 
+	/**
+	 * Requests a password reset for a user.
+	 *
+	 * @param email The email of the user for whom to reset a password.
+	 */
+	public async resetPassword(email: string): Promise<void> {
+		await this.post("user/reset_password", {email}).toPromise();
+	}
+
 }

--- a/experimental/traffic-portal/src/app/shared/currentUser/current-user.service.ts
+++ b/experimental/traffic-portal/src/app/shared/currentUser/current-user.service.ts
@@ -163,4 +163,13 @@ export class CurrentUserService {
 		console.log("query params:", queryParams);
 		this.router.navigate(["/login"], {queryParams});
 	}
+
+	/**
+	 * Requests a password reset for a user.
+	 *
+	 * @param email The email of the user for whom to reset a password.
+	 */
+	 public async resetPassword(email: string): Promise<void> {
+		await this.api.resetPassword(email);
+	}
 }

--- a/experimental/traffic-portal/src/polyfills.ts
+++ b/experimental/traffic-portal/src/polyfills.ts
@@ -32,16 +32,6 @@
  * BROWSER POLYFILLS
  */
 
-/** IE10 and IE11 requires the following for NgClass support on SVG elements */
-// import 'classlist.js';  // Run `npm install --save classlist.js`.
-
-/**
- * Web Animations `@angular/platform-browser/animations`
- * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.
- * Standard animation support in Angular DOES NOT require any polyfills (as of Angular 6.0).
- */
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
 /**
  * By default, zone.js will patch all possible macroTask and DomEvents
  * user can disable parts of macroTask/DomEvents patch by setting following flags


### PR DESCRIPTION
Adds a "Reset Password" button to TPv2, and fixes some slow compilation caused by #6391.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the TPv2 tests all still pass

The way I tested this was to make sure the button called the right API endpoint, and then going to `/login?token={{My user's token in the database}}` since this doesn't change the behavior of that endpoint there's no point I can see to going to the trouble of getting it to actually send an email.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**