### PR TITLE
Fix TR NPE when topology cachegroup doesn't exist in crconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Update traffic_portal dependencies to mitigate `npm audit` issues.
 - Fixed a cdn-in-a-box build issue when using `RHEL_VERSION=7`
 - [#6580](https://github.com/apache/trafficcontrol/issues/6580) Fixed cache config generation remap.config targets for MID-type servers in a Topology with other caches as parents and HTTPS origins.
+- Traffic Router: fixed a null pointer exception that caused snapshots to be rejected if a topology cachegroup did not have any online/reported/admin_down caches
 - [#6549](https://github.com/apache/trafficcontrol/issues/6549) Fixed internal server error while deleting a delivery service created from a DSR (Traafic Ops).
 - [#6538](https://github.com/apache/trafficcontrol/pull/6538) Fixed the incorrect use of secure.port on TrafficRouter and corrected to the httpsPort value from the TR server configuration.
 - [#6562](https://github.com/apache/trafficcontrol/pull/6562) Fixed incorrect template in Ansible dataset loader role when fallbackToClosest is defined.

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/config/ConfigHandler.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/config/ConfigHandler.java
@@ -499,6 +499,7 @@ public class ConfigHandler {
 						statMap.put(ds.getId(), dsNames);
 						return topologyMap.get(topologyName).stream();
 					})
+					.filter(node -> cacheRegister.getCacheLocation(node) != null)
 					.flatMap(node -> cacheRegister.getCacheLocation(node).getCaches().stream())
 					.filter(cache -> ds.hasRequiredCapabilities(cache.getCapabilities()))
 					.forEach(cache -> {

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TrafficRouterStart.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TrafficRouterStart.java
@@ -15,12 +15,15 @@
 
 package org.apache.traffic_control.traffic_router.core;
 
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
+
+import java.util.Collection;
 
 public class TrafficRouterStart {
 
@@ -37,11 +40,18 @@ public class TrafficRouterStart {
 		System.setProperty("dns.tcp.port", "1053");
 		System.setProperty("dns.udp.port", "1053");
 
-		LoggerContext.getContext().getLogger("org.springframework").setLevel(Level.WARN);
+		LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+		Configuration config = ctx.getConfiguration();
+		config.getLoggerConfig("org.springframework").setLevel(Level.WARN);
 
+		Collection<Appender> rootAppenders = ctx.getRootLogger().getAppenders().values();
+		for (Appender a : rootAppenders) {
+			ctx.getRootLogger().removeAppender(a);
+		}
 		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setName("TrafficRouterStart").setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
-		LoggerContext.getContext().getRootLogger().addAppender(consoleAppender);
-		LoggerContext.getContext().getRootLogger().setLevel(Level.INFO);
+		ctx.getRootLogger().addAppender(consoleAppender);
+		config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).setLevel(Level.INFO);
+		ctx.updateLoggers();
 
 		System.out.println("[" + System.currentTimeMillis() + "] >>>>>>>>>>>>>>>> Embedded Tomcat loading Traffic Router");
 		CatalinaTrafficRouter catalinaTrafficRouter = new CatalinaTrafficRouter(prefix + "/src/main/conf/server.xml", prefix + "/src/main/webapp" );


### PR DESCRIPTION
Also, fix TrafficRouterStart logging configuration so that it actually
logs at the INFO-level again (this was likely a regression from the
conversion to log4j2).

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
In an environment with a topology that is assigned to at least 1 delivery service in your CDN, start TR, let it process the current crconfig, set all the caches in a particular EDGE cachegroup of the topology to OFFLINE, snapshot the CDN, then observe TR. Before this fix, TR would reject the crconfig due to encountering a `NullPointerException`. With this fix, TR processes the snapshot successfully.

To verify the TrafficRouterStart logging, run TrafficRouterStart (typically in an IDE) and verify that it logs to the console at the INFO level.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 5.x
- 6.x

## PR submission checklist
- [x] This PR does not have tests
- [x] bugfix, no docs necessary
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
