### PR TITLE
Fix TR db file permissions

### DIFF
--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -308,8 +308,8 @@ public abstract class AbstractServiceUpdater {
 			deleteDatabase(existingDB);
 		}
 
-		newDB.setReadable(true, true);
-		newDB.setWritable(true, false);
+		newDB.setReadable(true);
+		newDB.setWritable(true);
 		final boolean renamed = newDB.renameTo(existingDB);
 
 		if (!renamed) {
@@ -325,8 +325,8 @@ public abstract class AbstractServiceUpdater {
 		LOGGER.info("[" + getClass().getSimpleName() + "] Moving Location database from: " + newDB + ", to: " + existingDB);
 
 		for (final File file : existingDB.listFiles()) {
-			file.setReadable(true, true);
-			file.setWritable(true, false);
+			file.setReadable(true);
+			file.setWritable(true);
 			file.delete();
 		}
 
@@ -367,6 +367,8 @@ public abstract class AbstractServiceUpdater {
 		}
 
 		final File outputFile = File.createTempFile(tmpPrefix, tmpSuffix);
+		outputFile.setReadable(true);
+		outputFile.setWritable(true);
 		try (InputStream in = conn.getInputStream();
 			 OutputStream out = new FileOutputStream(outputFile)
 		) {

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/util/AbstractResourceWatcher.java
@@ -154,6 +154,8 @@ public abstract class AbstractResourceWatcher extends AbstractServiceUpdater {
 		File databaseFile = null;
 		try {
 			databaseFile = File.createTempFile(tmpPrefix, tmpSuffix);
+			databaseFile.setReadable(true);
+			databaseFile.setWritable(true);
 			try (FileWriter fw = new FileWriter(databaseFile)) {
 				fw.write(jsonData);
 				fw.flush();


### PR DESCRIPTION
By default, some files created by TR in the /opt/traffic_router/db
directory are world-writable. Make these files only writable by the
owner (typically root) when they're created.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run TR, ensure that the files in the `/opt/traffic_router/db` directory are created as writable by the owner/user. Note: for existing files that remain unchanged, the existing file permissions will remain in place, so to test this you may need to delete existing files in the `db` directory or make a change in Traffic Ops (e.g. federations) which would change the resulting file.

## If this is a bugfix, which Traffic Control versions contained the bug?
all of the supported versions


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
