### PR TITLE
Fix tc-health-client to handle credentials files with special characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6712](https://github.com/apache/trafficcontrol/issues/6712) - Fixed error when loading the Traffic Vault schema from `create_tables.sql` more than once.
 - [#6834](https://github.com/apache/trafficcontrol/issues/6834) - In API 4.0, fixed `GET` for `/servers` to display all profiles irrespective of the index position. Also, replaced query param `profileId` with `profileName`.
 - [#6299](https://github.com/apache/trafficcontrol/issues/6299) User representations don't match
+- [#6933](https://github.com/apache/trafficcontrol/issues/6933) Fixed tc-health-client to handle credentials files with special characters in variables
 - [#6776](https://github.com/apache/trafficcontrol/issues/6776) User properties only required sometimes
 
 ### Removed

--- a/tc-health-client/config/config_test.go
+++ b/tc-health-client/config/config_test.go
@@ -20,6 +20,7 @@ package config
  */
 
 import (
+	"os"
 	"testing"
 
 	"github.com/apache/trafficcontrol/tc-health-client/util"
@@ -112,4 +113,47 @@ func TestLoadConfig(t *testing.T) {
 	if bindir != expect {
 		t.Fatalf("expected '%s', got %s\n", expect, bindir)
 	}
+}
+
+func TestGetCredentialsFromFile(t *testing.T) {
+
+	fi, err := os.CreateTemp("", "creds")
+	if err != nil {
+		t.Fatalf("creating temp credentials file: %v", err)
+	}
+	defer os.Remove(fi.Name())
+
+	credsFileContents := `
+# credentials
+export TO_URL="https://trafficops.example.net"
+export TO_USER="myuser"
+export TO_PASS="mypass"
+`
+	expectedURL := `https://trafficops.example.net`
+	expectedUser := `myuser`
+	expectedPass := `mypass`
+
+	if _, err := fi.Write([]byte(credsFileContents)); err != nil {
+		t.Fatalf("writing temp credentials file: %v", err)
+	}
+
+	if err := fi.Close(); err != nil {
+		t.Fatalf("closing temp credentials file: %v", err)
+	}
+
+	credsFilePath := fi.Name()
+	toURL, toUser, toPass, err := getCredentialsFromFile(credsFilePath)
+	if err != nil {
+		t.Fatalf("getting temp credentials file: %v", err)
+	}
+	if toURL != expectedURL {
+		t.Errorf("credentials file TO URL expected '%v' actual '%v'", expectedURL, toURL)
+	}
+	if toUser != expectedUser {
+		t.Errorf("credentials file TO User expected '%v' actual '%v'", expectedUser, toUser)
+	}
+	if toPass != expectedPass {
+		t.Errorf("credentials file TO Pass expected '%v' actual '%v'", expectedPass, toPass)
+	}
+
 }


### PR DESCRIPTION
Currently, the tc-health-client does its own parsing of the credentials file, and doesn't correctly parse variables with special characters like `=` and ` ` in them.

This fixes it to use `sh` to do the parsing, and return the result of declared variables. This will make it handle all special characters, comments, etc exactly like sh/bash, and should prevent any future issues with parsing.

Fixes #6931

## Which Traffic Control components are affected by this PR?
- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?
Run tc-health-client with a credentials file with ` ` or `=` in the user, password, or URL variables, verify it works correctly.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.1.x (but the Health Client is considered experimental)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
