### PR TITLE
Add missing DNSSEC Permissions to "admin-priv-level" Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6562](https://github.com/apache/trafficcontrol/pull/6562) Fixed incorrect template in Ansible dataset loader role when fallbackToClosest is defined.
 - [#6590](https://github.com/apache/trafficcontrol/pull/6590) Python client: Corrected parameter name in decorator for get_parameters_by_profile_id
 - [#6368](https://github.com/apache/trafficcontrol/pull/6368) Fixed validation response message from `/acme_accounts`
+- [#6603](https://github.com/apache/trafficcontrol/issues/6603) Fixed users with "admin" "Priv Level" not having Permission to view or delete DNSSEC keys.
 
 ### Removed
 - Remove traffic_portal dependencies to mitigate `npm audit` issues, specifically `grunt-concurrent`, `grunt-contrib-concat`, `grunt-contrib-cssmin`, `grunt-contrib-jsmin`, `grunt-contrib-uglify`, `grunt-contrib-htmlmin`, `grunt-newer`, and `grunt-wiredep`

--- a/traffic_ops/app/db/migrations/2022030308363540_add_dnssec_perms.down.sql
+++ b/traffic_ops/app/db/migrations/2022030308363540_add_dnssec_perms.down.sql
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+DELETE FROM public.role_capability
+WHERE cap_name IN (
+	VALUES
+		('DNS-SEC:READ'),
+		('DNS-SEC:DELETE')
+);

--- a/traffic_ops/app/db/migrations/2022030308363540_add_dnssec_perms.up.sql
+++ b/traffic_ops/app/db/migrations/2022030308363540_add_dnssec_perms.up.sql
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+INSERT INTO public.role_capability
+SELECT id, perm FROM public.role
+CROSS JOIN (
+	VALUES
+		('DNS-SEC:READ'),
+		('DNS-SEC:DELETE')
+) AS perms(perm)
+WHERE priv_level >= 30
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This PR fixes #6603.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops (database)

## What is the best way to verify this PR?
Create a Role with an "admin" "priv_level", then run the provided migration. Ensure the Role now has the DNS-SEC:READ and DNS-SEC:DELETE Permissions. Then run the "down" migration and ensure they no longer do (although that's probably much less important).

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- 6.1.0

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**