### PR TITLE
TMs peer with other TMs of the same status, not just ONLINE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Added Rocky Linux 8 support
+- Traffic Monitors now peer with other Traffic Monitors of the same status (e.g. ONLINE with ONLINE, OFFLINE with OFFLINE), instead of all peering with ONLINE.
 - Added permissions to the role form in traffic portal
 
 ## [6.1.0] - 2022-01-18

--- a/traffic_monitor/manager/monitorconfig_test.go
+++ b/traffic_monitor/manager/monitorconfig_test.go
@@ -392,12 +392,15 @@ func TestGetCacheGroupsToPoll(t *testing.T) {
 			ExpectErr: false,
 		},
 	} {
-		tmGroup, toPoll, err := getCacheGroupsToPoll(tc.DistributedPolling, tc.TMName, monitors, caches, cacheGroups)
+		tmGroup, tmStatus, toPoll, err := getCacheGroupsToPoll(tc.DistributedPolling, tc.TMName, monitors, caches, cacheGroups)
 		if tc.ExpectErr != (err != nil) {
 			t.Errorf("getting cachegroups to poll -- expect error: %t, actual error: %v", tc.ExpectErr, err)
 		}
 		if tc.ExpectedTMGroup != tmGroup {
 			t.Errorf("getting TM group -- expected: %s, actual: %s", tc.ExpectedTMGroup, tmGroup)
+		}
+		if tmStatus != "ONLINE" {
+			t.Errorf("expected TM status: ONLINE, actual: %s", tmStatus)
 		}
 		if !reflect.DeepEqual(tc.ExpectedToPoll, toPoll) {
 			t.Errorf("getting cachegroups to poll -- expected: %+v, actual: %+v", tc.ExpectedToPoll, toPoll)


### PR DESCRIPTION
Instead of every TM peering with every other ONLINE TM, make TMs peer
with other TMs of the same status. I.e. ONLINE TMs will peer with other
ONLINE TMs (like normal), but OFFLINE TMs will peer with other OFFLINE
TMs (instead of peering w/ ONLINE TMs). The same goes for TMs of any
other status.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
In an environment with at least 2 TMs, change their statuses to `OFFLINE`, then verify that they're peered with each other. One way to check this is to look at `/publish/PeerStates`, and check the `"peers"` map keys. Each key will be the hostname of a peer.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] no docs necessary
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
