### PR TITLE
ATS RPM: Only match tags ending in 3 digits or dots

### DIFF
--- a/cache-config/testing/docker/trafficserver/trafficserver.spec
+++ b/cache-config/testing/docker/trafficserver/trafficserver.spec
@@ -20,9 +20,9 @@
 
 %global src %{_topdir}/SOURCES/trafficserver
 %global git_args --git-dir="%{src}/.git" --work-tree="%{src}"
-%global tag %(git %{git_args} describe --long |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
-%global distance %(git %{git_args} describe --long | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
-%global commit %(git %{git_args} describe --long |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
+%global tag %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
+%global distance %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
+%global commit %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
 %global git_serial %(git %{git_args} rev-list HEAD | wc -l)
 %global install_prefix "/opt"
 %global api_stats "4096"

--- a/traffic_server/_tsb/trafficserver.spec
+++ b/traffic_server/_tsb/trafficserver.spec
@@ -20,9 +20,9 @@
 
 %global src %{_topdir}/SOURCES/src
 %global git_args --git-dir="%{src}/.git" --work-tree="%{src}"
-%global tag %(git %{git_args} describe --long |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
-%global distance %(git %{git_args} describe --long | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
-%global commit %(git %{git_args} describe --long |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
+%global tag %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' |      sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\1/' | sed 's/-/_/')
+%global distance %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' | sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\2/')
+%global commit %(git %{git_args} describe --long --match='*[0-9.][0-9.][0-9.]' |   sed 's/^\\\(.*\\\)-\\\([0-9]\\\+\\\)-g\\\([0-9a-f]\\\+\\\)$/\\\3/')
 %global git_serial %(git %{git_args} rev-list HEAD | wc -l)
 %global install_prefix "/opt"
 %global api_stats "4096"


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR causes the t3c integration tests's Traffic Server RPM SPEC to exclude release candidate tags in the version number.
Before:
```
trafficserver-8.1.4_rc0-0.965df952e.el8.x86_64.rpm
```

After:
```
trafficserver-8.1.3-10-965df952e.el8.x86_64.rpm
```

This matches the behavior expected by the [*fetch-github-branch-sha*](https://github.com/apache/trafficcontrol/tree/a0d33de24b/.github/actions/fetch-github-branch-sha) GitHub Action and the [`ats-version.sh`](https://github.com/apache/trafficcontrol/blob/a0d33de24b/infrastructure/cdn-in-a-box/bin/ats-version.sh) script used by the CDN in a Box makefile, so
- this should make the CDN in a Box GHA workflow pass again
- this should fix ATS RPM caching

Note that the t3c integration tests still fail, but that failure is not caused by this PR.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT) - ATS RPM
- CDN in a Box - ATS RPM

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Check the RPM name generated by the `trafficserver` step of the cache-config tests

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master (a0d33de24b)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

## Anything else
```shell
git describe --exclude='*[^0-9.]*'
```

would have been cleaner than

````shell
git describe --match='*[0-9.][0-9.][0-9.]'
````

but `--exclude` is not supported in git version 1.8.3.1, the version used in CentOS 7 currently.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->