### PR TITLE
Remove unnecessary t3c debug logging

### DIFF
--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -151,9 +151,6 @@ func Main() int {
 		return ExitCodeUserCheckError
 	}
 
-	toolName := trops.GetHeaderComment()
-	log.Debugf("toolname: %s\n", toolName)
-
 	// if running in Revalidate mode, check to see if it's
 	// necessary to continue
 	if cfg.Files == t3cutil.ApplyFilesFlagReval {

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -673,22 +673,6 @@ func (r *TrafficOpsReq) PrintWarnings() {
 	log.Infoln("======== End warning summary ========")
 }
 
-// GetHeaderComment looks up the tm.toolname parameter from traffic ops.
-func (r *TrafficOpsReq) GetHeaderComment() string {
-	result, err := getSystemInfo(r.Cfg)
-	if err != nil {
-		log.Errorln("getting system info: " + err.Error())
-		return "" // failing to get the toolname is an error, but not fatal
-	}
-	toolName := result["tm.toolname"]
-	if toolName, ok := toolName.(string); ok {
-		log.Infof("Found tm.toolname: %v\n", toolName)
-		return toolName
-	}
-	log.Errorln("Did not find tm.toolname!")
-	return "" // not having a tm.toolname Parameter is an error, but not fatal
-}
-
 // CheckRevalidateState retrieves and returns the revalidate status from Traffic Ops.
 func (r *TrafficOpsReq) CheckRevalidateState(sleepOverride bool) (UpdateStatus, error) {
 	log.Infoln("Checking revalidate state.")


### PR DESCRIPTION
Additionally, remove an unused method that was only being used by the
unnecessary debug logging.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Ensure the tests still pass and that `t3c` no longer prints this debug log.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
