### PR TITLE
Remove t3c debug print

### DIFF
--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -353,7 +353,6 @@ func makeParentDotConfigData(
 				parentAbstraction.Services = append(parentAbstraction.Services, txt)
 			}
 		} else if cacheIsTopLevel {
-			warnings = append(warnings, "DEBUG cacheIsTopLevel")
 			parentQStr := false
 			if dsParams.QueryStringHandling == "" && dsParams.Algorithm == tc.AlgorithmConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
 				parentQStr = true


### PR DESCRIPTION
Removes a missed debug print in t3c parent.config gen.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)
- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?
Observe code is trivially correct. Run t3c, verify debug warning isn't printed.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix

## PR submission checklist
~- [x] This PR has tests~ tests exist for all relevant functionality
~- [x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
~- [x] This PR has a CHANGELOG.md entry~ no changelog, no interface change, erroneous print is not in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
