### PR TITLE
Fix stored DSRs cannot be unmarshaled after changes to DS JSON representation

### DIFF
--- a/traffic_ops/app/db/migrations/2022022319353588_fix_dsr_geolimit.down.sql
+++ b/traffic_ops/app/db/migrations/2022022319353588_fix_dsr_geolimit.down.sql
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+UPDATE public.deliveryservice_request
+SET
+    deliveryservice =
+        CASE
+            WHEN deliveryservice -> 'geoLimitCountries' = '[]' OR deliveryservice -> 'geoLimitCountries' = 'null' THEN jsonb_set(deliveryservice, '{geoLimitCountries}', '""')
+            ELSE jsonb_set(
+                deliveryservice,
+                '{geoLimitCountries}',
+                replace(
+                    replace(
+                        trim(both '[]' from (deliveryservice->'geoLimitCountries')::text),
+                        ' ',
+                        ''
+                    ),
+                    '","',
+                    ','
+                )::jsonb
+            )
+        END
+WHERE
+    deliveryservice IS NOT NULL;
+
+UPDATE public.deliveryservice_request
+SET
+    original =
+        CASE
+            WHEN original -> 'geoLimitCountries' = '[]' OR original -> 'geoLimitCountries' = 'null' THEN jsonb_set(original, '{geoLimitCountries}', '""')
+            ELSE jsonb_set(
+                original,
+                '{geoLimitCountries}',
+                replace(
+                    replace(
+                        trim(both '[]' from (original->'geoLimitCountries')::text),
+                        ' ',
+                        ''
+                    ),
+                    '","',
+                    ','
+                )::jsonb
+            )
+        END
+WHERE
+    original IS NOT NULL;

--- a/traffic_ops/app/db/migrations/2022022319353588_fix_dsr_geolimit.up.sql
+++ b/traffic_ops/app/db/migrations/2022022319353588_fix_dsr_geolimit.up.sql
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+UPDATE public.deliveryservice_request
+SET
+    deliveryservice =
+        CASE
+            WHEN deliveryservice -> 'geoLimitCountries' = '""' THEN jsonb_set(deliveryservice, '{geoLimitCountries}', '[]')
+            ELSE jsonb_set(deliveryservice, '{geoLimitCountries}', ('[' || replace((deliveryservice->'geoLimitCountries')::text, ',', '","') || ']')::jsonb)
+        END
+WHERE
+    deliveryservice IS NOT NULL;
+
+UPDATE public.deliveryservice_request
+SET
+    original =
+        CASE
+            WHEN original -> 'geoLimitCountries' = '""' THEN jsonb_set(original, '{geoLimitCountries}', '[]')
+            ELSE jsonb_set(original, '{geoLimitCountries}', ('[' || replace((original->'geoLimitCountries')::text, ',', '","') || ']')::jsonb)
+        END
+WHERE
+    original IS NOT NULL;


### PR DESCRIPTION
Fixes a compatibility issue with #6441 and pre-existing Delivery Service Requests, causing them to be un-retrieve-able from the Traffic Ops API due to unmarshaling failure.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops (database only)

## What is the best way to verify this PR?
Create a Delivery Service Request at a point before #6441 was merged (actually creation afterward might still cause the issue now that I'm thinking of it, I haven't checked if that works), then upgrade TO to a version/ including #6441 and try to GET `/deliveryservice_requests`. Observe failure. Then run the migration in this PR and observe that it now works. Finally, downgrade the database and verify that it's broken again, then downgrade TO to a version that once again _doesn't_ include #6441 and verify that the old representation works again.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**