### PR TITLE
Allow opening `<p>` tag to contain attributes before closing `>`

### DIFF
--- a/.github/actions/pr-to-update-go/pr_to_update_go/constants.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/constants.py
@@ -93,7 +93,7 @@ GO_REPO_NAME: Final = 'golang/go'
 GO_VERSION_URL: Final = 'https://golang.org/dl/?mode=json'
 """A URL from which information about Go releases is fetched."""
 
-RELEASE_PAGE_URL: Final = 'https://golang.org/doc/devel/release.html'
+RELEASE_PAGE_URL: Final = 'https://go.dev/doc/devel/release'
 """The URL of a webpage containing changelog notes about Go releases."""
 
 

--- a/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/pr_to_update_go/go_pr_maker.py
@@ -146,7 +146,7 @@ def parse_release_notes(version: str, content: str) -> str:
 	"""
 	go_version_pattern = version.replace('.', r"\.")
 	release_notes_pattern = re.compile(
-		r"<p>\s*\n\s*go" + go_version_pattern + r".*?</p>",
+		r"<p[^>]*>\s*\n\s*go" + go_version_pattern + r".*?</p>",
 		re.MULTILINE | re.DOTALL
 	)
 	matches = release_notes_pattern.search(content)

--- a/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
+++ b/.github/actions/pr-to-update-go/tests/test_go_pr_maker.py
@@ -50,3 +50,14 @@ class TestGoPRMaker(TestCase):
         text <p>after</p> 4.15.7"""
 		actual_release_notes = parse_release_notes(go_version, content)
 		self.assertEqual(expected_release_notes, actual_release_notes)
+
+		go_version = '7.18.9'
+		expected_release_notes = '<p id="7.18.9"> go7.18.9 The expected release notes </p>'
+		release_notes_with_whitespace = f"""<p id="7.18.9">
+                go{go_version} The expected release notes
+            </p>"""
+		content = f"""go7.18.9 text before
+        {release_notes_with_whitespace}
+        text <p>after</p> 7.18.9"""
+		actual_release_notes = parse_release_notes(go_version, content)
+		self.assertEqual(expected_release_notes, actual_release_notes)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR allows the release notes paragraphs scraped by the *pr-to-update-go* action to contain HTML attributes, which they now do.

The fixed bug is the failure reason for GitHub Actions run [2659544228](https://github.com/apache/trafficcontrol/actions/runs/2659544228):
```
Found Go milestone Go1.18.4
  File "/opt/hostedtoolcache/Python/3.10.5/x64/lib/python3.10/site-packages/pr_to_update_go/go_pr_maker.py", line 154, in parse_release_notes
    raise Exception(f'could not find release notes for Go {version}')
Exception: could not find release notes for Go 1.18.4
Error: Process completed with exit code 1.
```
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - GitHub Actions<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run the unit tests:
```shell
cd .github/actions/pr-to-update-go
python3 -m unittest discover ./tests
```

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->