### PR TITLE
Change t3c non-topo non-parent line to origin

### DIFF
--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -524,6 +524,13 @@ func makeParentDotConfigData(
 					warnings = append(warnings, "DS '"+*ds.XMLID+"' had malformed origin  port: '"+orgURI.Port()+"': using "+strconv.Itoa(text.Port)+"! : "+err.Error())
 				}
 				text.GoDirect = true
+
+				text.Parents = []*ParentAbstractionServiceParent{&ParentAbstractionServiceParent{
+					FQDN:   text.DestDomain,
+					Port:   text.Port,
+					Weight: 1.0,
+				}}
+
 				// text += `dest_domain=` + orgURI.Hostname() + ` port=` + orgURI.Port() + ` go_direct=true` + "\n"
 			} else {
 


### PR DESCRIPTION
Previously, t3c non-topology DSes which didn't use parents would omit
the parent= from the parent.config line. The ATS docs seem to
indicate that should have worked, but it seems to only work for very
specific settings, e.g. parent_is_proxy=false made the line break
(along with potentially other settings).

This changes those DSes to set parent=origin, which appears to make
ATS behave correctly with parent_is_proxy, go_direct, and other
necessary settings.

Note Topology DSes were already doing this, this effectively
changes non-topo to match topo generation.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Generate config for a non-topology DS that doesn't use parents, verify parent.config line includes parent=origin, verify ATS works as expected with the generated parent.config and remap.config lines.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not in a release.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, bug isn't in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
