### PR TITLE
Fix cache config generation for MIDs with a cache parent and HTTPS origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Update traffic_portal dependencies to mitigate `npm audit` issues.
 - Fixed a cdn-in-a-box build issue when using `RHEL_VERSION=7`
+- [#6580](https://github.com/apache/trafficcontrol/issues/6580) Fixed cache config generation remap.config targets for MID-type servers in a Topology with other caches as parents and HTTPS origins.
 - [#6549](https://github.com/apache/trafficcontrol/issues/6549) Fixed internal server error while deleting a delivery service created from a DSR (Traafic Ops).
 - [#6538](https://github.com/apache/trafficcontrol/pull/6538) Fixed the incorrect use of secure.port on TrafficRouter and corrected to the httpsPort value from the TR server configuration.
 - [#6562](https://github.com/apache/trafficcontrol/pull/6562) Fixed incorrect template in Ansible dataset loader role when fallbackToClosest is defined.


### PR DESCRIPTION
Fixes cache config remap.config generation when a server is MID type
with other caches as parents in a Topology, and HTTPS origins.

The bug was inserting the Origin's URI verbatim in the remap target,
without changing HTTPS schemes to HTTP for the internal CDN request.

This bug existed for ages, and was fixed in most other scenarios,
but not this exact one.

Note the corresponding parent.config line correctly expects http/80. 
The bug is only in remap.config generation.

Includes tests.
Includes changelog.
No docs, no interface change.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (t3c, formerly ORT)

## What is the best way to verify this PR?
Run tests. Create a Topology with a MID-type server, with other caches as parents, and assign it to a Delivery Service with an HTTPS origin. Verify generated remap.config has an `http` target, not `https`.

## If this is a bugfix, which Traffic Control versions contained the bug?
Bug has existed forever.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
~- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->~ No docs, no interface change
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
