### PR TITLE
Document Traffic Monitor configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the unused `deliveryservice_tmuser` table from Traffic Ops database
 - Adds updates to the trafficcontrol-health-client to, use new ATS Host status formats, detect and use proper
   traffic_ctl commands, and adds new markup-poll-threshold config.
+- Traffic Monitor now defaults to 100 historical "CRConfig" Snapshots stored internally if not specified in configuration (previous default was 20,000)
 
 ## [6.1.0] - 2022-01-18
 ### Added

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -80,7 +80,7 @@ traffic_monitor.cfg
 	.. Note:: ``both`` will poll IPv4 and IPv6 and report on availability based on if the respective IP addresses are defined on the server. So if only an IPv4 address is defined and the protocol is set to ``both`` then it will only show the availability over IPv4, but if both addresses are defined then it will show availability based on IPv4 and IPv6.
 
 :``crconfig_backup_file``:   The path to a file within which a backup of the most recently fetched CDN :term:`Snapshot` will be stored. Default is ``/opt/traffic_monitor/crconfig.backup``.
-:``crconfig_history_count``: The number of historical CDN Snapshots to store, which can then be retrieved through the :ref:`tm-api`. Default is 20,000.
+:``crconfig_history_count``: The number of historical CDN Snapshots to store, which can then be retrieved through the :ref:`tm-api`. Default is 100.
 :``distributed_polling``:    A boolean that controls whether `Distributed Polling`_ is enabled. Default is ``false``.
 
 	.. seealso:: The `Distributed Polling`_ section has more information on this setting.

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -60,7 +60,7 @@ traffic_ops.cfg
 :``certFile``:      The path to an SSL certificate file that corresponds to ``keyFile`` which will be used for Traffic Monitor's HTTPS API server.
 :``httpListener``:  Sets the address and port on which Traffic Monitor will listen for HTTP requests in the format :samp:`{address}:{port}`. If ``address`` is omitted, Traffic Monitor will listen on all available addresses.
 :``httpsListener``: Sets the address and port on which Traffic Monitor will listen for HTTPS requests in the format :samp:`{address}:{port}`. If ``address`` is omitted, Traffic Monitor will listen on all available addresses. If not provided, ``null``, or the empty string, Traffic Monitor will only serve HTTP, and ``keyFile`` and ``certFile`` are not used. If this is provided, the ``httpListener`` address will be used only to redirect clients to use HTTPS.
-:``insecure``:      A boolean that controls whether to validate the HTTPS certificate prevented by the Traffic Ops server.
+:``insecure``:      A boolean that controls whether to validate the HTTPS certificate presented by the Traffic Ops server.
 :``keyFile``:       The path to an SSL key file that corresponds to ``certFile`` which will be used for Traffic Monitor's HTTPS API server.
 :``password``:      The password of the user identified by ``username``.
 :``url``:           The URL at which Traffic Ops may be reached e.g. ``"https://trafficops.infra.ciab.test"``.
@@ -73,7 +73,14 @@ traffic_ops.cfg
 
 traffic_monitor.cfg
 """""""""""""""""""
-:file:`traffic_monitor.cfg` contains log file locations, as well as detailed application configuration variables such as processing flush times, initial poll intervals, and the polling protocols. Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops which will override the options in this file and begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
+:file:`traffic_monitor.cfg` contains log file locations, as well as detailed application configuration variables such as processing flush times, initial poll intervals, and the polling protocols. Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops, and any :term:`Parameters` set on the Monitor's :term:`Profile` that configure the same thing as a field in this configuration file will take precedence over said fields. The :term:`Parameters` known to override configuration here are
+
+- ``tm.polling.interval``
+- ``health.polling.interval``
+- ``peers.polling.interval``
+- ``heartbeat.polling.interval``
+
+Upon receiving this configuration, Traffic Monitor begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
 
 :``cache_polling_protocol``: Defines the internet protocol used to communicate with :term:`cache servers`. This can be "ipv4only" to only allow IPv4 communication, "ipv6only" to only allow IPv6 communication, or "both" to alternate between each version. Default is "both".
 

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -48,17 +48,90 @@ These are the recommended hardware specifications for a production deployment of
 Configuring Traffic Monitor
 ===========================
 
-Configuration Overview
-----------------------
-Traffic Monitor is configured via two JSON configuration files, :file:`traffic_ops.cfg` and :file:`traffic_monitor.cfg`, by default located in the ``conf`` directory in the install location. :file:`traffic_ops.cfg` contains Traffic Ops connection information. Specify the URL, username, and password for the instance of Traffic Ops of which this Traffic Monitor is a member. :file:`traffic_monitor.cfg` contains log file locations, as well as detailed application configuration variables such as processing flush times, initial poll intervals, and the polling protocols. Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops and begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
+Configuration Files
+-------------------
+Traffic Monitor is configured via two JSON configuration files, :file:`traffic_ops.cfg` and :file:`traffic_monitor.cfg`, by default located in the ``conf`` directory in the install location.
 
-Polling protocol can be set for caches (``cache_polling_protocol`` in :file:`traffic_monitor.cfg`) and has 3 options:
+traffic_ops.cfg
+"""""""""""""""
+:file:`traffic_ops.cfg` contains Traffic Ops connection information. Specify the URL, username, and password for the instance of Traffic Ops of which this Traffic Monitor is a member. However, this *also* sets some settings relating to the Traffic Monitor API server.
 
-:ipv4only: Traffic Monitor will communicate with caches only over IPv4
-:ipv6only: Traffic Monitor will communicate with caches only over IPv6
-:both (the default): Traffic Monitor will alternate its communication between IPv4 and IPv6 (note: this does not affect the polling frequency so if polling frequency is 1 second IPv4 will be polled every 2 seconds)
+:``cdnName``:       The name of the CDN to which this Traffic Monitor belongs. Used to fetch configuration and to determine which :term:`cache servers` to monitor.
+:``certFile``:      The path to an SSL certificate file that corresponds to ``keyFile`` which will be used for Traffic Monitor's HTTPS API server.
+:``httpListener``:  Sets the address on which Traffic Monitor will listen for HTTP requests.
+:``httpsListener``: Sets the address on which Traffic Monitor will listen for HTTPS requests. If not provided, ``null``, or the empty string, Traffic Monitor will only serve HTTP, and ``keyFile`` and ``certFile`` are not used. If this is provided, the ``httpListener`` address will be used only to redirect clients to use HTTPS.
+:``insecure``:      A boolean that controls whether to validate the HTTPS certificate prevented by the Traffic Ops server.
+:``keyFile``:       The path to an SSL key file that corresponds to ``certFile`` which will be used for Traffic Monitor's HTTPS API server.
+:``password``:      The password of the user identified by ``username``.
+:``url``:           The URL at which Traffic Ops may be reached e.g. ``"https://trafficops.infra.ciab.test"``.
+:``username``:      The username of the user as whom to authenticate with Traffic Ops.
+:``usingDummyTO``:  A boolean with no real effect. This value is used internally within the runtime of Traffic Monitor, and should never be set manually in its configuration file.
 
-.. Note:: ``both`` will poll IPv4 and IPv6 and report on availability based on if the respective IP addresses are defined on the server.  So if only an IPv4 address is defined and the protocol is set to ``both`` then it will only show the availability over IPv4, but if both addresses are defined then it will show availability based on IPv4 and IPv6.
+	.. deprecated:: ATCv7
+		The dependency on this field being valid will be removed in the future. It already has no effect.
+
+
+traffic_monitor.cfg
+"""""""""""""""""""
+:file:`traffic_monitor.cfg` contains log file locations, as well as detailed application configuration variables such as processing flush times, initial poll intervals, and the polling protocols. Once started with the correct configuration, Traffic Monitor downloads its configuration from Traffic Ops which will override the options in this file and begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
+
+:``cache_polling_protocol``: Defines the internet protocol used to communicate with :term:`cache servers`. This can be "ipv4only" to only allow IPv4 communication, "ipv6only" to only allow IPv6 communication, or "both" to alternate between each version. Default is "both".
+
+	.. Note:: ``both`` will poll IPv4 and IPv6 and report on availability based on if the respective IP addresses are defined on the server. So if only an IPv4 address is defined and the protocol is set to ``both`` then it will only show the availability over IPv4, but if both addresses are defined then it will show availability based on IPv4 and IPv6.
+
+:``crconfig_backup_file``:   The path to a file within which a backup of the most recently fetched CDN :term:`Snapshot` will be stored. Default is ``/opt/traffic_monitor/crconfig.backup``.
+:``crconfig_history_count``: The number of historical CDN Snapshots to store, which can then be retrieved through the :ref:`tm-api`. Default is 20,000.
+:``distributed_polling``:    A boolean that controls whether `Distributed Polling`_ is enabled. Default is ``false``.
+
+	.. seealso:: The `Distributed Polling`_ section has more information on this setting.
+
+:``health_flush_interval_ms``: Defines an interval as a number of milliseconds on which Traffic Monitor will flush its collected health data such that it is made available through the :ref:`tm-api`. Default is 200.
+
+	.. seealso:: The `Stat and Health Flush Configuration`_ section has more information on this setting.
+
+:``http_polling_format``: A MIME-Type that will be sent in the :mailheader:`Accept` HTTP header in requests to :term:`cache servers` for health and stats data. Default is :mimetype:`text/json` (**not** :mimetype:`application/json`).
+
+	.. seealso:: The `HTTP Accept Header Configuration`_ section has more information on this setting.
+
+:``http_timeout_ms``:      Sets the timeout duration - in milliseconds - for all HTTP operations (both peer-polling and stat/health data polling). Default is 2000.
+:``log_location_access``:  A logfile location to which access logs will be written, or ``null`` to not log access events.\ [#log-locations]_ Default is ``null``
+:``log_location_debug``:   A logfile location to which debug logs will be written, or ``null`` to not log debug messages.\ [#log-locations]_ Default is ``null``
+:``log_location_error``:   A logfile location to which error logs will be written, or ``null`` to not log error messages.\ [#log-locations]_ Default is "stderr".
+:``log_location_event``:   A logfile location to which event logs will be written, or ``null`` to not log events.\ [#log-locations]_ Default is "stdout"
+:``log_location_info``:    A logfile location to which informational logs will be written, or ``null`` to not log informational messages.\ [#log-locations]_ Default is ``null``
+:``log_location_warning``: A logfile location to which warning logs will be written, or ``null`` to not log warning messages.\ [#log-locations]_ Default is "stdout"
+:``max_events``:           The maximum number of changes to stored aggregate data that should be retained at any one time. Default is 200.
+:``monitor_config_polling_interval_ms``: The interval - in milliseconds - on which to poll Traffic Ops for this Traffic Monitor's "monitoring configuration" as returned by :ref:`to-api-cdns-name-configs-monitoring`.
+:``peer_optimistic``:      This is a legacy field that does nothing. However, if present in the configuration file, this must be a valid boolean or Traffic Monitor will refuse to load the configuration file. Default is ``true``.
+
+	.. deprecated:: ATCv7
+		The dependency on this field being valid will be removed in the future. It already has no effect.
+
+:``peer_optimistic_quorum_min``: Specifies the minimum number of peers that must be available in order to participate in the optimistic health protocol. Default is zero.
+
+	.. seealso:: The `Peering and Optimistic Quorum`_ section has more information on this setting.
+
+:``serve_read_timeout_ms``:   Sets the timeout - in milliseconds - of the Traffic Monitor API server for reading incoming requests. Default is 10,000.
+:``serve_write_timeout_ms``:  Sets the timeout - in milliseconds - of the Traffic Monitor API server for writing responses. Default is 10,000.
+:``short_hostname_override``: Sets a hostname for the Traffic Monitor. It will behave as though this were its hostname, rather than the hostname actually reported by the operating system. If not provided, ``null``, or the empty string, the Traffic Monitor will use the hostname provided by its host operating system. Default is the empty string.
+:``stat_buffer_interval_ms``: An interval - in milliseconds - for which to buffer collected stats before processing them. If this is not provided, ``null``, or zero, then all stats will be processed immediately. Default is zero.
+
+	.. seealso:: The `Stat and Health Flush Configuration`_ section has more information on this setting.
+
+:``stat_flush_interval_ms``: Defines an interval as a number of milliseconds on which Traffic Monitor will flush its collected stats data such that it is made available through the :ref:`tm-api`. Default is 200.
+
+	.. seealso:: The `Stat and Health Flush Configuration`_ section has more information on this setting.
+
+:``stat_polling``: A boolean that controls whether :term:`cache servers` are polled for stats data. Default is ``true``.
+
+	.. seealso:: The `Optional Stat Polling`_ section has more information on this setting.
+
+:``static_file_dir``: The directory within which Traffic Monitor will look for its web interface's static files. Default is ``/opt/traffic_monitor/static``.
+:``tmconfig_backup_file``: A file location to which a backup of the "monitoring configuration" as returned by :ref:`to-api-cdns-name-configs-monitoring` currently in use by Traffic Monitor will be written. Default is ``/opt/traffic_monitor/tmconfig.backup``.
+:``traffic_ops_disk_retry_max``: The number of times Traffic Monitor should attempt to log in to Traffic Ops before using its backup monitoring configuration and CDN Snapshot (if those exist). Default is 2.
+:``traffic_ops_max_retry_interval_ms``: Traffic Monitor will exponentially increase the amount of time it waits between attempts to log in to Traffic Ops each time it fails (up to a maximum number of times set by ``traffic_ops_disk_retry_max``). This controls the maximum amount of time - in milliseconds - that this waiting duration will be. Default is 60,000.
+:``traffic_ops_min_retry_interval_ms``: Traffic Monitor will exponentially increase the amount of time it waits between attempts to log in to Traffic Ops each time it fails (up to a maximum number of times set by ``traffic_ops_disk_retry_max``). This controls the minimum amount of time - in milliseconds - that this waiting duration will be. Default is 100.
+
 
 Optional Stat Polling
 ---------------------
@@ -121,3 +194,5 @@ Importantly, though, a statistics provider *must* respond to HTTP GET requests o
 When using the ``stats_over_http`` extension this can be provided by the ``system_stats`` plugin which will inject that information in to the ATS stats which then get returned by ``stats_over_http``. The ``system_stats`` plugin can be used with any custom implementations as it is already included and built with ATS when building with experimental-plugins enabled.
 
 There are other optional and/or :term:`Delivery Service`-related statistics that may cause Traffic Stats to not have the right information if not provided, but the above are essential for implementing :ref:`health-proto`.
+
+.. [#log-locations] These respect the rules and special string constants of :atc-godoc:`lib/go-log`.

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -93,21 +93,16 @@ traffic_monitor.cfg
 
 	.. seealso:: The `HTTP Accept Header Configuration`_ section has more information on this setting.
 
-:``http_timeout_ms``:      Sets the timeout duration - in milliseconds - for all HTTP operations (both peer-polling and stat/health data polling). Default is 2000.
-:``log_location_access``:  A logfile location to which access logs will be written, or ``null`` to not log access events.\ [#log-locations]_ Default is ``null``
-:``log_location_debug``:   A logfile location to which debug logs will be written, or ``null`` to not log debug messages.\ [#log-locations]_ Default is ``null``
-:``log_location_error``:   A logfile location to which error logs will be written, or ``null`` to not log error messages.\ [#log-locations]_ Default is "stderr".
-:``log_location_event``:   A logfile location to which event logs will be written, or ``null`` to not log events.\ [#log-locations]_ Default is "stdout"
-:``log_location_info``:    A logfile location to which informational logs will be written, or ``null`` to not log informational messages.\ [#log-locations]_ Default is ``null``
-:``log_location_warning``: A logfile location to which warning logs will be written, or ``null`` to not log warning messages.\ [#log-locations]_ Default is "stdout"
-:``max_events``:           The maximum number of changes to stored aggregate data that should be retained at any one time. Default is 200.
+:``http_timeout_ms``:                    Sets the timeout duration - in milliseconds - for all HTTP operations (both peer-polling and stat/health data polling). Default is 2000.
+:``log_location_access``:                A logfile location to which access logs will be written, or ``null`` to not log access events.\ [#log-locations]_ Default is ``null``
+:``log_location_debug``:                 A logfile location to which debug logs will be written, or ``null`` to not log debug messages.\ [#log-locations]_ Default is ``null``
+:``log_location_error``:                 A logfile location to which error logs will be written, or ``null`` to not log error messages.\ [#log-locations]_ Default is "stderr".
+:``log_location_event``:                 A logfile location to which event logs will be written, or ``null`` to not log events.\ [#log-locations]_ Default is "stdout"
+:``log_location_info``:                  A logfile location to which informational logs will be written, or ``null`` to not log informational messages.\ [#log-locations]_ Default is ``null``
+:``log_location_warning``:               A logfile location to which warning logs will be written, or ``null`` to not log warning messages.\ [#log-locations]_ Default is "stdout"
+:``max_events``:                         The maximum number of changes to stored aggregate data that should be retained at any one time. Default is 200.
 :``monitor_config_polling_interval_ms``: The interval - in milliseconds - on which to poll Traffic Ops for this Traffic Monitor's "monitoring configuration" as returned by :ref:`to-api-cdns-name-configs-monitoring`.
-:``peer_optimistic``:      This is a legacy field that does nothing. However, if present in the configuration file, this must be a valid boolean or Traffic Monitor will refuse to load the configuration file. Default is ``true``.
-
-	.. deprecated:: ATCv7
-		The dependency on this field being valid will be removed in the future. It already has no effect.
-
-:``peer_optimistic_quorum_min``: Specifies the minimum number of peers that must be available in order to participate in the optimistic health protocol. Default is zero.
+:``peer_optimistic_quorum_min``:         Specifies the minimum number of peers that must be available in order to participate in the optimistic health protocol. Default is zero.
 
 	.. seealso:: The `Peering and Optimistic Quorum`_ section has more information on this setting.
 

--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -58,8 +58,8 @@ traffic_ops.cfg
 
 :``cdnName``:       The name of the CDN to which this Traffic Monitor belongs. Used to fetch configuration and to determine which :term:`cache servers` to monitor.
 :``certFile``:      The path to an SSL certificate file that corresponds to ``keyFile`` which will be used for Traffic Monitor's HTTPS API server.
-:``httpListener``:  Sets the address on which Traffic Monitor will listen for HTTP requests.
-:``httpsListener``: Sets the address on which Traffic Monitor will listen for HTTPS requests. If not provided, ``null``, or the empty string, Traffic Monitor will only serve HTTP, and ``keyFile`` and ``certFile`` are not used. If this is provided, the ``httpListener`` address will be used only to redirect clients to use HTTPS.
+:``httpListener``:  Sets the address and port on which Traffic Monitor will listen for HTTP requests in the format :samp:`{address}:{port}`. If ``address`` is omitted, Traffic Monitor will listen on all available addresses.
+:``httpsListener``: Sets the address and port on which Traffic Monitor will listen for HTTPS requests in the format :samp:`{address}:{port}`. If ``address`` is omitted, Traffic Monitor will listen on all available addresses. If not provided, ``null``, or the empty string, Traffic Monitor will only serve HTTP, and ``keyFile`` and ``certFile`` are not used. If this is provided, the ``httpListener`` address will be used only to redirect clients to use HTTPS.
 :``insecure``:      A boolean that controls whether to validate the HTTPS certificate prevented by the Traffic Ops server.
 :``keyFile``:       The path to an SSL key file that corresponds to ``certFile`` which will be used for Traffic Monitor's HTTPS API server.
 :``password``:      The password of the user identified by ``username``.

--- a/docs/source/api/v3/servers_hostname_update.rst
+++ b/docs/source/api/v3/servers_hostname_update.rst
@@ -47,9 +47,9 @@ Request Structure
 	| reval_updated (Deprecated) | no       | The value to set for the queue update flag on this server. May be 'true' or 'false'. |
 	+----------------------------+----------+--------------------------------------------------------------------------------------+
 
-	.. deprecated:: v3.1 Traffic Ops API
+.. deprecated:: 3.1
 
-		The boolean values above have resulted in an unintended race condition. These fields are removed in APIv4 and replaced.
+	The boolean values above have resulted in an unintended race condition. These fields are removed in APIv4 and replaced.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/servers_hostname_update.rst
+++ b/docs/source/api/v4/servers_hostname_update.rst
@@ -52,7 +52,7 @@ Request Structure
 	| revalidate_apply_time      | no       | The value to set for when a reval update is applied for this server. Must be a valid RFC333Nano timestamp.   |
 	+----------------------------+----------+--------------------------------------------------------------------------------------------------------------+
 
-	.. note:: While none of the timestamps is required individually, at least one must be sent to the API.
+.. note:: While none of the timestamps is required individually, at least one must be sent to the API.
 
 .. code-block:: http
 	:caption: Request Example

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -97,37 +97,79 @@ func (t *PollingProtocol) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Config is the configuration for the application. It includes myriad data, such as polling intervals and log locations.
+// Config is the configuration for the application. It includes myriad data,
+// such as polling intervals and log locations.
 type Config struct {
-	MonitorConfigPollingInterval time.Duration   `json:"-"`
-	HTTPTimeout                  time.Duration   `json:"-"`
-	PeerOptimistic               bool            `json:"peer_optimistic"`
-	PeerOptimisticQuorumMin      int             `json:"peer_optimistic_quorum_min"`
-	DistributedPolling           bool            `json:"distributed_polling"`
-	StatPolling                  bool            `json:"stat_polling"`
-	MaxEvents                    uint64          `json:"max_events"`
-	HealthFlushInterval          time.Duration   `json:"-"`
-	StatFlushInterval            time.Duration   `json:"-"`
-	StatBufferInterval           time.Duration   `json:"-"`
-	LogLocationError             string          `json:"log_location_error"`
-	LogLocationWarning           string          `json:"log_location_warning"`
-	LogLocationInfo              string          `json:"log_location_info"`
-	LogLocationDebug             string          `json:"log_location_debug"`
-	LogLocationEvent             string          `json:"log_location_event"`
-	LogLocationAccess            string          `json:"log_location_access"`
-	ServeReadTimeout             time.Duration   `json:"-"`
-	ServeWriteTimeout            time.Duration   `json:"-"`
-	StaticFileDir                string          `json:"static_file_dir"`
-	CRConfigHistoryCount         uint64          `json:"crconfig_history_count"`
-	TrafficOpsMinRetryInterval   time.Duration   `json:"-"`
-	TrafficOpsMaxRetryInterval   time.Duration   `json:"-"`
-	CRConfigBackupFile           string          `json:"crconfig_backup_file"`
-	TMConfigBackupFile           string          `json:"tmconfig_backup_file"`
-	TrafficOpsDiskRetryMax       uint64          `json:"traffic_ops_disk_retry_max"`
-	CachePollingProtocol         PollingProtocol `json:"cache_polling_protocol"`
-	HTTPPollingFormat            string          `json:"http_polling_format"`
+	// Sets the Internet Protocol version used for polling cache servers.
+	CachePollingProtocol PollingProtocol `json:"cache_polling_protocol"`
+	// A path to a file where CDN Snapshot backups are written.
+	CRConfigBackupFile string `json:"crconfig_backup_file"`
+	// The number of historical CDN Snapshots to store.
+	CRConfigHistoryCount uint64 `json:"crconfig_history_count"`
+	// Controls whether Distributed Polling is enabled.
+	DistributedPolling bool `json:"distributed_polling"`
+	// Defines an interval on which Traffic Monitor will flush its collected
+	// health data such that it is made available through the API.
+	HealthFlushInterval time.Duration `json:"-"`
+	// A MIME-Type that will be sent in the Accept HTTP header in requests to
+	// cache servers for health and stats data.
+	HTTPPollingFormat string `json:"http_polling_format"`
+	// Sets the timeout duration for all HTTP operations - peer-polling and
+	// health data polling.
+	HTTPTimeout time.Duration `json:"-"`
+	// A "lib/go-log"-compliant string defining the logging of Access-level
+	// logs.
+	LogLocationAccess string `json:"log_location_access"`
+	// A "lib/go-log"-compliant string defining the logging of Debug-level logs.
+	LogLocationDebug string `json:"log_location_debug"`
+	// A "lib/go-log"-compliant string defining the logging of Error-level logs.
+	LogLocationError string `json:"log_location_error"`
+	// A "lib/go-log"-compliant string defining the logging of Event-level logs.
+	LogLocationEvent string `json:"log_location_event"`
+	// A "lib/go-log"-compliant string defining the logging of Info-level logs.
+	LogLocationInfo string `json:"log_location_info"`
+	// A "lib/go-log"-compliant string defining the logging of Warning-level
+	// logs.
+	LogLocationWarning string `json:"log_location_warning"`
+	// The maximum number of events to keep in TM's buffer to be served via its
+	// API.
+	MaxEvents uint64 `json:"max_events"`
+	// The interval on which to poll for this TM's CDN's "monitoring config".
+	MonitorConfigPollingInterval time.Duration `json:"-"`
+	// This appears to do nothing.
+	//
+	// Deprecated: This serves no purpose and will be removed in the future.
+	PeerOptimistic bool `json:"peer_optimistic"`
+	// Specifies the minimum number of peers that must be available in order to
+	// participate in the optimistic health protocol.
+	PeerOptimisticQuorumMin int `json:"peer_optimistic_quorum_min"`
+	// The timeout for the API server for reading requests.
+	ServeReadTimeout time.Duration `json:"-"`
+	// The timeout for the API server for writing responses.
+	ServeWriteTimeout time.Duration `json:"-"`
 	// ShortHostnameOverride is for explicitly setting a hostname rather than using the output of `hostname -s`.
 	ShortHostnameOverride string `json:"short_hostname_override"`
+	// The interval for which to buffer stats data before processing it.
+	StatBufferInterval time.Duration `json:"-"`
+	// The interval on which Traffic Monitor will flush its collected stats data
+	// such that it is made available through the API.
+	StatFlushInterval time.Duration `json:"-"`
+	// The directory in which Traffic Monitor will look for the static files for
+	// its web UI.
+	StaticFileDir string `json:"static_file_dir"`
+	// Controls whether stats data is polled.
+	StatPolling bool `json:"stat_polling"`
+	// A file location to which a backup of the "monitoring configuration"
+	// currently in use by Traffic Monitor will be written.
+	TMConfigBackupFile string `json:"tmconfig_backup_file"`
+	// The number of times Traffic Monitor should attempt to log in to Traffic
+	// Ops before using its backup monitoring configuration and CDN Snapshot (if
+	// those exist).
+	TrafficOpsDiskRetryMax uint64 `json:"traffic_ops_disk_retry_max"`
+	// The maximum exponential backoff duration for logging in to Traffic Ops.
+	TrafficOpsMaxRetryInterval time.Duration `json:"-"`
+	// The minimum exponential backoff duration for logging in to Traffic Ops.
+	TrafficOpsMinRetryInterval time.Duration `json:"-"`
 }
 
 func (c Config) ErrorLog() log.LogLocation   { return log.LogLocation(c.LogLocationError) }
@@ -149,33 +191,33 @@ func GetAccessLogWriter(cfg Config) (io.WriteCloser, error) {
 
 // DefaultConfig is the default configuration for the application, if no configuration file is given, or if a given config setting doesn't exist in the config file.
 var DefaultConfig = Config{
-	MonitorConfigPollingInterval: 5 * time.Second,
+	CachePollingProtocol:         Both,
+	CRConfigBackupFile:           CRConfigBackupFile,
+	CRConfigHistoryCount:         20000,
+	HealthFlushInterval:          200 * time.Millisecond,
+	HTTPPollingFormat:            HTTPPollingFormat,
 	HTTPTimeout:                  2 * time.Second,
+	LogLocationAccess:            LogLocationNull,
+	LogLocationDebug:             LogLocationNull,
+	LogLocationError:             LogLocationStderr,
+	LogLocationEvent:             LogLocationStdout,
+	LogLocationInfo:              LogLocationNull,
+	LogLocationWarning:           LogLocationStdout,
+	MaxEvents:                    200,
+	MonitorConfigPollingInterval: 5 * time.Second,
 	PeerOptimistic:               true,
 	PeerOptimisticQuorumMin:      0,
-	StatPolling:                  true,
-	MaxEvents:                    200,
-	HealthFlushInterval:          200 * time.Millisecond,
-	StatFlushInterval:            200 * time.Millisecond,
-	StatBufferInterval:           0,
-	LogLocationError:             LogLocationStderr,
-	LogLocationWarning:           LogLocationStdout,
-	LogLocationInfo:              LogLocationNull,
-	LogLocationDebug:             LogLocationNull,
-	LogLocationEvent:             LogLocationStdout,
-	LogLocationAccess:            LogLocationNull,
 	ServeReadTimeout:             10 * time.Second,
 	ServeWriteTimeout:            10 * time.Second,
+	ShortHostnameOverride:        "",
+	StatBufferInterval:           0,
+	StatFlushInterval:            200 * time.Millisecond,
 	StaticFileDir:                StaticFileDir,
-	CRConfigHistoryCount:         20000,
-	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
-	TrafficOpsMaxRetryInterval:   60000 * time.Millisecond,
-	CRConfigBackupFile:           CRConfigBackupFile,
+	StatPolling:                  true,
 	TMConfigBackupFile:           TMConfigBackupFile,
 	TrafficOpsDiskRetryMax:       2,
-	CachePollingProtocol:         Both,
-	HTTPPollingFormat:            HTTPPollingFormat,
-	ShortHostnameOverride:        "",
+	TrafficOpsMaxRetryInterval:   60000 * time.Millisecond,
+	TrafficOpsMinRetryInterval:   100 * time.Millisecond,
 }
 
 // MarshalJSON marshals custom millisecond durations. Aliasing inspired by http://choly.ca/post/go-json-marshalling/

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -193,7 +193,7 @@ func GetAccessLogWriter(cfg Config) (io.WriteCloser, error) {
 var DefaultConfig = Config{
 	CachePollingProtocol:         Both,
 	CRConfigBackupFile:           CRConfigBackupFile,
-	CRConfigHistoryCount:         20000,
+	CRConfigHistoryCount:         100,
 	HealthFlushInterval:          200 * time.Millisecond,
 	HTTPPollingFormat:            HTTPPollingFormat,
 	HTTPTimeout:                  2 * time.Second,

--- a/traffic_monitor/config/config.go
+++ b/traffic_monitor/config/config.go
@@ -136,10 +136,6 @@ type Config struct {
 	MaxEvents uint64 `json:"max_events"`
 	// The interval on which to poll for this TM's CDN's "monitoring config".
 	MonitorConfigPollingInterval time.Duration `json:"-"`
-	// This appears to do nothing.
-	//
-	// Deprecated: This serves no purpose and will be removed in the future.
-	PeerOptimistic bool `json:"peer_optimistic"`
 	// Specifies the minimum number of peers that must be available in order to
 	// participate in the optimistic health protocol.
 	PeerOptimisticQuorumMin int `json:"peer_optimistic_quorum_min"`
@@ -205,7 +201,6 @@ var DefaultConfig = Config{
 	LogLocationWarning:           LogLocationStdout,
 	MaxEvents:                    200,
 	MonitorConfigPollingInterval: 5 * time.Second,
-	PeerOptimistic:               true,
 	PeerOptimisticQuorumMin:      0,
 	ServeReadTimeout:             10 * time.Second,
 	ServeWriteTimeout:            10 * time.Second,

--- a/traffic_monitor/config/config_test.go
+++ b/traffic_monitor/config/config_test.go
@@ -110,9 +110,6 @@ func TestConfigLoad(t *testing.T) {
 	if c.ShortHostnameOverride != "foobar" {
 		t.Errorf("ShortHostnameOverride - expected: foobar, actual: %s", c.ShortHostnameOverride)
 	}
-	if c.PeerOptimistic != false {
-		t.Errorf("PeerOmptimistic - expected: false, actual: %t", c.PeerOptimistic)
-	}
 	if c.PeerOptimisticQuorumMin != 3 {
 		t.Errorf("PeerOmptimisticQuorumMin - expected: 3, actual: %d", c.PeerOptimisticQuorumMin)
 	}
@@ -141,9 +138,6 @@ func TestConfigLoadDefaults(t *testing.T) {
 	c, err := LoadBytes([]byte(`{}`))
 	if err != nil {
 		t.Fatalf("loading empty config bytes - expected: no error, actual: %v", err)
-	}
-	if c.PeerOptimistic != true {
-		t.Errorf("PeerOptimistic default - expected: true, actual: %t", c.PeerOptimistic)
 	}
 	if c.StatPolling != true {
 		t.Errorf("StatPolling default - expected: true, actual: %t", c.StatPolling)

--- a/traffic_monitor/handler/handler.go
+++ b/traffic_monitor/handler/handler.go
@@ -30,17 +30,35 @@ const (
 	NOTIFY_ALWAYS
 )
 
+// OpsConfig holds configuration for a Traffic Monitor relating to its
+// connections with Traffic Ops **and** settings for its API/web UI server.
 type OpsConfig struct {
-	Username      string `json:"username"`
-	Password      string `json:"password"`
-	Url           string `json:"url"`
-	Insecure      bool   `json:"insecure"`
-	CdnName       string `json:"cdnName"`
-	HttpListener  string `json:"httpListener"`
+	// The name of the CDN to which this Traffic Monitor belongs.
+	CdnName string `json:"cdnName"`
+	// The path to an SSL certificate to use with KeyFile to provide HTTP
+	// encryption for the TM API and web UI.
+	CertFile string `json:"certFile"`
+	// The address on which to listen for HTTP requests.
+	HttpListener string `json:"httpListener"`
+	// The address on which to listen for HTTPS requests. If not set, TM serves
+	// its API and UI over HTTP. If this is set, the HTTP server is only used to
+	// redirect traffic to HTTPS.
 	HttpsListener string `json:"httpsListener"`
-	CertFile      string `json:"certFile"`
-	KeyFile       string `json:"keyFile"`
-	UsingDummyTO  bool   `json:"usingDummyTO"` // only used in the TM UI to indicate if TM started up with on-disk backup snapshots
+	// Controls whether to validate the HTTPS certificate prevented by the
+	// Traffic Ops server.
+	Insecure bool `json:"insecure"`
+	// The path to an SSL key to use with CertFile to provide HTTP encryption
+	// for the TM API and web UI.
+	KeyFile string `json:"keyFile"`
+	// The password of the user identified by Username.
+	Password string `json:"password"`
+	// The URL at which Traffic Ops may be reached.
+	Url string `json:"url"`
+	// The username of the user as whom to authenticate with Traffic Ops.
+	Username string `json:"username"`
+	// Only used in the TM UI to indicate if TM started up with on-disk backup
+	// Snapshots.
+	UsingDummyTO bool `json:"usingDummyTO"`
 }
 
 type Handler interface {


### PR DESCRIPTION
This PR adds/updates documentation for the configuration files used by Traffic Monitor (typically named `traffic_ops.cfg` and `traffic_monitor.cfg`).

This also fixes a bug in table rendering currently on master since #6569.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build without errors or warnings, and are accurate, thorough, and clear. 

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [x] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**