### PR TITLE
Fix timestamps to the correct format

### DIFF
--- a/lib/go-tc/traffic_stats.go
+++ b/lib/go-tc/traffic_stats.go
@@ -260,7 +260,7 @@ func (s TrafficStatsSeries) FormatTimestamps() error {
 			if err != nil {
 				return fmt.Errorf("error converting timestamp %s into RFC3339 format: %v", v[0], err)
 			}
-			s.Values[i][0] = t.String()
+			s.Values[i][0] = t.Format(time.RFC3339)
 		default:
 			return fmt.Errorf("Invalid type %T for datapoint %d (%v)", v[0], i, v)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to any issue

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Make a request to the `deliveryservice_stats` endpoint and make sure that the resultant timestamps are in RFC3339 format.
Sample request:
`GET https://<TO HOST:PORT>/api/4.0/deliveryservice_stats?deliveryServiceName=<NAME HERE>&startDate=2021-03-09T11%3A14%3A00-07%3A00&serverType=edge&metricType=kbps&interval=1m&endDate=2021-03-10T11%3A14%3A00-07%3A00`

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
