### PR TITLE
CiaB: Do not rebuild Traffic Server when the ATS RPM spec changes

### DIFF
--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -48,7 +48,6 @@ SPECIAL_SAUCE := $(TC_VERSION)-$(BUILD_NUMBER).el$(RHEL_VERSION).x86_64.rpm
 SPECIAL_SEASONING := $(TOMCAT_VERSION).$(TOMCAT_RELEASE)-1.el$(RHEL_VERSION).noarch.rpm
 SPECIAL_SYRUP := $(ATS_VERSION).el$(RHEL_VERSION).x86_64.rpm
 
-ATS_SOURCE := $(wildcard $(TC_DIR)/cache-config/testing/docker/trafficserver/**)
 TO_SOURCE := $(wildcard $(TC_DIR)/traffic_ops/**)
 TO_SOURCE += $(wildcard $(TC_DIR)/traffic_ops_db/**)
 ORT_SOURCE:= $(wildcard $(TC_DIR)/cache-config/**)
@@ -179,7 +178,7 @@ $(ORT_RPM_ABSOLUTE): $(ORT_DIST_RPM)
 	cp -f "$?" "$@"
 
 # Dist rpms
-$(ATS_DIST_RPM): $(ATS_SOURCE)
+$(ATS_DIST_RPM):
 	docker-compose -f $(TC_DIR)/cache-config/testing/docker/docker-compose-ats-build.yml build --parallel trafficserver_build && docker-compose -f $(TC_DIR)/cache-config/testing/docker/docker-compose-ats-build.yml run --rm trafficserver_build
 
 $(TM_DIST_RPM): $(TM_SOURCE)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR makes the ATS RPM no longer rebuild when Make detects that the files in `$(TC_DIR)/cache-config/testing/docker/trafficserver/` have changed, which saves 6-8 minutes of local build time for CDN in a Box.
The ATS RPM will still rebuild whenever a new commit is pushed to [`apache/trafficserver:8.1.x`](https://github.com/apache/trafficserver/commits/8.1.x/)
<!-- **^ Add meaningful description above** --><hr>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. In the CDN in a Box directory, build the targets using `make`
   ```shell
   make -j6
   ```
2. Update a file in the `cd cache-config/testing/docker/trafficserver` directory
   ```shell
   echo echo An update >> ../../cache-config/testing/docker/trafficserver/run.sh
   ```
3. Run `make` again, verify that no targets are rebuilt
   ```shell
   make
   ```
   Expected output:
   ```
   make: Nothing to be done for 'all'.
   ```

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->