### PR TITLE
Fix t3c cache to invalidate on version change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Correction where using the placeholder `__HOSTNAME__` in "unknown" files (others than the defaults ones), was being replaced by the full FQDN instead of the shot hostname.
 - [#6800](https://github.com/apache/trafficcontrol/issues/6800) Fixed incorrect error message for `/server/details` associated with query parameters.
 - [#6712](https://github.com/apache/trafficcontrol/issues/6712) - Fixed error when loading the Traffic Vault schema from `create_tables.sql` more than once.
+- [#6883](https://github.com/apache/trafficcontrol/issues/6883) Fix t3c cache to invalidate on version change
 - [#6834](https://github.com/apache/trafficcontrol/issues/6834) - In API 4.0, fixed `GET` for `/servers` to display all profiles irrespective of the index position. Also, replaced query param `profileId` with `profileName`.
 - [#6299](https://github.com/apache/trafficcontrol/issues/6299) User representations don't match
 - [#6776](https://github.com/apache/trafficcontrol/issues/6776) User properties only required sometimes

--- a/cache-config/t3c-request/config/config.go
+++ b/cache-config/t3c-request/config/config.go
@@ -162,6 +162,7 @@ func InitConfig(appVersion string, gitRevision string) (Cfg, error) {
 			TOURL:          toURLParsed,
 			RevalOnly:      *revalOnlyPtr,
 			TODisableProxy: *disableProxyPtr,
+			T3CVersion:     gitRevision,
 		},
 		Version:     appVersion,
 		GitRevision: gitRevision,

--- a/cache-config/t3cutil/getdata.go
+++ b/cache-config/t3cutil/getdata.go
@@ -54,6 +54,10 @@ type TCCfg struct {
 
 	// OldCfg is the previously fetched ConfigData, for 'config' requests. May be nil.
 	OldCfg *ConfigData
+
+	// T3CVersion is the version of the t3c app ecosystem
+	// This value will be the same for any t3c app.
+	T3CVersion string
 }
 
 func GetDataFuncs() map[string]func(TCCfg, io.Writer) error {
@@ -254,7 +258,7 @@ func SetUpdateStatusCompat(cfg TCCfg, serverName tc.CacheName, configApply, reva
 
 // WriteConfig writes the Traffic Ops data necessary to generate config to output.
 func WriteConfig(cfg TCCfg, output io.Writer) error {
-	cfgData, err := GetConfigData(cfg.TOClient, cfg.TODisableProxy, cfg.CacheHostName, cfg.RevalOnly, cfg.OldCfg)
+	cfgData, err := GetConfigData(cfg.TOClient, cfg.TODisableProxy, cfg.CacheHostName, cfg.RevalOnly, cfg.OldCfg, cfg.T3CVersion)
 	if err != nil {
 		return errors.New("getting config data: " + err.Error())
 	}

--- a/cache-config/t3cutil/getdatacfg.go
+++ b/cache-config/t3cutil/getdatacfg.go
@@ -39,6 +39,10 @@ import (
 const TrafficOpsProxyParameterName = `tm.rev_proxy.url`
 
 type ConfigData struct {
+	// Version is the version of the application which created the config data,
+	// primarily used for cache invalidation.
+	Version string `json:"version"`
+
 	// Servers must be all the servers from Traffic Ops. May include servers not on the current cdn.
 	Servers []atscfg.Server `json:"servers,omitempty"`
 
@@ -173,14 +177,26 @@ func MakeReqMetaData(respHdr http.Header) ReqMetaData {
 //
 // The cacheHostName is the hostname of the cache to get config generation data for.
 //
+// The oldCfg is previous config data which was cached. May be nil, if the caller has no previous data.
+// If it exists and is usable, If-Modified-Since requests will be made and the cache re-used where possible.
+//
+// The version is a unique version of the application, which should change with any compatibility changes.
+// Old config with a different version than the current won't be used (though in the future, smarter compatibility could be added).
+//
 // The revalOnly arg is whether to only get data necessary to revalidate, versus all data necessary to generate cache config.
-func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName string, revalOnly bool, oldCfg *ConfigData) (*ConfigData, error) {
+func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName string, revalOnly bool, oldCfg *ConfigData, version string) (*ConfigData, error) {
 	start := time.Now()
 	defer func() { log.Infof("GetTOData took %v\n", time.Since(start)) }()
 
 	toIPs := &sync.Map{} // each Traffic Ops request could get a different IP, so track them all
 	toData := &ConfigData{}
+	toData.Version = version
 	toData.MetaData.CacheHostName = cacheHostName
+
+	if oldCfg != nil && oldCfg.Version != toData.Version {
+		log.Infof("old config version '%s' doesn't match current version '%s', old config will not be used!\n", oldCfg.Version, toData.Version)
+		oldCfg = nil
+	}
 
 	serverProfilesParams := &sync.Map{}         // map[atscfg.ProfileName][]tc.Parameter
 	serverProfilesParamsMetaData := &sync.Map{} // map[atscfg.ProfileName]ReqMetaData


### PR DESCRIPTION
Previously, both upgrades and downgrades of `trafficcontrol-cache-config` could cause strange issues in config generation, from trying to re-use a cache with incompatibilities resulting in missing or different fields.

This fixes t3c to invalidate the cache if the running version is different than the version which created the cache.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run a previous version of t3c, upgrade, verify from log messages and/or HTTP IMS requests that the cache is not used.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0.0
- 6.0.1
- 6.0.2
- 6.1.0

## PR submission checklist
- ~[x] This PR has tests~ no tests, testing requires HTTP requests and thus can't be unit tested, and integration tests don't support multiple versions yet.
- ~[x] This PR has documentation~ no docs, cache behavior is not documented.
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
