### PR TITLE
Fix missing input in execution environment for API tests GHA

### DIFF
--- a/.github/actions/to-integration-tests/action.yml
+++ b/.github/actions/to-integration-tests/action.yml
@@ -45,3 +45,4 @@ runs:
         INPUT_SMTP_PORT: ${{ inputs.smtp_port }}
         INPUT_SMTP_ADDRESS: ${{ inputs.smtp_address }}
         INPUT_SMTP_PASSWORD: ${{ inputs.smtp_password }}
+        INPUT_VERSION: ${{ inputs.version }}

--- a/.github/actions/to-integration-tests/entrypoint.sh
+++ b/.github/actions/to-integration-tests/entrypoint.sh
@@ -16,6 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+set -o errexit
+
 gray_bg="$(printf '%s%s' $'\x1B' '[100m')";
 red_bg="$(printf '%s%s' $'\x1B' '[41m')";
 yellow_bg="$(printf '%s%s' $'\x1B' '[43m')";


### PR DESCRIPTION
The GHA for our API tests isn't setting one of its required input parameters, this PR fixes that. It also wasn't exiting with a failure state on failure, which is why we didn't notice - I fixed that too.

<hr/>

## Which Traffic Control components are affected by this PR?
- GitHub Actions

## What is the best way to verify this PR?
Make sure the actions _actually_ pass - you'll need to read the logs to be sure, even if they give out that green checkmark.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**