### PR TITLE
Fix internal server error and false positive when creating a server 

### DIFF
--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -2021,12 +2021,13 @@ func createV3(inf *api.APIInfo, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var origProfiles []string
-	err = inf.Tx.Tx.QueryRow("SELECT name from profile where id = $1", server.ProfileID).Scan(&origProfiles)
+	var origProfile string
+	err = inf.Tx.Tx.QueryRow("SELECT name from profile where id = $1", server.ProfileID).Scan(&origProfile)
 	if err != nil && err != sql.ErrNoRows {
 		api.HandleErr(w, r, inf.Tx.Tx, http.StatusInternalServerError, nil, fmt.Errorf("retreiving profile with id %d", *server.ProfileID))
 		return
 	}
+	var origProfiles = []string{origProfile}
 
 	userErr, sysErr, statusCode := insertServerProfile(int(serverID), origProfiles, inf.Tx.Tx)
 	if userErr != nil || sysErr != nil {


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Fixes: #6779 
Fixes: #6781 

With this fix there is no internal server error when creating a server without a profile key in v2 and v3

The other fix is when creating a server with multiple profiles in v4, if any of the profiles do not belong to the same CDN it will now fail as expected.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Build and test the following in TO:

`POST` request to `/api/2.0/servers` with no profile key in the request body

```
{
    "cachegroupId": 8,
    "cdnId": 2,
    "domainName": "ga.atlanta.kabletown.net",
    "hostName": "atlanta-edge-01",
    "interfaceMtu": 1500,
    "ipAddress": "172.16.239.120",
    "ipGateway": "172.16.239.1",
    "ipNetmask": "255.255.255.0",
    "ipIsService": true,
    "interfaceName": "eth0",
    "physLocationId": 2,
    "statusId": 3,
    "typeId": 11,
    "profileId": 13
}
```

Should succeed with no error:

```http
HTTP/1.1 200 OK
{
    "alerts": [
        {
            "text": "Server created",
            "level": "success"
        }
    ],
    "response": {...}
}
```

`POST` request to `/api/3.0/servers` with no profile key in the request body

```
{
    "cachegroupId": 8,
    "cdnId": 2,
    "domainName": "ga.atlanta.kabletown.net",
    "hostName": "atlanta-edge-01",
    "interfaces": [
        {
            "ipAddresses": [
                {
                    "address": "0.0.0.1",
                    "gateway": "0.0.0.1",
                    "serviceAddress": true
                }
            ],
            "name": "eth0"
        }
    ],
    "physLocationId": 2,
    "statusId": 3,
    "typeId": 11,
    "profileId": 13
}
```

Should succeed with no error:

```http
HTTP/1.1 201 Created
{
    "alerts": [
        {
            "text": "Server created",
            "level": "success"
        }
    ],
    "response": {...}
}
```

`POST` request to` /api/4.0/servers` with multiple profiles, where one profile belongs to a different cdn than the server (regardless of order)

```json
{
    "cachegroupId": 8,
    "cdnId": 2,
    "domainName": "test.net",
    "hostName": "test-01",
    "interfaces": [
        {
            "ipAddresses": [
                {
                    "address": "0.0.0.1",
                    "gateway": "0.0.0.1",
                    "serviceAddress": true
                }
            ],
            "name": "eth0"
        }
    ],
    "physLocationId": 2,
    "statusId": 3,
    "typeId": 11,
    "profileNames": ["ORG_MSO", "TRAFFIC_STATS", "CCR_CIAB"]
}
```

Should return an error:

```http
HTTP/1.1 400 Bad Request
{
    "alerts": [
        {
            "text": "CDN id '1' for profile 'TRAFFIC_STATS' does not match Server CDN '2'",
            "level": "error"
        }
    ]
}
```

## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
