### PR TITLE
Removes invalid 'ALL cdn' options from TP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Vault: Added additional flag to TV Riak (Deprecated) Util
 
 ### Fixed
+- [#6411](https://github.com/apache/trafficcontrol/pull/6411) Removes invalid 'ALL cdn' options from TP
 - [#6197](https://github.com/apache/trafficcontrol/issues/6197) - TO `/deliveryservices/:id/routing` makes requests to all TRs instead of by CDN.
 - Fixed Traffic Router crs/stats to prevent overflow and to correctly record the time used in averages.
 - [#6209](https://github.com/apache/trafficcontrol/pull/6209) Updated Traffic Router to use Java 11 to compile and run

--- a/traffic_portal/app/src/common/modules/form/cdn/form.cdn.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/cdn/form.cdn.tpl.html
@@ -24,8 +24,8 @@ under the License.
             <li class="active">{{cdnName}}</li>
         </ol>
         <div class="pull-right" ng-show="!settings.isNew">
-            <button name="diffCDNbtn" class="btn btn-primary" title="Diff CDN Snapshot" ng-click="viewConfig()"><i class="fa fa-camera"></i>&nbsp;&nbsp;Diff CDN Config Snapshot</button>
-            <div class="btn-group" role="group" uib-dropdown is-open="queue.isopen">
+            <button ng-show="cdn.name != 'ALL'" name="diffCDNbtn" class="btn btn-primary" title="Diff CDN Snapshot" ng-click="viewConfig()"><i class="fa fa-camera"></i>&nbsp;&nbsp;Diff CDN Config Snapshot</button>
+            <div ng-show="cdn.name != 'ALL'" class="btn-group" role="group" uib-dropdown is-open="queue.isopen">
                 <button type="button" class="btn btn-primary dropdown-toggle" uib-dropdown-toggle aria-haspopup="true" aria-expanded="false">
                     Queue Updates&nbsp;
                     <span class="caret"></span>
@@ -41,10 +41,10 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="manageDNSSEC()">Manage DNSSEC Keys</a></li>
-                    <li role="menuitem"><a ng-click="manageFederations()">Manage Federations</a></li>
-                    <li class="divider"></li>
-                    <li role="menuitem"><a ng-click="viewDeliveryServices()">View Delivery Services</a></li>
+                    <li ng-show="cdn.name != 'ALL'" role="menuitem"><a ng-click="manageDNSSEC()">Manage DNSSEC Keys</a></li>
+                    <li ng-show="cdn.name != 'ALL'" role="menuitem"><a ng-click="manageFederations()">Manage Federations</a></li>
+                    <li ng-show="cdn.name != 'ALL'" class="divider"></li>
+                    <li ng-show="cdn.name != 'ALL'" role="menuitem"><a ng-click="viewDeliveryServices()">View Delivery Services</a></li>
                     <li role="menuitem"><a ng-click="viewProfiles()">View Profiles</a></li>
                     <li role="menuitem"><a ng-click="viewServers()">View Servers</a></li>
                     <li class="divider"></li>

--- a/traffic_portal/app/src/common/modules/header/HeaderController.js
+++ b/traffic_portal/app/src/common/modules/header/HeaderController.js
@@ -113,7 +113,9 @@ var HeaderController = function($rootScope, $scope, $state, $uibModal, $location
                     return params;
                 },
                 collection: function() {
-                    return $scope.cdns;
+                    return $scope.cdns.filter(function(cdn) {
+                        return cdn.name != 'ALL';
+                    });
                 }
             }
         });
@@ -161,7 +163,9 @@ var HeaderController = function($rootScope, $scope, $state, $uibModal, $location
                     return params;
                 },
                 collection: function() {
-                    return $scope.cdns;
+                    return $scope.cdns.filter(function(cdn) {
+                        return cdn.name != 'ALL';
+                    });
                 }
             }
         });


### PR DESCRIPTION
Closes: #6411 

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
1. Open TP, click on the snapshot (camera) or queue updates (flag) button in the header. ensure the ALL cdn is not an cdn that can be selected for snapshot/queue.
2. navigate to the ALL cdn page and ensure invalid options do not exist (snapshot, queue, manage dnssec, manage federations and view delivery services)

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0.1
- 5.1.4

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
