### PR TITLE
Restores logging the cache status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Added
 - [#6448](https://github.com/apache/trafficcontrol/issues/6448) Added `status` and `lastPoll` fields to the `publish/CrStates` endpoint of Traffic Monitor (TM).
+- Added back to the health-client the `status` field logging with the addition of the filed to `publish/CrStates`
 - Added a new Traffic Ops endpoint to `GET` capacity and telemetry data for CDNi integration.
 - Added a Traffic Ops endpoints to `PUT` a requested configuration change for a full configuration or per host and an endpoint to approve or deny the request.
 - Traffic Monitor config option `distributed_polling` which enables the ability for Traffic Monitor to poll a subset of the CDN and divide into "local peer groups" and "distributed peer groups". Traffic Monitors in the same group are local peers, while Traffic Monitors in other groups are distibuted peers. Each TM group polls the same set of cachegroups and gets availability data for the other cachegroups from other TM groups. This allows each TM to be responsible for polling a subset of the CDN while still having a full view of CDN availability. In order to use this, `stat_polling` must be disabled.

--- a/tc-health-client/tmagent/tmagent.go
+++ b/tc-health-client/tmagent/tmagent.go
@@ -353,11 +353,7 @@ func (c *ParentInfo) PollAndUpdateCacheStatus() {
 					if !c.Cfg.EnableActiveMarkdowns && !tmAvailable {
 						log.Infof("TM reports that %s is not available and should be marked DOWN but, mark downs are disabled by configuration", hostName)
 					} else {
-						// See issue #6448, the status field used in api/cache-status is not
-						// available in the publish/CrStates endpoint.  For now, will not
-						// use it.
-						//if err = c.markParent(cs.Fqdn, *v.Status, tmAvailable); err != nil {
-						if err = c.markParent(cs.Fqdn, tmAvailable); err != nil {
+						if err = c.markParent(cs.Fqdn, v.Status, tmAvailable); err != nil {
 							log.Errorln(err.Error())
 						}
 					}
@@ -523,10 +519,7 @@ func (c *ParentInfo) execTrafficCtl(fqdn string, available bool) error {
 
 // used to mark a parent as up or down in the trafficserver HostStatus
 // subsystem.
-//
-// TODO see issue #6448, add cacheStatus back when available in CrStates
-//func (c *ParentInfo) markParent(fqdn string, cacheStatus string, available bool) error {
-func (c *ParentInfo) markParent(fqdn string, available bool) error {
+func (c *ParentInfo) markParent(fqdn string, cacheStatus string, available bool) error {
 	var hostAvailable bool
 	var err error
 	hostName := parseFqdn(fqdn)
@@ -553,10 +546,8 @@ func (c *ParentInfo) markParent(fqdn string, available bool) error {
 					log.Errorln(err.Error())
 				}
 				if err == nil {
-					// TODO see issue 6448, add cacheStatus back when available in CrStates
-					// log.Infof("marked parent %s DOWN, cache status was: %s\n", hostName, cacheStatus)
 					hostAvailable = false
-					log.Infof("marked parent %s DOWN", hostName)
+					log.Infof("marked parent %s DOWN, cache status was: %s\n", hostName, cacheStatus)
 				}
 			}
 		} else { // available
@@ -566,9 +557,7 @@ func (c *ParentInfo) markParent(fqdn string, available bool) error {
 				hostAvailable = true
 				// reset the unavilable poll count
 				unavailablePollCount = 0
-				// TODO see issue #6448, add cacheStatus back when available in CrStates
-				//log.Infof("marked parent %s UP, cache status was: %s\n", hostName, cacheStatus)
-				log.Infof("marked parent %s UP", hostName)
+				log.Infof("marked parent %s UP, cache status was: %s\n", hostName, cacheStatus)
 			} else {
 				hostAvailable = false
 			}


### PR DESCRIPTION
When the tc-health-client was switched to using the combined
TM CrStates endpoint, the ability to log the cache status was
lost, Issue #6448.  PR #6612 adds the cache status field to the
TM CrStates endpoint allowing cache status to be logged again.
This PR adds back the cache status logging.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #6448
Related: #6612 

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?

- Traffic Control Health Client (tc-health-client)
- Traffic Control Client <!-- Please specify which (Python, Go, or Java) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
run unit and integration tests.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
