### PR TITLE
Fix Internal Server Error when updating server without the id key

### DIFF
--- a/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
+++ b/traffic_ops/traffic_ops_golang/dbhelpers/db_helpers.go
@@ -2124,10 +2124,17 @@ func UpdateServerProfilesForV4(id int, profile []string, tx *sql.Tx) error {
 }
 
 // UpdateServerProfileTableForV2V3 updates CommonServerPropertiesV40 struct and server_profile table via Update (server) function for API v2/v3.
-func UpdateServerProfileTableForV2V3(id *int, newProfile *string, origProfile string, tx *sql.Tx) ([]string, error) {
+func UpdateServerProfileTableForV2V3(id *int, newProfileId *int, origProfile string, tx *sql.Tx) ([]string, error) {
 	var profileName []string
+
+	var newProfile string
+	err := tx.QueryRow("SELECT name from profile where id = $1", *newProfileId).Scan(&newProfile)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("selecting profile by name: %w", err)
+	}
+
 	query := `UPDATE server_profile SET profile_name=$1 WHERE server=$2 AND profile_name=$3`
-	_, err := tx.Exec(query, *newProfile, *id, origProfile)
+	_, err = tx.Exec(query, newProfile, *id, origProfile)
 	if err != nil {
 		return nil, fmt.Errorf("updating server_profile by profile_name: %w", err)
 	}

--- a/traffic_ops/traffic_ops_golang/server/servers.go
+++ b/traffic_ops/traffic_ops_golang/server/servers.go
@@ -1469,8 +1469,9 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	originalStatusID := *original.StatusID
 
 	var server tc.ServerV40
-	var serverV3 tc.ServerV30
 	var statusLastUpdatedTime time.Time
+	server.ID = new(int)
+	*server.ID = inf.IntParams["id"]
 	if inf.Version.Major >= 4 {
 		if err := json.NewDecoder(r.Body).Decode(&server); err != nil {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
@@ -1499,6 +1500,9 @@ func Update(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else if inf.Version.Major >= 3 {
+		var serverV3 tc.ServerV30
+		serverV3.ID = new(int)
+		*serverV3.ID = inf.IntParams["id"]
 		if err := json.NewDecoder(r.Body).Decode(&serverV3); err != nil {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
 			return
@@ -1516,7 +1520,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
 			return
 		}
-		profileName, err := dbhelpers.UpdateServerProfileTableForV2V3(serverV3.ID, serverV3.Profile, (original.ProfileNames)[0], tx)
+		profileName, err := dbhelpers.UpdateServerProfileTableForV2V3(serverV3.ID, serverV3.ProfileID, (original.ProfileNames)[0], tx)
 		if err != nil {
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("failed to update server_profile: %w", err))
 			return
@@ -1532,6 +1536,8 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		var legacyServer tc.ServerNullableV2
+		legacyServer.ID = new(int)
+		*legacyServer.ID = inf.IntParams["id"]
 		if err := json.NewDecoder(r.Body).Decode(&legacyServer); err != nil {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
 			return
@@ -1541,7 +1547,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, err, nil)
 			return
 		}
-		profileName, err := dbhelpers.UpdateServerProfileTableForV2V3(legacyServer.ID, legacyServer.Profile, (original.ProfileNames)[0], tx)
+		profileName, err := dbhelpers.UpdateServerProfileTableForV2V3(legacyServer.ID, legacyServer.ProfileID, (original.ProfileNames)[0], tx)
 		if err != nil {
 			api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("failed to update server_profile: %w", err))
 			return
@@ -1575,8 +1581,6 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	server.ID = new(int)
-	*server.ID = inf.IntParams["id"]
 	status, ok, err := dbhelpers.GetStatusByID(*server.StatusID, tx)
 	if err != nil {
 		sysErr = fmt.Errorf("getting server #%d status (#%d): %v", id, *server.StatusID, err)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #6828 

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Fixes: #6828 

Fixes issue where updating a server without an `id` key in the request body results in an Internal Server Error for api v3 and v4. This also fixes the issue when updating a server without a `profile` key in the request body results in an Internal Server Error for api v3 and v2.

In addition this fixes a previous bug in Traffic Ops that would not allow a user to update a server without the `id` key due to:

https://github.com/apache/trafficcontrol/blob/8c13de7054acf8554412c59fdf543ff30759b3ab/traffic_ops/traffic_ops_golang/server/servers.go#L653-L672

When the `id` key was omitted it resulted in that s.ID always being nil and resulting in the incorrect error message and incorrect 400 Bad Request.


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Make a `PUT` request to `/api/4.0/servers` without the `id` in the request body this should return a `200 OK`
Make a `PUT` request to `/api/3.1/servers` without the `id` in the request body this should return a `200 OK`

Make a `PUT` request to `/api/3.1/servers` without the `profile` in the request body this should return a `200 OK`
Make a `PUT` request to `/api/2.0/servers` without the `profile` in the request body this should return a `200 OK`

## PR submission checklist

- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
