### PR TITLE
Add the ability to register users to TPv2

### DIFF
--- a/experimental/traffic-portal/src/app/api/testing/user.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/user.service.ts
@@ -19,6 +19,16 @@ import type { GetResponseUser, PostRequestUser, PutOrPostResponseUser } from "tr
 import type { Role, Capability, CurrentUser, Tenant } from "src/app/models";
 
 /**
+ * Represents a request to register a user via email using the `/users/register`
+ * API endpoint.
+ */
+interface UserRegistrationRequest {
+	email: string;
+	role: number;
+	tenantId: number;
+}
+
+/**
  * UserService exposes API functionality related to Users, Roles and Capabilities.
  */
 @Injectable()
@@ -288,6 +298,48 @@ export class UserService {
 			roleName: response.rolename,
 			rolename: undefined
 		};
+	}
+
+	/**
+	 * Registers a new user via email.
+	 *
+	 * Note that in testing this has no real effect.
+	 *
+	 * @param request The full registration request.
+	 */
+	public async registerUser(request: UserRegistrationRequest): Promise<void>;
+	/**
+	 * Registers a new user via email.
+	 *
+	 * Note that in testing this has no real effect.
+	 *
+	 * @param email The email address to use for registration.
+	 * @param role The new user's Role (or just its ID).
+	 * @param tenant The new user's Tenant (or just its ID).
+	 */
+	public async registerUser(email: string, role: number | Role, tenant: number | Tenant): Promise<void>;
+	/**
+	 * Registers a new user via email.
+	 *
+	 * Note that in testing this has no real effect.
+	 *
+	 * @param userOrEmail Either the full registration request, or just the
+	 * email address to use for registration.
+	 * @param role The new user's Role (or just its ID). This is required if
+	 * `userOrEmail` is given as an email address, and is ignored otherwise.
+	 * @param tenant The new user's Tenant (or just its ID). This is required if
+	 * `userOrEmail` is given as an email address, and is ignored otherwise.
+	 */
+	public async registerUser(
+		userOrEmail: UserRegistrationRequest | string,
+		role?: number | Role,
+		tenant?: number | Tenant
+	): Promise<void> {
+		if (typeof(userOrEmail) === "string") {
+			if (role === undefined || tenant === undefined) {
+				throw new Error("arguments 'role' and 'tenant' must be supplied when 'userOrEmail' is an email address");
+			}
+		}
 	}
 
 	/** Fetches the Role with the given ID. */

--- a/experimental/traffic-portal/src/app/core/core.module.ts
+++ b/experimental/traffic-portal/src/app/core/core.module.ts
@@ -38,6 +38,7 @@ import { ServersTableComponent } from "./servers/servers-table/servers-table.com
 import { UpdateStatusComponent } from "./servers/update-status/update-status.component";
 import { TenantsComponent } from "./users/tenants/tenants.component";
 import { UserDetailsComponent } from "./users/user-details/user-details.component";
+import { UserRegistrationDialogComponent } from "./users/user-registration-dialog/user-registration-dialog.component";
 import { UsersComponent } from "./users/users.component";
 
 const routes: Routes = [
@@ -73,7 +74,8 @@ const routes: Routes = [
 		NewInvalidationJobDialogComponent,
 		UpdateStatusComponent,
 		UserDetailsComponent,
-		TenantsComponent
+		TenantsComponent,
+		UserRegistrationDialogComponent
 	],
 	exports: [
 	],

--- a/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.html
+++ b/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.html
@@ -1,0 +1,38 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<h2 mat-dialog-title>Register a new User</h2>
+<form method="dialog" ngNativeValidate (submit)="submit($event)">
+	<mat-dialog-content>
+		<mat-form-field>
+			<mat-label>Email Address</mat-label>
+			<input matInput type="email" required name="email" [(ngModel)]="email"/>
+		</mat-form-field>
+		<mat-form-field>
+			<mat-label>Role</mat-label>
+			<mat-select [(ngModel)]="role" required name="role">
+				<mat-option *ngFor="let r of roles" [value]="r">{{r.name}}</mat-option>
+			</mat-select>
+		</mat-form-field>
+		<mat-form-field>
+			<mat-label>Tenant</mat-label>
+			<mat-select [(ngModel)]="tenant" required name="tenant">
+				<mat-option *ngFor="let t of tenants" [value]="t">{{t.name}}</mat-option>
+			</mat-select>
+		</mat-form-field>
+	</mat-dialog-content>
+	<mat-dialog-actions>
+		<button mat-stroked-button>Submit</button>
+		<button mat-stroked-button color="warn" type="button" mat-dialog-close>Cancel</button>
+	</mat-dialog-actions>
+</form>

--- a/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.scss
+++ b/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.scss
@@ -1,0 +1,44 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+mat-dialog-actions {
+	display: inline-flex;
+	justify-content: space-between;
+	width: 100%;
+}
+
+mat-dialog-content {
+	display: grid;
+	grid-template-areas: "a a"
+	                     "b c";
+	column-gap: 15px;
+	mat-form-field{
+		&:first-child {
+			grid-area: a;
+		}
+		&:nth-child(2) {
+			grid-area: b;
+		}
+		&:nth-child(3) {
+			grid-area: c;
+		}
+	}
+}
+
+@media(max-width: 630px) {
+	mat-dialog-content {
+		grid-template-areas: "a"
+		                     "b"
+		                     "c";
+	}
+}

--- a/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.spec.ts
@@ -1,0 +1,36 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { UserRegistrationDialogComponent } from "./user-registration-dialog.component";
+
+describe("UserRegistrationDialogComponent", () => {
+	let component: UserRegistrationDialogComponent;
+	let fixture: ComponentFixture<UserRegistrationDialogComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			declarations: [ UserRegistrationDialogComponent ]
+		})
+			.compileComponents();
+
+		fixture = TestBed.createComponent(UserRegistrationDialogComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.spec.ts
@@ -11,17 +11,43 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { MatDialogRef } from "@angular/material/dialog";
+
+import { APITestingModule } from "src/app/api/testing";
+import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
 
 import { UserRegistrationDialogComponent } from "./user-registration-dialog.component";
 
 describe("UserRegistrationDialogComponent", () => {
 	let component: UserRegistrationDialogComponent;
 	let fixture: ComponentFixture<UserRegistrationDialogComponent>;
+	let dialogOpen = true;
 
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
-			declarations: [ UserRegistrationDialogComponent ]
+			declarations: [ UserRegistrationDialogComponent ],
+			imports: [APITestingModule],
+			providers: [
+				{
+					provide: CurrentUserService,
+					useValue: {
+						currentUser: {
+							role: 1,
+							tenantId: 1
+						},
+						hasCapability: (): true => true,
+					},
+				},
+				{
+					provide: MatDialogRef,
+					useValue: {
+						close: (): void => {
+							dialogOpen = false;
+						}
+					}
+				}
+			]
 		})
 			.compileComponents();
 
@@ -33,4 +59,10 @@ describe("UserRegistrationDialogComponent", () => {
 	it("should create", () => {
 		expect(component).toBeTruthy();
 	});
+
+	it("should close on success", fakeAsync(() => {
+		component.submit(new Event("submit"));
+		tick();
+		expect(dialogOpen).toBeFalse();
+	}));
 });

--- a/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.ts
+++ b/experimental/traffic-portal/src/app/core/users/user-registration-dialog/user-registration-dialog.component.ts
@@ -1,0 +1,87 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Component, OnInit } from "@angular/core";
+import { MatDialogRef } from "@angular/material/dialog";
+
+import { UserService } from "src/app/api";
+import { Role, Tenant } from "src/app/models";
+import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
+
+/**
+ * Controller for a dialog that opens to register a new user.
+ */
+@Component({
+	selector: "tp-user-registration-dialog",
+	styleUrls: ["./user-registration-dialog.component.scss"],
+	templateUrl: "./user-registration-dialog.component.html"
+})
+export class UserRegistrationDialogComponent implements OnInit {
+
+	public roles = new Array<Role>();
+	public tenants = new Array<Tenant>();
+
+	public role!: Role;
+	public tenant!: Tenant;
+	public email = "";
+
+	constructor(
+		private readonly userService: UserService,
+		private readonly auth: CurrentUserService,
+		private readonly dialogRef: MatDialogRef<UserRegistrationDialogComponent>
+	) { }
+
+	/**
+	 * Sets up Role and Tenant data using the API.
+	 */
+	public ngOnInit(): void {
+		this.userService.getRoles().then(
+			rs => {
+				this.roles = rs;
+				for (const role of rs) {
+					if (role.id === this.auth.currentUser?.role) {
+						this.role = role;
+					}
+				}
+			}
+		);
+		this.userService.getTenants().then(
+			ts => {
+				this.tenants = ts;
+				for (const tenant of ts) {
+					if (tenant.id === this.auth.currentUser?.tenantId) {
+						this.tenant = tenant;
+					}
+				}
+			}
+		);
+	}
+
+	/**
+	 * Submits the API request to create the user.
+	 *
+	 * @param e The form submittal event that triggered calling this method. Its
+	 * default is prevented, and its propagation stopped.
+	 */
+	public async submit(e: Event): Promise<void> {
+		e.preventDefault();
+		e.stopPropagation();
+
+		try {
+			await this.userService.registerUser(this.email, this.role, this.tenant);
+			this.dialogRef.close();
+		} catch (err) {
+			console.error("failed to register user:", err);
+		}
+	}
+}

--- a/experimental/traffic-portal/src/app/core/users/users.component.html
+++ b/experimental/traffic-portal/src/app/core/users/users.component.html
@@ -26,15 +26,15 @@ limitations under the License.
 	<div id="loading" *ngIf="loading"><tp-loading></tp-loading></div>
 </mat-card>
 
-<button class="expandable-fab" type="button" (cdkMenuClosed)="toggleMenu('closed')" (cdkMenuOpened)="toggleMenu('opened')" mat-fab [cdkMenuTriggerFor]="menu" aria-label="Add a user" title="Add a user">
+<button *ngIf="canCreateUsers()" class="expandable-fab" type="button" (cdkMenuClosed)="toggleMenu('closed')" (cdkMenuOpened)="toggleMenu('opened')" mat-fab [cdkMenuTriggerFor]="menu" aria-label="Add a user" title="Add a user">
 	<mat-icon [ngClass]="{'open': menuIsOpen}">add</mat-icon>
 </button>
 <ng-template #menu>
 	<menu @fadeInOut @slideInOut cdkMenu>
-	  <a *ngIf="canCreateUsers()" cdkMenuItem routerLink="new" color="accent" mat-mini-fab aria-label="Create user from scratch" title="Create user from scratch">
+	  <a cdkMenuItem routerLink="new" color="accent" mat-mini-fab aria-label="Create user from scratch" title="Create user from scratch">
 		<mat-icon>person_add</mat-icon>
 	  </a>
-	  <button cdkMenuItem color="accent" mat-mini-fab disabled aria-label="Register a new user by email" title="Register a new user by email">
+	  <button cdkMenuItem color="accent" mat-mini-fab color="accent" aria-label="Register a new user by email" title="Register a new user by email" (click)="register()">
 		<mat-icon>contact_mail</mat-icon>
 	  </button>
 	</menu>

--- a/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
@@ -14,6 +14,7 @@
 import { HttpClientModule } from "@angular/common/http";
 import { waitForAsync, ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { MatDialogModule } from "@angular/material/dialog";
 import { RouterTestingModule } from "@angular/router/testing";
 import type { ValueGetterParams } from "ag-grid-community";
 
@@ -69,7 +70,8 @@ describe("UsersComponent", () => {
 				FormsModule,
 				HttpClientModule,
 				ReactiveFormsModule,
-				RouterTestingModule
+				RouterTestingModule,
+				MatDialogModule
 			],
 			providers: [
 				{ provide: CurrentUserService, useValue: mockCurrentUserService }

--- a/experimental/traffic-portal/src/app/core/users/users.component.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.ts
@@ -13,6 +13,7 @@
 */
 import { animate, style, transition, trigger } from "@angular/animations";
 import { Component, type OnInit } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
 import type { ValueGetterParams } from "ag-grid-community";
 import { BehaviorSubject } from "rxjs";
 import { GetResponseUser } from "trafficops-types";
@@ -22,6 +23,8 @@ import { CurrentUserService } from "src/app/shared/currentUser/current-user.serv
 import type { ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
 import {TpHeaderService} from "src/app/shared/tp-header/tp-header.service";
 import { orderBy } from "src/app/utils";
+
+import { UserRegistrationDialogComponent } from "./user-registration-dialog/user-registration-dialog.component";
 
 const ANIMATION_DURATION = "150ms";
 
@@ -240,7 +243,8 @@ export class UsersComponent implements OnInit {
 	constructor(
 		private readonly api: UserService,
 		private readonly headerSvc: TpHeaderService,
-		private readonly currentUserService: CurrentUserService
+		private readonly currentUserService: CurrentUserService,
+		private readonly dialog: MatDialog
 	) {
 	}
 
@@ -299,5 +303,12 @@ export class UsersComponent implements OnInit {
 	 */
 	public canCreateUsers(): boolean {
 		return this.currentUserService.hasPermission("USER:CREATE");
+	}
+
+	/**
+	 * Opens a dialog for registering a new user.
+	 */
+	public register(): void {
+		this.dialog.open(UserRegistrationDialogComponent);
 	}
 }


### PR DESCRIPTION
Adds the ability to TPv2 to register a user by email.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Use TPv2 to register a user (I just verified it got as far as an internal server error because SMTP wasn't configured). Ensure the provided tests have decent coverage and all pass.

## PR submission checklist
- [x] This PR has tests
- [x] This PR has JSDOC documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**