### PR TITLE
t3c/regex_revalidate: remove STALE keyword for default rule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added layered profile feature to 4.0 for `GET` /servers/, `POST` /servers/, `PUT` /servers/{id} and `DELETE` /servers/{id}.
 - Added a Traffic Ops endpoint and Traffic Portal page to view all CDNi configuration update requests and approve or deny.
 - Added layered profile feature to 4.0 for `GET` /deliveryservices/{id}/servers/ and /deliveryservices/{id}/servers/eligible.
+- Change to t3c regex_revalidate so that STALE is no longer explicitly added for default revalidate rule for ATS version backwards compatibility.
 
 ### Fixed
 - [#6291](https://github.com/apache/trafficcontrol/issues/6291) Prevent Traffic Ops from modifying and/or deleting reserved statuses.

--- a/cache-config/testing/ort-tests/t3c-jobs_test.go
+++ b/cache-config/testing/ort-tests/t3c-jobs_test.go
@@ -74,8 +74,8 @@ func TestT3CJobs(t *testing.T) {
 			}
 			if strings.Contains(line, "refresh-test") {
 				sawRefresh = true
-				if !strings.HasSuffix(line, "STALE") {
-					t.Errorf("expected regex_revalidate.config refresh-test line to contain 'STALE', actual: %s", line)
+				if strings.HasSuffix(line, "STALE") || strings.HasSuffix(line, "MISS") {
+					t.Errorf("expected regex_revalidate.config refresh-test line to contain no type, actual: %s", line)
 				}
 			}
 			if strings.Contains(line, "refetch-test") {

--- a/lib/go-atscfg/regexrevalidatedotconfig.go
+++ b/lib/go-atscfg/regexrevalidatedotconfig.go
@@ -41,6 +41,12 @@ const DefaultMaxRevalDurationDays = 90
 const JobKeywordPurge = "PURGE"
 const RegexRevalidateMinTTL = time.Hour
 
+type RevalType string
+
+const MISS = RevalType("MISS")
+const STALE = RevalType("STALE")
+const DefaultRevalType = STALE
+
 const ContentTypeRegexRevalidateDotConfig = ContentTypeTextASCII
 const LineCommentRegexRevalidateDotConfig = LineCommentHash
 
@@ -110,8 +116,8 @@ func MakeRegexRevalidateDotConfig(
 	txt := makeHdrComment(opt.HdrComment)
 	for _, job := range cfgJobs {
 		txt += job.AssetURL + " " + strconv.FormatInt(job.PurgeEnd.Unix(), 10)
-		if job.Type != "" {
-			txt += " " + job.Type
+		if job.Type != "" && job.Type != DefaultRevalType {
+			txt += " " + string(job.Type)
 		}
 		txt += "\n"
 	}
@@ -127,7 +133,7 @@ func MakeRegexRevalidateDotConfig(
 type revalJob struct {
 	AssetURL string
 	PurgeEnd time.Time
-	Type     string // MISS or STALE (default)
+	Type     RevalType // MISS or STALE (default)
 }
 
 type jobsSort []revalJob
@@ -188,13 +194,10 @@ func filterJobs(tcJobs []InvalidationJob, maxReval time.Duration, minTTL time.Du
 	return newJobs
 }
 
-const MISS = "MISS"
-const STALE = "STALE"
-
 // processRefetch determines the type of Invalidation, returns the corresponding jobtype
 // and "cleans" the regex URL for the asset to be invalidated. REFETCH trumps REFRESH,
 // whether in the AssetURL or as InvalidationType
-func processRefetch(invalidationType, assetURL string) (string, string) {
+func processRefetch(invalidationType, assetURL string) (RevalType, string) {
 
 	if (len(invalidationType) > 0 && invalidationType == tc.REFETCH) || strings.HasSuffix(assetURL, RefetchSuffix) {
 		assetURL = strings.TrimSuffix(assetURL, RefetchSuffix)

--- a/lib/go-atscfg/regexrevalidatedotconfig.go
+++ b/lib/go-atscfg/regexrevalidatedotconfig.go
@@ -43,9 +43,9 @@ const RegexRevalidateMinTTL = time.Hour
 
 type RevalType string
 
-const MISS = RevalType("MISS")
-const STALE = RevalType("STALE")
-const DefaultRevalType = STALE
+const RevalTypeMiss = RevalType("MISS")
+const RevalTypeStale = RevalType("STALE")
+const RevalTypeDefault = RevalTypeStale
 
 const ContentTypeRegexRevalidateDotConfig = ContentTypeTextASCII
 const LineCommentRegexRevalidateDotConfig = LineCommentHash
@@ -116,7 +116,7 @@ func MakeRegexRevalidateDotConfig(
 	txt := makeHdrComment(opt.HdrComment)
 	for _, job := range cfgJobs {
 		txt += job.AssetURL + " " + strconv.FormatInt(job.PurgeEnd.Unix(), 10)
-		if job.Type != "" && job.Type != DefaultRevalType {
+		if job.Type != "" && job.Type != RevalTypeDefault {
 			txt += " " + string(job.Type)
 		}
 		txt += "\n"
@@ -133,7 +133,7 @@ func MakeRegexRevalidateDotConfig(
 type revalJob struct {
 	AssetURL string
 	PurgeEnd time.Time
-	Type     RevalType // MISS or STALE (default)
+	Type     RevalType // RevalTypeMiss or RevalTypeStale (default)
 }
 
 type jobsSort []revalJob
@@ -201,11 +201,11 @@ func processRefetch(invalidationType, assetURL string) (RevalType, string) {
 
 	if (len(invalidationType) > 0 && invalidationType == tc.REFETCH) || strings.HasSuffix(assetURL, RefetchSuffix) {
 		assetURL = strings.TrimSuffix(assetURL, RefetchSuffix)
-		return MISS, assetURL
+		return RevalTypeMiss, assetURL
 	}
 
 	// Default value. Either the InvalidationType == REFRESH
 	// or the suffix is ##REFRESH## or neither
 	assetURL = strings.TrimSuffix(assetURL, RefreshSuffix)
-	return STALE, assetURL
+	return RevalTypeStale, assetURL
 }

--- a/lib/go-atscfg/regexrevalidatedotconfig_test.go
+++ b/lib/go-atscfg/regexrevalidatedotconfig_test.go
@@ -122,7 +122,7 @@ func TestMakeRegexRevalidateDotConfig(t *testing.T) {
 	if strings.Contains(txt, "##REFETCH##") || !strings.Contains(txt, "MISS") {
 		t.Errorf("##REFETCH## directive not properly handled '%v'", txt)
 	}
-	if strings.Contains(txt, "##REFRESH##") || !strings.Contains(txt, "STALE") {
+	if strings.Contains(txt, "##REFRESH##") {
 		t.Errorf("##REFRESH## directive not properly handled '%v'", txt)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:
-->
Closes: #6858 
<!--
If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Fix to t3c's regex_revalidate handling to NOT add STALE to the end of a default regex_revalidate rule.  This allow for greater ATS version compatibility.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Create a default regex_revalidate rule with STALE.  Generated t3c file should not contain STALE anywhere in the file.  REFRESH rules will still have MISS in the same file.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation -- minor behavior change.
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
