### PR TITLE
Fix t3c nil reference on fallback

### DIFF
--- a/cache-config/t3cutil/toreq/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/clientfuncs.go
@@ -70,7 +70,7 @@ func (cl *TOClient) GetProfileByName(profileName string, reqHdr http.Header) (tc
 func (cl *TOClient) WriteFsCookie(fileName string) {
 	tmpFileName := fileName + ".tmp"
 	cookie := torequtil.FsCookie{}
-	u, err := url.Parse(cl.c.URL)
+	u, err := url.Parse(cl.URL())
 	if err != nil {
 		log.Warnln("Error parsing Traffic ops URL: ", err)
 		return


### PR DESCRIPTION
Fixes a nil reference in t3c on fallback.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c against a TO that doesn't serve the latest API, verify fallback does not crash.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release

## PR submission checklist
- ~[x] This PR has tests~ no tests, testing would require the Integration Test Framework support multiple TO versions, which would be ideal but is a large amount of work to add.
- ~[x] This PR has documentation~ no docs, no interface change
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, bug is not in a release
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
