### PR TITLE
Change TR to depend on java-11-openjdk-headless instead of java-11 

### DIFF
--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -236,7 +236,7 @@
 								</mapping>
 							</mappings>
 							<requires>
-								<require>java-11</require>
+								<require>java-11-openjdk-headless</require>
 								<require>tomcat >= ${env.TOMCAT_VERSION}.${env.TOMCAT_RELEASE}</require>
 								<require>apr >= 1.4.8</require>
 								<require>tomcat-native >= 1.2.23</require>

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -20,7 +20,7 @@ Summary:    Apache Tomcat Servlet/JSP Engine 9.0+, RI for Servlet 3.1/JSP 2.3 AP
 License:    Apache Software License
 URL:        https://github.com/apache/trafficcontrol/
 Source:     %{_sourcedir}/apache-tomcat-%{version}.tar.gz
-Requires:   java-11
+Requires:   java-11-openjdk-headless
 
 %define tomcat_home /opt/tomcat
 


### PR DESCRIPTION
While doing a test installation, noticed a lot of unnecessary packages were being installed along Traffic Router and tomcat. When checking why, I noticed Traffic Router has been marked to use java-11 as a dependency; however that package requires X11, and all the deps that come with X11.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Download trafficrouter RPM, run the installation for that RPM and see the dependencies required for java-11 and compare with java-11-openjdk-headless

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
