### PR TITLE
Fix t3c generate nil panic on bad input

### DIFF
--- a/cache-config/t3c-generate/t3c-generate.go
+++ b/cache-config/t3c-generate/t3c-generate.go
@@ -77,7 +77,10 @@ func main() {
 		os.Exit(config.ExitCodeErrGeneric)
 	}
 
-	if toData.Server.HostName == nil {
+	if toData.Server == nil {
+		log.Errorln("input had no server")
+		os.Exit(config.ExitCodeErrGeneric)
+	} else if toData.Server.HostName == nil {
 		log.Errorln("input server had no host name")
 		os.Exit(config.ExitCodeErrGeneric)
 	}


### PR DESCRIPTION
Fixed t3c-generate to return an error if the input is malformed, empty, or has no server.

The t3c run is going to fail anyway, so this isn't a huge deal. But it makes the error clearer and easier to figure out, should help debugging prod issues.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run t3c-generate with input with no server, verify an error is returned instead of a panic and application crash.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.


## PR submission checklist
- ~[x] This PR has tests~ no tests, this can't be unit tested, and we don't have an integration test framework for individual t3c sub-apps, and it isn't possible to make t3c-apply cause this error under normal circumstances. Normal, successful behavior is already tested <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, exact error messages aren't documented <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- ~[x] This PR has a CHANGELOG.md entry~ no changelog, this is far too trivial to clutter the changelog<!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
