### PR TITLE
Fixes the cache-config integration tests.

### DIFF
--- a/cache-config/testing/docker/docker-compose-ats-build.yml
+++ b/cache-config/testing/docker/docker-compose-ats-build.yml
@@ -26,19 +26,13 @@ volumes:
 services:
 
   trafficserver_build:
-    environment:
-      - ATS_VERSION=8.1.x
-      - CJOSE_URL=https://github.com/cisco/cjose
-      - CJOSE_TAG=latest
-      - JANSSON_URL=https://github.com/akheron/jansson
-      - JANSSON_TAG=v2.11
-      - OPENSSL_URL=https://github.com/openssl/openssl
-      - OPENSSL_TAG=OpenSSL_1_1_1
-      - RUN_ATS_UNIT_TESTS=false
+    env_file:
+      - variables.env
     build:
       context: ../../..
       dockerfile: cache-config/testing/docker/trafficserver/Dockerfile
       args:
-        RHEL_VERSION: ${RHEL_VERSION:-8}
+        - OS_VERSION=${OS_VERSION:-8}
+        - OS_DISTRO=${OS_DISTRO:-rockylinux}
     volumes:
       - ../../..:/trafficcontrol:z

--- a/cache-config/testing/docker/docker-compose.yml
+++ b/cache-config/testing/docker/docker-compose.yml
@@ -57,6 +57,9 @@ services:
     ports: 
       - "443:443"
     build:
+      args:
+        - OS_DISTRO=${OS_DISTRO:-rockylinux}
+        - OS_VERSION=${OS_VERSION:-8}
       context: ../../..
       dockerfile: cache-config/testing/docker/traffic_ops/Dockerfile
     volumes:
@@ -82,7 +85,8 @@ services:
       - variables.env
     build:
       args:
-        RHEL_VERSION: ${RHEL_VERSION:-8}
+        - OS_DISTRO=${OS_DISTRO:-rockylinux}
+        - OS_VERSION=${OS_VERSION:-8}
       context: .
       dockerfile: ort_test/Dockerfile
     cap_add: ['SYS_ADMIN'] # necessary for hostname tests

--- a/cache-config/testing/docker/ort_test/Dockerfile
+++ b/cache-config/testing/docker/ort_test/Dockerfile
@@ -23,13 +23,18 @@
 # The recommended minimum size for each block devices is 1G.
 # For example, `sudo modprobe brd rd_size=1048576 rd_nr=2`
 
-ARG RHEL_VERSION=8
-FROM centos:${RHEL_VERSION}
-ARG RHEL_VERSION=8
+ARG OS_VERSION=8
+ARG OS_DISTRO=rockylinux
+FROM ${OS_DISTRO}:${OS_VERSION}
+ARG OS_VERSION
+ARG OS_DISTRO
 # Makes RHEL_VERSION available in later layers without needing to specify it again
-ENV RHEL_VERSION=$RHEL_VERSION
+ENV OS_VERSION=${OS_VERSION}
+ENV OS_DISTRO=${OS_DISTRO}
 MAINTAINER dev@trafficcontrol.apache.org
 EXPOSE 80 443
+
+RUN echo "Image Version: ${OS_DISTRO}:${OS_VERSION}"
 
 RUN yum install -y epel-release && yum repolist && \
   yum install -y initscripts git jq gcc lua && \

--- a/cache-config/testing/docker/traffic_ops/Dockerfile
+++ b/cache-config/testing/docker/traffic_ops/Dockerfile
@@ -20,19 +20,23 @@
 # Based on CentOS 8
 ############################################################
 
-ARG RHEL_VERSION=8
-FROM centos:${RHEL_VERSION}
-ARG RHEL_VERSION=8
-# Makes RHEL_VERSION available in later layers without needing to specify it again
-ENV RHEL_VERSION=$RHEL_VERSION
+ARG OS_VERSION=8
+ARG OS_DISTRO=rockylinux
+FROM ${OS_DISTRO}:${OS_VERSION}
+ARG OS_VERSION
+ARG OS_DISTRO
+ENV OS_VERSION=${OS_VERSION}
+ENV OS_DISTRO=${OS_DISTRO}
 
-RUN if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
+RUN echo "Image Version: ${OS_DISTRO}:${OS_VERSION}"
+
+RUN if [[ "${OS_VERSION%%.*}" -eq 7 ]]; then \
 		yum -y install dnf || exit 1; \
 	fi
 
 RUN set -o nounset -o errexit && \
 	mkdir -p /etc/cron.d; \
-	if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
+	if [[ "${OS_VERSION%%.*}" -eq 7 ]]; then \
 		use_repo=''; \
 		enable_repo=''; \
 		# needed for llvm-toolset-7-clang, which is needed for postgresql13-devel-13.2-1PGDG, required by TO rpm
@@ -41,7 +45,7 @@ RUN set -o nounset -o errexit && \
 		use_repo='--repo=pgdg13'; \
 		enable_repo='--enablerepo=powertools'; \
 	fi; \
-	dnf -y install "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${RHEL_VERSION%%.*}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"; \
+	dnf -y install "https://download.postgresql.org/pub/repos/yum/reporpms/EL-${OS_VERSION%%.*}-x86_64/pgdg-redhat-repo-latest.noarch.rpm"; \
 	# libicu required by postgresql13
 	dnf -y install libicu; \
 	dnf -y $use_repo -- install postgresql13; \

--- a/cache-config/testing/docker/trafficserver/Dockerfile
+++ b/cache-config/testing/docker/trafficserver/Dockerfile
@@ -19,31 +19,34 @@
 # Dockerfile to build Traffic Server RPM
 ###############################################################
 
-ARG RHEL_VERSION=8
-FROM centos:${RHEL_VERSION}
-ARG RHEL_VERSION=8
+ARG OS_VERSION=8
+ARG OS_DISTRO=rockylinux
+FROM ${OS_DISTRO}:${OS_VERSION}
+ARG OS_VERSION
+ARG OS_DISTRO
 # Makes RHEL_VERSION available in later layers without needing to specify it again
-ENV RHEL_VERSION=$RHEL_VERSION
+ENV OS_VERSION=${OS_VERSION}
+ENV OS_DISTRO=${OS_DISTRO}
 
 MAINTAINER dev@trafficcontrol.apache.org
 
 VOLUME /atsbuild
 
-RUN echo "Image Version: ${RHEL_VERSION}"
+RUN echo "Image Version: ${OS_DISTRO}:${OS_DISTRO}"
 
 ### Common for all sub-component builds
 RUN set -o errexit; \
-    if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
-		rpm_gpg_key=RPM-GPG-KEY-centosofficial; \
+    if [[ ${OS_VERSION%%.*} -ge 8 ]]; then \
+		rpm_gpg_key=RPM-GPG-KEY-rockyofficial; \
 		yum install -y 'dnf-command(config-manager)'; \
 		yum config-manager --set-enabled powertools; \
 	else \
-		rpm_gpg_key="RPM-GPG-KEY-CentOS-${RHEL_VERSION%%.*}"; \
+		rpm_gpg_key="RPM-GPG-KEY-CentOS-${OS_VERSION%%.*}"; \
 		yum install -y deltarpm centos-release-scl-rh; \
 		yum-config-manager --enable rhel-server-rhscl-7-rpms; \
 	fi && \
-	rpm --import "/etc/pki/rpm-gpg/${rpm_gpg_key}" && \
-	rpm --import "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-${RHEL_VERSION%%.*}" && \
+#	rpm --import "/etc/pki/rpm-gpg/${rpm_gpg_key}" && \
+	rpm --import "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-${OS_VERSION%%.*}" && \
 	yum -y clean all && \
 	yum -y update ca-certificates && \
 	yum -y install \
@@ -53,7 +56,7 @@ RUN set -o errexit; \
 		epel-release && \
 	yum -y clean all
 
-RUN if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
+RUN if [[ ${OS_VERSION%%.*} -ge 8 ]]; then \
 		os_pkgs=( \
 			brotli \
 			brotli-devel \

--- a/cache-config/testing/docker/trafficserver/run.sh
+++ b/cache-config/testing/docker/trafficserver/run.sh
@@ -22,17 +22,19 @@ function die() {
   { test -n "$@" && echo "$@"; exit 1; } >&2 
 }
 
-RHEL_VERSION="${RHEL_VERSION}"
+OS_VERSION="${OS_VERSION}"
+OS_DISTRO=${OS_DISTRO}
 ATS_VERSION="${ATS_VERSION}"
 
-echo "RHEL_VERSION:${RHEL_VERSION}"
+echo "OS_DISTRO:${OS_DISTRO}"
+echo "OS_VERSION:${OS_VERSION}"
 echo "ATS_VERSION:${ATS_VERSION}"
 
 mkdir -p /opt/build
 cd /opt/build
 
-# build openssl 1.1.1 if RHEL_VERSION is not 8 or greater.
-if [[ ${RHEL_VERSION%%.*} -le 7 ]]; then
+# build openssl 1.1.1 if OS_VERSION is not 8 or greater.
+if [ ${OS_VERSION%%.*} -le 7 ]; then
   git clone $OPENSSL_URL --branch $OPENSSL_TAG || die "Failed to fetch the OpenSSL Source."
   (
     cd /opt/build/openssl && 
@@ -68,13 +70,13 @@ cd /root
 [ ! -e rpmbuild ] || { echo "Failed to clean up rpm build directory 'rpmbuild': $?" >&2; exit 1; }
 mkdir -p rpmbuild/{BUILD,BUILDROOT,RPMS,SPECS,SOURCES,SRPMS} || die "Failed to initialize the build environment"
 
-echo "Building a RPM for ATS version: $ATS_VERSION"
+echo "Building a RPM for ATS version: $ATS_VERSION and OS version: $OS_VERSION"
 
 # add the 'ats' user
 id ats &>/dev/null || /usr/sbin/useradd -u 176 -r ats -s /sbin/nologin -d /
 
 # setup the environment to use the devtoolset-9 tools.
-if [[ "${RHEL_VERSION%%.*}" -le 7 ]]; then 
+if [ "${OS_VERSION%%.*}" -le 7 ]; then 
   source scl_source enable devtoolset-9
 else
   source scl_source enable gcc-toolset-9

--- a/cache-config/testing/docker/trafficserver/trafficserver.spec
+++ b/cache-config/testing/docker/trafficserver/trafficserver.spec
@@ -20,9 +20,9 @@
 
 %global src %{_topdir}/SOURCES/trafficserver
 %global git_args --git-dir="%{src}/.git" --work-tree="%{src}"
-%global tag %(git %{git_args} describe --long '--exclude=*.*.*-rc*' |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
-%global distance %(git %{git_args} describe --long '--exclude=*.*.*-rc*' | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
-%global commit %(git %{git_args} describe --long '--exclude=*.*.*-rc*' |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
+%global tag %(git %{git_args} describe --long |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
+%global distance %(git %{git_args} describe --long | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
+%global commit %(git %{git_args} describe --long |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
 %global git_serial %(git %{git_args} rev-list HEAD | wc -l)
 %global install_prefix "/opt"
 %global api_stats "4096"

--- a/cache-config/testing/docker/variables.env
+++ b/cache-config/testing/docker/variables.env
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+# OS_DISTRO may be set to "centos", default is "rockylinux" since RHEL 8
+OS_DISTRO=rockylinux
+# RHEL_VERSION is 7 or 8
+OS_VERSION=8
 CDNCONF=/opt/traffic_ops/app/conf/cdn.conf
 CERT_COUNTRY=US
 CERT_STATE=Colorado
@@ -53,3 +57,13 @@ TV_HTTPS_PORT=8088
 TV_RIAK_USER=riakuser
 TV_RIAK_PASSWORD=tvsecret
 TV_DOMAIN=local
+# trafficserver build variables
+ATS_VERSION=8.1.x
+CJOSE_URL=https://github.com/cisco/cjose
+CJOSE_TAG=latest
+JANSSON_URL=https://github.com/akheron/jansson
+JANSSON_TAG=v2.11
+OPENSSL_URL=https://github.com/openssl/openssl
+OPENSSL_TAG=OpenSSL_1_1_1
+RUN_ATS_UNIT_TESTS=false
+


### PR DESCRIPTION
CentOS 8 docker images used in the cache-config integration
tests no-longer build as the CentOS 8 repositories have been
taken down.  This PR fixes the issue by switching the CentOS 8
images to Rocky Linux images that are compatable with RHEL 8.

## Which Traffic Control components are affected by this PR?

- Traffic Control Cache Config (T3C, formerly ORT)


## What is the best way to verify this PR?
Cache-config tests pass


## If this is a bugfix, which Traffic Control versions contained the bug?

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
