### PR TITLE
Fix the "PR-to-Update-Go" GitHub Action

### DIFF
--- a/.github/actions/pr-to-update-go/README.rst
+++ b/.github/actions/pr-to-update-go/README.rst
@@ -72,3 +72,9 @@ To run the unit tests:
 .. code-block:: shell
 
 	python3 -m unittest discover ./tests
+
+To run the doctests:
+
+.. code-block:: shell
+
+	python3 ./pr_to_update_go/go_pr_maker.py

--- a/.github/actions/pr-to-update-go/pr_to_update_go/__main__.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/__main__.py
@@ -10,6 +10,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+A utility for automatically updating Go. For full usage information, refer to
+the action's README.rst file.
+
+Options
+	--update-version-only   Exit after updating GO_VERSION file.
+"""
 import os
 import sys
 from argparse import ArgumentParser, Namespace
@@ -21,17 +28,23 @@ from pr_to_update_go.constants import ENV_GITHUB_TOKEN
 
 
 def main() -> None:
+	"""
+	The entrypoint for running the PR-maker.
+	"""
 	parser = ArgumentParser()
-	parser.add_argument('--update-version-only', type=bool, default=False, help='Exit after updating the GO_VERSION file')
+	parser.add_argument(
+		'--update-version-only',
+		action="store_true",
+		help='Exit after updating the GO_VERSION file'
+	)
 	args: Namespace = parser.parse_args()
 
 	try:
-		github_token: str = os.environ[ENV_GITHUB_TOKEN]
+		github_token = os.environ[ENV_GITHUB_TOKEN]
 	except KeyError:
 		print(f'Environment variable {ENV_GITHUB_TOKEN} must be defined.')
 		sys.exit(1)
-	gh = Github(login_or_token=github_token)
-	GoPRMaker(gh).run(args.update_version_only)
-
+	gh_api = Github(login_or_token=github_token)
+	GoPRMaker(gh_api).run(args.update_version_only)
 
 main()

--- a/.github/actions/pr-to-update-go/pr_to_update_go/constants.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/constants.py
@@ -10,14 +10,88 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+The constants module holds some constants used by the PR maker.
+
+Environment variable names, and the meanings of the values of those variables:
+
+	ENV_GIT_AUTHOR_NAME         - The username of the author for commits
+	ENV_GITHUB_REPOSITORY       - The "name" of the repository set by GHA (e.g. octocat/Hello-World)
+	ENV_GITHUB_REPOSITORY_OWNER - The repository owner's name set by GHA (e.g. octocat)
+	ENV_GITHUB_TOKEN            - The token used to access the GitHub API - set by GHA
+	ENV_GO_VERSION_FILE         - The repository-relative path to the file containing the Go version
+	ENV_ENV_FILE                - The repository-relative path to an environment file containing
+	                              a line setting the variable GO_VERSION to the Go version
+	                              (e.g. GO_VERSION=3.2.1)
+
+Miscellaneous:
+
+	GIT_AUTHOR_EMAIL_TEMPLATE - Template used to construct the Git Author's email address.
+	GO_REPO_NAME              - The name of the official Go repository.
+	GO_VERSION_URL            - A URL from which information about Go releases is fetched.
+	RELEASE_PAGE_URL          - The URL of a webpage containing changelog notes about Go releases.
+"""
 from typing import Final
 
 ENV_GIT_AUTHOR_NAME: Final = 'GIT_AUTHOR_NAME'
+"""
+The name of the environment variable set to username of the author for commits.
+"""
+
 ENV_GITHUB_REPOSITORY: Final = 'GITHUB_REPOSITORY'
+"""
+The name of the environment variable set to "name" of the repository set by GHA
+(e.g. octocat/Hello-World).
+"""
+
 ENV_GITHUB_REPOSITORY_OWNER: Final = 'GITHUB_REPOSITORY_OWNER'
+"""
+The name of the environment variable set to repository owner's name set by GHA
+(e.g. octocat).
+"""
+
 ENV_GITHUB_TOKEN: Final = 'GITHUB_TOKEN'
+"""
+The name of the environment variable set to token used to access the GitHub
+API - set by GHA.
+"""
+
 ENV_GO_VERSION_FILE: Final = 'GO_VERSION_FILE'
+"""
+The name of the environment variable set to repository-relative path to the file
+containing the Go version.
+"""
+
+ENV_ENV_FILE: Final = 'ENV_FILE'
+"""
+The name of the environment variable set to repository-relative path to an
+environment file containing a line setting the variable GO_VERSION to the Go
+version (e.g. GO_VERSION=3.2.1).
+"""
+
+
 GIT_AUTHOR_EMAIL_TEMPLATE: Final = '{git_author_name}@users.noreply.github.com'
+"""Template used to construct the Git Author's email address."""
+
 GO_REPO_NAME: Final = 'golang/go'
+"""The name of the official Go repository."""
+
 GO_VERSION_URL: Final = 'https://golang.org/dl/?mode=json'
+"""A URL from which information about Go releases is fetched."""
+
 RELEASE_PAGE_URL: Final = 'https://golang.org/doc/devel/release.html'
+"""The URL of a webpage containing changelog notes about Go releases."""
+
+
+__all__ = [
+	"ENV_GIT_AUTHOR_NAME",
+	"ENV_GITHUB_REPOSITORY",
+	"ENV_GITHUB_REPOSITORY_OWNER",
+	"ENV_GITHUB_TOKEN",
+	"ENV_GO_VERSION_FILE",
+	"ENV_ENV_FILE",
+	"GIT_AUTHOR_EMAIL_TEMPLATE",
+	"GO_REPO_NAME",
+	"GO_VERSION_URL",
+	"RELEASE_PAGE_URL",
+]

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -24,7 +24,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Optional, TypedDict, Any, Final
+from typing import Optional, TypedDict, Any
 
 import requests
 

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -41,7 +41,6 @@ from github.Label import Label
 from github.MainClass import Github
 from github.PullRequest import PullRequest
 from github.Repository import Repository
-from github.Requester import Requester
 
 from pr_to_update_go.constants import ENV_GITHUB_TOKEN, GO_VERSION_URL, ENV_GITHUB_REPOSITORY, \
 	ENV_GITHUB_REPOSITORY_OWNER, GO_REPO_NAME, RELEASE_PAGE_URL, ENV_GO_VERSION_FILE, \
@@ -192,13 +191,8 @@ class GoPRMaker:
 		Note that only fast-forward updates are possible, as this doesn't
 		"force" push.
 		"""
-		requester: Requester = self.repo._requester
-		patch_parameters = {
-			'sha': sha,
-		}
-		requester.requestJsonAndCheck(
-			'PATCH', self.repo.url + f'/git/refs/heads/{branch_name}', input=patch_parameters
-		)
+		ref = self.repo.get_git_ref(f"heads/{branch_name}")
+		ref.edit(sha)
 
 	def run(self, update_version_only: bool = False) -> None:
 		"""

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -328,7 +328,11 @@ class GoPRMaker:
 		for milestone in milestones:
 			if milestone.title == milestone_title:
 				print(f'Found Go milestone {milestone.title}')
-				return milestone.url
+				# Technically it would probably be best to use the 'html_url'
+				# returned by the GH API, but accessing that through PyGithub
+				# involves using poorly-documented properties of that library,
+				# as well as sacrificing type-safety.
+				return f"https://github.com/{GO_REPO_NAME}/milestone/{milestone.number}"
 		raise LookupError(f'could not find a milestone named {milestone_title}')
 
 	def file_contents(self, file: str, branch: str = "master") -> ContentFile:

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -418,3 +418,7 @@ class GoPRMaker:
 		except UnknownObjectException:
 			print('Unable to find a label named "go version"', file=sys.stderr)
 		print(f'Created pull request {pull_request.html_url}')
+
+if __name__ == "__main__":
+	import doctest
+	doctest.testmod()

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -87,6 +87,8 @@ def get_major_version(from_go_version: str) -> str:
 
 	>>> get_major_version("1.23.45-6rc7")
 	'1.23'
+	>>> get_major_version("1.2.3")
+	'1.2'
 	>>> get_major_version("not a release version")
 	''
 	"""

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -42,9 +42,18 @@ from github.MainClass import Github
 from github.PullRequest import PullRequest
 from github.Repository import Repository
 
-from pr_to_update_go.constants import ENV_GITHUB_TOKEN, GO_VERSION_URL, ENV_GITHUB_REPOSITORY, \
-	ENV_GITHUB_REPOSITORY_OWNER, GO_REPO_NAME, RELEASE_PAGE_URL, ENV_GO_VERSION_FILE, \
-	ENV_GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL_TEMPLATE
+from pr_to_update_go.constants import (
+	ENV_ENV_FILE,
+	ENV_GITHUB_TOKEN,
+	GO_VERSION_URL,
+	ENV_GITHUB_REPOSITORY,
+	ENV_GITHUB_REPOSITORY_OWNER,
+	GO_REPO_NAME,
+	RELEASE_PAGE_URL,
+	ENV_GO_VERSION_FILE,
+	ENV_GIT_AUTHOR_NAME,
+	GIT_AUTHOR_EMAIL_TEMPLATE
+)
 
 class GoVersion(TypedDict):
 	"""
@@ -141,7 +150,7 @@ def get_latest_major_upgrade(from_go_version: str) -> str:
 		if major_version == get_major_version(fetched_go_version):
 			break
 	else:
-		raise Exception(f'No supported {major_version} Go versions exist.')
+		raise Exception(f'no supported {major_version} Go versions exist')
 	print(f'Latest version of Go {major_version} is {fetched_go_version}')
 	return fetched_go_version
 

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -351,7 +351,7 @@ class GoPRMaker:
 		Gets the current Go version used at the head of the given branch (or not
 		given to use "master" by default) for the repository.
 		"""
-		return self.file_contents(getenv(ENV_GO_VERSION_FILE), branch).decoded_content.decode()
+		return self.file_contents(getenv(ENV_GO_VERSION_FILE), branch).decoded_content.decode().strip()
 
 	def set_go_version(self, go_version: str, commit_message: str,
 			source_branch_name: str) -> Commit:

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -325,7 +325,7 @@ class GoPRMaker:
 		go_repo = self.get_repo(GO_REPO_NAME)
 		milestones = go_repo.get_milestones(state='all', sort='due_on', direction='desc')
 		milestone_title = f'Go{go_version}'
-		for milestone in milestones:  # type: Milestone
+		for milestone in milestones:
 			if milestone.title == milestone_title:
 				print(f'Found Go milestone {milestone.title}')
 				return milestone.url

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -65,7 +65,7 @@ def _get_pr_body(go_version: str, milestone_url: str) -> str:
 	Generates the body of a Pull Request given a Go release version and a
 	URL that points to information about what changes were in said release.
 	"""
-	with open(os.path.join(os.path.dirname(__file__), '/pr_template.md'), encoding="UTF-8") as file:
+	with open(os.path.join(os.path.dirname(__file__), 'pr_template.md'), encoding="UTF-8") as file:
 		pr_template = file.read()
 	go_major_version = get_major_version(go_version)
 

--- a/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
@@ -10,13 +10,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+The unit testing module for the pr_to_update_go package.
+
+Note that this module merely reiterates the docstring tests - and only covers a
+proper subset of the test cases covered by said docstring tests.
+"""
+
 from unittest import TestCase
 
 from pr_to_update_go.go_pr_maker import get_major_version, GoPRMaker
 
 
 class TestGoPRMaker(TestCase):
+	"""
+	Tests the go_pr_maker module.
+
+	Note that this reiterates the docstring tests - and only covers a proper
+	subset of those test cases.
+	"""
+
 	def test_get_major_version(self) -> None:
+		"""Tests the get_major_version function."""
 		version: str = '1.2.3'
 		expected_major_version: str = '1.2'
 		actual_major_version: str = get_major_version(version)
@@ -24,6 +39,7 @@ class TestGoPRMaker(TestCase):
 		return
 
 	def test_get_release_notes(self) -> None:
+		"""Tests the get_release_notes function."""
 		go_version: str = '4.15.6'
 		expected_release_notes: str = f'<p> go4.15.6 The expected release notes </p>'
 		release_notes_with_whitespace: str = f"""<p>  

--- a/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
@@ -12,14 +12,14 @@
 #
 from unittest import TestCase
 
-from pr_to_update_go.go_pr_maker import GoPRMaker
+from pr_to_update_go.go_pr_maker import get_major_version, GoPRMaker
 
 
 class TestGoPRMaker(TestCase):
 	def test_get_major_version(self) -> None:
 		version: str = '1.2.3'
 		expected_major_version: str = '1.2'
-		actual_major_version: str = GoPRMaker.get_major_version(version)
+		actual_major_version: str = get_major_version(version)
 		self.assertEqual(expected_major_version, actual_major_version)
 		return
 

--- a/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
@@ -41,7 +41,6 @@ class TestGoPRMaker(TestCase):
 	def test_get_release_notes(self) -> None:
 		"""Tests the get_release_notes function."""
 		go_version: str = '4.15.6'
-		expected_release_notes: str = f'<p> go4.15.6 The expected release notes </p>'
 		release_notes_with_whitespace: str = f"""<p>  
                 go{go_version} The expected release notes
             </p>"""
@@ -49,4 +48,5 @@ class TestGoPRMaker(TestCase):
         {release_notes_with_whitespace}
         text <p>after</p> 4.15.7"""
 		actual_release_notes: str = GoPRMaker.get_release_notes(go_version, content)
+		expected_release_notes: str = '<p> go4.15.6 The expected release notes </p>'
 		self.assertEqual(expected_release_notes, actual_release_notes)

--- a/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
@@ -19,7 +19,7 @@ proper subset of the test cases covered by said docstring tests.
 
 from unittest import TestCase
 
-from pr_to_update_go.go_pr_maker import get_major_version, GoPRMaker
+from pr_to_update_go.go_pr_maker import get_major_version, parse_release_notes
 
 
 class TestGoPRMaker(TestCase):
@@ -40,13 +40,13 @@ class TestGoPRMaker(TestCase):
 
 	def test_get_release_notes(self) -> None:
 		"""Tests the get_release_notes function."""
-		go_version: str = '4.15.6'
-		release_notes_with_whitespace: str = f"""<p>  
+		go_version = '4.15.6'
+		expected_release_notes = '<p> go4.15.6 The expected release notes </p>'
+		release_notes_with_whitespace = f"""<p>
                 go{go_version} The expected release notes
             </p>"""
-		content: str = f"""go4.15.5 text before
+		content = f"""go4.15.5 text before
         {release_notes_with_whitespace}
         text <p>after</p> 4.15.7"""
-		actual_release_notes: str = GoPRMaker.get_release_notes(go_version, content)
-		expected_release_notes: str = '<p> go4.15.6 The expected release notes </p>'
+		actual_release_notes = parse_release_notes(go_version, content)
 		self.assertEqual(expected_release_notes, actual_release_notes)

--- a/.github/workflows/pr-to-update-go.yml
+++ b/.github/workflows/pr-to-update-go.yml
@@ -41,7 +41,7 @@ jobs:
         run: pip install .github/actions/pr-to-update-go
       - name: Update Go version
         if: ${{ steps.checkout.outcome == 'success' }}
-        run: python3 -m pr_to_update_go --update-version-only=true
+        run: python3 -m pr_to_update_go --update-version-only
         env:
           GIT_AUTHOR_NAME: asfgit
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr-to-update-go.yml
+++ b/.github/workflows/pr-to-update-go.yml
@@ -46,6 +46,7 @@ jobs:
           GIT_AUTHOR_NAME: asfgit
           GITHUB_TOKEN: ${{ github.token }}
           GO_VERSION_FILE: GO_VERSION
+          ENV_FILE: .env
       - name: Check Go version
         run: echo "::set-output name=value::$(cat GO_VERSION)"
         id: go-version
@@ -60,3 +61,4 @@ jobs:
           GIT_AUTHOR_NAME: asfgit
           GITHUB_TOKEN: ${{ github.token }}
           GO_VERSION_FILE: GO_VERSION
+          ENV_FILE: .env


### PR DESCRIPTION
Fixes the GHA for opening PRs to update our Go version, which has been broken in some fashion since #6532 was merged.

This also expands doctest coverage a bit, makes those easier to run, fixes the broken unit tests, fixes strict typing compliance, and fixes a myriad of linting problems.

<hr/>

## Which Traffic Control components are affected by this PR?
- GitHub Actions

## What is the best way to verify this PR?
What I did was change the contents of GO_VERSION on my fork's `master` branch to `1.17.6` and ran the action via manual trigger, verified that it opened a PR to update that file and also `.env` - see ocket8888#53. To run the unit tests use
```shell
python3 -m unittest discover .github/actions/pr-to-update-go/tests
```
To run the doctests use
```shell
python3 .github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
```

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [x] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**