### PR TITLE
Fix t3c Capability to not continue on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6590](https://github.com/apache/trafficcontrol/pull/6590) Python client: Corrected parameter name in decorator for get\_parameters\_by\_profile\_id
 - [#6368](https://github.com/apache/trafficcontrol/pull/6368) Fixed validation response message from `/acme_accounts`
 - [#6603](https://github.com/apache/trafficcontrol/issues/6603) Fixed users with "admin" "Priv Level" not having Permission to view or delete DNSSEC keys.
+- [#6626](https://github.com/apache/trafficcontrol/pull/6626) Fixed t3c Capabilities request failure issue which could result in malformed config.
 - [#6370](https://github.com/apache/trafficcontrol/pull/6370) Fixed docs for `POST` and response code for `PUT` to `/acme_accounts` endpoint
 
 ### Removed

--- a/cache-config/t3cutil/getdatacfg.go
+++ b/cache-config/t3cutil/getdatacfg.go
@@ -605,8 +605,7 @@ func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName st
 			caps, reqInf, err := toClient.GetServerCapabilitiesByID(nil, reqHdr) // TODO change to not take a param; it doesn't use it to request TO anyway.
 			log.Infoln(toreq.RequestInfoStr(reqInf, "GetServerCapabilitiesByID"))
 			if err != nil {
-				log.Errorln("Server Capabilities error, skipping!")
-				// return errors.New("getting server caps from Traffic Ops: " + err.Error())
+				return errors.New("getting server caps from Traffic Ops: " + err.Error())
 			} else {
 				if reqInf.StatusCode == http.StatusNotModified {
 					log.Infof("Getting config: %v not modified, using old config", "ServerCapabilities")
@@ -631,8 +630,7 @@ func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName st
 			caps, reqInf, err := toClient.GetDeliveryServiceRequiredCapabilitiesByID(nil, reqHdr)
 			log.Infoln(toreq.RequestInfoStr(reqInf, "GetDeliveryServiceRequiredCapabilitiesByID"))
 			if err != nil {
-				log.Errorln("DS Required Capabilities error, skipping!")
-				// return errors.New("getting DS required capabilities: " + err.Error())
+				return errors.New("getting DS required capabilities: " + err.Error())
 			} else {
 				if reqInf.StatusCode == http.StatusNotModified {
 					log.Infof("Getting config: %v not modified, using old config", "DSRequiredCapabilities")


### PR DESCRIPTION
This bug causes catastrophic config gen errors if the TO request
for ds_required_caps fails but server_reqs succeeds,
because then no servers have required caps, causing remap lines
for all DSes with required caps to be omitted.

This fixes it by making capability failures fail, rather than
continuing.

It formerly continued, because when capabilities were introduced,
it was necessary to continue if TO was older than t3c/ORT. But
now, the fallback API major version is 3.0, which has Capabilities.

If this bug wasn't fixed by simply always failing, it would have to
be fixed by making a server_caps error also set ds_req_caps to nil.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Verify t3c fails when it fails to get server_capabilities or delivery_service_required_capabilities, rather than continuing.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 4.0 thru 6.1

## PR submission checklist
- ~[x] This PR has tests~ no tests, unfortunately the t3c integration test framework isn't capable of simulating TO failures, it would require considerable extension to do so, and this is a TO request so it can't be unit tested.
- ~[x] This PR has documentation~ no docs, no interface change
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
