### PR TITLE
Minor improvements to Cachegroup Tests

### DIFF
--- a/traffic_ops/testing/api/v3/cachegroups_test.go
+++ b/traffic_ops/testing/api/v3/cachegroups_test.go
@@ -34,7 +34,7 @@ func TestCacheGroups(t *testing.T) {
 	WithObjs(t, []TCObj{Types, Parameters, CacheGroups, CDNs, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, Topologies}, func() {
 
 		tomorrow := time.Now().AddDate(0, 0, 1).Format(time.RFC1123)
-		currentTime := time.Now().UTC().Add(-5 * time.Second)
+		currentTime := time.Now().UTC().Add(-15 * time.Second)
 		currentTimeRFC := currentTime.Format(time.RFC1123)
 
 		methodTests := utils.V3TestCase{
@@ -95,26 +95,22 @@ func TestCacheGroups(t *testing.T) {
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
 				},
 				"PRECONDITION FAILED when updating with IMS & IUS Headers": {
-					EndpointId: GetCacheGroupId(t, "parentCachegroup"), ClientSession: TOSession,
-					RequestHeaders: http.Header{rfc.IfModifiedSince: {currentTimeRFC}, rfc.IfUnmodifiedSince: {currentTimeRFC}},
+					EndpointId: GetCacheGroupId(t, "cachegroup1"), ClientSession: TOSession,
+					RequestHeaders: http.Header{rfc.IfUnmodifiedSince: {currentTimeRFC}},
 					RequestBody: map[string]interface{}{
-						"latitude":  0,
-						"longitude": 0,
-						"name":      "parentCachegroup",
-						"shortName": "pg1",
-						"typeName":  "MID_LOC",
+						"name":      "cachegroup1",
+						"shortName": "changeName",
+						"typeName":  "EDGE_LOC",
 						"typeId":    -1,
 					},
 					Expectations: utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusPreconditionFailed)),
 				},
 				"PRECONDITION FAILED when updating with IFMATCH ETAG Header": {
-					EndpointId: GetCacheGroupId(t, "parentCachegroup2"), ClientSession: TOSession,
+					EndpointId: GetCacheGroupId(t, "cachegroup1"), ClientSession: TOSession,
 					RequestBody: map[string]interface{}{
-						"latitude":  0,
-						"longitude": 0,
-						"name":      "parentCachegroup2",
-						"shortName": "pg2",
-						"typeName":  "MID_LOC",
+						"name":      "cachegroup1",
+						"shortName": "changeName",
+						"typeName":  "EDGE_LOC",
 						"typeId":    -1,
 					},
 					RequestHeaders: http.Header{rfc.IfMatch: {rfc.ETag(currentTime)}},
@@ -134,7 +130,7 @@ func TestCacheGroups(t *testing.T) {
 			"GET AFTER CHANGES": {
 				"OK when CHANGES made": {
 					ClientSession:  TOSession,
-					RequestHeaders: http.Header{rfc.IfModifiedSince: {currentTimeRFC}, rfc.IfUnmodifiedSince: {currentTimeRFC}},
+					RequestHeaders: http.Header{rfc.IfModifiedSince: {currentTimeRFC}},
 					Expectations:   utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
 				},
 			},

--- a/traffic_ops/testing/api/v4/cachegroups_test.go
+++ b/traffic_ops/testing/api/v4/cachegroups_test.go
@@ -35,7 +35,7 @@ func TestCacheGroups(t *testing.T) {
 	WithObjs(t, []TCObj{Types, Parameters, CacheGroups, CDNs, Profiles, Statuses, Divisions, Regions, PhysLocations, Servers, Topologies}, func() {
 
 		tomorrow := time.Now().AddDate(0, 0, 1).Format(time.RFC1123)
-		currentTime := time.Now().UTC().Add(-5 * time.Second)
+		currentTime := time.Now().UTC().Add(-15 * time.Second)
 		currentTimeRFC := currentTime.Format(time.RFC1123)
 
 		methodTests := utils.V4TestCase{
@@ -167,30 +167,22 @@ func TestCacheGroups(t *testing.T) {
 					Expectations: utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusBadRequest)),
 				},
 				"PRECONDITION FAILED when updating with IMS & IUS Headers": {
-					EndpointId: GetCacheGroupId(t, "parentCachegroup"), ClientSession: TOSession,
-					RequestOpts: client.RequestOptions{
-						Header: http.Header{
-							rfc.IfModifiedSince: {currentTimeRFC}, rfc.IfUnmodifiedSince: {currentTimeRFC},
-						},
-					},
+					EndpointId: GetCacheGroupId(t, "cachegroup1"), ClientSession: TOSession,
+					RequestOpts: client.RequestOptions{Header: http.Header{rfc.IfUnmodifiedSince: {currentTimeRFC}}},
 					RequestBody: map[string]interface{}{
-						"latitude":  0,
-						"longitude": 0,
-						"name":      "parentCachegroup",
-						"shortName": "pg1",
-						"typeName":  "MID_LOC",
+						"name":      "cachegroup1",
+						"shortName": "changeName",
+						"typeName":  "EDGE_LOC",
 						"typeId":    -1,
 					},
 					Expectations: utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusPreconditionFailed)),
 				},
 				"PRECONDITION FAILED when updating with IFMATCH ETAG Header": {
-					EndpointId: GetCacheGroupId(t, "parentCachegroup2"), ClientSession: TOSession,
+					EndpointId: GetCacheGroupId(t, "cachegroup1"), ClientSession: TOSession,
 					RequestBody: map[string]interface{}{
-						"latitude":  0,
-						"longitude": 0,
-						"name":      "parentCachegroup2",
-						"shortName": "pg2",
-						"typeName":  "MID_LOC",
+						"name":      "cachegroup1",
+						"shortName": "changeName",
+						"typeName":  "EDGE_LOC",
 						"typeId":    -1,
 					},
 					RequestOpts:  client.RequestOptions{Header: http.Header{rfc.IfMatch: {rfc.ETag(currentTime)}}},
@@ -214,12 +206,8 @@ func TestCacheGroups(t *testing.T) {
 			"GET AFTER CHANGES": {
 				"OK when CHANGES made": {
 					ClientSession: TOSession,
-					RequestOpts: client.RequestOptions{
-						Header: http.Header{
-							rfc.IfModifiedSince: {currentTimeRFC}, rfc.IfUnmodifiedSince: {currentTimeRFC},
-						},
-					},
-					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
+					RequestOpts:   client.RequestOptions{Header: http.Header{rfc.IfModifiedSince: {currentTimeRFC}}},
+					Expectations:  utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
 				},
 			},
 		}

--- a/traffic_ops/testing/api/v4/cachegroups_test.go
+++ b/traffic_ops/testing/api/v4/cachegroups_test.go
@@ -179,13 +179,13 @@ func TestCacheGroups(t *testing.T) {
 				},
 				"PRECONDITION FAILED when updating with IFMATCH ETAG Header": {
 					EndpointId: GetCacheGroupId(t, "cachegroup1"), ClientSession: TOSession,
+					RequestOpts: client.RequestOptions{Header: http.Header{rfc.IfMatch: {rfc.ETag(currentTime)}}},
 					RequestBody: map[string]interface{}{
 						"name":      "cachegroup1",
 						"shortName": "changeName",
 						"typeName":  "EDGE_LOC",
 						"typeId":    -1,
 					},
-					RequestOpts:  client.RequestOptions{Header: http.Header{rfc.IfMatch: {rfc.ETag(currentTime)}}},
 					Expectations: utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusPreconditionFailed)),
 				},
 				"UNAUTHORIZED when NOT LOGGED IN": {


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR removes un-needed headers that were being used. Since `GET` requests only check the `If-Modified-Since` headers they don't need the `If-Unmodified-Since` headers and vice versa with `PUT` requests. 

The mod time was also changed from 5 to 15 seconds before current time to allow the tests time to perform necessary changes.

The cachegroup PUT request body was also simplified for the Precondition tests, to reduce additional lines.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops Tests


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Run the TO integration tests



## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
