### PR TITLE
updates to the trafficcontrol-health-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated the Profiles Traffic Portal page to use a more performant AG-Grid-based table.
 - Updated Go version to 1.18
 - Removed the unused `deliveryservice_tmuser` table from Traffic Ops database
+- Adds updates to the trafficcontrol-health-client to, use new ATS Host status formats, detect and use proper
+  traffic_ctl commands, and adds new markup-poll-threshold config.
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/tc-health-client/README.md
+++ b/tc-health-client/README.md
@@ -71,24 +71,24 @@ Requires Apache TrafficServer 8.1.0 or later.
 
 -f, -\-config-file=config-file 
   
-  Specify the config file to use.  
-  Defaults to /etc/trafficcontro-health-client/tc-health-client.json
+Specify the config file to use.  
+Defaults to /etc/trafficcontro-health-client/tc-health-client.json
 
 -h, -\-help 
 
-  Prints command line usage and exits
+Prints command line usage and exits
 
 -l, -\-logging-dir=logging-directory
 
-  Specify the directory where log files are kept.  The default location
-  is **/var/log/trafficcontrol/**
+Specify the directory where log files are kept.  The default location
+is **/var/log/trafficcontrol/**
 
 -v, -\-verbose
 
-  Logging verbosity.  Errors are logged to the default log file 
-  **/var/log/trafficcontrol/tc-health-client.log**
-  To add Warnings, use -v.  To add Warnings and Informational 
-  logging, use -vv.  Finally you may add Debug logging using -vvv.
+Logging verbosity.  Errors are logged to the default log file 
+**/var/log/trafficcontrol/tc-health-client.log**
+To add Warnings, use -v.  To add Warnings and Informational 
+logging, use -vv.  Finally you may add Debug logging using -vvv.
 
 # CONFIGURATION
 
@@ -109,6 +109,7 @@ Sample configuarion file:
     "tm-proxy-url", "http://sample-http-proxy.cdn.net:80",
     "to-login-dispersion-factor": 90,
     "unavailable-poll-threshold": 2,
+    "markup-poll-threshold": 1,
     "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
     "trafficserver-bin-dir": "/opt/trafficserver/bin",
     "poll-state-json-log": "/var/log/trafficcontrol/poll-state.json",
@@ -118,85 +119,91 @@ Sample configuarion file:
 
 ### cdn-name 
 
-  The name of the CDN that the Traffic Server host is a member of.
+The name of the CDN that the Traffic Server host is a member of.
 
 ### enable-active-markdowns
 
-  When enabled, the client will actively mark down Traffic Server parents.
-  When disabled, the client will only log that it would have marked down
-  Traffic Server parents.  Down Parents are always marked UP if Traffic Monitor
-  reports them available irregardless of this setting.
+When enabled, the client will actively mark down Traffic Server parents.
+When disabled, the client will only log that it would have marked down
+Traffic Server parents.  Down Parents are always marked UP if Traffic Monitor
+reports them available irregardless of this setting.
 
 ### reason-code
 
-  Use the reason code **active** or **local** when marking down Traffic Server
-  hosts in the Traffic Server **HostStatus** subsystem.
+Use the reason code **active** or **local** when marking down Traffic Server
+hosts in the Traffic Server **HostStatus** subsystem.
 
 ### to-credential-file
 
-  The file where **Traffic Ops** credentials are read.  The file should define the 
-  following variables:
+The file where **Traffic Ops** credentials are read.  The file should define the 
+following variables:
 
-  * TO_URL="https://trafficops.cdn.com"
-  * TO_USER="touser"
-  * TO_PASS="touser_password"
+* TO_URL="https://trafficops.cdn.com"
+* TO_USER="touser"
+* TO_PASS="touser_password"
 
 ### to-url
 
-  The **Traffic Ops** URL
+The **Traffic Ops** URL
 
 ### to-request-timeout-seconds
 
-  The time in seconds to wait for a query response from both **Traffic Ops** and
-  the **Traffic Monitors**
+The time in seconds to wait for a query response from both **Traffic Ops** and
+the **Traffic Monitors**
 
 ### tm-poll-interval-seconds
 
-  The polling interval in seconds used to update **Traffic Server** parent
-  status.
+The polling interval in seconds used to update **Traffic Server** parent
+status.
 
 ### tm-proxy-url
 
-  If not nil, all Traffic Monitor requests will be proxied through this 
-  proxy endpoint.  This is useful when there are large numbers of caches
-  polling a Traffic Monitor and you wish to funnel queries through a caching
-  proxy server to limit direct direct connections to Traffic Monitor.
+If not nil, all Traffic Monitor requests will be proxied through this 
+proxy endpoint.  This is useful when there are large numbers of caches
+polling a Traffic Monitor and you wish to funnel queries through a caching
+proxy server to limit direct direct connections to Traffic Monitor.
 
 ### to-login-dispersion-factor
 
-  This is used to calculate TrafficOps login dispersion.  It is related to the
-  **tm-poll-interval-seconds**.  The login dispersion is computed by multiplying
-  **tm-poll-interval-seconds** by the **to-login-dispersion-factor**.  For example
-  if to-login-dispersion-factor is 90 and the **tm-poll-interval-seconds** is 10s
-  the the dispersion modulo window is 900s.
+This is used to calculate TrafficOps login dispersion.  It is related to the
+**tm-poll-interval-seconds**.  The login dispersion is computed by multiplying
+**tm-poll-interval-seconds** by the **to-login-dispersion-factor**.  For example
+if to-login-dispersion-factor is 90 and the **tm-poll-interval-seconds** is 10s
+the the dispersion modulo window is 900s.
 
 ### unavailable-poll-threshold
 
-  This controls when an unhealthy parent is marked down.  An unhealthy parent
-  will be marked down when the number of consecutive polls reaches this threshold
-  with the parent reported as unhealthy.  The default threshold is 2.
+This controls when an unhealthy parent is marked down.  An unhealthy parent
+will be marked down when the number of consecutive polls reaches this threshold
+with the parent reported as unhealthy.  The default threshold is 2.
+
+### markup-poll-threshold
+
+This controls when a healthy parent is marked up.  An healthy parent
+will be marked up when the number of consecutive polls reaches this threshold
+with the parent reported as healthy.  The default threshold is 1.
 
 ### trafficserver-config-dir
 
-  The location on the host where **Traffic Server** configuration files are 
-  located.
+The location on the host where **Traffic Server** configuration files are 
+located.
 
 ### trafficserver-bin-dir
 
-  The location on the host where **Traffic Server** **traffic_ctl** tool may
-  be found.
+The location on the host where **Traffic Server** **traffic_ctl** tool may
+be found.
 
 ### poll-state-json-log ###
 
-  The full path to the polling state file which contains information 
-  about the current status of parents and the health client configuration.
-  Polling state data is written to this file after each polling cycle when
-  enabled, see **enable-poll-state-log**
+The full path to the polling state file which contains information 
+about the current status of parents and the health client configuration.
+Polling state data is written to this file after each polling cycle when
+enabled, see **enable-poll-state-log**
 
 ### enable-poll-state-log ###
 
-  Enable writing the Polling state to the **poll-state-json-log** after
-  eache polling cycle.  Default **false**, disabled
+Enable writing the Polling state to the **poll-state-json-log** after
+eache polling cycle.  Default **false**, disabled
 
 # Files
 
@@ -209,4 +216,3 @@ Sample configuarion file:
 * Traffic Server **strategies.yaml**
 * Traffic Server **traffic_ctl** command
   
-   

--- a/tc-health-client/config/config.go
+++ b/tc-health-client/config/config.go
@@ -55,6 +55,7 @@ const (
 	DefaultTrafficServerConfigDir   = "/opt/trafficserver/etc/trafficserver"
 	DefaultTrafficServerBinDir      = "/opt/trafficserver/bin"
 	DefaultUnavailablePollThreshold = 2
+	DefaultMarkupPollThreshold      = 1
 )
 
 type Cfg struct {
@@ -70,6 +71,7 @@ type Cfg struct {
 	TmPollIntervalSeconds    string          `json:"tm-poll-interval-seconds"`
 	TOLoginDispersionFactor  int             `json:"to-login-dispersion-factor"`
 	UnavailablePollThreshold int             `json:"unavailable-poll-threshold"`
+	MarkUpPollThreshold      int             `json:"markup-poll-threshold"`
 	TrafficServerConfigDir   string          `json:"trafficserver-config-dir"`
 	TrafficServerBinDir      string          `json:"trafficserver-bin-dir"`
 	PollStateJSONLog         string          `json:"poll-state-json-log"`


### PR DESCRIPTION
updates to the trafficcontrol-health-client:

- updates the host status commands used by the health-client
  to support both ATS 9 and ATS 10 traffic_ctl commands.
- updates the parsing of host statuses output to support both
  ATS 9 and ATS 10 output formats.
- adds a **markup-poll-threshold** config variable that may be used to control 
   how many poll intervals must pass with a healthy cache status before the cache
   is marked up.  The idea here is to reduce flapping between marking up and down
   a cache


## Which Traffic Control components are affected by this PR?

- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?

The health-client has been updated to process ATS version 9 and ATS version 10-Dev traffic_ctl host
commands.  Verify the health client can verify ATS host statuses and mark up or down caches
wether the cache is running ATS 9 or 10-Dev.  This functionality has been tested by me.

## If this is a bugfix, which Traffic Control versions contained the bug?

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
