### PR TITLE
adding strategies peering ring generation to t3c

### DIFF
--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -997,6 +997,10 @@ The following :term:`Parameters` must have the :ref:`Config File <parameter-conf
 
 	.. caution:: The actual permitted TLS versions are the union of those laid out in this :term:`Parameter` and those configured as the `TLS Versions`_ property of the Delivery Service.
 
+- ``use_peering`` - on a Deliver Service :term:`Profile`, if this exists and is ``true``, the ``strategy ring_mode`` will be set to ``peering_ring`` for large library DNS support.
+
+	.. impl-detail:: This :term:`Parameter` does not affect the contents of ``parent.config``, but instead ``strategies.yaml`` in :abbr:`ATS (Apache Traffic Server)` 9. It has the ``parent.config`` :ref:`parameter-config-file` value for consistency.
+
 	.. deprecated:: ATCv6.2
 		In :ref:`to-api` version 4 (unstable at the time of this writing), TLS versions should be configured using the `TLS Versions`_ property of the Delivery Service, and support for this :term:`Parameter` will be removed at some point after the stabilization of :ref:`to-api` version 4.
 

--- a/lib/go-atscfg/parentabstraction.go
+++ b/lib/go-atscfg/parentabstraction.go
@@ -28,6 +28,9 @@ import (
 // ParentAbstraction contains all the data necessary to build either parent.config or strategies.yaml.
 type ParentAbstraction struct {
 	Services []*ParentAbstractionService
+	// Peers is the list of peer proxy caches to be used in a strategy peering group.
+	// a cache will only have one set of peers for potential use in all delivery services.
+	Peers []*ParentAbstractionServiceParent
 }
 
 // ParentAbstractionService represents a single delivery service's parent data.
@@ -67,6 +70,12 @@ type ParentAbstractionService struct {
 	// Becomes parent.config secondary_mode directive
 	// Becomes strategies.yaml TODO
 	SecondaryMode ParentAbstractionServiceParentSecondaryMode
+
+	// CachePeerResult is used only when the RetryPolicy is set to
+	// 'consistent_hash' and the SecondaryMode is set to 'peering'.
+	// In the case that it's used and set to 'true', query results
+	// from peer caches will not be cached locally.
+	CachePeerResult bool
 
 	// GoDirect is whether to go direct to parents via normal HTTP requests.
 	// False means to make proxy requests to the parents.
@@ -131,6 +140,7 @@ type ParentAbstractionServiceParentSecondaryMode string
 
 const ParentAbstractionServiceParentSecondaryModeExhaust = ParentAbstractionServiceParentSecondaryMode("exhaust")
 const ParentAbstractionServiceParentSecondaryModeAlternate = ParentAbstractionServiceParentSecondaryMode("alternate")
+const ParentAbstractionServiceParentSecondaryModePeering = ParentAbstractionServiceParentSecondaryMode("peering")
 const ParentAbstractionServiceParentSecondaryModeInvalid = ParentAbstractionServiceParentSecondaryMode("")
 
 const ParentAbstractionServiceParentSecondaryModeDefault = ParentAbstractionServiceParentSecondaryModeAlternate

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -65,6 +65,7 @@ const ParentConfigCacheParamPort = "port"
 const ParentConfigCacheParamUseIP = "use_ip_address"
 const ParentConfigCacheParamRank = "rank"
 const ParentConfigCacheParamNotAParent = "not_a_parent"
+const StrategyConfigUsePeering = "use_peering"
 
 type OriginHost string
 type OriginFQDN string
@@ -237,6 +238,7 @@ func makeParentDotConfigData(
 
 	nameTopologies := makeTopologyNameMap(topologies)
 
+	cgPeers := map[int]Server{}   // map[serverID]server
 	cgServers := map[int]Server{} // map[serverID]server
 	for _, sv := range servers {
 		if sv.ID == nil {
@@ -258,6 +260,15 @@ func makeParentDotConfigData(
 		if *sv.CDNName != *server.CDNName {
 			continue
 		}
+		// save cachegroup peer servers
+		if *sv.CDNName == *server.CDNName && *sv.Cachegroup == *server.Cachegroup {
+			if *sv.Status == string(tc.CacheStatusReported) || *sv.Status == string(tc.CacheStatusOnline) {
+				if _, ok := cgPeers[*sv.ID]; !ok {
+					cgPeers[*sv.ID] = sv
+				}
+			}
+			continue
+		}
 		if _, ok := parentCacheGroups[*sv.Cachegroup]; !ok {
 			continue
 		}
@@ -270,6 +281,15 @@ func makeParentDotConfigData(
 			continue
 		}
 		cgServers[*sv.ID] = sv
+	}
+
+	// save the cache group peers
+	for _, v := range cgPeers {
+		peer := &ParentAbstractionServiceParent{}
+		peer.FQDN = *v.HostName + "." + *v.DomainName
+		peer.Port = *v.TCPPort
+		peer.Weight = 0.999
+		parentAbstraction.Peers = append(parentAbstraction.Peers, peer)
 	}
 
 	cgServerIDs := map[int]struct{}{}
@@ -471,6 +491,11 @@ func makeParentDotConfigData(
 
 			text := &ParentAbstractionService{}
 			text.Name = *ds.XMLID
+
+			// peering ring check
+			if dsParams.UsePeering {
+				secondaryMode = ParentAbstractionServiceParentSecondaryModePeering
+			}
 
 			orgFQDNStr := *ds.OrgServerFQDN
 			// if this cache isn't the last tier, i.e. we're not going to the origin, use http not https
@@ -814,6 +839,7 @@ type parentDSParams struct {
 	MaxUnavailableServerRetries     string
 	QueryStringHandling             string
 	TryAllPrimariesBeforeSecondary  bool
+	UsePeering                      bool
 	MergeGroups                     []string
 }
 
@@ -839,7 +865,11 @@ func getParentDSParams(ds DeliveryService, profileParentConfigParams map[string]
 	if !ok {
 		return params, warnings
 	}
-
+	if val, ok := dsParams[StrategyConfigUsePeering]; ok {
+		if val == "true" {
+			params.UsePeering = true
+		}
+	}
 	// the following may be blank, no default
 	params.QueryStringHandling = dsParams[ParentConfigParamQStringHandling]
 	params.MergeGroups = strings.Split(dsParams[ParentConfigParamMergeGroups], " ")


### PR DESCRIPTION
Adds in to t3c strategies peering support when the DS profile parameter `use_peering` exists and is `true`

- Add's a peer group list in strategies.yaml
- adds the cache_peer_result flag to a strategy configured to use_peering
- sets the ring_mode on a strategy to `peering_ring` when configured to use_peering
- adds a DS parameter **use_peering**

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?

- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Add the DS param **use_peering** to a Delivery service.  It should generate a strategy in strategies.yaml with a peer group set of hosts and the ring_mode should be set to **peering_ring**


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
