### PR TITLE
Send fallbackToClosest as a boolean instead of a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a cdn-in-a-box build issue when using `RHEL_VERSION=7`
 - [#6549](https://github.com/apache/trafficcontrol/issues/6549) Fixed internal server error while deleting a delivery service created from a DSR (Traafic Ops).
 - [#6538](https://github.com/apache/trafficcontrol/pull/6538) Fixed the incorrect use of secure.port on TrafficRouter and corrected to the httpsPort value from the TR server configuration.
+- [#6562](https://github.com/apache/trafficcontrol/pull/6562) Fixed incorrect template in Ansible dataset loader role when fallbackToClosest is defined.
 
 ### Removed
 - Remove traffic_portal dependencies to mitigate `npm audit` issues, specifically `grunt-concurrent`, `grunt-contrib-concat`, `grunt-contrib-cssmin`, `grunt-contrib-jsmin`, `grunt-contrib-uglify`, `grunt-contrib-htmlmin`, `grunt-newer`, and `grunt-wiredep`

--- a/infrastructure/ansible/roles/dataset_loader/templates/cachegroup.j2
+++ b/infrastructure/ansible/roles/dataset_loader/templates/cachegroup.j2
@@ -13,7 +13,7 @@
 #}
 {
 {% if item.fallbackToClosest is defined and item.fallbackToClosest is not none %}
-  "fallbackToClosest": "{{ item.fallbackToClosest }}",
+  "fallbackToClosest": {{ item.fallbackToClosest }},
 {% endif %}
 {% if item.latitude is defined and item.latitude is not none %}
   "latitude": {{ item.latitude }},


### PR DESCRIPTION
Closes: #6539

Adjusting the Ansible dataset loader cacheGroup jinja template to send fallbackToClosest ( if provided ) as a boolean instead of a string.

<hr/>

## Which Traffic Control components are affected by this PR?

- Automation (Ansible)

## What is the best way to verify this PR?
An example to trigger this is listed with the issue #6539 

## If this is a bugfix, which Traffic Control versions contained the bug?
5.1.x
6.x

## PR submission checklist
- [ ] This PR has tests 
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
