### PR TITLE
Fix t3c panic on failed TO request

### DIFF
--- a/cache-config/t3cutil/getdatacfg.go
+++ b/cache-config/t3cutil/getdatacfg.go
@@ -794,10 +794,12 @@ func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName st
 		return true
 	})
 
-	err := error(nil)
-	toData.ServerParams, err = atscfg.GetServerParameters(toData.Server, combineParams(toData.ServerProfilesParams))
-	if err != nil {
-		errs = append(errs, err)
+	if len(errs) == 0 && toData.Server != nil {
+		err := error(nil)
+		toData.ServerParams, err = atscfg.GetServerParameters(toData.Server, combineParams(toData.ServerProfilesParams))
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	return toData, util.JoinErrs(errs)
@@ -835,7 +837,10 @@ func runParallel(fs []func() error) []error {
 		go func() { doneChan <- f() }()
 	}
 	for i := 0; i < len(fs); i++ {
-		errs = append(errs, <-doneChan)
+		err := <-doneChan
+		if err != nil {
+			errs = append(errs, err)
+		}
 	}
 	return errs
 }


### PR DESCRIPTION
Fixes a t3c panic when the Traffic Ops /servers request fails. When that happens, the t3c run is going to fail anyway, but the panic causes it to not print the real error, the failed request.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Verify normal t3c run succeeds. Verifying the actual fix would be very difficult; you'd have to simulate a TO that succeeds on every request except /servers.

## If this is a bugfix, which Traffic Control versions contained the bug?
- `master`

## PR submission checklist
- ~[x] This PR has tests~ no tests, fix requires integration tests because it involves HTTP requests, and would require an integration test framework capable of simulating very specific server failures, which doesn't exist today and would be considerable work to create. <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, not in a release <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
