### PR TITLE
Add t3c profile layering

### DIFF
--- a/lib/go-atscfg/atscfg_test.go
+++ b/lib/go-atscfg/atscfg_test.go
@@ -20,6 +20,7 @@ package atscfg
  */
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -107,6 +108,133 @@ func TestGetATSMajorVersionFromATSVersion(t *testing.T) {
 		if actual, err := getATSMajorVersionFromATSVersion(input); err == nil {
 			t.Errorf("input %v expected: error, actual: nil error '%v'", input, actual)
 		}
+	}
+}
+
+func TestLayerProfiles(t *testing.T) {
+	profileNames := []string{
+		"FOO",
+		"BAR",
+		"BAZ",
+	}
+
+	allParams := []tc.Parameter{
+		{
+			ConfigFile: "cfg_a",
+			ID:         1000,
+			Name:       "param_a",
+			Profiles:   json.RawMessage(`["FOO"]`),
+			Value:      "alpha",
+		},
+		{
+			ConfigFile: "cfg_a",
+			ID:         1000,
+			Name:       "param_a",
+			Profiles:   json.RawMessage(`["BAR"]`),
+			Value:      "beta",
+		},
+		{
+			ConfigFile: "cfg_b",
+			ID:         1000,
+			Name:       "param_a",
+			Profiles:   json.RawMessage(`["BAR"]`),
+			Value:      "gamma",
+		},
+		{
+			ConfigFile: "cfg_c",
+			ID:         1000,
+			Name:       "param_c",
+			Profiles:   json.RawMessage(`["BAZ"]`),
+			Value:      "epsilon",
+		},
+		{
+			ConfigFile: "cfg_c",
+			ID:         1000,
+			Name:       "param_c",
+			Profiles:   json.RawMessage(`["BAR"]`),
+			Value:      "delta",
+		},
+		{
+			ConfigFile: "cfg_a",
+			ID:         1000,
+			Name:       "param_b",
+			Profiles:   json.RawMessage(`["BAR"]`),
+			Value:      "zeta",
+		},
+		{
+			ConfigFile: "cfg_d",
+			ID:         1000,
+			Name:       "param_d",
+			Profiles:   json.RawMessage(`["BAR"]`),
+			Value:      "eta",
+		},
+		{
+			ConfigFile: "cfg_d",
+			ID:         1000,
+			Name:       "param_d",
+			Profiles:   json.RawMessage(`["BAZ"]`),
+			Value:      "theta",
+		},
+		{
+			ConfigFile: "cfg_d",
+			ID:         1000,
+			Name:       "param_d",
+			Profiles:   json.RawMessage(`["FOO"]`),
+			Value:      "iota",
+		},
+	}
+
+	// per the params, on the layered profiles "FOO,BAR,BAZ" (in that order):
+	// (1) beta in BAR should override alpha FOO,
+	//    because they share the ConfigFile+Name key and BAR is later in the layering
+	// (2) gamma should be added, but not override
+	//    because the key is ConfigFile+Name, which isn't on any previous profile
+	// (3) epsilon in BAZ should override delta in BAR
+	//    because they share the ConfigFile+Name key and BAZ is later in the layering
+	//    - this tests the parameters being in a different order than (1)
+	// (4) zeta should be added, but not override
+	//    because the key is ConfigFile+Name, which isn't on any previous profile
+	//    - this tests the name matching but not config file, reverse of (2).
+	// (5) theta in BAZ should override eta and iota in FOO and BAR
+	//    because they share the ConfigFile+Name key and BAZ is last in the layering
+	//    - this tests multiple overrides
+
+	layeredParams, err := LayerProfiles(profileNames, allParams)
+	if err != nil {
+		t.Fatalf("expected LayerProfiles nil error, actual: %+v", err)
+	}
+
+	vals := map[string]struct{}{}
+	for _, param := range layeredParams {
+		vals[param.Value] = struct{}{}
+	}
+
+	if _, ok := vals["alpha"]; ok {
+		t.Errorf("expected: param 'beta' to override 'alpha', actual: alpha in layered parameters")
+	}
+	if _, ok := vals["beta"]; !ok {
+		t.Errorf("expected: param 'beta' to override 'alpha', actual: beta not in layered parameters")
+	}
+	if _, ok := vals["gamma"]; !ok {
+		t.Errorf("expected: param 'gamma' with no ConfigFile+Name in another profile to be in layered parameters, actual: gamma not in layered parameters")
+	}
+	if _, ok := vals["delta"]; ok {
+		t.Errorf("expected: param 'epsilon' to override 'delta' in prior profile, actual: delta in layered parameters")
+	}
+	if _, ok := vals["epsilon"]; !ok {
+		t.Errorf("expected: param 'epsilon' to override 'delta' in prior profile, actual: epsilon not in layered parameters")
+	}
+	if _, ok := vals["zeta"]; !ok {
+		t.Errorf("expected: param 'zeta' with no ConfigFile+Name in another profile to be in layered parameters, actual: zeta not in layered parameters")
+	}
+	if _, ok := vals["theta"]; !ok {
+		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: theta not in layered parameters")
+	}
+	if _, ok := vals["eta"]; ok {
+		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: eta in layered parameters")
+	}
+	if _, ok := vals["iota"]; ok {
+		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: iota in layered parameters")
 	}
 }
 

--- a/lib/go-atscfg/cachedotconfig.go
+++ b/lib/go-atscfg/cachedotconfig.go
@@ -81,16 +81,7 @@ func makeCacheDotConfigEdge(
 			warnings = append(warnings, "servers had server with nil id, skipping!")
 			continue
 		}
-		if len(sv.ProfileNames) != len(server.ProfileNames) {
-			continue
-		}
-		profilesTheSame := true
-		for i, _ := range server.ProfileNames {
-			if sv.ProfileNames[i] != server.ProfileNames[i] {
-				profilesTheSame = false
-			}
-		}
-		if !profilesTheSame {
+		if !ServerProfilesMatch(server, &sv) {
 			continue
 		}
 		profileServerIDsMap[*sv.ID] = struct{}{}

--- a/lib/go-atscfg/loggingdotconfig.go
+++ b/lib/go-atscfg/loggingdotconfig.go
@@ -53,8 +53,8 @@ func MakeLoggingDotConfig(
 	}
 	warnings := []string{}
 
-	if len(server.ProfileNames) == 0 {
-		return Cfg{}, makeErr(warnings, "this server missing Profile")
+	if server.HostName == nil {
+		return Cfg{}, makeErr(warnings, "this server missing HostName")
 	}
 
 	paramData, paramWarns := paramsToMap(filterParams(serverParams, LoggingFileName, "", "", "location"))
@@ -75,7 +75,7 @@ func MakeLoggingDotConfig(
 			format := paramData[logFormatField+".Format"]
 			if format == "" {
 				// TODO determine if the line should be excluded. Perl includes it anyway, without checking.
-				warnings = append(warnings, fmt.Sprintf("profile '%v' has logging.config format '%v' Name Parameter but no Format Parameter. Setting blank Format!\n", server.ProfileNames, logFormatField))
+				warnings = append(warnings, fmt.Sprintf("server '%v' profile has logging.config format '%v' Name Parameter but no Format Parameter. Setting blank Format!\n", *server.HostName, logFormatField))
 			}
 			format = strings.Replace(format, `"`, `\"`, -1)
 			text += logFormatName + " = format {\n"
@@ -94,7 +94,7 @@ func MakeLoggingDotConfig(
 			filter := paramData[logFilterField+".Filter"]
 			if filter == "" {
 				// TODO determine if the line should be excluded. Perl includes it anyway, without checking.
-				warnings = append(warnings, fmt.Sprintf("profile '%v' has logging.config format '%v' Name Parameter but no Filter Parameter. Setting blank Filter!\n", server.ProfileNames, logFilterField))
+				warnings = append(warnings, fmt.Sprintf("server '%v' profile has logging.config format '%v' Name Parameter but no Filter Parameter. Setting blank Filter!\n", *server.HostName, logFilterField))
 			}
 
 			filter = strings.Replace(filter, `\`, `\\`, -1)

--- a/lib/go-atscfg/loggingdotyaml.go
+++ b/lib/go-atscfg/loggingdotyaml.go
@@ -50,6 +50,10 @@ func MakeLoggingDotYAML(
 	warnings := []string{}
 	requiredIndent := 0
 
+	if server.HostName == nil {
+		return Cfg{}, makeErr(warnings, "this server missing HostName")
+	}
+
 	if len(server.ProfileNames) == 0 {
 		return Cfg{}, makeErr(warnings, "this server missing Profile")
 	}
@@ -82,7 +86,7 @@ func MakeLoggingDotYAML(
 			format := paramData[logFormatField+".Format"]
 			if format == "" {
 				// TODO determine if the line should be excluded. Perl includes it anyway, without checking.
-				warnings = append(warnings, fmt.Sprintf("profile '%v' has logging.yaml format '%v' Name Parameter but no Format Parameter. Setting blank Format!\n", server.ProfileNames, logFormatField))
+				warnings = append(warnings, fmt.Sprintf("server '%v' profile has logging.yaml format '%v' Name Parameter but no Format Parameter. Setting blank Format!\n", *server.HostName, logFormatField))
 			}
 			text += indentSpaces + " - name: " + logFormatName + " \n"
 			text += indentSpaces + "   format: '" + format + "'\n"
@@ -99,7 +103,7 @@ func MakeLoggingDotYAML(
 			filter := paramData[logFilterField+".Filter"]
 			if filter == "" {
 				// TODO determine if the line should be excluded. Perl includes it anyway, without checking.
-				warnings = append(warnings, fmt.Sprintf("profile '%v' has logging.yaml filter '%v' Name Parameter but no Filter Parameter. Setting blank Filter!\n", server.ProfileNames, logFilterField))
+				warnings = append(warnings, fmt.Sprintf("server '%v' profile has logging.yaml filter '%v' Name Parameter but no Filter Parameter. Setting blank Filter!\n", *server.HostName, logFilterField))
 			}
 			logFilterType := paramData[logFilterField+".Type"]
 			if logFilterType == "" {

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -1197,17 +1197,16 @@ func getTopologyQueryStringIgnore(
 
 // serverParentageParams gets the Parameters used for parent= line, or defaults if they don't exist
 // Returns the Parameters used for parent= lines for the given server, and any warnings.
-func serverParentageParams(sv *Server, params []parameterWithProfilesMap) (parentServerParams, []string) {
+func serverParentageParams(sv *Server, allParentConfigParams []parameterWithProfilesMap) (parentServerParams, []string) {
 	warnings := []string{}
 	// TODO deduplicate with atstccfg/parentdotconfig.go
 	parentServerParams := defaultParentServerParams()
 	if sv.TCPPort != nil {
 		parentServerParams.Port = *sv.TCPPort
 	}
-	for _, param := range params {
-		if _, ok := param.ProfileNames[(sv.ProfileNames)[0]]; !ok {
-			continue
-		}
+
+	serverParentConfigParams := layerProfilesFromMap(sv.ProfileNames, allParentConfigParams)
+	for _, param := range serverParentConfigParams {
 		switch param.Name {
 		case ParentConfigCacheParamWeight:
 			parentServerParams.Weight = param.Value

--- a/lib/go-atscfg/storagedotconfig.go
+++ b/lib/go-atscfg/storagedotconfig.go
@@ -55,6 +55,10 @@ func MakeStorageDotConfig(
 		return Cfg{}, makeErr(warnings, "server missing Profiles")
 	}
 
+	if server.HostName == nil {
+		return Cfg{}, makeErr(warnings, "server missing HostName")
+	}
+
 	paramData, paramWarns := paramsToMap(filterParams(serverParams, StorageFileName, "", "", "location"))
 	warnings = append(warnings, paramWarns...)
 
@@ -64,7 +68,7 @@ func MakeStorageDotConfig(
 	if drivePrefix := paramData["Drive_Prefix"]; drivePrefix != "" {
 		driveLetters := strings.TrimSpace(paramData["Drive_Letters"])
 		if driveLetters == "" {
-			warnings = append(warnings, fmt.Sprintf("profile %+v has Drive_Prefix parameter, but no Drive_Letters; creating anyway", server.ProfileNames[0]))
+			warnings = append(warnings, fmt.Sprintf("server %+v profile has Drive_Prefix parameter, but no Drive_Letters; creating anyway", *server.HostName))
 		}
 		text += makeStorageVolumeText(drivePrefix, driveLetters, nextVolume)
 		nextVolume++
@@ -73,7 +77,7 @@ func MakeStorageDotConfig(
 	if ramDrivePrefix := paramData["RAM_Drive_Prefix"]; ramDrivePrefix != "" {
 		ramDriveLetters := strings.TrimSpace(paramData["RAM_Drive_Letters"])
 		if ramDriveLetters == "" {
-			warnings = append(warnings, fmt.Sprintf("profile %+v has RAM_Drive_Prefix parameter, but no RAM_Drive_Letters; creating anyway", server.ProfileNames[0]))
+			warnings = append(warnings, fmt.Sprintf("server %+v profile has RAM_Drive_Prefix parameter, but no RAM_Drive_Letters; creating anyway", *server.HostName))
 		}
 		text += makeStorageVolumeText(ramDrivePrefix, ramDriveLetters, nextVolume)
 		nextVolume++
@@ -82,7 +86,7 @@ func MakeStorageDotConfig(
 	if ssdDrivePrefix := paramData["SSD_Drive_Prefix"]; ssdDrivePrefix != "" {
 		ssdDriveLetters := strings.TrimSpace(paramData["SSD_Drive_Letters"])
 		if ssdDriveLetters == "" {
-			warnings = append(warnings, fmt.Sprintf("profile %+v has SSD_Drive_Prefix parameter, but no SSD_Drive_Letters; creating anyway", server.ProfileNames[0]))
+			warnings = append(warnings, fmt.Sprintf("server %+v profile has SSD_Drive_Prefix parameter, but no SSD_Drive_Letters; creating anyway", *server.HostName))
 		}
 		text += makeStorageVolumeText(ssdDrivePrefix, ssdDriveLetters, nextVolume)
 		nextVolume++


### PR DESCRIPTION
Adds cache config profile layering

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. TO won't allow users to assign multiple profiles until the next version, so other than tests, there isn't a good way to manually verify this, other than hand-crafting the JSON and calling t3c-generate. Or maybe putting hand-crafted JSON in the t3c cache file.


## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, no interface change <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
