### PR TITLE
Fix t3c strategy peer yaml typo

### DIFF
--- a/lib/go-atscfg/strategiesdotconfig.go
+++ b/lib/go-atscfg/strategiesdotconfig.go
@@ -252,7 +252,7 @@ func getStrategyGroupsSection(pa *ParentAbstraction) string {
 	if len(pa.Peers) != 0 {
 		txt += "\n" + `  - &peers_group`
 		for i, peer := range pa.Peers {
-			txt += "\n" + `    - << *peer` + strconv.Itoa(i+1)
+			txt += "\n" + `    - <<: *peer` + strconv.Itoa(i+1)
 			txt += "\n" + `      weight: ` + strconv.FormatFloat(peer.Weight, 'f', 3, 64)
 		}
 	}

--- a/lib/go-atscfg/strategiesdotconfig_test.go
+++ b/lib/go-atscfg/strategiesdotconfig_test.go
@@ -445,4 +445,9 @@ func TestMakeStrategiesHTTPSOrigin(t *testing.T) {
 	if strings.Contains(txt, "port: 443") {
 		t.Errorf("expected edge parent.config of https origin to use internal http port 80 and not https/443, actual: '%v'", txt)
 	}
+
+	// checks for properly-formed merge keys
+	if strings.Contains(cfg.Text, "<< ") {
+		t.Errorf("expected yaml merge keys to be '<<: ', actual malformed '<< ': %v", cfg.Text)
+	}
 }


### PR DESCRIPTION
Fixes a typo in cache config generation where strategies.yaml yaml peer merge keys were `<< ` instead of `<<: `, resulting in malformed yaml that ATS failed to load.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c with strategies generated, verify ATS loads strategy file successfully.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, minor bug fix <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, bug not in a release<!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
