### PR TITLE
Fix incorrect template strings

### DIFF
--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -305,7 +305,7 @@ class GoPRMaker:
 		kwargs = {
 			"branch": source_branch_name,
 			"committer": NotSet,
-			"content": f"${go_version}\n",
+			"content": f"{go_version}\n",
 			"path": go_version_file,
 			"message": commit_message,
 			"sha": self.file_contents(go_version_file, source_branch_name).sha
@@ -379,7 +379,7 @@ class GoPRMaker:
 		milestone_url = self.get_go_milestone(latest_go_version)
 		if milestone_url is None:
 			#TODO subclass this
-			raise LookupError(f"no milestone found for '${latest_go_version}'")
+			raise LookupError(f"no milestone found for '{latest_go_version}'")
 		pr_body = get_pr_body(latest_go_version, milestone_url)
 		pull_request: PullRequest = self.repo.create_pull(
 			title=commit_message,


### PR DESCRIPTION
This PR fixes an issue introduced in #6532 where some template strings use Javascript syntax like
```javascript
`${variableName}`;
```
but they should use Python syntax like
```python3
f"{variable_name}"
```
<hr/>

## Which Traffic Control components are affected by this PR?
- GitHub Actions

## What is the best way to verify this PR?
Run the GHA on your fork, verify the resulting PR

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**