### PR TITLE
Separate the job for Traffic Ops Go client/API integration tests into one per major API version

### DIFF
--- a/.github/workflows/traffic-ops.yml
+++ b/.github/workflows/traffic-ops.yml
@@ -57,7 +57,7 @@ on:
 
 jobs:
 
-  API_tests:
+  APIv2Tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
@@ -128,6 +128,59 @@ jobs:
       with:
         name: v2 Traffic Ops logs
         path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
+
+  APIv3Tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: traffic_ops
+          POSTGRES_PASSWORD: twelve
+          POSTGRES_DB: traffic_ops
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      smtp:
+        image: maildev/maildev:2.0.0-beta3
+        ports:
+          - 25:25
+        options: >-
+          --entrypoint=bin/maildev
+          --user=root
+          --health-cmd="sh -c \"[[ \$(wget -qO- http://smtp/healthz) == true ]]\""
+          --
+          maildev/maildev:2.0.0-beta3
+          --smtp=25
+          --hide-extensions=STARTTLS
+          --web=80
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Cache Alpine Docker image
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/docker-images
+        key: docker-images/alpine@${{ env.ALPINE_VERSION }}.tar.gz
+    - name: Import cached Alpine Docker image
+      run: .github/actions/save-alpine-tar/entrypoint.sh load ${{ env.ALPINE_VERSION }}
+    - name: Initialize Traffic Ops Database
+      id: todb
+      uses: ./.github/actions/todb-init
+    - name: Initialize Traffic Vault Database
+      id: tvdb
+      uses: ./.github/actions/tvdb-init
+    - name: Check Go Version
+      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      id: go-version
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.go-version.outputs.value }}
     - name: Run API v3 tests
       id: v3Tests
       if: ${{ steps.todb.outcome == 'success' && always() }}
@@ -147,6 +200,59 @@ jobs:
       with:
         name: v3 Traffic Ops logs
         path: ${{ github.workspace }}/traffic_ops/traffic_ops_golang/traffic.ops.log
+
+  APIv4Tests:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:13
+        env:
+          POSTGRES_USER: traffic_ops
+          POSTGRES_PASSWORD: twelve
+          POSTGRES_DB: traffic_ops
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+      smtp:
+        image: maildev/maildev:2.0.0-beta3
+        ports:
+          - 25:25
+        options: >-
+          --entrypoint=bin/maildev
+          --user=root
+          --health-cmd="sh -c \"[[ \$(wget -qO- http://smtp/healthz) == true ]]\""
+          --
+          maildev/maildev:2.0.0-beta3
+          --smtp=25
+          --hide-extensions=STARTTLS
+          --web=80
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - name: Cache Alpine Docker image
+      uses: actions/cache@v2
+      with:
+        path: ${{ github.workspace }}/docker-images
+        key: docker-images/alpine@${{ env.ALPINE_VERSION }}.tar.gz
+    - name: Import cached Alpine Docker image
+      run: .github/actions/save-alpine-tar/entrypoint.sh load ${{ env.ALPINE_VERSION }}
+    - name: Initialize Traffic Ops Database
+      id: todb
+      uses: ./.github/actions/todb-init
+    - name: Initialize Traffic Vault Database
+      id: tvdb
+      uses: ./.github/actions/tvdb-init
+    - name: Check Go Version
+      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      id: go-version
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ steps.go-version.outputs.value }}
     - name: Run API v4 tests
       id: v4Tests
       if: ${{ steps.todb.outcome == 'success' && always() }}


### PR DESCRIPTION
This PR separates the single GHA job for running all the client tests into one job per major API version. This may slow down tests overall, but in scenarios where a single version fails it will allow re-testing only that version without re-running *all* tests.
<hr/>

## Which Traffic Control components are affected by this PR?
- Automation - GitHub Actions

## What is the best way to verify this PR?
Make sure all the jobs pass.

## PR submission checklist
- [x] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**