### PR TITLE
t3c: add support for merge_parent_groups for parent.config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added cache config `__CACHEGROUP__` preprocess directive, to allow injecting the local server's cachegroup name into any config file
 - Added t3c experimental strategies generation.
 - Added support for a DS profile parameter 'LastRawRemapPre' and 'LastRawRemapPost' which allows raw text lines to be pre or post pended to remap.config.
+- Added DS parameter 'merge_parent_groups' to allow primary and secondary parents to be merged into the primary parent list in parent.config.
 
 ### Fixed
 - [#6411](https://github.com/apache/trafficcontrol/pull/6411) Removes invalid 'ALL cdn' options from TP

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -985,6 +985,16 @@ A Delivery Service Profile_ can have :term:`Parameters` that affect Multi-Site O
 
 .. warning:: The ``mso.simple_retry_response_codes`` :term:`Parameter` has no apparent, possible use according to the :abbr:`ATS (Apache Traffic Server)` `parent.config documentation <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/files/parent.config.en.html>`_. Whether or not it has any effect - let alone the *intended* effect - is not known, and its use is therefore strongly discouraged.
 
+Additional Delivery Service Profile_ :term:`Parameters` have been introduced that affects `parent.config` line generation
+
+.. table:: :term:`Parameters` of a Delivery Service Profile_ that Affect :abbr:`MSO (Multi-Site-Origin)` Parenting
+	+---------------------------------------------+----------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
+	| Name                                        | field value                                                                | Effect                                                                              |
+	+=============================================+============================================================================+=====================================================================================+
+	| merge_parent_groups                         | space separated list of cache groups to combine                            | Moves the secondary_parent list into the primary parent.  This can be used to       |
+	|                                             |                                                                            | combine all parents into a single consistent hash ring.                             |
+	+---------------------------------------------+----------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
+
 .. seealso:: A quick guide on setting up Multi-Site Origins is given in :ref:`multi-site-origin-qht`.
 
 .. seealso:: See the `Apache Traffic Server documentation <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/files/parent.config.en.html>`_ for more information on its implementation of Multi-Site Origins.


### PR DESCRIPTION
For MSO configuration with topologies, this will move all
secondary_parent entries into the primary parent.  This
allows for consistent hashing across 2 parent cache groups.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This allows a mid tier to parent into a single consistent hash ring using 2 different parent cache groups.  Each different parent hash group might have their own different priority parents.  Meant to work only with topologies.

This is a temporary workaround until a proper TO fix is implemented.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Control Cache Config (T3C, formerly ORT)
- Automation <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->
- unknown

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

For an MSO topology DS, take an edge cache group with 2 mid cache groups as parents.  one as primary, one as secondary.

Add DS parameter like the following (list of cache groups space separated):
```
merge_cache_groups
parent.config
<mid cg0> <mid cg1>
```

Verify that the generated parent.config only has parent= with all cache group members.  No secondary_parent list should be present.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
