### PR TITLE
TP: adds permissions to roles form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Added Rocky Linux 8 support
+- Added permissions to the role form in traffic portal
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
@@ -44,9 +44,15 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(roleForm.description), 'has-feedback': hasError(roleForm.description)}">
                 <label for="description" class="control-label col-md-2 col-sm-2 col-xs-12">Description</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="description" id="description" ng-readonly="!hasPropertyError(roleForm.name, 'pattern') && role.name === 'admin'" type="text" class="form-control" ng-model="role.description" rows="10" required autofocus></textarea>
+                    <textarea name="description" id="description" ng-readonly="!hasPropertyError(roleForm.name, 'pattern') && role.name === 'admin'" type="text" class="form-control" ng-model="role.description" rows="3" required autofocus></textarea>
                     <small class="input-error" ng-show="hasPropertyError(roleForm.description, 'required')">Required</small>
                     <span ng-show="hasError(roleForm.description)" class="form-control-feedback"><i class="fa fa-times"></i></span>
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="permissions" class="control-label col-md-2 col-sm-2 col-xs-12">Permissions</label>
+                <div class="col-md-10 col-sm-10 col-xs-12">
+                    <textarea name="permissions" id="permissions" type="text" class="form-control" ng-model="role.permissions.join('\n')" rows="10" readonly autofocus></textarea>
                 </div>
             </div>
             <div class="modal-footer">

--- a/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/role/form.role.tpl.html
@@ -44,7 +44,7 @@ under the License.
             <div class="form-group" ng-class="{'has-error': hasError(roleForm.description), 'has-feedback': hasError(roleForm.description)}">
                 <label for="description" class="control-label col-md-2 col-sm-2 col-xs-12">Description</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="description" id="description" ng-readonly="!hasPropertyError(roleForm.name, 'pattern') && role.name === 'admin'" type="text" class="form-control" ng-model="role.description" rows="3" required autofocus></textarea>
+                    <textarea name="description" id="description" ng-readonly="!hasPropertyError(roleForm.name, 'pattern') && role.name === 'admin'" type="text" class="form-control" ng-model="role.description" rows="3" required></textarea>
                     <small class="input-error" ng-show="hasPropertyError(roleForm.description, 'required')">Required</small>
                     <span ng-show="hasError(roleForm.description)" class="form-control-feedback"><i class="fa fa-times"></i></span>
                 </div>
@@ -52,7 +52,7 @@ under the License.
             <div class="form-group">
                 <label for="permissions" class="control-label col-md-2 col-sm-2 col-xs-12">Permissions</label>
                 <div class="col-md-10 col-sm-10 col-xs-12">
-                    <textarea name="permissions" id="permissions" type="text" class="form-control" ng-model="role.permissions.join('\n')" rows="10" readonly autofocus></textarea>
+                    <textarea name="permissions" id="permissions" class="form-control" ng-value="role.permissions.join('\n')" rows="10" readonly></textarea>
                 </div>
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
This PR adds a read-only view of the permissions associated with a role to TP.

![image](https://user-images.githubusercontent.com/251272/152268568-53825579-ee17-41c5-bb5b-20df926d7331.png)

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
In TP, navigate to a role. i.e. https://tp.domain.tld/#!/roles/edit/operations and observe the permissions associated with that role. The form should not allow you to change the permissions.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
