### PR TITLE
Cdnjs integrity hashes

### DIFF
--- a/test/router/index.html
+++ b/test/router/index.html
@@ -24,14 +24,47 @@ under the License.
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Traffic Router Loadtest</title>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.6/d3.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.15.1/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"></script>
-    <script src="https://unpkg.com/babel-core@5.8.38/browser.min.js"></script>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script
+        integrity="sha384-HERpnF+tlZ/PxhCuxaUfTFrU8tKctj33vfD60o0LCNaYDxhrZsk45o1QG9L8GV1y"
+        crossorigin="anonymous"
+        src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.2.6/d3.min.js"
+    ></script>
+    <script
+        integrity="sha384-7pfELK0arQ3VANqV4kiPWPh5wOsrfitjFGF/NdyHXUJ3JJPy/rNhasPtdkaNKhul"
+        crossorigin="anonymous"
+        src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.15.1/moment.min.js"
+    ></script>
+    <script
+        integrity="sha384-bQIyvl+8Ufi5KiKZPG9VItNWmhcAXA1pa5nHIEoBGob+rdbjJnpNV3s288Mz2yZu"
+        crossorigin="anonymous"
+        src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react.js"
+    ></script>
+    <script
+        integrity="sha384-ZzFfcTbsRst34N23lWs6TtlfonXwDgpeALh+ObwYXav5BSo0j7KsaAtcdn+xrnS1"
+        crossorigin="anonymous"
+        src="https://cdnjs.cloudflare.com/ajax/libs/react/15.3.2/react-dom.js"
+    ></script>
+    <script
+        integrity="sha384-Fw04PJPC6ayYz0V6lPpRaiQxouxskHt/AjlelA2NWboTMnn5niXpXMyN4hftijud"
+        crossorigin="anonymous"
+        src="https://unpkg.com/babel-core@5.8.38/browser.min.js"
+    ></script>
+    <link
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+        crossorigin="anonymous"
+        rel="stylesheet"
+        href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    >
+    <script
+        integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ"
+        crossorigin="anonymous"
+        src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"
+    ></script>
+    <script
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"
+        src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+    ></script>
     <link href="css/loadtest.css" rel="stylesheet">
     <script src="js/load-test.jsx" type="text/babel"></script>
 </head>


### PR DESCRIPTION
This PR adds integrity hashes to resources loaded from CDNs by the `test/router` TR load tests. It also sets their `crossorigin` behavior to `anonymous`. This shouldn't really matter because they're just tests, but it's exceedingly easy to do.

This PR also eliminates some prototype pollution I found in the load-test script.

<hr/>

## Which Traffic Control components are affected by this PR?
- unknown

## What is the best way to verify this PR?
You could run the TR load tests. I don't know how. For the integrity hashes, it should suffice to just load `index.html` into a browser and verify that the scripts load - if they don't it means the hashes are wrong.

## PR submission checklist
- [x] This PR has tests 
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**