### PR TITLE
Remove unnecessary logging of SSL cert/key paths

### DIFF
--- a/traffic_ops/install/bin/_postinstall.py
+++ b/traffic_ops/install/bin/_postinstall.py
@@ -909,12 +909,10 @@ def setup_certificates(conf, root, ops_user, ops_group): # type: (SSLConfig, str
 	listen = hypnotoad["listen"][0]
 
 	if "cert={certpath}".format(certpath=certpath) not in listen or "key={keypath}".format(keypath=keypath) not in listen:
-		log_msg = """	The "listen" portion of %s is:
-	%s
-	and does not reference the same "cert=" and "key=" values as are created here.
+		log_msg = """	The "listen" portion of %s does not reference the same "cert=" and "key=" values as are created here.
 	Please modify %s to add the following as parameters:
-	?cert=%s&key=%s"""
-		logging.error(log_msg, cdn_conf_path, listen, cdn_conf_path, certpath, keypath)
+	?cert=/path/to/SSL/certificate&key=/path/to/SSL/key"""
+		logging.error(log_msg, cdn_conf_path, cdn_conf_path)
 		return 1
 
 	return 0


### PR DESCRIPTION
Currently, if `cdn.conf` specifies cert/key paths that don't match the values supplied to postinstall, it will log all four specified SSL key/cert paths. This is a bit unnecessary, since anyone with the permissions to be setting those values usefully will already have access to all four, and we need not clutter the logging output with it.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops (postinstall)

## What is the best way to verify this PR?
Make sure postinstall tests still pass, make a Traffic Ops config then run postinstall with mismatched values for the ssl key/cert paths and make sure they don't get logged.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**