### PR TITLE
Fix IMS error: Couldn't get the max last updated time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6834](https://github.com/apache/trafficcontrol/issues/6834) - In API 4.0, fixed `GET` for `/servers` to display all profiles irrespective of the index position. Also, replaced query param `profileId` with `profileName`.
 - [#6299](https://github.com/apache/trafficcontrol/issues/6299) User representations don't match
 - [#6776](https://github.com/apache/trafficcontrol/issues/6776) User properties only required sometimes
+- Fixed TO API `GET /deliveryservicesserver` causing error when an IMS request is made with the `cdn` and `maxRevalDurationDays` parameters set.
 
 ### Removed
 - Remove traffic\_portal dependencies to mitigate `npm audit` issues, specifically `grunt-concurrent`, `grunt-contrib-concat`, `grunt-contrib-cssmin`, `grunt-contrib-jsmin`, `grunt-contrib-uglify`, `grunt-contrib-htmlmin`, `grunt-newer`, and `grunt-wiredep`

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -208,16 +208,20 @@ func (dss *TODeliveryServiceServer) readDSS(h http.Header, tx *sqlx.Tx, user *au
 	}
 	dss.ServerIDs = serverIDs
 	dss.DeliveryServiceIDs = dsIDs
-	cdn := params["cdn"]
+
+	queryValues := map[string]interface{}{}
+	cdn := ""
+	if cdnName, ok := params["cdn"]; ok {
+		cdn = cdnName
+		queryValues["cdn"] = cdnName
+	}
 	dss.CDN = cdn
 	query1, err := selectQuery(orderby, strconv.Itoa(limit), strconv.Itoa(offset), dsIDs, serverIDs, true, cdn)
 	if err != nil {
 		log.Warnf("Error getting the max last updated query %v", err)
 	}
 	if useIMS {
-		queryValues := map[string]interface{}{
-			"accessibleTenants": pq.Array(tenantIDs),
-		}
+		queryValues["accessibleTenants"] = pq.Array(tenantIDs)
 		runSecond, maxTime = ims.TryIfModifiedSinceQuery(tx, h, queryValues, query1)
 		if !runSecond {
 			log.Debugln("IMS HIT")


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes this IMS error:

```
ERROR: ims.go:65: 2022-06-17T16:48:00.814904484Z: Couldn't get the max last updated time: could not find name cdn in map[string]interface {}{"accessibleTenants":pq.GenericArray{A:[]int{...}}}
``` 

This error occurs whenever there is a `GET` request made to: `/api/4.0/deliveryserviceserver?cdn=CDN-in-a-Box&maxRevalDurationDays=""` with those query parameters and the `If-Modified-Since` Header. 

This issue is due to deliveryserviceserver not setting the right variable when the cdn query parameter is set.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops



## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Before this change if you build CiaB and check the error.log you will see:

```
ERROR: ims.go:65: 2022-06-17T16:48:00.814904484Z: Couldn't get the max last updated time: could not find name cdn in map[string]interface {}{"accessibleTenants":pq.GenericArray{A:[]int{1, 2, 3, 4, 5, 6}}}
``` 

After this change if you build CiaB you will no longer see the error above.

You can also verify by making a `GET` request to `/api/4.0/deliveryserviceserver?cdn=CDN-in-a-Box&maxRevalDurationDays=""` with the `If-Modified-Since` header set. 

Check the `error.log` and you should not see any error. 


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
6.1.x


## PR submission checklist
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
