### PR TITLE
Update unversioned references to Traffic Ops client library to API v4

### DIFF
--- a/cache-config/t3c-generate/update-to-client/update-to-client.go
+++ b/cache-config/t3c-generate/update-to-client/update-to-client.go
@@ -86,7 +86,7 @@ The arguments are the t3c-generate directory, and the name of the branch to vend
 
 This script should always be called from trafficcontrol/cache-config/t3c-generate.
 
-It copies the traffic_ops/client from that branch into toreq/vendor,
+It copies the traffic_ops/v4-client from that branch into toreq/vendor,
 and then updates all references to cfg.TOClientNew to cfg.TOClient.
 
 This must be done as soon as a release is made, before any new features are added to t3c-generate.

--- a/cache-config/t3c-generate/update-to-client/update-to-client.go
+++ b/cache-config/t3c-generate/update-to-client/update-to-client.go
@@ -72,7 +72,7 @@ Also be aware! This is very specific to the current code. If symbols or patterns
 
 Expecations:
 - t3c-generate is at github.com/apache/trafficcontrol/cache-config/t3c-generate
-- The master TO client is at github.com/apache/trafficcontrol/traffic_ops/client
+- The master TO client is at github.com/apache/trafficcontrol/traffic_ops/v4-client
 - The previous major version client is vendored at t3c-generate/toreq/vendor
 - The master client wrapper for t3c-generate is at t3c-generate/toreqnew
 - The clients are stored in config.TCCfg.TOClient and config.TCCfg.TOClientNew

--- a/docs/source/development/traffic_ops.rst
+++ b/docs/source/development/traffic_ops.rst
@@ -147,7 +147,7 @@ Traffic Ops Project Tree Overview
 	- ort/ - Contains :term:`ORT` and :abbr:`ATS (Apache Traffic Server)` configuration file-generation logic and tooling
 	- testing/ - Holds utilities for testing the :ref:`to-api`
 
-		- api/ - Integration testing for the `Traffic Ops Go client <https://pkg.go.dev/github.com/apache/trafficcontrol/traffic_ops/client>`_ and Traffic Ops
+		- api/ - Integration testing for the `Traffic Ops Go client <https://pkg.go.dev/github.com/apache/trafficcontrol/traffic_ops/v4-client>`_ and Traffic Ops
 
 	- traffic_ops_golang/ - The root of the Go implementation's code-base
 

--- a/docs/source/development/traffic_stats.rst
+++ b/docs/source/development/traffic_stats.rst
@@ -46,8 +46,8 @@ In general `Go fmt <https://golang.org/cmd/gofmt/>`_ is the standard for formatt
 Installing The Developer Environment
 ====================================
 #. Clone the traffic_control repository using Git into a location accessible by your $GOPATH
-#. Navigate to the traffic_ops/client directory of your cloned repository. (This is the directory containing Traffic Ops client code used by Traffic Stats)
-#. From the traffic_ops/client directory run ``go test`` to test the client code. This will run all unit tests for the client and return the results. If there are missing dependencies you will need to run ``go mod vendor -v`` to get the dependencies
+#. Navigate to the :atc-file:`traffic_ops/v4-client` directory of your cloned repository. (This is the directory containing Traffic Ops client code used by Traffic Stats)
+#. From the :atc-file:`traffic_ops/v4-client` directory, run ``go test`` to test the client code. This will run all unit tests for the client and return the results. If there are missing dependencies you will need to run ``go mod vendor -v`` to get the dependencies
 #. Once the tests pass, run ``go install`` to build and install the Traffic Ops client package. This makes it accessible to Traffic Stats.
 #. Navigate to your cloned repository under Traffic Stats
 #. Run ``go build traffic_stats.go`` to build traffic_stats.  You will need to run ``go mod vendor -v`` for any missing dependencies.

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -80,7 +80,7 @@ func ToDeliveryServices(dses []tc.DeliveryServiceV40) []DeliveryService {
 	return ad
 }
 
-// V40ToDeliveryServices converts a slice of the old traffic_ops/client type to the local alias.
+// V40ToDeliveryServices converts a slice of the old traffic_ops/v4-client type to the local alias.
 func V40ToDeliveryServices(dses []tc.DeliveryServiceV40) []DeliveryService {
 	ad := make([]DeliveryService, 0, len(dses))
 	for _, ds := range dses {


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR updates places in the codebase (besides the changelog that reference `github.com/apache/trafficcontrol/traffic_ops/client` to instead reference `github.com/apache/trafficcontrol/traffic_ops/v4-client`).
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Control Cache Config (`t3c`, formerly ORT)

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->