### PR TITLE
Fix build failures resulting from new bulid-time requirements in go1.18

### DIFF
--- a/dev/t3c/Dockerfile
+++ b/dev/t3c/Dockerfile
@@ -23,7 +23,7 @@ RUN tar -xf trafficserver-9.1.1.tar.bz2 && cd trafficserver-9.1.1 && mkdir /ats 
 
 FROM golang:${GO_VERSION}-alpine AS t3c-dev
 
-ENV TC="/root/go/src/github.com/apache/trafficcontrol/"
+ENV TC="/root/go/src/github.com/apache/trafficcontrol/" GOFLAGS="--buildvcs=false"
 VOLUME /root/go/src/github.com/apache/trafficcontrol
 EXPOSE 80 8081
 

--- a/dev/traffic_monitor/Dockerfile
+++ b/dev/traffic_monitor/Dockerfile
@@ -14,7 +14,7 @@
 ARG GO_VERSION
 FROM golang:${GO_VERSION}-alpine AS trafficmonitor-dev
 
-ENV TC=/root/go/src/github.com/apache/trafficcontrol
+ENV TC=/root/go/src/github.com/apache/trafficcontrol GOFLAGS="--buildvcs=false"
 VOLUME /root/go/src/github.com/apache/trafficcontrol
 EXPOSE 80 81
 

--- a/dev/traffic_ops/Dockerfile
+++ b/dev/traffic_ops/Dockerfile
@@ -24,7 +24,7 @@ RUN openssl genrsa -passout pass:x -out server.pass.key 2048 && \
 
 FROM golang:${GO_VERSION}-alpine AS trafficops-dev
 
-ENV TC="/root/go/src/github.com/apache/trafficcontrol/"
+ENV TC="/root/go/src/github.com/apache/trafficcontrol/" GOFLAGS="--buildvcs=false"
 VOLUME /root/go/src/github.com/apache/trafficcontrol
 ENV ADMIN="$TC/traffic_ops/app/db/admin"
 EXPOSE 443 6444


### PR DESCRIPTION
The developer environment fails to build Go binaries due to an external `git` binary being required for the Go compiler to work in Go 1.18, whenever the compiler can find a `.git` directory in the filesystem hierarchy that contains the working directory. At the time of this writing, there is ongoing discussion in golang/go#51748 that might result in changes being made that would fix this problem for us, but as a resolution hasn't yet been adopted and there's no timetable for when it might be implemented if one were adopted, this just fixes the issue by adding a new build flag explicitly disabling the new feature.

<hr/>

## Which Traffic Control components are affected by this PR?
None.

## What is the best way to verify this PR?
`atc start && atc ready -w` should exit within a few minutes with exit code 0.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master as of #6656.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** 