### PR TITLE
TR should support aggressive NSEC queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6590](https://github.com/apache/trafficcontrol/pull/6590) Python client: Corrected parameter name in decorator for get\_parameters\_by\_profile\_id
 - [#6368](https://github.com/apache/trafficcontrol/pull/6368) Fixed validation response message from `/acme_accounts`
 - [#6603](https://github.com/apache/trafficcontrol/issues/6603) Fixed users with "admin" "Priv Level" not having Permission to view or delete DNSSEC keys.
+- Fixed Traffic Router to handle aggressive NSEC correctly.
 - [#6626](https://github.com/apache/trafficcontrol/pull/6626) Fixed t3c Capabilities request failure issue which could result in malformed config.
 - [#6370](https://github.com/apache/trafficcontrol/pull/6370) Fixed docs for `POST` and response code for `PUT` to `/acme_accounts` endpoint
 

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManager.java
@@ -940,7 +940,7 @@ public class ZoneManager extends Resolver {
 			final DNSRouteResult result = trafficRouter.route(request, track);
 
 			if (result != null) {
-				final Zone dynamicZone = fillDynamicZone(dynamicZoneCache, staticZone, request, result);
+				final Zone dynamicZone = fillDynamicZone(getDynamicZoneCache(), staticZone, request, result);
 				track.setResultCode(dynamicZone, request.getName(), request.getQueryType());
 				if (result.getDeliveryService() == null) {
 					builder.deliveryServiceXmlIds(null);
@@ -1039,7 +1039,7 @@ public class ZoneManager extends Resolver {
 				}
 
 				try {
-					final ZoneKey zoneKey = signatureManager.generateDynamicZoneKey(staticZone.getOrigin(), records, request.isDnssec());
+					final ZoneKey zoneKey = getSignatureManager().generateDynamicZoneKey(staticZone.getOrigin(), records, request.isDnssec());
 					final Zone zone = dzc.get(zoneKey);
 					return zone;
 				} catch (ExecutionException e) {
@@ -1217,5 +1217,12 @@ public class ZoneManager extends Resolver {
 
 	public CacheStats getDynamicCacheStats() {
 		return dynamicZoneCache.stats();
+	}
+
+	public static SignatureManager getSignatureManager() {
+		return signatureManager;
+	}
+	public static LoadingCache<ZoneKey, Zone> getDynamicZoneCache() {
+		return dynamicZoneCache;
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR is not related to any issue. It fixes the way TR responds to aggressive NSEC queries.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Make sure all the unit/ integration tests pass/ run `mvn clean verify` succeeds.
Make the following DNS queries:
`
dig nsec speedtest-prod.xcr.comcast.net. +dnssec
`
`
dig nsec voice-guidance-tts.xcr.comcast.net +dnssec
`
Notice how the first one returns an incorrect `NSEC` response, saying that the next lexical record is at `cdn-tr-...`, whereas, the next record should be `cdn.speedtest-prod.xcr.comcast.net.`.
For the second one, it incorrectly returns two different `NSEC` responses:
`voice-guidance-tts.xcr.comcast.net. 30 IN NSEC cdn-ec-alb-301.voice-guidance-tts.xcr.comcast.net. NS SOA RRSIG NSEC DNSKEY
voice-guidance-tts.xcr.comcast.net. 30 IN NSEC ccr.voice-guidance-tts.xcr.comcast.net. NS SOA RRSIG NSEC DNSKEY`
The above two records cannot be true at the same time, because it implies that the next lexical record is `cdn-ec-alb...` and there is nothing in between them, while also saying that the next record is `ccr.voice...` so there is lexically nothing between them. Both those statements cannot be true at the same time.

Now, run the same two queries but by pointing it at your TR with the changes of this PR.
Notice the correct responses this time around.
## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
