### PR TITLE
Add TrafficOps login dispersion

### DIFF
--- a/tc-health-client/README.md
+++ b/tc-health-client/README.md
@@ -1,3 +1,6 @@
+% tc-health-client(1) tc-health-client 6.2.0 | ATC tc-health-client Manual
+%
+% 2022-03-09
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -104,7 +107,7 @@ Sample configuarion file:
     "to-request-timeout-seconds": "5s",
     "tm-poll-interval-seconds": "60s",
     "tm-proxy-url", "http://sample-http-proxy.cdn.net:80",
-    "tm-update-cycles": 5,
+    "to-login-dispersion-factor": 90,
     "unavailable-poll-threshold": 2,
     "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
     "trafficserver-bin-dir": "/opt/trafficserver/bin",
@@ -159,11 +162,13 @@ Sample configuarion file:
   polling a Traffic Monitor and you wish to funnel queries through a caching
   proxy server to limit direct direct connections to Traffic Monitor.
 
-### tm-update-cycles
+### to-login-dispersion-factor
 
-  Each time a polling cycle completes a count is incremented. When the count
-  reaches **tm-update-cycles**, TrafficOps is polled for a new list of available
-  TrafficMonitors for the CDN and the poll count is reset to 0.
+  This is used to calculate TrafficOps login dispersion.  It is related to the
+  **tm-poll-interval-seconds**.  The login dispersion is computed by multiplying
+  **tm-poll-interval-seconds** by the **to-login-dispersion-factor**.  For example
+  if to-login-dispersion-factor is 90 and the **tm-poll-interval-seconds** is 10s
+  the the dispersion modulo window is 900s.
 
 ### unavailable-poll-threshold
 

--- a/tc-health-client/config/config.go
+++ b/tc-health-client/config/config.go
@@ -21,6 +21,8 @@ package config
 
 import (
 	"bufio"
+	"crypto/md5"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -39,17 +41,19 @@ import (
 	"github.com/pborman/getopt/v2"
 )
 
+var userAgent = "tc-health-client/1.0"
 var tmPollingInterval time.Duration
 var toRequestTimeout time.Duration
+var toSession *toclient.Session = nil
 
 const (
 	DefaultPollStateJSONLog         = "/var/log/trafficcontrol/poll-state.json"
 	DefaultConfigFile               = "/etc/trafficcontrol/tc-health-client.json"
 	DefaultLogDirectory             = "/var/log/trafficcontrol"
 	DefaultLogFile                  = "tc-health-client.log"
+	DefaultTOLoginDispersionFactor  = 90
 	DefaultTrafficServerConfigDir   = "/opt/trafficserver/etc/trafficserver"
 	DefaultTrafficServerBinDir      = "/opt/trafficserver/bin"
-	DefaultTmUpdateCycles           = 10
 	DefaultUnavailablePollThreshold = 2
 )
 
@@ -64,7 +68,7 @@ type Cfg struct {
 	TOUser                   string          `json:"to-user"`
 	TmProxyURL               string          `json:"tm-proxy-url"`
 	TmPollIntervalSeconds    string          `json:"tm-poll-interval-seconds"`
-	TmUpdateCycles           int             `json:"tm-update-cycles"`
+	TOLoginDispersionFactor  int             `json:"to-login-dispersion-factor"`
 	UnavailablePollThreshold int             `json:"unavailable-poll-threshold"`
 	TrafficServerConfigDir   string          `json:"trafficserver-config-dir"`
 	TrafficServerBinDir      string          `json:"trafficserver-bin-dir"`
@@ -245,6 +249,9 @@ func GetConfig() (Cfg, error, bool) {
 		return cfg, err, false
 	}
 
+	dispersion := GetTOLoginDispersion(cfg.TOLoginDispersionFactor)
+	log.Infof("waiting %v seconds before logging into TrafficOps", dispersion.Seconds())
+	time.Sleep(dispersion)
 	err = GetTrafficMonitors(&cfg)
 	if err != nil {
 		return cfg, err, false
@@ -263,12 +270,18 @@ func GetTrafficMonitors(cfg *Cfg) error {
 	qry.Add("status", "ONLINE")
 
 	// login to traffic ops.
-	session, _, err := toclient.LoginWithAgent(cfg.TOUrl, cfg.TOUser, cfg.TOPass, true, "tc-health-client", false, GetRequestTimeout())
-	if err != nil {
-		return fmt.Errorf("could not establish a TrafficOps session: %w", err)
+	if toSession == nil {
+		session, _, err := toclient.LoginWithAgent(cfg.TOUrl, cfg.TOUser, cfg.TOPass, true, userAgent, false, GetRequestTimeout())
+		if err != nil {
+			return fmt.Errorf("could not establish a TrafficOps session: %w", err)
+		} else {
+			toSession = session
+		}
 	}
-	srvs, _, err := session.GetServers(&qry)
+	srvs, _, err := toSession.GetServers(&qry)
 	if err != nil {
+		// next time we'll login again and get a new session.
+		toSession = nil
 		return errors.New("error fetching Trafficmonitor server list: " + err.Error())
 	}
 
@@ -285,6 +298,22 @@ func GetTrafficMonitors(cfg *Cfg) error {
 
 func GetTMPollingInterval() time.Duration {
 	return tmPollingInterval
+}
+
+func GetTOLoginDispersion(dispersionFactor int) time.Duration {
+	dispersionSeconds := uint64(tmPollingInterval.Seconds()) * uint64(dispersionFactor)
+	hostName, err := os.Hostname()
+	if err != nil {
+		log.Errorf("the OS hostname is not set, cannot continue: %s", err.Error())
+		os.Exit(1)
+	}
+	md5hash := md5.Sum([]byte(hostName))
+	sl := md5hash[0:8]
+	disp := (binary.BigEndian.Uint64(sl) % dispersionSeconds)
+	if disp < uint64(tmPollingInterval.Seconds()*2) {
+		disp = ((disp * 2) + uint64(tmPollingInterval.Seconds()))
+	}
+	return time.Duration(disp) * time.Second
 }
 
 func GetRequestTimeout() time.Duration {
@@ -313,6 +342,9 @@ func LoadConfig(cfg *Cfg) (bool, error) {
 		if err != nil {
 			return updated, errors.New("parsing TMPollingIntervalSeconds: " + err.Error())
 		}
+		if cfg.TOLoginDispersionFactor == 0 {
+			cfg.TOLoginDispersionFactor = DefaultTOLoginDispersionFactor
+		}
 		toRequestTimeout, err = time.ParseDuration(cfg.TORequestTimeOutSeconds)
 		if err != nil {
 			return updated, errors.New("parsing TORequestTimeOutSeconds: " + err.Error())
@@ -325,9 +357,6 @@ func LoadConfig(cfg *Cfg) (bool, error) {
 		}
 		if cfg.TrafficServerBinDir == "" {
 			cfg.TrafficServerBinDir = DefaultTrafficServerBinDir
-		}
-		if cfg.TmUpdateCycles == 0 {
-			cfg.TmUpdateCycles = DefaultTmUpdateCycles
 		}
 		if cfg.UnavailablePollThreshold == 0 {
 			cfg.UnavailablePollThreshold = DefaultUnavailablePollThreshold
@@ -372,7 +401,10 @@ func UpdateConfig(cfg *Cfg, newCfg *Cfg) {
 	cfg.TOUrl = newCfg.TOUrl
 	cfg.TOUser = newCfg.TOUser
 	cfg.TmPollIntervalSeconds = newCfg.TmPollIntervalSeconds
-	cfg.TmUpdateCycles = newCfg.TmUpdateCycles
+	cfg.TOLoginDispersionFactor = newCfg.TOLoginDispersionFactor
+	if cfg.TOLoginDispersionFactor == 0 {
+		cfg.TOLoginDispersionFactor = DefaultTOLoginDispersionFactor
+	}
 	cfg.UnavailablePollThreshold = newCfg.UnavailablePollThreshold
 	cfg.TrafficServerConfigDir = newCfg.TrafficServerConfigDir
 	cfg.TrafficServerBinDir = newCfg.TrafficServerBinDir

--- a/tc-health-client/tc-health-client.go
+++ b/tc-health-client/tc-health-client.go
@@ -53,7 +53,7 @@ func main() {
 		os.Exit(Success)
 	}
 
-	log.Infof("Polling interval: %d\n", config.GetTMPollingInterval())
+	log.Infof("Polling interval: %v seconds\n", config.GetTMPollingInterval().Seconds())
 	tmInfo, err := tmagent.NewParentInfo(cfg)
 	if err != nil {
 		log.Errorf("startup could not initialize parent info, check that trafficserver is running: %s\n", err.Error())

--- a/tc-health-client/tc-health-client.json
+++ b/tc-health-client/tc-health-client.json
@@ -6,8 +6,8 @@
   "to-url": "https://tp.cdn.com:443", 
   "to-request-timeout-seconds": "5s",
   "tm-proxy-url":, "proxy.net:80",
-  "tm-poll-interval-seconds": "15s",
-  "tm-update-cycles": 5,
+  "tm-poll-interval-seconds": "10s",
+  "to-login-dispersion-factor": 90,
   "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
   "trafficserver-bin-dir": "/opt/trafficserver/bin"
 }

--- a/tc-health-client/testing/docker/health-check-test/tc-health-client.json
+++ b/tc-health-client/testing/docker/health-check-test/tc-health-client.json
@@ -5,7 +5,7 @@
   "to-credential-file": "/etc/to-creds",
   "to-request-timeout-seconds": "5s",
   "tm-poll-interval-seconds": "10s",
-  "tm-update-cycles": 20,
+  "to-login-dispersion-factor": 90,
   "unavailable-poll-threshold": 2,
   "enable-poll-state-log": true,
   "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",


### PR DESCRIPTION
Optimizing TrafficOps logins.

- Adds TrafficOps login dispersion
- Adds session re-use to limit TrafficOps logins.

## Which Traffic Control components are affected by this PR?

- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
