### PR TITLE
Fix user update to raise exception when the username contains spaces

### DIFF
--- a/lib/go-tc/users.go
+++ b/lib/go-tc/users.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-rfc"
@@ -487,6 +488,8 @@ func (u *CurrentUserUpdateRequestUser) UnmarshalAndValidate(user *User) error {
 			errs = append(errs, fmt.Errorf("username: %w", err))
 		} else if user.Username == nil || *user.Username == "" {
 			errs = append(errs, errors.New("username: cannot be null or empty string"))
+		} else if strings.Contains(*user.Username, " ") {
+			errs = append(errs, errors.New("username: cannot contain spaces"))
 		}
 	}
 

--- a/traffic_ops/testing/api/v2/user_test.go
+++ b/traffic_ops/testing/api/v2/user_test.go
@@ -17,13 +17,13 @@ package v2
 import (
 	"bytes"
 	"fmt"
-	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"net/http"
 	"net/mail"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-rfc"
 	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/lib/go-util"
 	toclient "github.com/apache/trafficcontrol/traffic_ops/v2-client"
@@ -272,6 +272,30 @@ func UserSelfUpdateTest(t *testing.T) {
 		t.Errorf("Email missing or null after update")
 	} else if *resp2[0].Email != currentEmail {
 		t.Errorf("Expected Email to still be '%s', but it was '%s'", currentEmail, *resp2[0].Email)
+	}
+
+	// Now test using an invalid username
+	currentUsername := *user.Username
+	user.Username = new("ops man")
+	updateResp, _, err = TOSession.UpdateCurrentUser(user)
+	if err == nil {
+		t.Fatal("error was expected updating user with username: 'ops man' - got none")
+	}
+
+	// Ensure it wasn't actually updated
+	resp2, _, err = TOSession.GetUserByID(*user.ID)
+	if err != nil {
+		t.Fatalf("error getting user #%d: %v", *user.ID, err)
+	}
+
+	if len(resp2) < 1 {
+		t.Fatalf("no user returned when requesting user #%d", *user.ID)
+	}
+
+	if resp2[0].Username == nil {
+		t.Errorf("Username missing or null after update")
+	} else if *resp2[0].Username != currentUsername {
+		t.Errorf("Expected Username to still be '%s', but it was '%s'", currentUsername, *resp2[0].Username)
 	}
 }
 


### PR DESCRIPTION
This PR fixes #4240 by adding checks to raise an exception when the username contains spaces.
<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Run integration tests

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
