### PR TITLE
ats.yml: Filter out empty lines of storage.config

### DIFF
--- a/infrastructure/ansible/roles/ats/tasks/ats.yml
+++ b/infrastructure/ansible/roles/ats/tasks/ats.yml
@@ -102,7 +102,7 @@
       command: /opt/trafficserver/bin/traffic_server -Cclear
 
     - name: Get list of targeted ATS cache disks
-      shell: cat /opt/trafficserver/etc/trafficserver/storage.config | grep -v '#' | cut -d' ' -f1
+      shell: cat /opt/trafficserver/etc/trafficserver/storage.config | grep -ve '#' -ve '^$' | cut -d' ' -f1
       register: cachedisk_results
       changed_when: false
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

A part of the ATS roles is getting a list of disks to use for caching: https://github.com/apache/trafficcontrol/blob/757b0eb9c304d365d64838471c11138b24075d0c/infrastructure/ansible/roles/ats/tasks/ats.yml#L104-L107

and removing them from `/etc/fstab`: https://github.com/apache/trafficcontrol/blob/757b0eb9c304d365d64838471c11138b24075d0c/infrastructure/ansible/roles/ats/tasks/ats.yml#L109-L114

But if `storage.config` contains any empty lines, `"{{ item }}.*"` will match all fstab lines for removal. So this PR excludes empty lines.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - Ansible Roles<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Save this file as `/opt/trafficserver/etc/trafficserver/storage.config`:
```storage.config
# DO NOT EDIT - Generated for * by t3c-generate 6.2.0..xxxxxxxx from https://x.x.x.x:xxx ips (x.x.x.x,x.x.x.x:xxx) on 2022-XX-XXTXX:XX:XX.XXXXXXXXXZ

/dev/vdb volume=1
/dev/ram0 volume=2
/dev/ram1 volume=2
/dev/ram2 volume=2
/dev/ram3 volume=2
/dev/ram4 volume=2
/dev/ram5 volume=2
/dev/ram6 volume=2
/dev/ram7 volume=2
```

and verify that running the modified command does not include comments or empty lines.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
6.1.0

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->