### PR TITLE
t3c parent.config: fix for merge_parent_groups cachegroup name search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6626](https://github.com/apache/trafficcontrol/pull/6626) Fixed t3c Capabilities request failure issue which could result in malformed config.
 - [#6370](https://github.com/apache/trafficcontrol/pull/6370) Fixed docs for `POST` and response code for `PUT` to `/acme_accounts` endpoint
 - [#6369](https://github.com/apache/trafficcontrol/pull/6369) Fixed `/acme_accounts` endpoint to validate email and URL fields
+- Fixed searching of the ds parameter merge_parent_groups slice.
 
 ### Removed
 - Remove traffic\_portal dependencies to mitigate `npm audit` issues, specifically `grunt-concurrent`, `grunt-contrib-concat`, `grunt-contrib-cssmin`, `grunt-contrib-jsmin`, `grunt-contrib-uglify`, `grunt-contrib-htmlmin`, `grunt-newer`, and `grunt-wiredep`

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -843,9 +843,6 @@ func getParentDSParams(ds DeliveryService, profileParentConfigParams map[string]
 	// the following may be blank, no default
 	params.QueryStringHandling = dsParams[ParentConfigParamQStringHandling]
 	params.MergeGroups = strings.Split(dsParams[ParentConfigParamMergeGroups], " ")
-	if 0 < len(params.MergeGroups) {
-		sort.Strings(params.MergeGroups)
-	}
 
 	// TODO deprecate & remove "mso." Parameters - there was never a reason to restrict these settings to MSO.
 	if isMSO {
@@ -1412,8 +1409,7 @@ func getTopologyParents(
 	}
 
 	if 0 < len(dsMergeGroups) && 0 < len(secondaryParentStrs) {
-		if sort.SearchStrings(dsMergeGroups, parentCG) < len(dsMergeGroups) &&
-			sort.SearchStrings(dsMergeGroups, secondaryParentCG) < len(dsMergeGroups) {
+		if util.ContainsStr(dsMergeGroups, parentCG) && util.ContainsStr(dsMergeGroups, secondaryParentCG) {
 			parentStrs = append(parentStrs, secondaryParentStrs...)
 			secondaryParentStrs = nil
 		}

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -2935,28 +2935,16 @@ func TestMakeParentDotConfigHTTPSOriginTopology(t *testing.T) {
 func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 	hdr := &ParentConfigOpts{AddComments: true, HdrComment: "myHeaderComment"}
 
-	/*
-		ds0 := makeParentDS()
-		ds0Type := tc.DSTypeHTTP
-		ds0.Type = &ds0Type
-		ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
-		ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
-		ds0.ProfileID = util.IntPtr(311)
-		ds0.ProfileName = util.StrPtr("ds0Profile")
-	*/
+	ds0 := makeParentDS()
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+	ds0.ProfileID = util.IntPtr(311)
+	ds0.ProfileName = util.StrPtr("ds0Profile")
+	ds0.Topology = util.StrPtr("t0")
 
-	ds1 := makeParentDS()
-	ds1.ID = util.IntPtr(43)
-	ds1Type := tc.DSTypeDNS
-	ds1.Type = &ds1Type
-	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
-	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
-	ds1.Topology = util.StrPtr("t0")
-	ds1.ProfileID = util.IntPtr(312)
-	ds1.ProfileName = util.StrPtr("ds0Profile")
-
-	//dses := []DeliveryService{*ds0, *ds1}
-	dses := []DeliveryService{*ds1}
+	dses := []DeliveryService{*ds0}
 
 	parentConfigParams := []tc.Parameter{
 		{
@@ -2980,14 +2968,8 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 		{
 			Name:       ParentConfigParamMergeGroups,
 			ConfigFile: "parent.config",
-			Value:      "midCG midCG2",
+			Value:      "oplCG0 oplCG1",
 			Profiles:   []byte(`["ds0Profile"]`),
-		},
-		{
-			Name:       ParentConfigParamMergeGroups,
-			ConfigFile: "parent.config",
-			Value:      "midCG midCG2",
-			Profiles:   []byte(`["ds1Profile"]`),
 		},
 	}
 
@@ -3005,20 +2987,34 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 	edge.CachegroupID = util.IntPtr(400)
 
 	mid0 := makeTestParentServer()
-	mid0.Cachegroup = util.StrPtr("midCG")
+	mid0.Cachegroup = util.StrPtr("midCG0")
 	mid0.CachegroupID = util.IntPtr(500)
-	mid0.HostName = util.StrPtr("mymid")
+	mid0.HostName = util.StrPtr("mymid0")
 	mid0.ID = util.IntPtr(45)
 	setIP(mid0, "192.168.2.2")
 
 	mid1 := makeTestParentServer()
-	mid1.Cachegroup = util.StrPtr("midCG2")
+	mid1.Cachegroup = util.StrPtr("midCG1")
 	mid1.CachegroupID = util.IntPtr(501)
 	mid1.HostName = util.StrPtr("mymid1")
 	mid1.ID = util.IntPtr(46)
-	setIP(mid1, "192.168.2.3")
+	setIP(mid0, "192.168.2.3")
 
-	servers := []Server{*edge, *mid0, *mid1}
+	opl0 := makeTestParentServer()
+	opl0.Cachegroup = util.StrPtr("oplCG0")
+	opl0.CachegroupID = util.IntPtr(600)
+	opl0.HostName = util.StrPtr("myopl0")
+	opl0.ID = util.IntPtr(47)
+	setIP(opl0, "192.168.2.4")
+
+	opl1 := makeTestParentServer()
+	opl1.Cachegroup = util.StrPtr("oplCG1")
+	opl1.CachegroupID = util.IntPtr(601)
+	opl1.HostName = util.StrPtr("myopl1")
+	opl1.ID = util.IntPtr(48)
+	setIP(opl0, "192.168.2.5")
+
+	servers := []Server{*edge, *mid0, *mid1, *opl0, *opl1}
 
 	topologies := []tc.Topology{
 		{
@@ -3029,10 +3025,18 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 					Parents:    []int{1, 2},
 				},
 				{
-					Cachegroup: "midCG",
+					Cachegroup: "midCG0",
+					Parents:    []int{3, 4},
 				},
 				{
-					Cachegroup: "midCG2",
+					Cachegroup: "midCG1",
+					Parents:    []int{3, 4},
+				},
+				{
+					Cachegroup: "oplCG0",
+				},
+				{
+					Cachegroup: "oplCG1",
 				},
 			},
 		},
@@ -3051,24 +3055,48 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 	eCGType := tc.CacheGroupEdgeTypeName
 	eCG.Type = &eCGType
 
-	mCG := &tc.CacheGroupNullable{}
-	mCG.Name = mid0.Cachegroup
-	mCG.ID = mid0.CachegroupID
-	mCGType := tc.CacheGroupMidTypeName
-	mCG.Type = &mCGType
+	mCG0 := &tc.CacheGroupNullable{}
+	mCG0.Name = mid0.Cachegroup
+	mCG0.ID = mid0.CachegroupID
+	mCG0.ParentName = opl0.Cachegroup
+	mCG0.ParentCachegroupID = opl0.CachegroupID
+	mCG0.SecondaryParentName = opl1.Cachegroup
+	mCG0.SecondaryParentCachegroupID = opl1.CachegroupID
+	mCGType0 := tc.CacheGroupMidTypeName
+	mCG0.Type = &mCGType0
 
-	mCG2 := &tc.CacheGroupNullable{}
-	mCG2.Name = mid1.Cachegroup
-	mCG2.ID = mid1.CachegroupID
-	mCGType2 := tc.CacheGroupMidTypeName
-	mCG2.Type = &mCGType2
+	mCG1 := &tc.CacheGroupNullable{}
+	mCG1.Name = mid1.Cachegroup
+	mCG1.ID = mid1.CachegroupID
+	mCG1.ParentName = opl1.Cachegroup
+	mCG1.ParentCachegroupID = opl1.CachegroupID
+	mCG1.SecondaryParentName = opl0.Cachegroup
+	mCG1.SecondaryParentCachegroupID = opl0.CachegroupID
+	mCGType1 := tc.CacheGroupMidTypeName
+	mCG1.Type = &mCGType1
 
-	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *mCG2}
+	oCG0 := &tc.CacheGroupNullable{}
+	oCG0.Name = opl0.Cachegroup
+	oCG0.ID = opl0.CachegroupID
+	oCGType0 := tc.CacheGroupMidTypeName
+	oCG0.Type = &oCGType0
+
+	oCG1 := &tc.CacheGroupNullable{}
+	oCG1.Name = opl1.Cachegroup
+	oCG1.ID = opl1.CachegroupID
+	oCGType1 := tc.CacheGroupMidTypeName
+	oCG1.Type = &oCGType1
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG0, *mCG1, *oCG0, *oCG1}
 
 	dss := []DeliveryServiceServer{
 		{
 			Server:          *edge.ID,
-			DeliveryService: *ds1.ID,
+			DeliveryService: *ds0.ID,
+		},
+		{
+			Server:          *mid0.ID,
+			DeliveryService: *ds0.ID,
 		},
 	}
 	cdn := &tc.CDN{
@@ -3076,20 +3104,38 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 		Name:       "my-cdn-name",
 	}
 
-	cfg, err := MakeParentDotConfig(dses, edge, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, hdr)
-	if err != nil {
-		t.Fatal(err)
+	{ // test edge config
+		cfg, err := MakeParentDotConfig(dses, edge, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txt := cfg.Text
+
+		testComment(t, txt, hdr.HdrComment)
+
+		if !strings.Contains(txt, `dest_domain=ds0.example.net port=80 parent="mymid0.mydomain.example.net:80|0.999" secondary_parent="mymid1.mydomain.example.net:80|0.999"`) {
+			t.Errorf("expected topology parent.config of ds0 edge to have parent only: '%v'", txt)
+		}
+
+		if strings.Count(txt, "secondary_parent") != 2 {
+			t.Errorf("expected 2 secondary parents for edge (dest_domain=.): '%v'", txt)
+		}
 	}
-	txt := cfg.Text
 
-	testComment(t, txt, hdr.HdrComment)
+	{ // test mid config
+		cfg, err := MakeParentDotConfig(dses, mid0, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, hdr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txt := cfg.Text
 
-	if !strings.Contains(txt, `dest_domain=ds1.example.net port=80 parent="mymid.mydomain.example.net:80|0.999;mymid1.mydomain.example.net:80|0.999"`) {
-		t.Errorf("expected topology parent.config of ds1 to have parent only: '%v'", txt)
-	}
+		testComment(t, txt, hdr.HdrComment)
 
-	if strings.Count(txt, "secondary_parent") != 1 {
-		t.Errorf("expected only one secondary parent (dest_domain=.): '%v'", txt)
+		if !strings.Contains(txt, `dest_domain=ds0.example.net port=80 parent="myopl0.mydomain.example.net:80|0.999;myopl1.mydomain.example.net:80|0.999"`) {
+			t.Errorf("expected topology parent.config of ds0 mid1 to have parent only: '%v'", txt)
+		} else if strings.Count(txt, "secondary_parent") != 1 {
+			t.Errorf("expected one secondary parent for mid1 (dest_domain=.): '%v'", txt)
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Unit tests cover it. However one can also create a ds parameter merge_parent_groups with parent.config file and space separated garbage strings, assign to any ds that has primary and secondary parents generated in the parent.config.  Verify none of the parent lists are collapsed into a single parent="..." list.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->, fix aligns code with documentation.
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
