### PR TITLE
Use absolute ordering in web.xml

### DIFF
--- a/traffic_router/core/src/main/webapp/WEB-INF/web.xml
+++ b/traffic_router/core/src/main/webapp/WEB-INF/web.xml
@@ -18,6 +18,8 @@
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
                       http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1" metadata-complete="true">
+    <!-- https://stackoverflow.com/questions/55445720 -->
+    <absolute-ordering />
     <context-param>
         <param-name>log4jConfigLocation</param-name>
         <param-value>/WEB-INF/classes/log4j.xml</param-value>


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This fixes an issue encountered by Traffic Router in Dev CDN in a Box, probably since Spring Framework was upgraded to 5.2.20 in #6705:
```java
	Caused by: java.lang.IllegalArgumentException: More than one fragment with the name [spring_web] was found. This is not legal with relative ordering. See section 8.2.2 2c of the Servlet specification for details. Consider using absolute ordering.
```
<details><summary>More complete log</summary>

```java
07-Apr-2022 20:24:41.353 INFO [main] org.apache.catalina.startup.Catalina.load Server initialization in [3064] milliseconds
07-Apr-2022 20:24:41.465 INFO [main] org.apache.catalina.core.StandardService.startInternal Starting service [traffic_router_core]
07-Apr-2022 20:24:41.465 INFO [main] org.apache.catalina.core.StandardEngine.startInternal Starting Servlet engine: [Apache Tomcat/9.0.43]
07-Apr-2022 20:24:41.798 SEVERE [main] org.apache.catalina.core.ContainerBase.startInternal A child container failed during start
	java.util.concurrent.ExecutionException: org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[traffic_router_core].StandardHost[localhost].StandardContext[]]
		at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
		at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
		at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:916)
		at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:843)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1384)
		at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1374)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
		at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
		at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:140)
		at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:909)
		at org.apache.catalina.core.StandardEngine.startInternal(StandardEngine.java:262)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.core.StandardService.startInternal(StandardService.java:434)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.core.StandardServer.startInternal(StandardServer.java:930)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		at org.apache.catalina.startup.Catalina.start(Catalina.java:772)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
		at org.apache.catalina.startup.Bootstrap.start(Bootstrap.java:342)
		at org.apache.catalina.startup.Bootstrap.main(Bootstrap.java:473)
	Caused by: org.apache.catalina.LifecycleException: Failed to start component [StandardEngine[traffic_router_core].StandardHost[localhost].StandardContext[]]
		at org.apache.catalina.util.LifecycleBase.handleSubClassException(LifecycleBase.java:440)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:198)
		at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1384)
		at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1374)
		at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
		at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
		at java.base/java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:140)
		at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:909)
		... 21 more
	Caused by: java.lang.IllegalArgumentException: More than one fragment with the name [spring_web] was found. This is not legal with relative ordering. See section 8.2.2 2c of the Servlet specification for details. Consider using absolute ordering.
		at org.apache.tomcat.util.descriptor.web.WebXml.orderWebFragments(WebXml.java:2260)
		at org.apache.tomcat.util.descriptor.web.WebXml.orderWebFragments(WebXml.java:2218)
		at org.apache.catalina.startup.ContextConfig.webConfig(ContextConfig.java:1294)
		at org.apache.catalina.startup.ContextConfig.configureStart(ContextConfig.java:986)
		at org.apache.catalina.startup.ContextConfig.lifecycleEvent(ContextConfig.java:303)
		at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
		at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5082)
		at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
		... 27 more

```
</details>

<strike>Note: This PR includes commits from #6727 so it will work, so #6727 should be merged first.</strike>
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Remove CrConfig backups (`rm -rf dev/{traffic_router/db,traffic_monitor/*.backup.*}`) and take a snapshot, as long as #6727 is still open
2. In the Dev CDN in a Box, wait for Traffic Router to finish starting, until it says
   ```java
   org.apache.traffic_control.traffic_router.core.config.ConfigHandler - Exiting processConfig: No json data to process
   ```
3. Verify that Traffic Router routes the Dev CiaB Delivery Service:
    ```shell
    dig @localhost -p 3053  cdn.dev-ds.ciab.test
    curl -vHHost:cdn.dev-ds.ciab.test localhost:3080
    ```

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master (bf47303484)

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->