### PR TITLE
`api/{{version}/deliveryservices/{id}/health` returns no info if the delivery service uses a topology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed Traffic Ops ignoring the configured database port value, which was prohibiting the use of anything other than port 5432 (the PostgreSQL default)
 - [#6580](https://github.com/apache/trafficcontrol/issues/6580) Fixed cache config generation remap.config targets for MID-type servers in a Topology with other caches as parents and HTTPS origins.
 - Traffic Router: fixed a null pointer exception that caused snapshots to be rejected if a topology cachegroup did not have any online/reported/admin\_down caches
+- [#6271](https://github.com/apache/trafficcontrol/issues/6271) `api/{{version}/deliveryservices/{id}/health` returns no info if the delivery service uses a topology.
 - [#6549](https://github.com/apache/trafficcontrol/issues/6549) Fixed internal server error while deleting a delivery service created from a DSR (Traafic Ops).
 - [#6538](https://github.com/apache/trafficcontrol/pull/6538) Fixed the incorrect use of secure.port on TrafficRouter and corrected to the httpsPort value from the TR server configuration.
 - [#6562](https://github.com/apache/trafficcontrol/pull/6562) Fixed incorrect template in Ansible dataset loader role when fallbackToClosest is defined.

--- a/traffic_ops/traffic_ops_golang/deliveryservice/health.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/health.go
@@ -122,6 +122,7 @@ func addHealth(ds tc.DeliveryServiceName, data map[tc.CacheGroupName]tc.HealthDa
 	var topology string
 	var cacheGroupNameMap = make(map[string]bool)
 	var cacheCapabilities = make(map[string]bool)
+	var skip bool
 
 	if deliveryService, ok = crConfig.DeliveryServices[string(ds)]; !ok {
 		log.Errorln("delivery service not found in CRConfig")
@@ -163,13 +164,17 @@ func addHealth(ds tc.DeliveryServiceName, data map[tc.CacheGroupName]tc.HealthDa
 			if _, ok := cacheGroupNameMap[*cache.CacheGroup]; !ok {
 				continue
 			}
-		}
-		cacheCapabilities = make(map[string]bool)
-		for _, cap := range cache.Capabilities {
-			cacheCapabilities[cap] = true
-		}
-		for _, rc := range deliveryService.RequiredCapabilities {
-			if _, ok = cacheCapabilities[rc]; !ok {
+			cacheCapabilities = make(map[string]bool)
+			for _, cap := range cache.Capabilities {
+				cacheCapabilities[cap] = true
+			}
+			for _, rc := range deliveryService.RequiredCapabilities {
+				if _, ok = cacheCapabilities[rc]; !ok {
+					skip = true
+					continue
+				}
+			}
+			if skip {
 				continue
 			}
 		}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/health_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/health_test.go
@@ -1,0 +1,165 @@
+package deliveryservice
+
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+
+	"encoding/json"
+	"testing"
+)
+
+const crConfigJson = `
+{
+  "config": {},
+  "contentServers": {
+    "cache1": {
+      "cacheGroup": "cg1",
+      "capabilities": [
+        "cap1",
+        "cap2"
+      ],
+      "status": "REPORTED",
+      "type": "EDGE",
+      "deliveryServices": {
+        "ds1": [
+          "edge.ds1.test.net"
+        ]
+       }
+    },
+    "cache2": {
+      "cacheGroup": "cg2",
+      "capabilities": [
+        "cap2",
+        "cap3"
+      ],
+      "status": "REPORTED",
+      "type": "EDGE"
+    },
+    "cache3": {
+      "cacheGroup": "cg2",
+      "capabilities": [
+        "cap3",
+        "cap4"
+      ],
+      "status": "REPORTED",
+      "type": "EDGE"
+    }
+  },
+  "deliveryServices": {
+    "ds1": {},
+    "ds2-topology": {
+      "topology": "test_topology",
+      "requiredCapabilities": ["cap2"]
+    }
+  },
+  "contentRouters": {
+    "tr1": {}
+  },
+  "edgeLocations": {
+    "edge1": {}
+  },
+  "trafficRouterLocations": {
+    "tr-loc": {}
+  },
+  "monitors": {
+    "tm-host": {}
+  },
+  "stats": {},
+  "topologies": {
+    "test_topology": {
+      "nodes": [
+        "cg2"
+      ]
+    }
+  }
+}
+`
+const crStatesJson = `
+{
+  "caches": {
+    "cache1": {
+      "isAvailable": true,
+      "ipv4Available": true,
+      "ipv6Available": true,
+      "status": "REPORTED - available",
+      "lastPoll": "2022-05-11T19:50:55.036253631Z"
+    },
+    "cache2": {
+      "isAvailable": true,
+      "ipv4Available": true,
+      "ipv6Available": true,
+      "status": "REPORTED - available",
+      "lastPoll": "2022-05-11T19:51:06.965095596Z"
+    },
+    "cache3": {
+      "isAvailable": true,
+      "ipv4Available": true,
+      "ipv6Available": true,
+      "status": "REPORTED - available",
+      "lastPoll": "2022-05-11T19:51:06.965095596Z"
+    }
+  },
+  "deliveryServices": {
+    "ds1": {
+      "disabledLocations": [],
+      "isAvailable": true
+    },
+    "ds2-topology": {
+      "disabledLocations": [],
+      "isAvailable": true
+    }
+  }
+}
+`
+
+func TestAddHealth(t *testing.T) {
+	crStates := tc.CRStates{}
+	crConfig := tc.CRConfig{}
+	err := json.Unmarshal([]byte(crStatesJson), &crStates)
+	if err != nil {
+		t.Fatalf("error unmarshalling crStates: %v", err)
+	}
+	err = json.Unmarshal([]byte(crConfigJson), &crConfig)
+	if err != nil {
+		t.Fatalf("error unmarshalling crConfig: %v", err)
+	}
+	data := make(map[tc.CacheGroupName]tc.HealthDataCacheGroup)
+	data[tc.CacheGroupName("cache1")] = tc.HealthDataCacheGroup{
+		Offline: 0,
+		Online:  0,
+		Name:    "cg1",
+	}
+	data[tc.CacheGroupName("cache2")] = tc.HealthDataCacheGroup{
+		Offline: 0,
+		Online:  0,
+		Name:    "cg2",
+	}
+	data[tc.CacheGroupName("cache3")] = tc.HealthDataCacheGroup{
+		Offline: 0,
+		Online:  0,
+		Name:    "cg2",
+	}
+	_, available, unAvailable := addHealth("ds1", data, 0, 0, crStates, crConfig)
+	if available != 1 || unAvailable != 0 {
+		t.Errorf("expected ds1 to have 1 online and 0 offline caches, but got %d online and %d offline instead", available, unAvailable)
+	}
+	// Even though there are 2 REPORTED EDGE caches in cg2, the result should just include 1, because one of them should get filtered out because it's missing a required capability (cap2)
+	_, available, unAvailable = addHealth("ds2-topology", data, 0, 0, crStates, crConfig)
+	if available != 1 || unAvailable != 0 {
+		t.Errorf("expected ds2-topology to have 1 online and 0 offline caches, but got %d online and %d offline instead", available, unAvailable)
+	}
+}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/health_test.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/health_test.go
@@ -118,7 +118,7 @@ func TestAddHealth(t *testing.T) {
 		Online:  0,
 		Name:    "cg2",
 	}
-	err, _, available, unAvailable := addHealth("ds1", data, 0, 0, crStates, crConfig)
+	_, available, unAvailable, err := addHealth("ds1", data, 0, 0, crStates, crConfig)
 	if err != nil {
 		t.Fatalf("expected no error while adding health of ds1, but got %v", err)
 	}
@@ -126,7 +126,7 @@ func TestAddHealth(t *testing.T) {
 		t.Errorf("expected ds1 to have 1 online and 0 offline caches, but got %d online and %d offline instead", available, unAvailable)
 	}
 	// Even though there are 2 REPORTED EDGE caches in cg2, the result should just include 1, because one of them should get filtered out because it's missing a required capability (cap2)
-	err, _, available, unAvailable = addHealth("ds2-topology", data, 0, 0, crStates, crConfig)
+	_, available, unAvailable, err = addHealth("ds2-topology", data, 0, 0, crStates, crConfig)
 	if err != nil {
 		t.Fatalf("expected no error while adding health of ds2, but got %v", err)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #6271 
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Closes: #6271 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run CDN-in-a-box.
Create two ds, one with and another without a valid topology.
Assign some "REPORTED" EDGE caches to the topology, and also do the same for the first DS (without topology).
Snap both the delivery services.
Make a call to GET `deliveryservices/{id}/health` for the both the DS's.
Make sure that both DS's show valid counts of online/ offline caches.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->

- master
## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
