### PR TITLE
Fix t3c obsolete warning

### DIFF
--- a/lib/go-atscfg/meta.go
+++ b/lib/go-atscfg/meta.go
@@ -74,11 +74,6 @@ func MakeConfigFilesList(
 	atsMajorVer, verWarns := getATSMajorVersion(serverParams)
 	warnings = append(warnings, verWarns...)
 
-	tmURL, tmReverseProxyURL := getTOURLAndReverseProxy(globalParams)
-	if tmURL == "" {
-		warnings = append(warnings, "global tm.url parameter missing or empty! Setting empty in meta config!")
-	}
-
 	dses, dsWarns := filterConfigFileDSes(server, deliveryServices, deliveryServiceServers)
 	warnings = append(warnings, dsWarns...)
 
@@ -134,7 +129,7 @@ locationParamsFor:
 		configFiles = append(configFiles, atsCfg)
 	}
 
-	configFiles, configDirWarns, err := addMetaObjConfigDir(configFiles, configDir, server, tmURL, tmReverseProxyURL, locationParams, uriSignedDSes, dses, cacheGroupArr, topologies, atsMajorVer)
+	configFiles, configDirWarns, err := addMetaObjConfigDir(configFiles, configDir, server, locationParams, uriSignedDSes, dses, cacheGroupArr, topologies, atsMajorVer)
 	warnings = append(warnings, configDirWarns...)
 	return configFiles, warnings, err
 }
@@ -148,8 +143,6 @@ func addMetaObjConfigDir(
 	configFiles []CfgMeta,
 	configDir string,
 	server *Server,
-	tmURL string, // global tm.url Parameter
-	tmReverseProxyURL string, // global tm.rev_proxy.url Parameter
 	locationParams map[string]configProfileParams, // map[configFile]params; 'location' and 'URL' Parameters on serverHostName's Profile
 	uriSignedDSes []tc.DeliveryServiceName,
 	dses map[tc.DeliveryServiceName]DeliveryService,


### PR DESCRIPTION
Removes an unused Parameter and its corresponding warning.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c, verify it still generates as expected. Run t3c against a Traffic Ops with no `tm.url` Parameter, verify no warning is logged about it missing.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.

## PR submission checklist
- ~[x] This PR has tests~ existing tests cover existing behavior, no additional behavior is added <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, no interface change <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
