### PR TITLE
TR logging: Archive logs using an integer counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Traffic Ops: Sanitize username before executing LDAP query
 - [#6367](https://github.com/apache/trafficcontrol/issues/6367) - Fix PUT `user/current` to work with v4 User Roles and Permissions
 - [#6266](https://github.com/apache/trafficcontrol/issues/6266) - Removed postgresql13-devel requirement for traffic_ops
+- [#6446](https://github.com/apache/trafficcontrol/issues/6446) - Revert Traffic Router rollover file pattern to the one previously used in `log4j.properties` with Log4j 1.2
 
 ### Changed
 - Updated `t3c` to request less unnecessary deliveryservice-server assignment and invalidation jobs data via new query params supported by Traffic Ops

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -135,7 +135,7 @@ tr_log4j2_opts: |
           </Console>
           <RollingFile name="traffic_router_access"
                        fileName="{{tr_log_dir}}/access.log"
-                       filePattern="{{tr_log_dir}}/access-%d{yyyy-MM-dd}.log" >
+                       filePattern="{{tr_log_dir}}/access.log.%i" >
               <PatternLayout pattern="%m%n" />
               <Policies>
                   <SizeBasedTriggeringPolicy size="200MB" />
@@ -145,7 +145,7 @@ tr_log4j2_opts: |
           </RollingFile>
           <RollingFile name="traffic_router"
                        fileName="{{tr_log_dir}}/traffic_router.log"
-                       filePattern="{{tr_log_dir}}/traffic_router-%d{yyyy-MM-dd}.log" >
+                       filePattern="{{tr_log_dir}}/traffic_router.log.%i" >
               <PatternLayout pattern="%-5p %d{yyyy-MM-dd'T'HH:mm:ss.SSS} [%t] %c - %m%n" />
               <Policies>
                   <SizeBasedTriggeringPolicy size="100MB" />

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -150,6 +150,7 @@ tr_log4j2_opts: |
               <Policies>
                   <SizeBasedTriggeringPolicy size="100MB" />
               </Policies>
+              <DefaultRolloverStrategy max="1" />
               <ThresholdFilter level="ALL" />
           </RollingFile>
       </Appenders>

--- a/traffic_router/core/src/main/conf/log4j2.xml
+++ b/traffic_router/core/src/main/conf/log4j2.xml
@@ -20,7 +20,7 @@
         </Console>
         <RollingFile name="traffic_router_access"
                      fileName="${deploy.dir}/var/log/access.log"
-                     filePattern="${deploy.dir}/var/log/access-%d{yyyy-MM-dd}.log" >
+                     filePattern="${deploy.dir}/var/log/access.log.%i" >
             <PatternLayout pattern="%m%n" />
             <Policies>
                 <SizeBasedTriggeringPolicy size="200MB" />
@@ -30,7 +30,7 @@
         </RollingFile>
         <RollingFile name="traffic_router"
                      fileName="${deploy.dir}/var/log/traffic_router.log"
-                     filePattern="${deploy.dir}/var/log/traffic_router-%d{yyyy-MM-dd}.log" >
+                     filePattern="${deploy.dir}/var/log/traffic_router.log.%i" >
             <PatternLayout pattern="%-5p %d{yyyy-MM-dd'T'HH:mm:ss.SSS} [%t] %c - %m%n" />
             <Policies>
                 <SizeBasedTriggeringPolicy size="100MB" />

--- a/traffic_router/core/src/main/conf/log4j2.xml
+++ b/traffic_router/core/src/main/conf/log4j2.xml
@@ -35,6 +35,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="100MB" />
             </Policies>
+            <DefaultRolloverStrategy max="1" />
             <ThresholdFilter level="ALL" />
         </RollingFile>
     </Appenders>

--- a/traffic_router/core/src/test/conf/log4j2.xml
+++ b/traffic_router/core/src/test/conf/log4j2.xml
@@ -20,7 +20,7 @@
         </Console>
         <RollingFile name="traffic_router_access"
                      fileName="${deploy.dir}/var/log/access.log"
-                     filePattern="${deploy.dir}/var/log/access-%d{yyyy-MM-dd}.log" >
+                     filePattern="${deploy.dir}/var/log/access.log.%i" >
             <PatternLayout pattern="%m%n" />
             <Policies>
                 <SizeBasedTriggeringPolicy size="200MB" />
@@ -30,7 +30,7 @@
         </RollingFile>
         <RollingFile name="traffic_router"
                      fileName="${deploy.dir}/var/log/traffic_router.log"
-                     filePattern="${deploy.dir}/var/log/traffic_router-%d{yyyy-MM-dd}.log" >
+                     filePattern="${deploy.dir}/var/log/traffic_router.log.%i" >
             <PatternLayout pattern="%-5p %d{yyyy-MM-dd'T'HH:mm:ss.SSS} [%t] %c - %m%n" />
             <Policies>
                 <SizeBasedTriggeringPolicy size="100MB" />

--- a/traffic_router/core/src/test/conf/log4j2.xml
+++ b/traffic_router/core/src/test/conf/log4j2.xml
@@ -35,6 +35,7 @@
             <Policies>
                 <SizeBasedTriggeringPolicy size="100MB" />
             </Policies>
+            <DefaultRolloverStrategy max="1" />
             <ThresholdFilter level="ALL" />
         </RollingFile>
     </Appenders>


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

#6450 fixes #6446 by revert the Traffic Router rollover file patterns to the one previously used in `log4j.properties` with Log4j 1.2, as well as ensuring that `traffic_router.log` only keeps 1 archive.
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router
- Automation - Ansible Roles<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. For convenience, change the value of `SizeBasedTriggeringPolicy` in `log4j2.xml` from `200MB` and `100MB` to `1MB` so log file rollovers happen more frequently
2. Fill `access.log`, `access.log.1`, `traffic_router.log`, and `traffic_router.log.1` with content so they are over 1MB in size:
   ```shell
   cd /opt/traffic_router/var/log;
   for file in {access.log,traffic_router.log}{,.1}; do
     for ((i = 0; i < 117528; i++)); do
       echo "$file" >> "$file";
     done;
   done
   sync;
   ```
3. Start Traffic Router and verify that `traffic_router.log` rolls over, resulting in the old `traffic_router.log` being copied to `traffic_router.log.1` and the old `traffic_router.log.1` being removed
4. Send requests to Traffic Router until `access.log` rolls over 10 times.
5. Verify that you end up these logs related to `access.log`:
   ```
   access.log
   access.log.1
   access.log.2
   access.log.3
   access.log.4
   access.log.5
   access.log.6
   access.log.7
   access.log.8
   access.log.9
   access.log.10
   ```

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 6.0.2
- 5.1.5

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->