### PR TITLE
Fix Pkg Build Order to Mirror docker-compose.yml

### DIFF
--- a/pkg
+++ b/pkg
@@ -155,6 +155,8 @@ while getopts h78abdf:lopqvsSL opt; do
 	esac
 done
 
+# Weasel must be built first otherwise it will fail from build artifacts/cache in an environment that doesn't have git
+# e.g. the environment produced by `./pkg source`.
 PROJECTS="weasel"$'\n'"$("${COMPOSECMD[@]}" -f $COMPOSE_FILE config --services | sed '/^weasel$/d')"
 HELP_TEXT="$(cat <<HELP_TEXT
 Usage: $SELF [options] [projects]

--- a/pkg
+++ b/pkg
@@ -155,7 +155,7 @@ while getopts h78abdf:lopqvsSL opt; do
 	esac
 done
 
-PROJECTS="$("${COMPOSECMD[@]}" -f $COMPOSE_FILE config --services)"
+PROJECTS="$(cat infrastructure/docker/build/docker-compose.yml | grep -E '^\s\s[a-zA-Z_-]+:$' | sed 's/[: ]//g')"
 HELP_TEXT="$(cat <<HELP_TEXT
 Usage: $SELF [options] [projects]
   -7           Build RPMs targeting CentOS 7

--- a/pkg
+++ b/pkg
@@ -155,7 +155,7 @@ while getopts h78abdf:lopqvsSL opt; do
 	esac
 done
 
-PROJECTS="$(cat infrastructure/docker/build/docker-compose.yml | grep -E '^\s\s[a-zA-Z_-]+:$' | sed 's/[: ]//g')"
+PROJECTS="weasel"$'\n'"$("${COMPOSECMD[@]}" -f $COMPOSE_FILE config --services | sed '/^weasel$/d')"
 HELP_TEXT="$(cat <<HELP_TEXT
 Usage: $SELF [options] [projects]
   -7           Build RPMs targeting CentOS 7


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This changes `pkg` to (by default) build services in the order listed in `infrastructure/docker/build/docker-compose.yml` as opposed to alphabetical order. 

This issue was originally fixed in #5368, but was reintroduced in #6274 as `docker-compose config --services` lists services in alphabetical order.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Build

## What is the best way to verify this PR?
Run `./pkg source` and then extract the produced source and run `./pkg -v` again. Weasel should not fail from build artifacts such as [these](https://lists.apache.org/thread/okndcgcxn3qr5nkqg1tokbf0w6p38h9n)
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
 - 6.1.0
 - 7.0.0 RC0
 - master


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
