### PR TITLE
Add t3c api profiles compatibility

### DIFF
--- a/cache-config/t3cutil/toreq/clientfuncs.go
+++ b/cache-config/t3cutil/toreq/clientfuncs.go
@@ -130,7 +130,7 @@ func (cl *TOClient) GetServers(reqHdr http.Header) ([]atscfg.Server, toclientlib
 	servers := []atscfg.Server{}
 	reqInf := toclientlib.ReqInf{}
 	err := torequtil.GetRetry(cl.NumRetries, "servers", &servers, func(obj interface{}) error {
-		toServers, toReqInf, err := cl.c.GetServers(*ReqOpts(reqHdr))
+		toServers, toReqInf, err := cl.GetServersCompat(*ReqOpts(reqHdr))
 		if err != nil {
 			return errors.New("getting servers from Traffic Ops '" + torequtil.MaybeIPStr(reqInf.RemoteAddr) + "': " + err.Error())
 		}
@@ -158,7 +158,7 @@ func (cl *TOClient) GetServerByHostName(serverHostName string, reqHdr http.Heade
 	err := torequtil.GetRetry(cl.NumRetries, "server-name-"+serverHostName, &server, func(obj interface{}) error {
 		params := url.Values{}
 		params.Add("hostName", serverHostName)
-		toServers, toReqInf, err := cl.c.GetServers(toclient.RequestOptions{
+		toServers, toReqInf, err := cl.GetServersCompat(toclient.RequestOptions{
 			QueryParameters: params,
 			Header:          reqHdr,
 		})


### PR DESCRIPTION
Adds a compatibility layer to t3c servers request, to handle profile or profileNames from different TO versions.

Based on https://github.com/apache/trafficcontrol/pull/6822 - recommend merging that first

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c against different TO versions which send servers objects with profile and profileNames, verify both work and generate config successfully.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release.


## PR submission checklist
- ~[x] This PR has tests~ no tests, HTTP requests can't realistically be unit tested, and integration test framework doesn't support multiple TO versions yet <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change. <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, no interface change <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
