### PR TITLE
Add cache config action log

### DIFF
--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -1037,10 +1037,13 @@ func (r *TrafficOpsReq) RevalidateWhileSleeping(metaData *t3cutil.ApplyMetaData)
 
 		updateStatus, err := r.ProcessConfigFiles(metaData)
 		if err != nil {
+			t3cutil.WriteActionLog(t3cutil.ActionLogActionUpdateFilesReval, t3cutil.ActionLogStatusFailure, metaData)
 			return updateStatus, err
+		} else {
+			t3cutil.WriteActionLog(t3cutil.ActionLogActionUpdateFilesReval, t3cutil.ActionLogStatusSuccess, metaData)
 		}
 
-		if err := r.StartServices(&updateStatus); err != nil {
+		if err := r.StartServices(&updateStatus, metaData); err != nil {
 			return updateStatus, errors.New("failed to start services: " + err.Error())
 		}
 
@@ -1057,7 +1060,7 @@ func (r *TrafficOpsReq) RevalidateWhileSleeping(metaData *t3cutil.ApplyMetaData)
 // StartServices reloads, restarts, or starts ATS as necessary,
 // according to the changed config files and run mode.
 // Returns nil on success or any error.
-func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
+func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus, metaData *t3cutil.ApplyMetaData) error {
 	serviceNeeds := t3cutil.ServiceNeedsNothing
 	if r.Cfg.ServiceAction == t3cutil.ApplyServiceActionFlagRestart {
 		serviceNeeds = t3cutil.ServiceNeedsRestart
@@ -1103,8 +1106,10 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
 			startStr = "start"
 		}
 		if _, err := util.ServiceStart("trafficserver", startStr); err != nil {
+			t3cutil.WriteActionLog(t3cutil.ActionLogActionATSRestart, t3cutil.ActionLogStatusFailure, metaData)
 			return errors.New("failed to restart trafficserver")
 		}
+		t3cutil.WriteActionLog(t3cutil.ActionLogActionATSRestart, t3cutil.ActionLogStatusSuccess, metaData)
 		log.Infoln("trafficserver has been " + startStr + "ed")
 		if *syncdsUpdate == UpdateTropsNeeded {
 			*syncdsUpdate = UpdateTropsSuccessful
@@ -1119,11 +1124,15 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus) error {
 		} else if serviceNeeds == t3cutil.ServiceNeedsReload {
 			log.Infoln("ATS configuration has changed, Running 'traffic_ctl config reload' now.")
 			if _, _, err := util.ExecCommand(config.TSHome+config.TrafficCtl, "config", "reload"); err != nil {
+				t3cutil.WriteActionLog(t3cutil.ActionLogActionATSReload, t3cutil.ActionLogStatusFailure, metaData)
+
 				if *syncdsUpdate == UpdateTropsNeeded {
 					*syncdsUpdate = UpdateTropsFailed
 				}
 				return errors.New("ATS configuration has changed and 'traffic_ctl config reload' failed, check ATS logs: " + err.Error())
 			}
+			t3cutil.WriteActionLog(t3cutil.ActionLogActionATSReload, t3cutil.ActionLogStatusSuccess, metaData)
+
 			if *syncdsUpdate == UpdateTropsNeeded {
 				*syncdsUpdate = UpdateTropsSuccessful
 			}

--- a/cache-config/t3cutil/actionlog.go
+++ b/cache-config/t3cutil/actionlog.go
@@ -1,0 +1,87 @@
+package t3cutil
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-log"
+)
+
+// ActionLogAction is an action t3c performs which affects the state of the machine.
+// Things that don't affect the state of the machine are not considered actions.
+//
+// For example, requesting Traffic Ops is not an 'action',
+// but restarting ATS or modifying a config file is.
+//
+// Actions also include the t3c-apply run starting and finishing,
+// to help delineate the actions of different runs in the log.
+//
+type ActionLogAction string
+
+const (
+	// ActionLogActionApplyStart is the start of the t3c-apply run.
+	// The status of this should always be success.
+	ActionLogActionApplyStart = ActionLogAction("apply-start")
+
+	// ActionLogActionGitInit is creating a git repo in the ATS config directory.
+	ActionLogActionGitInit = ActionLogAction("git-init")
+
+	// ActionLogActionGitCommitInitial is the initial commit at the start of the run.
+	ActionLogActionGitCommitInitial = ActionLogAction("create-git-commit-initial")
+
+	// ActionLogActionGitCommitInitial is the final commit at the end of the run.
+	ActionLogActionGitCommitFinal = ActionLogAction("create-git-commit-final")
+
+	// ActionLogActionUpdateFilesAll is writing and updating ATS config files.
+	ActionLogActionUpdateFilesAll = ActionLogAction("update-files-all")
+
+	// ActionLogActionUpdateFilesReval is writing and updating only revalidate ATS config files.
+	ActionLogActionUpdateFilesReval = ActionLogAction("update-files-reval")
+
+	// ActionLogActionATSReload is calling service reload on ATS.
+	ActionLogActionATSReload = ActionLogAction("ats-reload")
+
+	// ActionLogActionATSReload is calling service restart on ATS.
+	ActionLogActionATSRestart = ActionLogAction("ats-restart")
+
+	// ActionLogActionApplyEnd is the end of the t3c-apply run.
+	ActionLogActionApplyEnd = ActionLogAction("apply-end")
+)
+
+type ActionLogStatus string
+
+const (
+	ActionLogStatusSuccess = ActionLogStatus("success")
+	ActionLogStatusFailure = ActionLogStatus("failure")
+)
+
+// WriteActionLog writes the given action and status to both the info log and the given metadata object.
+//
+// The metaData may be nil, and should be if this is being called after the final git commit,
+// to prevent modifying the file after the commit.
+//
+func WriteActionLog(action ActionLogAction, status ActionLogStatus, metaData *ApplyMetaData) {
+	if metaData != nil {
+		metaData.Actions = append(metaData.Actions, ApplyMetaDataAction{
+			Action: string(action),
+			Status: string(status),
+		})
+	}
+	log.Infoln(`ACTION='` + string(action) + `' STATUS='` + string(status) + `'` + "\n")
+}

--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -236,8 +236,9 @@ func UserAgentStr(appName string, versionNum string, gitRevision string) string 
 func NewApplyMetaData() *ApplyMetaData {
 	return &ApplyMetaData{
 		Version:           MetaDataVersion,
-		InstalledPackages: []string{}, // construct a slice, so JSON serializes '[]' not 'null'.
-		OwnedFilePaths:    []string{}, // construct a slice, so JSON serializes '[]' not 'null'.
+		InstalledPackages: []string{},              // construct a slice, so JSON serializes '[]' not 'null'.
+		OwnedFilePaths:    []string{},              // construct a slice, so JSON serializes '[]' not 'null'.
+		Actions:           []ApplyMetaDataAction{}, // construct a map, so JSON serializes '{}' not 'null'.
 	}
 }
 
@@ -329,6 +330,12 @@ type ApplyMetaData struct {
 	// are strongly encouraged to set alarms and read logs in the event it occurs,
 	// to determine what was changed, what failed, and what actions need taken.
 	PartialSuccess bool `json:"partial-success"`
+
+	Actions []ApplyMetaDataAction `json:"actions"`
+}
+type ApplyMetaDataAction struct {
+	Action string `json:"action"`
+	Status string `json:"status"`
 }
 
 // Format prints the ApplyMetaData in a format designed to be written to a file,

--- a/cache-config/testing/ort-tests/t3c-action-log_test.go
+++ b/cache-config/testing/ort-tests/t3c-action-log_test.go
@@ -1,0 +1,44 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+)
+
+func TestT3cActionLog(t *testing.T) {
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		stdErr, exitCode := t3cUpdateReload(DefaultCacheHostName, "badass")
+		if exitCode != 0 {
+			t.Fatalf("t3c badass failed, code: %v", exitCode)
+		}
+
+		startActionMsg := `ACTION='` + t3cutil.ActionLogActionApplyStart + `'`
+		if !strings.Contains(stdErr, string(startActionMsg)) {
+			t.Errorf("expected log to contain action log message '%s', actual: %s", startActionMsg, string(stdErr))
+		}
+
+	})
+}

--- a/cache-config/testing/ort-tests/t3c-create-metadata-file_test.go
+++ b/cache-config/testing/ort-tests/t3c-create-metadata-file_test.go
@@ -18,8 +18,10 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
 	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/util"
 )
@@ -57,5 +59,14 @@ func TestT3cCreateMetaDataFile(t *testing.T) {
 		if err := json.Unmarshal(mdFileBts, &mdObj); err != nil {
 			t.Errorf("expected metadata file '%s' to be a json object, actual: %s", filePath, err)
 		}
+
+		metaDataStr := string(mdFileBts)
+		if !strings.Contains(metaDataStr, `"actions":`) {
+			t.Errorf("expected metadata file '%s' to contain action log, actual: %s", filePath, metaDataStr)
+		}
+		if !strings.Contains(metaDataStr, `"`+string(t3cutil.ActionLogActionApplyStart)+`"`) {
+			t.Errorf("expected metadata file '%s' to contain action log apply start message '%v', actual: %s", filePath, t3cutil.ActionLogActionApplyStart, metaDataStr)
+		}
+
 	})
 }


### PR DESCRIPTION
Adds an "action log" to t3c.

It can be difficult to figure out what "actions" t3c actually did, with how spammy the log is. But we need all that log data.
This makes it easy to see changes with e.g. `tail -F syncds.log | grep ACTION`.

It also adds the action data to the metadata file. 

This logs all changes to the local system. For example, fetching data from Traffic Ops isn't an "action," but updating config files and reloading ATS are.

Both are independently useful: the log makes it possible to easily see where an action occurred respective to other log lines, and e.g. to find details about why an action failed in the previous lines. While the metadata file makes it easy to see what actions happened in the latest run, as well as what actions occurred and succeeded or failed in the git config history.

This depends on #6905 - recommend merging that first.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify log and metadata file contain ACTION data.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, log and metadata formats aren't documented or guaranteed to be consistent <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ No changelog, log format isn't documented and metadata file isn't stable enough to be in a public changelog or feature list yet <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
