### PR TITLE
Fix t3c parent.config abstraction bugs

### DIFF
--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -187,11 +187,16 @@ func makeParentDotConfigData(
 
 	profileParentConfigParams, parentWarns := getProfileParentConfigParams(tcParentConfigParams)
 	warnings = append(warnings, parentWarns...)
-	// profileParentConfigParams, err := tcParamsToParamsWithProfiles(tcParentConfigParams)
-	// if err != nil {
-	// 	return nil, warnings, errors.New("adding profiles to parent config params: " + err.Error())
-	// }
 
+	parentConfigParamsWithProfiles, err := tcParamsToParamsWithProfiles(tcParentConfigParams)
+	if err != nil {
+		return nil, warnings, errors.New("adding profiles to parent config params: " + err.Error())
+	}
+
+	// parentConfigParams are the parent.config params for all profiles (needed for parents)
+	parentConfigParams := parameterWithProfilesToMap(parentConfigParamsWithProfiles)
+
+	// serverParams are the parent.config params for this particular server
 	serverParams := getServerParentConfigParams(server, profileParentConfigParams)
 
 	parentCacheGroups := map[string]struct{}{}
@@ -333,6 +338,7 @@ func makeParentDotConfigData(
 				servers,
 				&ds,
 				serverParams,
+				parentConfigParams,
 				nameTopologies,
 				serverCapabilities,
 				dsRequiredCapabilities,
@@ -440,7 +446,7 @@ func makeParentDotConfigData(
 				textLine.SecondaryMode = secondaryMode
 				textLine.RetryPolicy = dsParams.Algorithm // TODO convert
 				textLine.IgnoreQueryStringInParentSelection = !parentQStr
-				textLine.GoDirect = false
+				textLine.GoDirect = true
 
 				// textLine += parents + secondaryParents + ` round_robin=` + dsParams.Algorithm + ` qstring=` + parentQStr + ` go_direct=false parent_is_proxy=false`
 				prWarns := []string{}
@@ -911,6 +917,7 @@ func getTopologyParentConfigLine(
 	servers []Server,
 	ds *DeliveryService,
 	serverParams map[string]string,
+	parentConfigParams []parameterWithProfilesMap, // all params with configFile parent.config
 	nameTopologies map[TopologyName]tc.Topology,
 	serverCapabilities map[int]map[ServerCapability]struct{},
 	dsRequiredCapabilities map[int]map[ServerCapability]struct{},
@@ -960,7 +967,7 @@ func getTopologyParentConfigLine(
 	}
 	// txt += "dest_domain=" + orgURI.Hostname() + " port=" + orgURI.Port()
 
-	parents, secondaryParents, parentWarnings, err := getTopologyParents(server, ds, servers, serverParams, topology, serverPlacement.IsLastTier, serverCapabilities, dsRequiredCapabilities, dsOrigins, dsParams.MergeGroups)
+	parents, secondaryParents, parentWarnings, err := getTopologyParents(server, ds, servers, parentConfigParams, topology, serverPlacement.IsLastTier, serverCapabilities, dsRequiredCapabilities, dsOrigins, dsParams.MergeGroups)
 	warnings = append(warnings, parentWarnings...)
 	if err != nil {
 		return nil, warnings, errors.New("getting topology parents for '" + *ds.XMLID + "': skipping! " + err.Error())
@@ -984,7 +991,7 @@ func getTopologyParentConfigLine(
 	txt.RetryPolicy = getTopologyRoundRobin(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm)
 	// txt += ` round_robin=` + getTopologyRoundRobin(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm)
 
-	txt.GoDirect = getTopologyGoDirect(ds, serverPlacement.IsLastTier)
+	txt.GoDirect = getTopologyGoDirect(ds, serverPlacement.IsLastTier, serverPlacement.IsLastCacheTier)
 	// txt += ` go_direct=` + getTopologyGoDirect(ds, serverPlacement.IsLastTier)
 
 	// TODO convert
@@ -1001,6 +1008,7 @@ func getTopologyParentConfigLine(
 	tqWarns := []string{}
 	txt.IgnoreQueryStringInParentSelection, tqWarns = getTopologyQueryStringIgnore(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm, useQueryStringInParentSelection)
 	warnings = append(warnings, tqWarns...)
+
 	// txt += ` qstring=` + getTopologyQueryString(ds, serverParams, serverPlacement.IsLastCacheTier, dsParams.Algorithm, dsParams.QueryStringHandling)
 
 	// TODO ensure value is always !goDirect, and determine what to do if not
@@ -1148,7 +1156,10 @@ func getTopologyRoundRobin(
 	return ParentAbstractionServiceRetryPolicyConsistentHash
 }
 
-func getTopologyGoDirect(ds *DeliveryService, serverIsLastTier bool) bool {
+func getTopologyGoDirect(ds *DeliveryService, serverIsLastTier bool, serverIsLastCacheTier bool) bool {
+	if serverIsLastCacheTier {
+		return true
+	}
 	if !serverIsLastTier {
 		return false
 	}
@@ -1171,14 +1182,19 @@ func getTopologyQueryStringIgnore(
 	warnings := []string{}
 	if serverIsLastTier {
 		if ds.MultiSiteOrigin != nil && *ds.MultiSiteOrigin && qStringHandling == nil && algorithm == ParentAbstractionServiceRetryPolicyConsistentHash && ds.QStringIgnore != nil && tc.QStringIgnore(*ds.QStringIgnore) == tc.QStringIgnoreUseInCacheKeyAndPassUp {
-			return true, warnings
+			return false, warnings
 		}
-		return false, warnings
+
+		if qStringHandling != nil {
+			return !(*qStringHandling), warnings
+		}
+
+		return true, warnings
 	}
 
 	if param := serverParams[ParentConfigParamQStringHandling]; param != "" {
 		if useQStr := ParentSelectParamQStringHandlingToBool(param); useQStr != nil {
-			return *useQStr, warnings
+			return !(*useQStr), warnings
 		} else if param != "" {
 			warnings = append(warnings, "Server param '"+ParentConfigParamQStringHandling+"' value '"+param+"' malformed, not using!")
 		}
@@ -1195,36 +1211,40 @@ func getTopologyQueryStringIgnore(
 
 // serverParentageParams gets the Parameters used for parent= line, or defaults if they don't exist
 // Returns the Parameters used for parent= lines for the given server, and any warnings.
-func serverParentageParams(sv *Server, serverParams map[string]string) (profileCache, []string) {
+func serverParentageParams(sv *Server, params []parameterWithProfilesMap) (profileCache, []string) {
 	warnings := []string{}
 	// TODO deduplicate with atstccfg/parentdotconfig.go
 	profileCache := defaultProfileCache()
 	if sv.TCPPort != nil {
 		profileCache.Port = *sv.TCPPort
 	}
-	for paramName, paramVal := range serverParams {
-		switch paramName {
+	for _, param := range params {
+		if _, ok := param.ProfileNames[*sv.Profile]; !ok {
+			continue
+		}
+		switch param.Name {
 		case ParentConfigCacheParamWeight:
-			profileCache.Weight = paramVal
+			profileCache.Weight = param.Value
 		case ParentConfigCacheParamPort:
-			if i, err := strconv.Atoi(paramVal); err != nil {
+			if i, err := strconv.Atoi(param.Value); err != nil {
 				warnings = append(warnings, "port param is not an integer, skipping! : "+err.Error())
 			} else {
 				profileCache.Port = i
 			}
 		case ParentConfigCacheParamUseIP:
-			profileCache.UseIP = paramVal == "1"
+			profileCache.UseIP = param.Value == "1"
 		case ParentConfigCacheParamRank:
 
-			if i, err := strconv.Atoi(paramVal); err != nil {
+			if i, err := strconv.Atoi(param.Value); err != nil {
 				warnings = append(warnings, "rank param is not an integer, skipping! : "+err.Error())
 			} else {
 				profileCache.Rank = i
 			}
 		case ParentConfigCacheParamNotAParent:
-			profileCache.NotAParent = paramVal != "false"
+			profileCache.NotAParent = param.Value != "false"
 		}
 	}
+
 	return profileCache, warnings
 }
 
@@ -1262,7 +1282,7 @@ func getTopologyParents(
 	server *Server,
 	ds *DeliveryService,
 	servers []Server,
-	serverParams map[string]string, // all params with configFile parent.confign
+	parentConfigParams []parameterWithProfilesMap, // all params with configFile parent.config
 	topology tc.Topology,
 	serverIsLastTier bool,
 	serverCapabilities map[int]map[ServerCapability]struct{},
@@ -1290,6 +1310,7 @@ func getTopologyParents(
 			Port:   orgPort,
 			Weight: DefaultParentWeight,
 		}
+
 		return []*ParentAbstractionServiceParent{parent}, nil, warnings, nil
 	}
 
@@ -1332,7 +1353,7 @@ func getTopologyParents(
 
 	serversWithParams := []serverWithParams{}
 	for _, sv := range servers {
-		serverParentParams, parentWarns := serverParentageParams(&sv, serverParams)
+		serverParentParams, parentWarns := serverParentageParams(&sv, parentConfigParams)
 		warnings = append(warnings, parentWarns...)
 		serversWithParams = append(serversWithParams, serverWithParams{
 			Server: sv,


### PR DESCRIPTION
Fixes several issues with the recent parent.config strategies
abstraction, specifically around MSO parents not getting the right
go_direct, parent_is_proxy, and qstring directives.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (T3C, formerly ORT)

## What is the best way to verify this PR?
Run tests. Generate config for a Mid with an MSO DS with qstring parameters, verify go_direct=true and parent_is_proxy=false, verify qstring= matches the parameters and/or DS qstring settings.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, bug is not in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
