### PR TITLE
Add t3c metadata file

### DIFF
--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -21,6 +21,7 @@ package t3cutil
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"html"
@@ -29,8 +30,10 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"sort"
 	"strings"
 	"syscall"
+	"time"
 )
 
 type ATSConfigFile struct {
@@ -227,4 +230,183 @@ func UserAgentStr(appName string, versionNum string, gitRevision string) string 
 		gitRevision = gitRevision[:8]
 	}
 	return appName + "/" + versionNum + ".." + gitRevision
+}
+
+// NewApplyMetaData creates a new, empty ApplyMetaData object.
+func NewApplyMetaData() *ApplyMetaData {
+	return &ApplyMetaData{
+		Version:           MetaDataVersion,
+		InstalledPackages: []string{}, // construct a slice, so JSON serializes '[]' not 'null'.
+		OwnedFilePaths:    []string{}, // construct a slice, so JSON serializes '[]' not 'null'.
+	}
+}
+
+// MetaDataVersion is the version of the metadata file.
+// This should update the major version with breaking changes,
+// and t3c versions should strive to maintain compatibility
+// at least one major version back, so features like tracking
+// t3c-owned files continue to work through upgrades.
+const MetaDataVersion = "1.0"
+
+// ApplyMetaData is metadata about a t3c-apply run.
+// Always use NewApplyMetaData, don't use a literal to construct a new object.
+type ApplyMetaData struct {
+	// Version is the metadata version of this metadata object or file. See MetaDataVersion.
+	Version string `json:"version"`
+
+	// ServerFQDN is the FQDN of this server.
+	// The primary purpose of this field is to allow distinguishing
+	// metadata files from different servers.
+	ServerHostName string `json:"server-hostname"`
+
+	// Time is an RFC3339Nano timestamp of the time t3c-apply ran for this metadata.
+	// This should be treated as approximate, as it could be the start time, end time, or
+	// any inexact time in-between.
+	// However, times of different metadata files should always be monotonically increasing.
+	Time string `json:"time"`
+
+	// ReloadedATS is whether this run restarted ATS.
+	// Note this is whether ATS was actually restarted, not whether it would have been,
+	// e.g. because of --report-only or --service-action.
+	ReloadedATS bool `json:"reloaded-ats"`
+
+	// RestartedATS is whether this run restarted ATS.
+	// Note this is whether ATS was actually restarted, not whether it would have been,
+	// e.g. because of --report-only or --service-action.
+	RestartedATS bool `json:"restarted-ats"`
+
+	// UnsetUpdateFlag is whether this t3c-apply run unset the update flag for this server.
+	// Note this is whether the flag was actually unset, not whether it would have been e.g.
+	// because of --no-unset-update-flag or --report-only.
+	UnsetUpdateFlag bool `json:"unset-update-flag"`
+
+	// UnsetRevalFlag is whether this t3c-apply run unset the revalidate flag for this server.
+	// Note this is whether the flag was actually unset, not whether it would have been e.g.
+	// because of --no-unset-reval-flag or --report-only.
+	UnsetRevalFlag bool `json:"unset-reval-flag"`
+
+	// InstalledPackages is which yum packages were installed.
+	// Note this packages actually installed, not what would have been e.g.
+	// because of --install-packages=false or --report-only.
+	InstalledPackages []string `json:"installed-packages"`
+
+	// OwnedFilePaths is the list of files t3c-apply produced in this run.
+	//
+	// This can be used to know which files in the ATS config directory were produced by t3c,
+	// and which were produced by some other means.
+	//
+	// Note this is all files produced, not necessarily all files written to disk. This
+	// will include files generated, but not changed on disk because they had no
+	// semantic diff from the existing file.
+	//
+	// This may be used in the future for t3c-apply to delete files produced by a previous
+	// run which no longer exist (for example, Header Rewrites from a Delivery Service
+	// no longer assigned to this server).
+	//
+	// Files are the full path and file name.
+	OwnedFilePaths []string `json:"owned-files"`
+
+	// Succeeded is whether this t3c-apply run generally succeeded.
+	//
+	// Note not all scenarios are black or white success-or-fail.
+	// For example, files may be successfully created, but reloading ATS may fail.
+	// In these scenarios, t3c-apply will attempt to set Succeeded to false,
+	// but also attempt to set other metadata about what was actually performed.
+	//
+	// But when partial failure occurrs, nothing is guaranteed in the metadata.
+	// Operators should consider the logs authoritative over the metadata.
+	Succeeded bool `json:"succeeded"`
+
+	// PartialSuccess indicates that some actions were successful, but
+	// later actions failed.
+	//
+	// This is a bad place to be, because it means some things were changed,
+	// but not everything that needed to be. This is often not fatal, because,
+	// for example, if config files were changed by ATS failed to reload,
+	// those config files typically needed placed anyway.
+	//
+	// But nevertheless, partial success is potentially catastrophic, and operators
+	// are strongly encouraged to set alarms and read logs in the event it occurs,
+	// to determine what was changed, what failed, and what actions need taken.
+	PartialSuccess bool `json:"partial-success"`
+}
+
+// Format prints the ApplyMetaData in a format designed to be written to a file,
+// and structured but pretty-printed to work well with line-based diffs (e.g. in git).
+func (md *ApplyMetaData) Format() ([]byte, error) {
+	bts, err := json.MarshalIndent(md, "", "  ")
+	if err != nil {
+		return nil, errors.New("marshalling metadata file: " + err.Error())
+	}
+	bts = append(bts, '\n') // newline at the end of the file, so it's a valid POSIX text file
+
+	return bts, nil
+}
+
+// SetTime sets the Time field in the prescribed format, based on the given time.
+// To set to the current time, call SetTime(time.Now()).
+// The format is UTC RFC3339Nano. See ApplyMetaData.
+func (md *ApplyMetaData) SetTime(tm time.Time) {
+	md.Time = tm.UTC().Format(time.RFC3339Nano)
+}
+
+// CombineOwnedFilePaths combines the owned file paths of two metadata objects.
+//
+// This is primarily useful when a config run, such as revalidate, adds owned files, but not
+// all owned files, but we don't want to write metadata incidating we don't own existing files,
+// so this can be used to combine the new files with the previous metadata.
+//
+// Both am and bm are may be nil, in which case the files from the non-nil object is returned,
+// or an empty array if both are nil.
+func CombineOwnedFilePaths(am *ApplyMetaData, bm *ApplyMetaData) []string {
+	if am == nil && bm == nil {
+		return []string{}
+	} else if am == nil {
+		sort.Strings(bm.OwnedFilePaths) // the func guarantees the returned array will always be sorted
+		return bm.OwnedFilePaths
+	} else if bm == nil {
+		sort.Strings(am.OwnedFilePaths) // the func guarantees the returned array will always be sorted
+		return am.OwnedFilePaths
+	}
+	return sortAndCombineStrs(am.OwnedFilePaths, bm.OwnedFilePaths)
+}
+
+// sortAndCombineStrs sorts as and bs, and then returns an array containing
+// the unique strings in each, without duplicates.
+func sortAndCombineStrs(as []string, bs []string) []string {
+	sort.Strings(as)
+	sort.Strings(bs)
+	combined := []string{}
+	ai := 0
+	bi := 0
+	for ai < len(as) && bi < len(bs) {
+		if as[ai] == bs[bi] {
+			combined = append(combined, as[ai])
+			ai++
+			bi++
+			continue
+		}
+		// at this point we know they don't match
+		// so add the lesser, increment it, and loop (but don't add or increment the greater)
+		if as[ai] < bs[bi] {
+			combined = append(combined, as[ai])
+			ai++
+			continue
+		}
+		combined = append(combined, bs[bi])
+		bi++
+	}
+
+	// at this point, we added everything up to the end of one of the arrays,
+	// but potentially not the other. So add the remaining strings in the other
+
+	for ai < len(as) {
+		combined = append(combined, as[ai])
+		ai++
+	}
+	for bi < len(bs) {
+		combined = append(combined, bs[bi])
+		bi++
+	}
+	return combined
 }

--- a/cache-config/t3cutil/t3cutil_test.go
+++ b/cache-config/t3cutil/t3cutil_test.go
@@ -1,0 +1,72 @@
+package t3cutil
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSortAndCombineStrs(t *testing.T) {
+	type Expected struct {
+		InputA   []string
+		InputB   []string
+		Expected []string
+	}
+	expecteds := []Expected{
+		{
+			InputA:   []string{"foo", "bar", "baz"},
+			InputB:   []string{"alpha", "bar", "beta"},
+			Expected: []string{"alpha", "bar", "baz", "beta", "foo"},
+		},
+		{
+			InputA:   []string{"remap.config", "regex_revalidate.config", "parent.config"},
+			InputB:   []string{"regex_revalidate.config"},
+			Expected: []string{"parent.config", "regex_revalidate.config", "remap.config"},
+		},
+		{
+			InputA:   []string{"remap.config", "parent.config"},
+			InputB:   []string{"regex_revalidate.config"},
+			Expected: []string{"parent.config", "regex_revalidate.config", "remap.config"},
+		},
+		{
+			InputA:   []string{},
+			InputB:   []string{"remap.config", "regex_revalidate.config", "parent.config"},
+			Expected: []string{"parent.config", "regex_revalidate.config", "remap.config"},
+		},
+		{
+			InputA:   []string{"remap.config", "regex_revalidate.config", "parent.config"},
+			InputB:   []string{},
+			Expected: []string{"parent.config", "regex_revalidate.config", "remap.config"},
+		},
+		{
+			InputA:   []string{},
+			InputB:   []string{},
+			Expected: []string{},
+		},
+	}
+
+	for _, ex := range expecteds {
+		actual := sortAndCombineStrs(ex.InputA, ex.InputB)
+		if !reflect.DeepEqual(actual, ex.Expected) {
+			t.Errorf("sortAndCombineStrs(%+v,%+v) expected %+v actual %+v", ex.InputA, ex.InputB, ex.Expected, actual)
+		}
+	}
+}

--- a/cache-config/testing/ort-tests/t3c-create-metadata-file_test.go
+++ b/cache-config/testing/ort-tests/t3c-create-metadata-file_test.go
@@ -1,0 +1,61 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/util"
+)
+
+func TestT3cCreateMetaDataFile(t *testing.T) {
+	// t3c should create a metadata file
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		err := t3cUpdateCreateEmptyFile(DefaultCacheHostName, "badass")
+		if err != nil {
+			t.Fatalf("t3c badass failed: %v", err)
+		}
+
+		const metaDataFileName = `t3c-apply-metadata.json`
+
+		filePath := filepath.Join(TestConfigDir, metaDataFileName)
+
+		if !util.FileExists(filePath) {
+			t.Fatalf("missing metadata file '%s'", filePath)
+		}
+
+		mdFileBts, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			t.Fatalf("reading file '%s': %v", filePath, err)
+		}
+
+		// Test that the file is a valid JSON object.
+		// Other than that, we don't want to assert any particular data.
+		mdObj := map[string]interface{}{}
+		if err := json.Unmarshal(mdFileBts, &mdObj); err != nil {
+			t.Errorf("expected metadata file '%s' to be a json object, actual: %s", filePath, err)
+		}
+	})
+}


### PR DESCRIPTION
Adds a t3c metadata file.

Currently, this is just to help operational debugging. No behavior changes, other than writing the file.

But a critical future feature this enables is deleting old files. Currently, t3c never deletes files, because it has no way of knowing what it dropped in the past, versus files in the ATS config directory places manually or by other tools. The metadata file tracks "owned" files, making it possible to safely delete old files. Though this PR doesn't add that.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify a `t3c-apply-metadata.json` file is placed in the ATS config directory, with some useful information about the run.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, the metadata file is not stable or documented <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, no documented behavior changes <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
