### PR TITLE
Fix user Permissions calculated incorrectly/inconsistently

### DIFF
--- a/experimental/traffic-portal/src/app/app.ui.module.ts
+++ b/experimental/traffic-portal/src/app/app.ui.module.ts
@@ -22,6 +22,7 @@ import { MatDatepickerModule } from "@angular/material/datepicker";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatDividerModule } from "@angular/material/divider";
 import { MatExpansionModule } from "@angular/material/expansion";
+import { MatIconModule } from "@angular/material/icon";
 import { MatInputModule } from "@angular/material/input";
 import { MatListModule } from "@angular/material/list";
 import { MatRadioModule } from "@angular/material/radio";
@@ -49,6 +50,7 @@ import { AgGridModule } from "ag-grid-angular";
 		MatCardModule,
 		MatDividerModule,
 		MatExpansionModule,
+		MatIconModule,
 		MatInputModule,
 		MatListModule,
 		MatRadioModule,

--- a/experimental/traffic-portal/src/app/core/currentuser/currentuser.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/currentuser/currentuser.component.spec.ts
@@ -63,6 +63,7 @@ describe("CurrentuserComponent", () => {
 						get currentUser(): CurrentUser | null {
 							return currentUser;
 						},
+						hasPermission: (): boolean => true,
 						updateCurrentUser: async (): Promise<boolean> => updateSpy()
 					}
 				},

--- a/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.html
+++ b/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.html
@@ -19,4 +19,4 @@ limitations under the License.
 	</article>
 	<div id="loading" *ngIf="loading"><tp-loading></tp-loading></div>
 </main>
-<a mat-fab id="new" *ngIf="canCreateDeliveryServices" title="Create a new Delivery Service" routerLink="/core/new.Delivery.Service">+</a>
+<a mat-fab id="new" *ngIf="canCreateDeliveryServices" title="Create a new Delivery Service" routerLink="/core/new.Delivery.Service"><mat-icon>add</mat-icon></a>

--- a/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.scss
+++ b/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.scss
@@ -77,14 +77,4 @@ a#new {
 	position: fixed;
 	bottom: 5px;
 	right: 5px;
-	width: 2em;
-	height: 2em;
-	background-color: $theme_tertiary;
-	color: white;
-	text-decoration: none;
-	padding: 1em;
-	border-radius: 2em;
-	text-align: center;
-	vertical-align: middle;
-	line-height: 2em;
 }

--- a/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.spec.ts
@@ -36,7 +36,7 @@ describe("DashboardComponent", () => {
 	let router: Router;
 
 	beforeEach(async () => {
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"],
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"],
 			{capabilities: new Set<string>()});
 
 		await TestBed.configureTestingModule({

--- a/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.ts
+++ b/experimental/traffic-portal/src/app/core/dashboard/dashboard.component.ts
@@ -64,7 +64,9 @@ export class DashboardComponent implements OnInit {
 	 * Whether or not the currently logged-in user has permission to create
 	 * Delivery Services.
 	 */
-	public canCreateDeliveryServices = false;
+	public get canCreateDeliveryServices(): boolean {
+		return this.auth.hasPermission("DELIVERY-SERVICE:CREATE");
+	}
 
 	/**
 	 * The date and time at which the page loaded.
@@ -77,9 +79,6 @@ export class DashboardComponent implements OnInit {
 	/** Fuzzy search control */
 	public fuzzControl = new FormControl("", {updateOn: "change"});
 
-	/**
-	 * Constructor.
-	 */
 	constructor(
 		private readonly dsAPI: DeliveryServiceService,
 		private readonly route: ActivatedRoute,
@@ -114,8 +113,6 @@ export class DashboardComponent implements OnInit {
 				}
 			}
 		);
-
-		this.canCreateDeliveryServices = this.auth.capabilities.has("ds-create");
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/core/deliveryservice/deliveryservice.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/deliveryservice/deliveryservice.component.spec.ts
@@ -32,7 +32,7 @@ describe("DeliveryserviceComponent", () => {
 
 	beforeEach(async () => {
 		// mock the API
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"]);
 
 		await TestBed.configureTestingModule({
 			declarations: [

--- a/experimental/traffic-portal/src/app/core/invalidation-jobs/invalidation-jobs.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/invalidation-jobs/invalidation-jobs.component.spec.ts
@@ -36,7 +36,7 @@ describe("InvalidationJobsComponent", () => {
 
 	beforeEach(async () => {
 		// mock the API
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"]);
 
 		await TestBed.configureTestingModule({
 			declarations: [

--- a/experimental/traffic-portal/src/app/core/new-delivery-service/new-delivery-service.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/new-delivery-service/new-delivery-service.component.spec.ts
@@ -38,7 +38,7 @@ describe("NewDeliveryServiceComponent", () => {
 
 	beforeEach(async () => {
 		// mock the API
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"], {currentUser: {
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"], {currentUser: {
 			tenant: "root",
 			tenantId: 1
 		}});

--- a/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.spec.ts
@@ -31,7 +31,7 @@ describe("ServersTableComponent", () => {
 	let router: Router;
 
 	beforeEach(() => {
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"]);
 		TestBed.configureTestingModule({
 			declarations: [ ServersTableComponent, TpHeaderComponent ],
 			imports: [

--- a/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
@@ -29,8 +29,9 @@ describe("UsersComponent", () => {
 
 	beforeEach(waitForAsync(() => {
 		// mock the API
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"]);
 		mockCurrentUserService.updateCurrentUser.and.returnValue(new Promise(r => r(false)));
+		mockCurrentUserService.hasPermission.and.returnValue(true);
 
 		TestBed.configureTestingModule({
 			declarations: [

--- a/experimental/traffic-portal/src/app/models/user.ts
+++ b/experimental/traffic-portal/src/app/models/user.ts
@@ -163,3 +163,6 @@ export interface Capability {
 	/** The date/time at which the Capability was last updated. */
 	lastUpdated?: Date;
 }
+
+/** The name of a special Role that is always allowed to do whatever it wants. */
+export const ADMIN_ROLE = "admin";

--- a/experimental/traffic-portal/src/app/shared/currentUser/current-user.service.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/currentUser/current-user.service.spec.ts
@@ -56,7 +56,7 @@ describe("CurrentUserService", () => {
 		service.logout();
 		expect(service.loggedIn).toBeFalse();
 		expect(service.currentUser).toBeNull();
-		expect(service.capabilities.size).toBe(0);
+		expect(service.capabilities.getValue().size).toBe(0);
 	});
 
 	it("should update user data properly", () => {
@@ -151,18 +151,24 @@ describe("CurrentUserService", () => {
 	it("should update user permissions properly", () => {
 		service.setUser(newCurrentUser(), new Set(["a different permission"]));
 		expect(service.hasPermission("a different permission")).toBeTrue();
+
 		service.logout();
+
 		expect(service.hasPermission("a different permission")).toBeFalse();
+
 		service.setUser(newCurrentUser(), new Set(["a permission"]));
-		expect(service.capabilities.has("a permission")).toBeTrue();
 		expect(service.hasPermission("a permission")).toBeTrue();
-		expect(service.capabilities.has("a different permission")).toBeFalse();
 		expect(service.hasPermission("a different permission")).toBeFalse();
+
 		service.setUser(newCurrentUser(), [{description: "", name: "a permission"}]);
-		expect(service.capabilities.has("a permission")).toBeTrue();
 		expect(service.hasPermission("a permission")).toBeTrue();
-		expect(service.capabilities.has("a different permission")).toBeFalse();
 		expect(service.hasPermission("a different permission")).toBeFalse();
+	});
+
+	it("lets 'admin' users do things even when they don't have permission", () => {
+		service.setUser({...newCurrentUser(), roleName: "admin"}, new Set());
+		expect(service.capabilities.getValue().has("a permission")).toBeFalse();
+		expect(service.hasPermission("a permission")).toBeTrue();
 	});
 
 	it("fetches the current user when appropriate", async () => {

--- a/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.html
+++ b/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.html
@@ -18,8 +18,8 @@ limitations under the License.
 	<nav id="expanded">
 		<ul>
 			<li><a routerLink="/core/">Home</a></li>
-			<li ><a routerLink="/core/users">Users</a></li>
-			<li ><a routerLink="/core/servers">Servers</a></li>
+			<li *ngIf="hasPermission('USER:READ')"><a routerLink="/core/users">Users</a></li>
+			<li *ngIf="hasPermission('SERVER:READ')"><a routerLink="/core/servers">Servers</a></li>
 			<li><button class="menubutton" type="button" (click)="logout()">Logout</button></li>
 			<li><a routerLink="/core/me"><svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" viewBox="0 0 16 16"><g id="surface1"><path d="M 8 2 C 6.347656 2 5 3.347656 5 5 C 5 6.652344 6.347656 8 8 8 C 9.652344 8 11 6.652344 11 5 C 11 3.347656 9.652344 2 8 2 Z M 8 8 C 5.246094 8 3 10.246094 3 13 L 4 13 C 4 10.785156 5.785156 9 8 9 C 10.214844 9 12 10.785156 12 13 L 13 13 C 13 10.246094 10.753906 8 8 8 Z M 8 3 C 9.109375 3 10 3.890625 10 5 C 10 6.109375 9.109375 7 8 7 C 6.890625 7 6 6.109375 6 5 C 6 3.890625 6.890625 3 8 3 Z "></path></g></svg>
 			</a></li>
@@ -30,8 +30,8 @@ limitations under the License.
 		<label for="collapsed-menu"></label>
 		<ul>
 			<li><a routerLink="/core/">Home</a></li>
-			<li><a routerLink="/core/users">Users</a></li>
-			<li><a routerLink="/core/servers">Servers</a></li>
+			<li *ngIf="hasPermission('USER:READ')"><a routerLink="/core/users">Users</a></li>
+			<li *ngIf="hasPermission('SERVER:READ')"><a routerLink="/core/servers">Servers</a></li>
 			<li><a href="#">Tools</a></li>
 			<li><a href="/core/me">Profile</a></li>
 			<li><button type="button" class="menubutton" (click)="logout()">Logout</button></li>

--- a/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.spec.ts
@@ -27,7 +27,7 @@ describe("TpHeaderComponent", () => {
 	let logOutSpy: jasmine.Spy;
 
 	beforeEach(waitForAsync(() => {
-		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "login", "logout"]);
+		const mockCurrentUserService = jasmine.createSpyObj(["updateCurrentUser", "hasPermission", "login", "logout"]);
 		logOutSpy = mockCurrentUserService.logout;
 		TestBed.configureTestingModule({
 			declarations: [ TpHeaderComponent ],

--- a/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.ts
+++ b/experimental/traffic-portal/src/app/shared/tp-header/tp-header.component.ts
@@ -11,7 +11,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Component, Input, OnInit } from "@angular/core";
+import { Component, Input } from "@angular/core";
 
 import { UserService } from "src/app/api";
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
@@ -24,12 +24,7 @@ import { CurrentUserService } from "src/app/shared/currentUser/current-user.serv
 	styleUrls: ["./tp-header.component.scss"],
 	templateUrl: "./tp-header.component.html"
 })
-export class TpHeaderComponent implements OnInit {
-
-	/**
-	 * The set of permissions available to the authenticated user.
-	 */
-	public permissions = new Set<string>();
+export class TpHeaderComponent {
 
 	/**
 	 * The title to be used in the header.
@@ -38,13 +33,18 @@ export class TpHeaderComponent implements OnInit {
 	 */
 	@Input() public title?: string;
 
-	/** Constructor */
 	constructor(private readonly auth: CurrentUserService, private readonly api: UserService) {
 	}
 
-	/** Sets up data dependencies. */
-	public ngOnInit(): void {
-		this.permissions = this.auth.capabilities;
+	/**
+	 * Checks for a Permission afforded to the currently authenticated user.
+	 *
+	 * @param perm The Permission for which to check.
+	 * @returns Whether the currently authenticated user has the Permission
+	 * `perm`.
+	 */
+	public hasPermission(perm: string): boolean {
+		return this.auth.hasPermission(perm);
 	}
 
 	/**


### PR DESCRIPTION
Permissions also updated to reflect those actually laid out in the documentation (although TPv2 only uses stable API versions).

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure the included tests pass. Start TPv2, log in as an "admin"-Role user, make sure you can do everything. Log in as a read-only user, make sure that the "New Delivery Service" button has disappeared from the dashboard. Log in as a user who doesn't have Permissions to see users and/or servers, then verify that the associated menu items in the header vanish appropriately.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**