### PR TITLE
Add t3c-preprocess cachegroup directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6405](https://github.com/apache/trafficcontrol/issues/6405) Added cache config version to all t3c apps and config file headers
 - Traffic Vault: Added additional flag to TV Riak (Deprecated) Util
 - Added Traffic Vault Postgres columns, a Traffic Ops API endpoint, and Traffic Portal page to show SSL certificate expiration information.
+- Added cache config `__CACHEGROUP__` preprocess directive, to allow injecting the local server's cachegroup name into any config file
 - Added support for a DS profile parameter 'LastRawRemapPre' and 'LastRawRemapPost' which allows raw text lines to be pre or post pended to remap.config.
 
 ### Fixed

--- a/cache-config/t3c-preprocess/README.md
+++ b/cache-config/t3c-preprocess/README.md
@@ -65,6 +65,8 @@ The following directives will be replaced. These directives may be placed anywhe
     __FULL_HOSTNAME__   is replaced with the Server's HostName, a dot, and the Server's DomainName
                         from Traffic Ops (i.e. the Server's Fully Qualified Domain Name).
 
+    __CACHEGROUP__      is replaced with the Server's Cachegroup name from Traffic Ops.
+
     __RETURN__          is replaced with a newline character, and any whitespace before or after
                         it is removed.
 

--- a/cache-config/t3c-preprocess/t3c-preprocess.go
+++ b/cache-config/t3c-preprocess/t3c-preprocess.go
@@ -95,6 +95,12 @@ func PreprocessConfigFile(server *atscfg.Server, cfgFile string) string {
 	} else {
 		cfgFile = strings.Replace(cfgFile, `__FULL_HOSTNAME__`, *server.HostName+`.`+*server.DomainName, -1)
 	}
+	if server.Cachegroup != nil && *server.Cachegroup != "" {
+		cfgFile = strings.Replace(cfgFile, `__CACHEGROUP__`, *server.Cachegroup, -1)
+	} else {
+		log.Errorln("Preprocessing: this server missing Cachegroup, cannot replace __CACHEGROUP__ directives!")
+	}
+
 	cfgFile = returnRegex.ReplaceAllString(cfgFile, "\n")
 	return cfgFile
 }

--- a/cache-config/t3c-preprocess/t3c-preprocess_test.go
+++ b/cache-config/t3c-preprocess/t3c-preprocess_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestPreprocessConfigFile(t *testing.T) {
 	// the TCP port replacement is fundamentally different for 80 vs non-80, so test both
-	{
+	t.Run("verify port 80 replace", func(t *testing.T) {
 		server := &atscfg.Server{}
 		server.TCPPort = util.IntPtr(8080)
 		server.Interfaces = []tc.ServerInterfaceInfoV40{}
@@ -54,9 +54,9 @@ func TestPreprocessConfigFile(t *testing.T) {
 		if expected != actual {
 			t.Errorf("PreprocessConfigFile expected '%v' actual '%v'", expected, actual)
 		}
-	}
+	})
 
-	{
+	t.Run("verify nonstandard port replace", func(t *testing.T) {
 		server := &atscfg.Server{}
 		server.TCPPort = util.IntPtr(80)
 		server.Interfaces = []tc.ServerInterfaceInfoV40{}
@@ -82,5 +82,23 @@ func TestPreprocessConfigFile(t *testing.T) {
 		if expected != actual {
 			t.Errorf("PreprocessConfigFile expected '%v' actual '%v'", expected, actual)
 		}
-	}
+	})
+
+	t.Run("verify cachegroup replace", func(t *testing.T) {
+		server := &atscfg.Server{}
+		server.TCPPort = util.IntPtr(80)
+		server.Cachegroup = util.StrPtr("mycachegroup")
+		server.HostName = util.StrPtr("my-edge")
+		server.DomainName = util.StrPtr("example.net")
+
+		cfgFile := "abc__CACHEGROUP__defghi __RETURN__  \t __HOSTNAME__ jkl __FULL_HOSTNAME__ \n__SOMETHING__ __ELSE__\nmno\r\n"
+
+		actual := PreprocessConfigFile(server, cfgFile)
+
+		expected := "abcmycachegroupdefghi\nmy-edge jkl my-edge.example.net \n__SOMETHING__ __ELSE__\nmno\r\n"
+
+		if expected != actual {
+			t.Errorf("PreprocessConfigFile expected '%v' actual '%v'", expected, actual)
+		}
+	})
 }


### PR DESCRIPTION
Adds a `__CACHEGROUP__` preprocess directive to t3c. This allows users to, for example, inject the local server's cachegroup into a Header Rewrite, or the records.config server name to be put in the Via header.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests. Generate config with the `__CACHEGROUP__` directive somewhere (config file Parameter, Header Rewrite, etc), verify the directive is replaced with the server's cachegroup name.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
