### PR TITLE
Ansible Dataset Loader: Queue Caches after performing Snapshots

### DIFF
--- a/infrastructure/ansible/roles/dataset_loader/tasks/dataset_loader.yml
+++ b/infrastructure/ansible/roles/dataset_loader/tasks/dataset_loader.yml
@@ -1043,3 +1043,18 @@
   delay: 10
   vars:
     error_query: "alerts[?level=='error'].text[?!contains(@,'already exists')]"
+
+- name: Queue Caches in all CDNs
+  uri:
+    url: "{{ dl_to_url }}/api/{{ dl_to_api_version }}/cdns/{{ item.id }}/queue_update"
+    method: POST
+    body:
+      action: "queue"
+  with_items: "{{ get_all_cdns.json.response[1:] }}"
+  register: snapshot_out
+  failed_when: (snapshot_out.status == 400 and snapshot_out.json | to_json | from_json | json_query(error_query) | length != 0) or (snapshot_out.status > 400 and snapshot_out.status < 600)
+  no_log: true
+  retries: 10
+  delay: 10
+  vars:
+    error_query: "alerts[?level=='error'].text[?!contains(@,'action must be')]"

--- a/infrastructure/ansible/roles/dataset_loader/tasks/dataset_loader.yml
+++ b/infrastructure/ansible/roles/dataset_loader/tasks/dataset_loader.yml
@@ -1051,8 +1051,8 @@
     body:
       action: "queue"
   with_items: "{{ get_all_cdns.json.response[1:] }}"
-  register: snapshot_out
-  failed_when: (snapshot_out.status == 400 and snapshot_out.json | to_json | from_json | json_query(error_query) | length != 0) or (snapshot_out.status > 400 and snapshot_out.status < 600)
+  register: queue_out
+  failed_when: (queue_out.status == 400 and queue_out.json | to_json | from_json | json_query(error_query) | length != 0) or (queue_out.status > 400 and queue_out.status < 600)
   no_log: true
   retries: 10
   delay: 10


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

As noted in #6963, as of #6569, `POST /api/3.1/servers` and `PUT /api/3.1/servers` can no longer change `updPending`. In the Ansible Roles, this breaks deploying Grove, as Grove will not generate `/etc/grove/remap.json` if updates are not pending for that server.

This PR queues updates on Caches in all CDNs after performing snapshots at the end of the Dataset Loader.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - Ansible Roles<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Test Dataset Loader, verify updates are queued for all Caches

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->