### PR TITLE
Fix Federation and Steering Test Issues

### DIFF
--- a/traffic_ops/testing/api/v3/federations_test.go
+++ b/traffic_ops/testing/api/v3/federations_test.go
@@ -18,6 +18,7 @@ package v3
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"testing"
 	"time"
 
@@ -230,6 +231,10 @@ func validateFederationFields(expectedResp []map[string]interface{}) utils.CkReq
 			for _, federation := range federationResp {
 				if federation.DeliveryService.String() == expectedFed["DeliveryService"] {
 					assert.RequireEqual(t, 1, len(federation.Mappings), "expected 1 mapping, got %d", len(federation.Mappings))
+					sort.Strings(federation.Mappings[0].Resolve4)
+					sort.Strings(federation.Mappings[0].Resolve6)
+					sort.Strings(expectedFed["Resolve4"].([]string))
+					sort.Strings(expectedFed["Resolve6"].([]string))
 					assert.Exactly(t, expectedFed["Resolve4"], federation.Mappings[0].Resolve4, "checking federation resolver mappings, expected: %+v, actual: %+v", expectedFed["Resolve4"], federation.Mappings[0].Resolve4)
 					assert.Exactly(t, expectedFed["Resolve6"], federation.Mappings[0].Resolve6, "checking federation resolver mappings, expected: %+v, actual: %+v", expectedFed["Resolve6"], federation.Mappings[0].Resolve6)
 				}

--- a/traffic_ops/testing/api/v3/steering_test.go
+++ b/traffic_ops/testing/api/v3/steering_test.go
@@ -31,7 +31,7 @@ func TestSteering(t *testing.T) {
 			"GET": {
 				"OK when VALID request": {
 					ClientSession: TOSession,
-					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(1),
+					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(2),
 						validateSteeringFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
 							"TargetsGeoOrderPtr": (*int)(nil), "TargetsLongitudePtr": (*float64)(nil), "TargetsLatitudePtr": (*float64)(nil), "TargetsWeight": int32(42)})),
 				},

--- a/traffic_ops/testing/api/v3/steering_test.go
+++ b/traffic_ops/testing/api/v3/steering_test.go
@@ -32,7 +32,7 @@ func TestSteering(t *testing.T) {
 				"OK when VALID request": {
 					ClientSession: TOSession,
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(1),
-						validateSteeringTargetFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
+						validateSteeringFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
 							"TargetsGeoOrderPtr": (*int)(nil), "TargetsLongitudePtr": (*float64)(nil), "TargetsLatitudePtr": (*float64)(nil), "TargetsWeight": int32(42)})),
 				},
 			},
@@ -55,7 +55,7 @@ func TestSteering(t *testing.T) {
 	})
 }
 
-func validateSteeringTargetFields(expectedResp map[string]interface{}) utils.CkReqFunc {
+func validateSteeringFields(expectedResp map[string]interface{}) utils.CkReqFunc {
 	return func(t *testing.T, _ toclientlib.ReqInf, resp interface{}, _ tc.Alerts, _ error) {
 		assert.RequireNotNil(t, resp, "Expected Steering response to not be nil.")
 		steeringResp := resp.([]tc.Steering)

--- a/traffic_ops/testing/api/v4/federations_test.go
+++ b/traffic_ops/testing/api/v4/federations_test.go
@@ -18,6 +18,7 @@ package v4
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 	"testing"
 	"time"
 
@@ -231,6 +232,10 @@ func validateFederationFields(expectedResp []map[string]interface{}) utils.CkReq
 			for _, federation := range federationResp {
 				if federation.DeliveryService.String() == expectedFed["DeliveryService"] {
 					assert.RequireEqual(t, 1, len(federation.Mappings), "expected 1 mapping, got %d", len(federation.Mappings))
+					sort.Strings(federation.Mappings[0].Resolve4)
+					sort.Strings(federation.Mappings[0].Resolve6)
+					sort.Strings(expectedFed["Resolve4"].([]string))
+					sort.Strings(expectedFed["Resolve6"].([]string))
 					assert.Exactly(t, expectedFed["Resolve4"], federation.Mappings[0].Resolve4, "checking federation resolver mappings, expected: %+v, actual: %+v", expectedFed["Resolve4"], federation.Mappings[0].Resolve4)
 					assert.Exactly(t, expectedFed["Resolve6"], federation.Mappings[0].Resolve6, "checking federation resolver mappings, expected: %+v, actual: %+v", expectedFed["Resolve6"], federation.Mappings[0].Resolve6)
 				}

--- a/traffic_ops/testing/api/v4/steering_test.go
+++ b/traffic_ops/testing/api/v4/steering_test.go
@@ -31,7 +31,7 @@ func TestSteering(t *testing.T) {
 			"GET": {
 				"OK when VALID request": {
 					ClientSession: TOSession,
-					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(1),
+					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(2),
 						validateSteeringFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
 							"TargetsGeoOrderPtr": (*int)(nil), "TargetsLongitudePtr": (*float64)(nil), "TargetsLatitudePtr": (*float64)(nil), "TargetsWeight": int32(42)})),
 				},

--- a/traffic_ops/testing/api/v4/steering_test.go
+++ b/traffic_ops/testing/api/v4/steering_test.go
@@ -32,7 +32,7 @@ func TestSteering(t *testing.T) {
 				"OK when VALID request": {
 					ClientSession: TOSession,
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK), utils.ResponseHasLength(1),
-						validateSteeringTargetFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
+						validateSteeringFields(map[string]interface{}{"TargetsLength": 1, "TargetsOrder": int32(0),
 							"TargetsGeoOrderPtr": (*int)(nil), "TargetsLongitudePtr": (*float64)(nil), "TargetsLatitudePtr": (*float64)(nil), "TargetsWeight": int32(42)})),
 				},
 			},
@@ -55,7 +55,7 @@ func TestSteering(t *testing.T) {
 	})
 }
 
-func validateSteeringTargetFields(expectedResp map[string]interface{}) utils.CkReqFunc {
+func validateSteeringFields(expectedResp map[string]interface{}) utils.CkReqFunc {
 	return func(t *testing.T, _ toclientlib.ReqInf, resp interface{}, _ tc.Alerts, _ error) {
 		assert.RequireNotNil(t, resp, "Expected Steering response to not be nil.")
 		steeringResp := resp.([]tc.Steering)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Fixes an issue where the validation for the federation mapping IP fields are not equal due to being out of order.

This also fixes the issue where there was a duplicate function that was created from two separate PRs (now both merged) that the test was not catching.

And changes the response length check for the steering test to 2 since the steering_target test added an additional steering prerequisite.


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops Tests

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Run TO Integration Tests


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
