### PR TITLE
tm int tests GHA: Make /opt/traffic_monitor/crconfig.backup exist

### DIFF
--- a/.github/actions/tm-integration-tests/entrypoint.sh
+++ b/.github/actions/tm-integration-tests/entrypoint.sh
@@ -118,6 +118,9 @@ cd "${repo_dir}/traffic_monitor"
 go mod vendor
 go build
 
+# fixes `failed to write CRConfig backup file: open /opt/traffic_monitor/crconfig.backup: no such file or directory`
+sudo ln -s $(pwd | xargs realpath) /opt/traffic_monitor
+
 cat > ./traffic_monitor.cfg <<- EOF
   {
       "monitor_config_polling_interval_ms": 15000,


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes #6649 by symlinking the directory that `traffic_monitor` runs from to `/opt/traffic_monitor`, which will make `/opt/traffic_monitor/crconfig.backup` exist.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - Traffic Monitor Integration Tests GitHub Action<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Look at the TM Integration Tests GitHub Action, verify that that the
```go
Traffic Monitor: ERROR: towrap.go:410: 2022-03-11T22:04:01.300139017Z: failed to write CRConfig backup file: open /opt/traffic_monitor/crconfig.backup: no such file or directory
```
error is not present

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] <strike>This PR has documentation</strike> <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] <strike>This PR has a CHANGELOG.md entry</strike> <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->