### PR TITLE
TP expired DS certs: adds color coding to expired and soon-expired certs

### DIFF
--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -219,6 +219,12 @@ div.dropdown button.menu-item-button {
       text-decoration: line-through;
     }
   }
+  .ag-row.expired-cert {
+    background-color: #f8d7da;
+  }
+  .ag-row.soon-expired-cert {
+    background-color: #fff3cd;
+  }
 }
 
 div.grid-comp {

--- a/traffic_portal/app/src/common/modules/table/certExpirations/TableCertExpirationsController.js
+++ b/traffic_portal/app/src/common/modules/table/certExpirations/TableCertExpirationsController.js
@@ -84,6 +84,17 @@ var TableCertExpirationsController = function(tableName, certExpirations, $scope
 				// Event is outside the digest cycle, so we need to trigger one.
 				$scope.$apply();
 			}
+		},
+		rowClassRules: {
+			'expired-cert': function(params) {
+				let now = new Date();
+				return params.data.expiration < now;
+			},
+			'soon-expired-cert': function(params) {
+				let thirtyDays = new Date();
+				thirtyDays.setDate(thirtyDays.getDate()+30);
+				return params.data.expiration >= new Date() && params.data.expiration <= thirtyDays;
+			}
 		}
 	};
 


### PR DESCRIPTION
## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
- Start TP
- Navigate to https://tp.domain.tld/#!/cert-expirations
- Expired certs will have a red row
- Soon expired certs (30 days or less) will have a yellow row

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
