### PR TITLE
Ansible TR: Keep hourly archives of `access.log`

### DIFF
--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -135,7 +135,7 @@ tr_log4j2_opts: |
           </Console>
           <RollingFile name="traffic_router_access"
                        fileName="{{tr_log_dir}}/access.log"
-                       filePattern="{{tr_log_dir}}/access.log.%i" >
+                       filePattern="{{tr_log_dir}}/access.log.%d{MM-dd-yyyy}-%2i" >
               <PatternLayout pattern="%m%n" />
               <Policies>
                   <CronTriggeringPolicy schedule="0 0 * * * ?"/>

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -140,7 +140,7 @@ tr_log4j2_opts: |
               <Policies>
                   <SizeBasedTriggeringPolicy size="200MB" />
               </Policies>
-              <DefaultRolloverStrategy max="10" />
+              <DefaultRolloverStrategy max="50" />
               <ThresholdFilter level="INFO" />
           </RollingFile>
           <RollingFile name="traffic_router"

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -138,7 +138,8 @@ tr_log4j2_opts: |
                        filePattern="{{tr_log_dir}}/access.log.%d{MM-dd-yyyy}-%2i" >
               <PatternLayout pattern="%m%n" />
               <Policies>
-                  <CronTriggeringPolicy schedule="0 0 * * * ?"/>
+                  <SizeBasedTriggeringPolicy size="200MB" />
+                  <CronTriggeringPolicy schedule="0 0 * * * ?" />
               </Policies>
               <DefaultRolloverStrategy max="50" />
               <ThresholdFilter level="INFO" />

--- a/infrastructure/ansible/roles/traffic-router/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic-router/defaults/main.yml
@@ -138,7 +138,7 @@ tr_log4j2_opts: |
                        filePattern="{{tr_log_dir}}/access.log.%i" >
               <PatternLayout pattern="%m%n" />
               <Policies>
-                  <SizeBasedTriggeringPolicy size="200MB" />
+                  <CronTriggeringPolicy schedule="0 0 * * * ?"/>
               </Policies>
               <DefaultRolloverStrategy max="50" />
               <ThresholdFilter level="INFO" />


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR updates the Ansible Roles to configure Log4j in Traffic Router to keep hourly archives of `access.log` for a maximum of 50 archives.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - Ansible playbooks<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Test Traffic Router with the options added to `log4j2.xml`, verify that
- A new `access.log` archive is created every hour
- No more than 50 access.log archives are kept
- The date an and a counter are in `access.log` filenames. For example, the 3rd archive on January 19, 2021 should be named `access.log-2021-01-19-03`.

## PR submission checklist
- [x] Existing tests are sufficient for this PR<!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] Documentation for this PR is unnecessary<!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] A changelog entry for this PR is not necessary <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->