### PR TITLE
Refactor t3c client login

### DIFF
--- a/cache-config/t3c-request/t3c-request.go
+++ b/cache-config/t3c-request/t3c-request.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/trafficcontrol/cache-config/t3c-request/config"
 	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/cache-config/t3cutil/toreq"
+	"github.com/apache/trafficcontrol/cache-config/t3cutil/toreq/torequtil"
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
 
@@ -68,5 +69,5 @@ func main() {
 			os.Exit(3)
 		}
 	}
-	cfg.TCCfg.TOClient.WriteFsCookie(toreq.FsCookiePath + cfg.TOUser + ".cookie")
+	cfg.TCCfg.TOClient.WriteFsCookie(torequtil.CookieCachePath(cfg.TOUser))
 }

--- a/cache-config/t3c-update/t3c-update.go
+++ b/cache-config/t3c-update/t3c-update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/trafficcontrol/cache-config/t3c-update/config"
 	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/cache-config/t3cutil/toreq"
+	"github.com/apache/trafficcontrol/cache-config/t3cutil/toreq/torequtil"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
@@ -89,5 +90,5 @@ func main() {
 	if cfg.RevalApplyTime != nil && !(*cfg.RevalApplyTime).Round(time.Microsecond).Equal((*cur_status.RevalidateApplyTime).Round(time.Microsecond)) {
 		log.Errorf("Failed to set reval_apply_time.\nSent: %v\nRecv: %v", *cfg.RevalApplyTime, *cur_status.RevalidateApplyTime)
 	}
-	cfg.TCCfg.TOClient.WriteFsCookie(toreq.FsCookiePath + cfg.TOUser + ".cookie")
+	cfg.TCCfg.TOClient.WriteFsCookie(torequtil.CookieCachePath(cfg.TOUser))
 }

--- a/cache-config/t3cutil/toreq/torequtil/torequtil.go
+++ b/cache-config/t3cutil/toreq/torequtil/torequtil.go
@@ -28,6 +28,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,12 +36,30 @@ import (
 	"github.com/apache/trafficcontrol/lib/go-tc"
 )
 
+const CookieCacheDir = `/var/lib/trafficcontrol-cache-config/`
+
+func CookieCacheFileName(userName string) string {
+	return userName + ".cookie"
+}
+
+func CookieCachePath(userName string) string {
+	return filepath.Join(CookieCacheDir, CookieCacheFileName(userName))
+}
+
 type Cookie struct {
 	Cookie *http.Cookie `json:"cookie"`
 }
 
 type FsCookie struct {
 	Cookies []Cookie `json:"cookies"`
+}
+
+func (fc *FsCookie) GetHTTPCookies() []*http.Cookie {
+	cookies := []*http.Cookie{}
+	for _, cookie := range fc.Cookies {
+		cookies = append(cookies, cookie.Cookie)
+	}
+	return cookies
 }
 
 // GetRetry attempts to get the given object, retrying with exponential backoff up to cfg.NumRetries.


### PR DESCRIPTION
Refactors the t3c client login, cookie cache, and fallback.

We saw some more edge cases around fallback and cookie usage ending
up with nil dereferences. This breaks it into smaller functions
and reduces the nested if-else blocks, hopefully making it easier
to work with and less likely to have issues.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify cookie usage in logs, verify fallback behavior against new and old TO.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release

## PR submission checklist
- ~[x] This PR has tests~ existing tests cover cookie behavior, and t3c Integration Tests don't support multiple TO versions <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no interface change, any potential bugs aren't in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
