### PR TITLE
Fix Traffic Portal affected server count in Profile change confirmation dialogs

### DIFF
--- a/traffic_portal/app/src/common/modules/table/profilesParamsCompare/TableProfilesParamsCompareController.js
+++ b/traffic_portal/app/src/common/modules/table/profilesParamsCompare/TableProfilesParamsCompareController.js
@@ -22,17 +22,13 @@ var TableProfilesParamsCompareController = function(profile1, profile2, profiles
 	let updateProfile1 = false,
 		updateProfile2 = false;
 
-	let getProfileUsage = function(profile, profNum) {
+	async function getProfileUsage(profile, profNum) {
 		if (profile.type === 'DS_PROFILE') { // if this is a ds profile, then it is used by delivery service(s) so we'll fetch the ds count...
-			deliveryServiceService.getDeliveryServices({ profile: profile.id }).
-				then(function(result) {
-					$scope['profile' + profNum + 'Usage'] = result.length + ' delivery services';
-				});
+			const result = await deliveryServiceService.getDeliveryServices({ profile: profile.id });
+			$scope[`profile${profNum}Usage`] = `${result.length} delivery services`;
 		} else { // otherwise the profile is used by servers so we'll fetch the server count...
-			serverService.getServers({ profileId: profile.id }).
-				then(function(result) {
-					$scope['profile' + profNum + 'Usage'] = result.length + ' servers';
-			});
+			const result = await serverService.getServers({ profileName: profile.name });
+			$scope[`profile${profNum}Usage`] = `${result.length} servers`;
 		}
 	};
 


### PR DESCRIPTION
Due to using a removed query string parameter to filter servers by Profile, there were several places in Traffic Portal that would incorrectly report that a Profile was used by all servers across all CDNs. This fixes that by updating the usage of the API to be consistent with the version of it that Traffic Portal uses.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure existing tests still pass, compare two profiles to see their usage, add and remove Parameters to verify that the confirmation dialogs accurately report the number of servers used by the Profile.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**