### PR TITLE
Assign Triage Role GHA: Use defaults if inputs are not set

### DIFF
--- a/.github/workflows/assign-triage-role.yml
+++ b/.github/workflows/assign-triage-role.yml
@@ -33,6 +33,10 @@ on:
     # 14:00 UTC on the first day of each month
     - cron: '0 14 1 * *'
 
+env:
+  DEFAULT_MINIMUM_COMMITS: '2'
+  DEFAULT_SINCE_DAYS_AGO: '31'
+
 jobs:
   assign-triage-role:
     runs-on: ubuntu-latest
@@ -54,5 +58,5 @@ jobs:
         env:
           GIT_AUTHOR_NAME: asfgit
           GITHUB_TOKEN: ${{ github.token }}
-          MINIMUM_COMMITS: '${{ github.event.inputs.minimum-commits }}'
-          SINCE_DAYS_AGO: '${{ github.event.inputs.since-days-ago }}'
+          MINIMUM_COMMITS: '${{ github.event.inputs.minimum-commits || env.DEFAULT_MINIMUM_COMMITS }}'
+          SINCE_DAYS_AGO: '${{ github.event.inputs.since-days-ago || env.DEFAULT_SINCE_DAYS_AGO }}'


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR resolves [an error](https://github.com/apache/trafficcontrol/runs/5022299459) caused by the *Assign Triage Role* GitHub Actions workflow not having default values set for the `MINIMUM_COMMITS` or `SINCE_DAYS_AGO` environment variables when being triggered on a schedule, as opposed to being manually dispatched (in which case, in addition to defaults being defined, you can set them from input fields).

```python
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.2/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.2/x64/lib
    GIT_AUTHOR_NAME: asfgit
    GITHUB_TOKEN: ***
    MINIMUM_COMMITS: 
    SINCE_DAYS_AGO: 
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/assign_triage_role/__main__.py", line 25, in <module>
    TriageRoleAssigner(login_or_token=GITHUB_TOKEN).run()
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/assign_triage_role/triage_role_assigner.py", line 58, in __init__
    self.minimum_commits = int(MINIMUM_COMMITS)
ValueError: invalid literal for int() with base 10: ''
Error: Process completed with exit code 1.
```
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - GitHub Actions<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Push the [`zrhoffman:triage-cron-defaults`](https://github.com/zrhoffman/trafficcontrol/tree/triage-cron-defaults) branch to the `master` branch of your own ATC fork
2. In the *Assign Triage Role* GHA workflow file, set `- cron:` to `'* * * * *'`
3. Remove this line in the *Assign Triage Role* GHA workflow file, since this is a rare case when we are testing the job when dispatched by a schedule:
   ```gha
        if: ${{ (github.repository_owner == 'apache' && github.ref == 'refs/heads/master' ) || github.event_name != 'schedule' }}
   ```
4. Wait (1-2 hours) until a Pull Request shows up on your fork titled *ATC Collaborators for February 2022*
5. Set `- cron:` back to `'0 14 1 * *'` so it doesn't run every minute of the day anymore

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->