### PR TITLE
CIAB: set GOPROXY to use go module mirror for CentOS 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Fixed
 - Update traffic_portal dependencies to mitigate `npm audit` issues.
+- Fixed a cdn-in-a-box build issue when using `RHEL_VERSION=7`
 
 ### Removed
 - Remove traffic_portal dependencies to mitigate `npm audit` issues, specifically `grunt-concurrent`, `grunt-contrib-concat`, `grunt-contrib-cssmin`, `grunt-contrib-jsmin`, `grunt-contrib-uglify`, `grunt-contrib-htmlmin`, `grunt-newer`, and `grunt-wiredep`

--- a/infrastructure/cdn-in-a-box/cache/Dockerfile
+++ b/infrastructure/cdn-in-a-box/cache/Dockerfile
@@ -117,7 +117,7 @@ CMD /run.sh
 
 FROM common-traffic-server-dependencies AS get-delve
 RUN dnf -y install golang && \
-    go get -u github.com/go-delve/delve/cmd/dlv
+    GOPROXY='https://proxy.golang.org' go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM common-cache-config-layers AS mid
 ENV CACHE_TYPE=mid

--- a/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
@@ -66,8 +66,8 @@ HEALTHCHECK --interval=10s --timeout=1s \
 
 FROM trafficmonitor-dependencies as get-delve
 
-RUN dnf -y install golang git && \
-    go get -u github.com/go-delve/delve/cmd/dlv
+RUN dnf -y install golang && \
+    GOPROXY='https://proxy.golang.org' go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM trafficmonitor as trafficmonitor-debug
 COPY --from=get-delve /root/go/bin /usr/bin

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -114,8 +114,8 @@ HEALTHCHECK --interval=10s --timeout=1s \
 
 FROM trafficops-dependencies as get-delve
 
-RUN dnf -y install git golang && \
-    go get -u github.com/go-delve/delve/cmd/dlv
+RUN dnf -y install golang && \
+    GOPROXY='https://proxy.golang.org' go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM trafficops AS trafficops-debug
 COPY --from=get-delve /root/go/bin /usr/bin

--- a/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
@@ -58,8 +58,8 @@ ENTRYPOINT /run.sh
 
 FROM trafficstats-dependencies AS get-delve
 
-RUN dnf -y install golang git && \
-    go get -u github.com/go-delve/delve/cmd/dlv
+RUN dnf -y install golang && \
+    GOPROXY='https://proxy.golang.org' go get -u github.com/go-delve/delve/cmd/dlv
 
 FROM trafficstats AS trafficstats-debug
 COPY --from=get-delve /root/go/bin /usr/bin


### PR DESCRIPTION
On CentOS 7, the available version of git and/or go is too old and has
an issue when running `go get`:

    git fetch-pack: expected shallow list

By setting GOPROXY, git isn't required for `go get` and solves this
issue. See https://github.com/golang/go/issues/38373 for more details.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Build CIAB using the env var `RHEL_VERSION=7`.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
I suspect this probably affects 5.1.x and 6.1.x as well.

## PR submission checklist
- [ ] No tests b/c it's a CIAB build issue <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] Docs unnecessary <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
