### PR TITLE
When targets are ignored, only build delve if debug compose file is used

### DIFF
--- a/infrastructure/cdn-in-a-box/cache/Dockerfile
+++ b/infrastructure/cdn-in-a-box/cache/Dockerfile
@@ -120,8 +120,12 @@ RUN rpm -Uvh /$(basename $ORT_RPM) &&\
 CMD /run.sh
 
 FROM common-traffic-server-dependencies AS get-delve
-RUN dnf -y install golang && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+RUN if [[ "$DEBUG_ENABLE" == true ]]; then \
+        dnf -y install golang && \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
+    else \
+        mkdir -p /root/go/bin; \
+    fi
 
 FROM common-cache-config-layers AS mid
 ENV CACHE_TYPE=mid

--- a/infrastructure/cdn-in-a-box/enroller/Dockerfile
+++ b/infrastructure/cdn-in-a-box/enroller/Dockerfile
@@ -60,7 +60,11 @@ RUN set -o errexit -o nounset; \
     go build -ldflags "$ldflags" -gcflags "$gcflags"
 
 FROM enroller-dependencies as get-delve
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN if [[ "$DEBUG_ENABLE" == true ]]; then \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
+    else \
+        mkdir -p /go/bin; \
+    fi
 
 FROM debian:bullseye AS enroller
 

--- a/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.debugging.yml
@@ -25,6 +25,7 @@ services:
     build:
       target: enroller-debug
       args:
+        DEBUG_ENABLE: 'true'
         ENROLLER_DEBUG_BUILD: 'true'
     image: enroller-debug
     ports:
@@ -32,12 +33,16 @@ services:
   trafficmonitor:
     build:
       target: trafficmonitor-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: trafficmonitor-debug
     ports:
       - "2344:2344" # Delve debugging port
   trafficops:
     build:
       target: trafficops-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: trafficops-debug
     ports:
       - "2345:2345" # Delve debugging port
@@ -47,24 +52,32 @@ services:
   trafficstats:
     build:
       target: trafficstats-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: trafficstats-debug
     ports:
       - "2346:2346" # Delve debugging port
   edge:
     build:
       target: edge-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: edge-debug
     ports:
       - "2347:2347" # Delve debugging port
   mid-01:
     build:
       target: mid-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: mid-debug
     ports:
       - "2348:2348" # Delve debugging port
   mid-02:
     build:
       target: mid-debug
+      args:
+        DEBUG_ENABLE: 'true'
     image: mid-debug
     ports:
       - "2349:2349" # Delve debugging port

--- a/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_monitor/Dockerfile
@@ -70,8 +70,12 @@ HEALTHCHECK --interval=10s --timeout=1s \
 
 FROM trafficmonitor-dependencies as get-delve
 
-RUN dnf -y install golang && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+RUN if [[ "$DEBUG_ENABLE" == true ]]; then \
+        dnf -y install golang && \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
+    else \
+        mkdir -p /root/go/bin; \
+    fi
 
 FROM trafficmonitor as trafficmonitor-debug
 COPY --from=get-delve /root/go/bin /usr/bin

--- a/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_ops/Dockerfile
@@ -118,8 +118,12 @@ HEALTHCHECK --interval=10s --timeout=1s \
 
 FROM trafficops-dependencies as get-delve
 
-RUN dnf -y install golang && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+RUN if [[ "$DEBUG_ENABLE" == true ]]; then \
+        dnf -y install golang && \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
+    else \
+        mkdir -p /root/go/bin; \
+    fi
 
 FROM trafficops AS trafficops-debug
 COPY --from=get-delve /root/go/bin /usr/bin

--- a/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile
@@ -62,8 +62,12 @@ ENTRYPOINT /run.sh
 
 FROM trafficstats-dependencies AS get-delve
 
-RUN dnf -y install golang && \
-    go install github.com/go-delve/delve/cmd/dlv@latest
+RUN if [[ "$DEBUG_ENABLE" == true ]]; then \
+        dnf -y install golang && \
+        go install github.com/go-delve/delve/cmd/dlv@latest; \
+    else \
+        mkdir -p /root/go/bin; \
+    fi
 
 FROM trafficstats AS trafficstats-debug
 COPY --from=get-delve /root/go/bin /usr/bin


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes a hard-to-reproduce bug encountered when building the CDN in a Box images from within a Jenkins pipeline.
The bug is that Docker build targets are ignored, so even though `dlv` should not be installed in non-debug images, it ends up being installed in the `trafficops`, `trafficmonitor`, `trafficstats`, `enroller`, `edge`, `mid-01`, and `mid-02` images. As a result, if there is any issue building `dlv` in this environment, building the entire image will fail.

This PR adds, in the `optional/docker-compose.debugging.yml` file, a `DEBUG_ENABLE` build arg to each of the compose services listed above. That way, even if build targets are ignored, `dlv` will not be built unless `optional/docker-compose.debugging.yml` is included in the docker-compose command.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
```shell
docker-compose -f docker-compose.yml -f optional/docker-compose.debugging.yml build --build-arg DEBUG_ENABLE=false trafficops
```
then
```shell
docker-compose -f docker-compose.yml -f optional/docker-compose.debugging.yml build --build-arg DEBUG_ENABLE=false trafficops
```

Finally,
```shell
docker run --rm -it trafficops sh -c dlv
```
expected output:
```
sh: dlv: command not found
```

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->