### PR TITLE
Add more t3c profile layering

### DIFF
--- a/cache-config/t3c-generate/config/config.go
+++ b/cache-config/t3c-generate/config/config.go
@@ -29,7 +29,6 @@ import (
 	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/lib/go-atscfg"
 	"github.com/apache/trafficcontrol/lib/go-log"
-	"github.com/apache/trafficcontrol/lib/go-tc"
 
 	"github.com/pborman/getopt/v2"
 )
@@ -179,69 +178,4 @@ func ValidateURL(u *url.URL) error {
 		return errors.New("no host")
 	}
 	return nil
-}
-
-// TOData is the Traffic Ops data needed to generate configs.
-// See each field for details on the data required.
-// - If a field says 'must', the creation of TOData is guaranteed to do so, and users of the struct may rely on that.
-// - If it says 'may', the creation may or may not do so, and therefore users of the struct must filter if they
-//   require the potential fields to be omitted to generate correctly.
-type TOData struct {
-	// Servers must be all the servers from Traffic Ops. May include servers not on the current cdn.
-	Servers []atscfg.Server
-
-	// CacheGroups must be all cachegroups in Traffic Ops with Servers on the current server's cdn. May also include CacheGroups without servers on the current cdn.
-	CacheGroups []tc.CacheGroupNullable
-
-	// GlobalParams must be all Parameters in Traffic Ops on the tc.GlobalProfileName Profile. Must not include other parameters.
-	GlobalParams []tc.Parameter
-
-	// ServerParams must be all Parameters on the Profile of the current server. Must not include other Parameters.
-	ServerParams []tc.Parameter
-
-	// RemapConfigParams must be all Parameters with the ConfigFile "remap.config". Also includes cachekey.config parameters
-	RemapConfigParams []tc.Parameter
-
-	// ParentConfigParams must be all Parameters with the ConfigFile "parent.config.
-	ParentConfigParams []tc.Parameter
-
-	// DeliveryServices must include all Delivery Services on the current server's cdn, including those not assigned to the server. Must not include delivery services on other cdns.
-	DeliveryServices []atscfg.DeliveryService
-
-	// DeliveryServiceServers must include all delivery service servers in Traffic Ops for all delivery services on the current cdn, including those not assigned to the current server.
-	DeliveryServiceServers []tc.DeliveryServiceServer
-
-	// Server must be the server we're fetching configs from
-	Server *atscfg.Server
-
-	// Jobs must be all Jobs on the server's CDN. May include jobs on other CDNs.
-	Jobs []tc.Job
-
-	// CDN must be the CDN of the server.
-	CDN *tc.CDN
-
-	// DeliveryServiceRegexes must be all regexes on all delivery services on this server's cdn.
-	DeliveryServiceRegexes []tc.DeliveryServiceRegexes
-
-	// Profile must be the Profile of the server being requested.
-	Profile tc.Profile
-
-	// URISigningKeys must be a map of every delivery service which is URI Signed, to its keys.
-	URISigningKeys map[tc.DeliveryServiceName][]byte
-
-	// URLSigKeys must be a map of every delivery service which uses URL Sig, to its keys.
-	URLSigKeys map[tc.DeliveryServiceName]tc.URLSigKeys
-
-	// ServerCapabilities must be a map of all server IDs on this server's CDN, to a set of their capabilities. May also include servers from other cdns.
-	ServerCapabilities map[int]map[atscfg.ServerCapability]struct{}
-
-	// DSRequiredCapabilities must be a map of all delivery service IDs on this server's CDN, to a set of their required capabilities. Delivery Services with no required capabilities may not have an entry in the map.
-	DSRequiredCapabilities map[int]map[atscfg.ServerCapability]struct{}
-
-	// SSLKeys must be all the ssl keys for the server's cdn.
-	SSLKeys []tc.CDNSSLKeys
-
-	// Topologies must be all the topologies for the server's cdn.
-	// May incude topologies of other cdns.
-	Topologies []tc.Topology
 }

--- a/cache-config/t3c-generate/t3c-generate.go
+++ b/cache-config/t3c-generate/t3c-generate.go
@@ -82,12 +82,6 @@ func main() {
 		os.Exit(config.ExitCodeErrGeneric)
 	}
 
-	// toData, toIPs, err := cfgfile.GetTOData(tccfg)
-	// if err != nil {
-	// 	log.Errorln("getting data from traffic ops: " + err.Error())
-	// 	os.Exit(config.ExitCodeErrGeneric)
-	// }
-
 	configs, err := cfgfile.GetAllConfigs(toData, cfg)
 	if err != nil {
 		log.Errorln("Getting config for'" + *toData.Server.HostName + "': " + err.Error())

--- a/cache-config/t3cutil/getdata.go
+++ b/cache-config/t3cutil/getdata.go
@@ -159,16 +159,22 @@ func GetPackages(cfg TCCfg) ([]Package, error) {
 		return nil, errors.New("getting server: " + err.Error())
 	} else if len(server.ProfileNames) == 0 {
 		return nil, errors.New("getting server: nil profile")
+	} else if server.HostName == nil {
+		return nil, errors.New("getting server: nil hostName")
 	}
-	params, _, err := cfg.TOClient.GetServerProfileParameters(server.ProfileNames[0], nil)
+	allPackageParams, reqInf, err := cfg.TOClient.GetConfigFileParameters(atscfg.PackagesParamConfigFile, nil)
+	log.Infoln(toreq.RequestInfoStr(reqInf, "GetPackages.GetConfigFileParameters("+atscfg.PackagesParamConfigFile+")"))
 	if err != nil {
-		return nil, errors.New("getting server profile '" + server.ProfileNames[0] + "' parameters: " + err.Error())
+		return nil, errors.New("getting server '" + *server.HostName + "' package parameters: " + err.Error())
 	}
+
+	serverPackageParams, err := atscfg.GetServerParameters(server, allPackageParams)
+	if err != nil {
+		return nil, errors.New("calculating server '" + *server.HostName + "' package parameters: " + err.Error())
+	}
+
 	packages := []Package{}
-	for _, param := range params {
-		if param.ConfigFile != atscfg.PackagesParamConfigFile {
-			continue
-		}
+	for _, param := range serverPackageParams {
 		packages = append(packages, Package{Name: param.Name, Version: param.Value})
 	}
 	return packages, nil
@@ -198,16 +204,23 @@ func GetChkconfig(cfg TCCfg) ([]ChkConfigEntry, error) {
 		return nil, errors.New("getting server: " + err.Error())
 	} else if len(server.ProfileNames) == 0 {
 		return nil, errors.New("getting server: nil profile")
+	} else if server.HostName == nil {
+		return nil, errors.New("getting server: nil hostName")
 	}
-	params, _, err := cfg.TOClient.GetServerProfileParameters(server.ProfileNames[0], nil)
+
+	allChkconfigParams, reqInf, err := cfg.TOClient.GetConfigFileParameters(atscfg.ChkconfigParamConfigFile, nil)
+	log.Infoln(toreq.RequestInfoStr(reqInf, "GetChkconfig.GetConfigFileParameters("+atscfg.ChkconfigParamConfigFile+")"))
 	if err != nil {
-		return nil, errors.New("getting server profile '" + server.ProfileNames[0] + "' parameters: " + err.Error())
+		return nil, errors.New("getting server '" + *server.HostName + "' chkconfig parameters: " + err.Error())
 	}
+
+	serverChkconfigParams, err := atscfg.GetServerParameters(server, allChkconfigParams)
+	if err != nil {
+		return nil, errors.New("calculating server '" + *server.HostName + "' chkconfig parameters: " + err.Error())
+	}
+
 	chkconfig := []ChkConfigEntry{}
-	for _, param := range params {
-		if param.ConfigFile != atscfg.ChkconfigParamConfigFile {
-			continue
-		}
+	for _, param := range serverChkconfigParams {
 		chkconfig = append(chkconfig, ChkConfigEntry{Name: param.Name, Val: param.Value})
 	}
 	return chkconfig, nil

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -46,6 +46,7 @@ type DeliveryServiceID int
 type ProfileID int
 type ServerID int
 
+type ProfileName string
 type TopologyName string
 type CacheGroupType string
 type ServerCapability string

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -197,8 +197,19 @@ func makeParentDotConfigData(
 	// parentConfigParams are the parent.config params for all profiles (needed for parents)
 	parentConfigParams := parameterWithProfilesToMap(parentConfigParamsWithProfiles)
 
+	serversWithParams := []serverWithParams{}
+	for _, sv := range servers {
+		serverParentParams, parentWarns := serverParentageParams(&sv, parentConfigParams)
+		warnings = append(warnings, parentWarns...)
+		serversWithParams = append(serversWithParams, serverWithParams{
+			Server: sv,
+			Params: serverParentParams,
+		})
+	}
+	sort.Sort(serversWithParamsSortByRank(serversWithParams))
+
 	// serverParams are the parent.config params for this particular server
-	serverParams := getServerParentConfigParams(server, profileParentConfigParams)
+	serverParams := getServerParentConfigParams(server, parentConfigParams)
 
 	parentCacheGroups := map[string]struct{}{}
 	if cacheIsTopLevel {
@@ -238,9 +249,9 @@ func makeParentDotConfigData(
 
 	nameTopologies := makeTopologyNameMap(topologies)
 
-	cgPeers := map[int]Server{}   // map[serverID]server
-	cgServers := map[int]Server{} // map[serverID]server
-	for _, sv := range servers {
+	cgPeers := map[int]serverWithParams{}   // map[serverID]server
+	cgServers := map[int]serverWithParams{} // map[serverID]server
+	for _, sv := range serversWithParams {
 		if sv.ID == nil {
 			warnings = append(warnings, "TO servers had server with missing ID, skipping!")
 			continue
@@ -307,7 +318,7 @@ func makeParentDotConfigData(
 		parentServerDSes[dss.Server][dss.DeliveryService] = struct{}{}
 	}
 
-	originServers, orgProfWarns, err := getOriginServers(cgServers, parentServerDSes, profileParentConfigParams, dses, serverCapabilities)
+	originServers, orgProfWarns, err := getOriginServers(cgServers, parentServerDSes, dses, serverCapabilities)
 	warnings = append(warnings, orgProfWarns...)
 	if err != nil {
 		return nil, warnings, errors.New("getting origin servers and profile caches: " + err.Error())
@@ -355,7 +366,7 @@ func makeParentDotConfigData(
 		if ds.Topology != nil && *ds.Topology != "" {
 			txt, topoWarnings, err := getTopologyParentConfigLine(
 				server,
-				servers,
+				serversWithParams,
 				&ds,
 				serverParams,
 				parentConfigParams,
@@ -525,8 +536,8 @@ func makeParentDotConfigData(
 				}
 				text.GoDirect = true
 				// text += `dest_domain=` + orgURI.Hostname() + ` port=` + orgURI.Port() + ` go_direct=true` + "\n"
-			} else {
 
+			} else {
 				// check for profile psel.qstring_handling.  If this parameter is assigned to the server profile,
 				// then edges will use the qstring handling value specified in the parameter for all profiles.
 
@@ -575,7 +586,6 @@ func makeParentDotConfigData(
 				text.IgnoreQueryStringInParentSelection = !*parentQStr
 				// text += `dest_domain=` + orgURI.Hostname() + ` port=` + orgURI.Port() + ` ` + parents + ` ` + secondaryParents + ` ` + roundRobin + ` ` + goDirect + ` qstring=` + parentQStr + "\n"
 			}
-
 			parentAbstraction.Services = append(parentAbstraction.Services, text)
 		}
 	}
@@ -894,7 +904,7 @@ func getParentDSParams(ds DeliveryService, profileParentConfigParams map[string]
 // If the given DS is not used by the server, returns a nil ParentAbstractionService and nil error.
 func getTopologyParentConfigLine(
 	server *Server,
-	servers []Server,
+	serversWithParams []serverWithParams,
 	ds *DeliveryService,
 	serverParams map[string]string,
 	parentConfigParams []parameterWithProfilesMap, // all params with configFile parent.config
@@ -947,7 +957,7 @@ func getTopologyParentConfigLine(
 	}
 	// txt += "dest_domain=" + orgURI.Hostname() + " port=" + orgURI.Port()
 
-	parents, secondaryParents, parentWarnings, err := getTopologyParents(server, ds, servers, parentConfigParams, topology, serverPlacement.IsLastTier, serverCapabilities, dsRequiredCapabilities, dsOrigins, dsParams.MergeGroups)
+	parents, secondaryParents, parentWarnings, err := getTopologyParents(server, ds, serversWithParams, parentConfigParams, topology, serverPlacement.IsLastTier, serverCapabilities, dsRequiredCapabilities, dsOrigins, dsParams.MergeGroups)
 	warnings = append(warnings, parentWarnings...)
 	if err != nil {
 		return nil, warnings, errors.New("getting topology parents for '" + *ds.XMLID + "': skipping! " + err.Error())
@@ -1262,11 +1272,11 @@ func serverParentStr(sv *Server, svParams parentServerParams) (*ParentAbstractio
 	}, nil
 }
 
-// GetTopologyParents returns the parents, secondary parents, any warnings, and any error.
+// getTopologyParents returns the parents, secondary parents, any warnings, and any error.
 func getTopologyParents(
 	server *Server,
 	ds *DeliveryService,
-	servers []Server,
+	serversWithParams []serverWithParams,
 	parentConfigParams []parameterWithProfilesMap, // all params with configFile parent.config
 	topology tc.Topology,
 	serverIsLastTier bool,
@@ -1335,17 +1345,6 @@ func getTopologyParents(
 
 	parentStrs := []*ParentAbstractionServiceParent{}
 	secondaryParentStrs := []*ParentAbstractionServiceParent{}
-
-	serversWithParams := []serverWithParams{}
-	for _, sv := range servers {
-		serverParentParams, parentWarns := serverParentageParams(&sv, parentConfigParams)
-		warnings = append(warnings, parentWarns...)
-		serversWithParams = append(serversWithParams, serverWithParams{
-			Server: sv,
-			Params: serverParentParams,
-		})
-	}
-	sort.Sort(serversWithParamsSortByRank(serversWithParams))
 
 	for _, sv := range serversWithParams {
 		if sv.ID == nil {
@@ -1622,9 +1621,8 @@ func unavailableServerRetryResponsesValid(s string) bool {
 
 // getOriginServers returns the origin servers with parameters, any warnings, and any error.
 func getOriginServers(
-	cgServers map[int]Server,
+	cgServers map[int]serverWithParams,
 	parentServerDSes map[int]map[int]struct{},
-	profileParentConfigParams map[string]map[string]string, // map[profileName][paramName]paramVal
 	dses []DeliveryService,
 	serverCapabilities map[int]map[ServerCapability]struct{},
 ) (map[OriginHost][]serverWithParams, []string, error) {
@@ -1664,16 +1662,7 @@ func getOriginServers(
 		return nil, warnings, errors.New("getting DS origins: " + err.Error())
 	}
 
-	profileParams, profParamWarns := getParentConfigProfileParams(cgServers, profileParentConfigParams)
-	warnings = append(warnings, profParamWarns...)
-
 	for _, cgSv := range cgServers {
-		parentServerParams, profileParamsHasProfile := profileParams[cgSv.ProfileNames[0]]
-		if !profileParamsHasProfile {
-			warnings = append(warnings, fmt.Sprintf("cachegroup has server %+v profile with no parameters\n", *cgSv.HostName))
-			parentServerParams = defaultParentServerParams()
-		}
-
 		if cgSv.ID == nil {
 			warnings = append(warnings, "getting origin servers: got server with nil ID, skipping!")
 			continue
@@ -1703,7 +1692,7 @@ func getOriginServers(
 			continue
 		}
 
-		ipAddr := getServerIPAddress(&cgSv)
+		ipAddr := getServerIPAddress(&cgSv.Server)
 		if ipAddr == nil {
 			warnings = append(warnings, "getting origin servers: got server with no valid IP Address, skipping!")
 			continue
@@ -1717,75 +1706,14 @@ func getOriginServers(
 					continue
 				}
 				orgHost := OriginHost(orgURI.Host)
-				originServers[orgHost] = append(originServers[orgHost], serverWithParams{
-					Server: cgSv,
-					Params: parentServerParams,
-				})
+				originServers[orgHost] = append(originServers[orgHost], cgSv)
 			}
 		} else {
-			originServers[deliveryServicesAllParentsKey] = append(originServers[deliveryServicesAllParentsKey], serverWithParams{
-				Server: cgSv,
-				Params: parentServerParams,
-			})
+			originServers[deliveryServicesAllParentsKey] = append(originServers[deliveryServicesAllParentsKey], cgSv)
 		}
 	}
 
 	return originServers, warnings, nil
-}
-
-// GetParentConfigProfileParams returns the parent config profile params, and any warnings.
-func getParentConfigProfileParams(
-	cgServers map[int]Server,
-	profileParentConfigParams map[string]map[string]string, // map[profileName][paramName]paramVal
-) (map[string]parentServerParams, []string) {
-	warnings := []string{}
-	parentConfigServerCacheProfileParams := map[string]parentServerParams{} // map[profileName]parentServerParams
-	for _, cgServer := range cgServers {
-		if len(cgServer.ProfileNames) == 0 {
-			warnings = append(warnings, "getting parent config profile params: server has nil profiles, skipping!")
-			continue
-		}
-		serverParams, ok := parentConfigServerCacheProfileParams[cgServer.ProfileNames[0]]
-		if !ok {
-			serverParams = defaultParentServerParams()
-		}
-		params, ok := profileParentConfigParams[cgServer.ProfileNames[0]]
-		if !ok {
-			parentConfigServerCacheProfileParams[cgServer.ProfileNames[0]] = serverParams
-			continue
-		}
-		for name, val := range params {
-			switch name {
-			case ParentConfigCacheParamWeight:
-				// f, err := strconv.ParseFloat(param.Val, 64)
-				// if err != nil {
-				// 	warnings = append(warnings, "parent.config generation: weight param is not a float, skipping! : " + err.Error())
-				// } else {
-				// 	parentServerParams.Weight = f
-				// }
-				// TODO validate float?
-				serverParams.Weight = val
-			case ParentConfigCacheParamPort:
-				if i, err := strconv.Atoi(val); err != nil {
-					warnings = append(warnings, "port param is not an integer, skipping! : "+err.Error())
-				} else {
-					serverParams.Port = i
-				}
-			case ParentConfigCacheParamUseIP:
-				serverParams.UseIP = val == "1"
-			case ParentConfigCacheParamRank:
-				if i, err := strconv.Atoi(val); err != nil {
-					warnings = append(warnings, "rank param is not an integer, skipping! : "+err.Error())
-				} else {
-					serverParams.Rank = i
-				}
-			case ParentConfigCacheParamNotAParent:
-				serverParams.NotAParent = val != "false"
-			}
-		}
-		parentConfigServerCacheProfileParams[cgServer.ProfileNames[0]] = serverParams
-	}
-	return parentConfigServerCacheProfileParams, warnings
 }
 
 // getDSOrigins takes a map[deliveryServiceID]DeliveryService, and returns a map[DeliveryServiceID]OriginURI, any warnings, and any error.
@@ -1882,7 +1810,6 @@ func getProfileParentConfigParams(tcParentConfigParams []tc.Parameter) (map[stri
 		warnings = append(warnings, "error getting profiles from Traffic Ops Parameters, Parameters will not be considered for generation! : "+err.Error())
 		parentConfigParamsWithProfiles = []parameterWithProfiles{}
 	}
-	// parentConfigParams := parameterWithProfilesToMap(parentConfigParamsWithProfiles)
 
 	// this is an optimization, to avoid looping over all params, for every DS. Instead, we loop over all params only once, and put them in a profile map.
 	profileParentConfigParams := map[string]map[string]string{} // map[profileName][paramName]paramVal
@@ -1899,16 +1826,17 @@ func getProfileParentConfigParams(tcParentConfigParams []tc.Parameter) (map[stri
 
 // getServerParentConfigParams returns a map[name]value.
 // Intended to be called with the result of getProfileParentConfigParams.
-func getServerParentConfigParams(server *Server, profileParentConfigParams map[string]map[string]string) map[string]string {
+func getServerParentConfigParams(server *Server, allParentConfigParams []parameterWithProfilesMap) map[string]string {
 	// We only need parent.config params, don't need all the params on the server
 	serverParams := map[string]string{}
-	if len(server.ProfileNames) != 0 || server.ProfileNames[0] != "" { // TODO warn/error if false? Servers requires profiles
-		for name, val := range profileParentConfigParams[server.ProfileNames[0]] {
-			if name == ParentConfigParamQStringHandling ||
-				name == ParentConfigParamAlgorithm ||
-				name == ParentConfigParamQString {
-				serverParams[name] = val
-			}
+	serverParentConfigParams := layerProfilesFromMap(server.ProfileNames, allParentConfigParams)
+	for _, pa := range serverParentConfigParams {
+		name := pa.Name
+		val := pa.Value
+		if name == ParentConfigParamQStringHandling ||
+			name == ParentConfigParamAlgorithm ||
+			name == ParentConfigParamQString {
+			serverParams[name] = val
 		}
 	}
 	return serverParams

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -3402,6 +3402,197 @@ func TestMakeParentDotConfigMergeParentGroupTopology(t *testing.T) {
 	}
 }
 
+func TestMakeParentDotConfigTopologiesServerMultipleProfileParams(t *testing.T) {
+	hdr := &ParentConfigOpts{AddComments: false, HdrComment: "myHeaderComment"}
+
+	ds1 := makeParentDS()
+	ds1.ID = util.IntPtr(43)
+	ds1Type := tc.DSTypeDNS
+	ds1.Type = &ds1Type
+	ds1.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreDrop))
+	ds1.OrgServerFQDN = util.StrPtr("http://ds1.example.net")
+	ds1.Topology = util.StrPtr("t0")
+	ds1.ProfileName = util.StrPtr("ds1Profile")
+	ds1.ProfileID = util.IntPtr(994)
+	ds1.MultiSiteOrigin = util.BoolPtr(true)
+
+	dses := []DeliveryService{*ds1}
+
+	parentConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       ParentConfigParamQStringHandling,
+			ConfigFile: "parent.config",
+			Value:      "myQStringHandlingParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      tc.AlgorithmConsistentHash,
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamQString,
+			ConfigFile: "parent.config",
+			Value:      "myQstringParam",
+			Profiles:   []byte(`["serverprofile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamAlgorithm,
+			ConfigFile: "parent.config",
+			Value:      "consistent_hash",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamParentRetry,
+			ConfigFile: "parent.config",
+			Value:      "both",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamUnavailableServerRetryResponses,
+			ConfigFile: "parent.config",
+			Value:      `"400,503"`,
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxSimpleRetries,
+			ConfigFile: "parent.config",
+			Value:      "14",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigParamMaxUnavailableServerRetries,
+			ConfigFile: "parent.config",
+			Value:      "9",
+			Profiles:   []byte(`["ds1Profile"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigCacheParamWeight,
+			ConfigFile: "parent.config",
+			Value:      "100",
+			Profiles:   []byte(`["serverprofile0"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigCacheParamWeight,
+			ConfigFile: "parent.config",
+			Value:      "200",
+			Profiles:   []byte(`["serverprofile1"]`),
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "8",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigCacheParamWeight,
+			ConfigFile: "parent.config",
+			Value:      "100",
+			Profiles:   []byte(`["serverprofile0"]`),
+		},
+		tc.Parameter{
+			Name:       ParentConfigCacheParamWeight,
+			ConfigFile: "parent.config",
+			Value:      "200",
+			Profiles:   []byte(`["serverprofile1"]`),
+		},
+	}
+
+	server := makeTestParentServer()
+	server.Cachegroup = util.StrPtr("edgeCG")
+	server.CachegroupID = util.IntPtr(400)
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+	origin0.ProfileNames = []string{"serverprofile0", "serverprofile1"}
+
+	origin1 := makeTestParentServer()
+	origin1.Cachegroup = util.StrPtr("originCG")
+	origin1.CachegroupID = util.IntPtr(500)
+	origin1.HostName = util.StrPtr("myorigin1")
+	origin1.ID = util.IntPtr(46)
+	setIP(origin1, "192.168.2.3")
+	origin1.Type = tc.OriginTypeName
+	origin1.TypeID = util.IntPtr(991)
+	origin1.ProfileNames = []string{"serverprofile1", "serverprofile0"}
+
+	servers := []Server{*server, *origin0, *origin1}
+
+	topologies := []tc.Topology{
+		tc.Topology{
+			Name: "t0",
+			Nodes: []tc.TopologyNode{
+				tc.TopologyNode{
+					Cachegroup: "edgeCG",
+					Parents:    []int{1},
+				},
+				tc.TopologyNode{
+					Cachegroup: "originCG",
+				},
+			},
+		},
+	}
+
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = server.Cachegroup
+	eCG.ID = server.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *origin0.ID,
+			DeliveryService: *ds1.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *origin1.ID,
+			DeliveryService: *ds1.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	cfg, err := MakeParentDotConfig(dses, server, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, hdr.HdrComment)
+
+	if !strings.Contains(txt, "myorigin0.mydomain.example.net:80|200") {
+		t.Errorf("expected origin 0 with profiles [0,1] to have weight 200 from profile 1, actual: '%v'", txt)
+	}
+	if !strings.Contains(txt, "myorigin1.mydomain.example.net:80|100") {
+		t.Errorf("expected origin 0 with profiles [1,0] to have weight 100 from profile 0, actual: '%v'", txt)
+	}
+}
+
 // warningsContains returns whether the given warnings has str as a substring of any warning.
 // Note this is different than lib/go-util.ContainsStr, which only returns if the array has the exact value as one of its values.
 func warningsContains(warnings []string, str string) bool {


### PR DESCRIPTION
Fixes more places of t3c and lib/go-atscfg to layer profiles

I think this is the last of the t3c profile layering stuff. Halfway between bug and feature. Part of a new feature, but will be a bug if it isn't added before the next release.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c, verify behavior is still correct for single profile. Can't currently assign multiple profiles in TO, but you could hypothetically manually test multiple by running t3c-request, saving the output, manually editing it to have multiple profiles, then passing that to t3c-generate.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix / not in a release.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, layered profiles docs already exist, and t3c behavior doesn't do anything special <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, changelog for layered profiles already exists <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
