### PR TITLE
Remove invalid 'scale' figure option

### DIFF
--- a/docs/source/admin/ansible-labs/ansible_labs.rst
+++ b/docs/source/admin/ansible-labs/ansible_labs.rst
@@ -37,7 +37,6 @@ Lab Implementation Concepts
 ===========================
 
 .. figure:: ATC.lab.layers.svg
-	:scale: 100 %
 	:align: center
 	:figclass: align-center
 
@@ -150,7 +149,6 @@ It's very useful to still review the Administrator's Guide in the documentation 
 If you're attempting to optimize the wallclock time needed to deploy all the components in parallel, they should be installed like the following:
 
 .. figure:: ATC.Installation.dependencies.svg
-	:scale: 100 %
 	:align: center
 	:figclass: align-center
 


### PR DESCRIPTION
Since #3585, the docs have been applying a "scale" option to `.. figure::` directives in the `ansible_labs.rst` file that include SVG images which have no definite size. The option is, therefore, extraneous at best, and is generating warnings in our docs builds.

This fixes that by removing that option from those figures.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build with no warnings.

## If this is a bugfix, which Traffic Control versions contained the bug?
- unknown and I'm not going to waste time figuring it out for such a minor bug.

## PR submission checklist
- [ ] This PR has tests
- [x] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**