### PR TITLE
Add running db/admin for Traffic Vault in Traffic Ops upgrade example

### DIFF
--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -237,6 +237,7 @@ To upgrade from older Traffic Ops versions, stop the service, use :manpage:`yum(
 	yum upgrade traffic_ops
 	pushd /opt/traffic_ops/app/
 	./db/admin --env production upgrade
+	./db/admin --env production --trafficvault upgrade
 	popd
 
 After this completes, see Guide_ for instructions on running the :program:`postinstall` script. Once the :program:`postinstall` script, has finished, run the following command as the root user (or with :manpage:`sudo(8)`): ``systemctl start traffic_ops`` to start the service.


### PR DESCRIPTION
This PR adds a line showing the running of the `traffic_ops/app/db/admin.go` program (typically referred to by its TO app install path-relative name `db/admin`) for Traffic Vault during an upgrade of Traffic Ops, which is now necessary if you're using the only non-deprecated Traffic Vault implementation/back-end.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the call signature is correct, and verify that there's nothing wrong with e.g. the order in which it's being done.

## PR submission checklist
- [ ] This PR has tests - documentation doesn't need tests
- [x] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry - this change doesn't merit such an entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**