### PR TITLE
Fix t3c TO API fallback

### DIFF
--- a/.github/actions/go-fmt/entrypoint.sh
+++ b/.github/actions/go-fmt/entrypoint.sh
@@ -34,9 +34,21 @@ mkdir -p "$SRCDIR"
 ln -s "$PWD" "$SRCDIR/trafficcontrol"
 cd "$SRCDIR/trafficcontrol"
 
+printf "about to gofmt, pwd: %s\n" "$(pwd)"
+
 /usr/local/go/bin/go fmt ./...
+printf "gofmt returned %d\n" "$?"
+
+
+git config --global --add safe.directory /github/workspace
+printf "git config add safe.directory returned  %d\n" "$?"
+
+#git status
+
+printf "about to git-diff, pwd: %s\n" "$(pwd)"
 DIFF_FILE="$(mktemp)"
 git diff >"$DIFF_FILE"
+printf "git diff returned %d\n" "$?"
 
 if [ -s "$DIFF_FILE" ]; then
 	./misc/parse_diffs.py <"$DIFF_FILE";

--- a/cache-config/t3cutil/toreq/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/clientfuncs.go
@@ -75,7 +75,7 @@ func (cl *TOClient) WriteFsCookie(fileName string) {
 		log.Warnln("Error parsing Traffic ops URL: ", err)
 		return
 	}
-	for _, c := range cl.c.Client.Jar.Cookies(u) {
+	for _, c := range cl.HTTPClient().Jar.Cookies(u) {
 		fsCookie := torequtil.Cookie{Cookie: &http.Cookie{
 			Name:  c.Name,
 			Value: c.Value,
@@ -701,7 +701,7 @@ func (cl *TOClient) GetStatuses(reqHdr http.Header) ([]tc.Status, toclientlib.Re
 	err := torequtil.GetRetry(cl.NumRetries, "statuses", &statuses, func(obj interface{}) error {
 		toStatus, toReqInf, err := cl.c.GetStatuses(*ReqOpts(reqHdr))
 		if err != nil {
-			return errors.New("getting server update status from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
+			return errors.New("getting server update statuses from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}
 		status := obj.(*[]tc.Status)
 		*status = toStatus.Response
@@ -709,7 +709,7 @@ func (cl *TOClient) GetStatuses(reqHdr http.Header) ([]tc.Status, toclientlib.Re
 		return nil
 	})
 	if err != nil {
-		return nil, reqInf, errors.New("getting server update status: " + err.Error())
+		return nil, reqInf, errors.New("getting server update statuses: " + err.Error())
 	}
 	return statuses, reqInf, nil
 }

--- a/cache-config/t3cutil/toreq/toreqold/client.go
+++ b/cache-config/t3cutil/toreq/toreqold/client.go
@@ -27,6 +27,7 @@ package toreqold
 
 import (
 	"errors"
+	"net/http"
 	"net/url"
 	"strconv"
 	"time"
@@ -47,6 +48,10 @@ func (cl *TOClient) URL() string {
 
 func (cl *TOClient) SetURL(newURL string) {
 	cl.c.URL = newURL
+}
+
+func (cl *TOClient) HTTPClient() *http.Client {
+	return cl.c.Client
 }
 
 func (cl *TOClient) APIVersion() string {

--- a/cache-config/t3cutil/toreq/toreqold/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/toreqold/clientfuncs.go
@@ -533,7 +533,7 @@ func (cl *TOClient) GetStatuses() ([]tc.Status, toclientlib.ReqInf, error) {
 	err := torequtil.GetRetry(cl.NumRetries, "statuses", &statuses, func(obj interface{}) error {
 		toStatus, toReqInf, err := cl.c.GetStatuses()
 		if err != nil {
-			return errors.New("getting server update status from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
+			return errors.New("getting old server update status from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}
 		status := obj.(*[]tc.Status)
 		*status = toStatus
@@ -541,7 +541,7 @@ func (cl *TOClient) GetStatuses() ([]tc.Status, toclientlib.ReqInf, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, reqInf, errors.New("getting server update status: " + err.Error())
+		return nil, reqInf, errors.New("getting old server update status: " + err.Error())
 	}
 	return statuses, reqInf, nil
 }


### PR DESCRIPTION
Fix t3c nil pointer crash on TO API fallback

Also fixes fallback with cookie login

Unfortunately, as before, these things can't be tested without an Integration Test Framework that supports multiple TO versions. Which we'd really like, but it's also a lot of work to add.

I manually tested against both a TO with the latest API (4.x), and a TO only serving the previous (3.x), both succeeded and generated config correctly, previous fell back as expected for both initial username and subsequent cookie login, latest did not fall back.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify config is generated correctly against a latest TO, verify config is generated correctly against a TO not serving the latest major API.

## If this is a bugfix, which Traffic Control versions contained the bug?
Bug, but not in a release.


## PR submission checklist
- ~[x] This PR has tests~ framework doesn't exist, would be a large undertaking to add <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ not in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
