### PR TITLE
Reduce over-verbose logging

### DIFF
--- a/cache-config/testing/docker/ort_test/run.sh
+++ b/cache-config/testing/docker/ort_test/run.sh
@@ -48,7 +48,7 @@ TERM=xterm; export TERM
 if [ -f /trafficcontrol/GO_VERSION ]; then
   go_version=$(cat /trafficcontrol/GO_VERSION) && \
       curl -Lo go.tar.gz https://dl.google.com/go/go${go_version}.linux-amd64.tar.gz && \
-        tar -C /usr/local -xvzf go.tar.gz && \
+        tar -C /usr/local -xzf go.tar.gz && \
         ln -s /usr/local/go/bin/go /usr/bin/go && \
         rm go.tar.gz
 else
@@ -65,7 +65,7 @@ fi
 cd "$(realpath /ort-tests)"
 
 # fetch dependent packages for tests
-go mod vendor -v
+go mod vendor
 
 cp /ort-tests/tc-fixtures.json /tc-fixtures.json
 ATS_RPM=`basename /yumserver/test-rpms/trafficserver-[0-9]*.rpm |


### PR DESCRIPTION
The "ORT tests" (`t3c` integration tests) print every file extracted from the Go distribution archive and the name of every Go module dependency the project has every time they run. That constitutes about 13,600 lines in a test that outputs 15,000 with the current failure (less on success, but that matters less since you'd probably never look at the logs in that case) which makes it about 90% of the test output. That information has never been helpful yet (afaik) and I'm skeptical it ever will be in the future, so this PR aims to make looking at the test output less annoying by removing it.


<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (tests)

## What is the best way to verify this PR?
Check the t3c test workflow action output on this PR, verify the logs from the "ORT Test" step are now roughly 2k lines instead of 15k (assuming the current failure continues).

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 