### PR TITLE
add support for __REGEX_REMAP_DIRECTIVE__ to remap.config processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Change to t3c diff to flag a config file for replacement if owner/group settings are not `ats` [#6879](https://github.com/apache/trafficcontrol/issues/6879).
 - t3c now looks in the executable dir path for t3c- utilities
 - Added support for parent.config markdown/retry DS parameters using first./inner./last. prefixes.  mso. and <null> prefixes should be deprecated.
+- Add new __REGEX_REMAP_DIRECTIVE__ support to raw remap text to allow moving the regex_remap placement.
 
 ### Fixed
 - Fixed TO to default route ID to 0, if it is not present in the request context.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -691,7 +691,7 @@ Another example might be a Delivery Service which modifies the uri in a way that
 | __CACHEKEY_DIRECTIVE__    | Inserts cachekey plugin and args (if any) |
 | __RANGE_DIRECTIVE__       | Inserts range directive args (if any)     |
 | __REGEX_REMAP_DIRECTIVE__ | Inserts regex_remap directive (if any)    |
-+---------------------------+===========================================+
++---------------------------+-------------------------------------------+
 
 .. _ds-regex-remap:
 

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -685,13 +685,13 @@ Another example might be a Delivery Service which modifies the uri in a way that
 
 .. table:: Supported Raw Remap Directives
 
-+---------------------------+-------------------------------------------+
-| Name                      | Use(s)                                    |
-+===========================+===========================================+
-| __CACHEKEY_DIRECTIVE__    | Inserts cachekey plugin and args (if any) |
-| __RANGE_DIRECTIVE__       | Inserts range directive args (if any)     |
-| __REGEX_REMAP_DIRECTIVE__ | Inserts regex_remap directive (if any)    |
-+---------------------------+-------------------------------------------+
+	+---------------------------+-------------------------------------------+
+	| Name                      | Use(s)                                    |
+	+===========================+===========================================+
+	| __CACHEKEY_DIRECTIVE__    | Inserts cachekey plugin and args (if any) |
+	| __RANGE_DIRECTIVE__       | Inserts range directive args (if any)     |
+	| __REGEX_REMAP_DIRECTIVE__ | Inserts regex_remap directive (if any)    |
+	+---------------------------+-------------------------------------------+
 
 .. _ds-regex-remap:
 

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -675,11 +675,23 @@ For HTTP and DNS-:ref:`Routed <ds-types>` Delivery Services, this will be added 
 Directives
 """
 
-The Raw Remap text is ordinarily added at the end of the line, after everything else. However, it may be necessary to add Range Request Handling after the Raw Remap. For example, if you have a plugin which manipulates the Range header. In this case, you can insert the text ``__RANGE_DIRECTIVE__`` in the Raw Remap text, and the range request handling directives will be added at that point.
+The Raw Remap text is ordinarily added at the end of the line, after everything else. However, it may be necessary to change the normal arg ordering, especially if the user needs to modify the cachekey, range headers or URI in a way that may change cachekey or regex_remap behaviors.
+
+It may be necessary to add Range Request Handling after the Raw Remap. For example, if you have a plugin which manipulates the Range header. In this case, you can insert the text ``__RANGE_DIRECTIVE__`` in the Raw Remap text, and the range request handling directives will be added at that point.
 
 For example, if you have an Apache Traffic Server lua plugin which manipulates the range, and are using Slice Range Request Handling which needs to run after your plugin, you can set a Raw Remap, ``@plugin=tslua.so @pparam=range.lua __RANGE_DIRECTIVE__``, and the ``@plugin=slice.so`` range directive will be inserted after your plugin.
 
-Similarly the text ``__CACHEKEY_DIRECTIVE__`` can be moved into the Raw Remap text to allow the Raw Remap text to manipulate the uri contents before the cachekey is generated.
+Another example might be a Delivery Service which modifies the uri in a way that changes the cachey key (cachekey), and affects parent routing (regex_remap) with the possibility of range request handling via background fetch.  Raw Remap Text might then look like: ``@plugin=tslua.so @pparam=uri-manip.lua __CACHEKEY_DIRECTIVE__ __REGEX_REMAP_DIRECTIVE__ __RANGE_DIRECTIVE__``.  This would set things up such that background_fetch would issue a request to the proper remap parent.
+
+.. table:: Supported Raw Remap Directives
+
++---------------------------+-------------------------------------------+
+| Name                      | Use(s)                                    |
++===========================+===========================================+
+| __CACHEKEY_DIRECTIVE__    | Inserts cachekey plugin and args (if any) |
+| __RANGE_DIRECTIVE__       | Inserts range directive args (if any)     |
+| __REGEX_REMAP_DIRECTIVE__ | Inserts regex_remap directive (if any)    |
++---------------------------+===========================================+
 
 .. _ds-regex-remap:
 

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -5859,6 +5859,139 @@ func TestMakeRemapDotConfigRawRemapCachekeyDirective(t *testing.T) {
 	}
 }
 
+func TestMakeRemapDotConfigRawRemapRegexRemapDirective(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	server := makeTestRemapServer()
+	server.Type = "EDGE"
+
+	ds := DeliveryService{}
+	ds.ID = util.IntPtr(48)
+	dsType := tc.DSType("HTTP_LIVE_NATNL")
+	ds.Type = &dsType
+	ds.OrgServerFQDN = util.StrPtr("origin.example.test")
+	ds.MidHeaderRewrite = util.StrPtr("")
+	ds.RemapText = util.StrPtr("@plugin=tslua.so @pparam=uri-manipulator.lua __REGEX_REMAP_DIRECTIVE__")
+	ds.EdgeHeaderRewrite = nil
+	ds.SigningAlgorithm = util.StrPtr("foo")
+	ds.XMLID = util.StrPtr("mydsname")
+	ds.QStringIgnore = util.IntPtr(int(tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp))
+	ds.RegexRemap = util.StrPtr("myregexremap")
+	ds.FQPacingRate = util.IntPtr(0)
+	ds.DSCP = util.IntPtr(0)
+	ds.RoutingName = util.StrPtr("myroutingname")
+	ds.MultiSiteOrigin = util.BoolPtr(false)
+	ds.OriginShield = util.StrPtr("myoriginshield")
+	ds.ProfileID = util.IntPtr(49)
+	ds.ProfileName = util.StrPtr("dsprofile")
+	ds.Protocol = util.IntPtr(int(tc.DSProtocolHTTPAndHTTPS))
+	ds.AnonymousBlockingEnabled = util.BoolPtr(false)
+	ds.Active = util.BoolPtr(true)
+	ds.RangeSliceBlockSize = util.IntPtr(262144)
+
+	dses := []DeliveryService{ds}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds.ID,
+		},
+	}
+
+	dsRegexes := []tc.DeliveryServiceRegexes{
+		tc.DeliveryServiceRegexes{
+			DSName: *ds.XMLID,
+			Regexes: []tc.DeliveryServiceRegex{
+				tc.DeliveryServiceRegex{
+					Type:      string(tc.DSMatchTypeHostRegex),
+					SetNumber: 0,
+					Pattern:   `myliteralpattern__http__foo`,
+				},
+			},
+		},
+	}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.Parameter{
+			Name:       "serverpkgval",
+			ConfigFile: "package",
+			Value:      "serverpkgval __HOSTNAME__ foo",
+			Profiles:   []byte(server.ProfileNames[0]),
+		},
+		tc.Parameter{
+			Name:       "dscp_remap_no",
+			ConfigFile: "package",
+			Value:      "notused",
+			Profiles:   []byte(server.ProfileNames[0]),
+		},
+	}
+
+	remapConfigParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "not_location",
+			ConfigFile: "cachekey.config",
+			Value:      "notinconfig",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	topologies := []tc.Topology{}
+	cgs := []tc.CacheGroupNullable{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, hdr)
+
+	txtLines := strings.Split(txt, "\n")
+
+	if len(txtLines) != 4 { // 2 remaps plus header comment plus blank
+		t.Fatalf("expected a comment header, a blank line, and 2 remaps from HTTP_AND_HTTPS DS, actual: '%v' count %v", txt, len(txtLines))
+	}
+
+	remapLine := txtLines[2]
+
+	if !strings.HasPrefix(remapLine, "map") {
+		t.Errorf("expected to start with 'map', actual '%v'", txt)
+	}
+
+	if 1 != strings.Count(remapLine, "regex_remap.so") {
+		t.Errorf("expected remap on edge server to contain a single regex_remap plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "@plugin=tslua.so @pparam=uri-manipulator.lua  @plugin=regex_remap.so") {
+		t.Errorf("expected regex_remap to come after tslua, actual '%v'", txt)
+	}
+	if strings.Contains(remapLine, "__REGEX_REMAP_DIRECTIVE__") {
+		t.Errorf("expected raw remap regex_remap directive to be replaced, actual '%v'", txt)
+	}
+	if count := strings.Count(remapLine, "regex_remap.so"); count != 1 { // Individual line should only have 1 regex_remap.so
+		t.Errorf("expected raw remap regex_remap directive to be replaced not duplicated, actual count %v '%v'", count, txt)
+	}
+	if count := strings.Count(txt, "regex_remap.so"); count != 2 { // All lines should have 2 regex_remap.so - HTTP and HTTPS lines
+		t.Errorf("expected raw remap regex_remap directive to have one regex_remap.so for HTTP and one for HTTPS remap, actual count %v '%v'", count, txt)
+	}
+}
+
 func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 	hdr := "myHeaderComment"
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Another remap.config Raw Remap Text "hack" which will allow users to modify the uri path and/or query string args that would affect regex_remap behavior.

A sample usage might be:

```
@plugin=tslua.so @pparam=uri-manipulation.lua __REGEX_REMAP_DIRECTIVE__
```

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

On the TP Delivery Service Page:

- Populate the regex remap text field
- Set raw remap text to: '@plugin=uri-manip.so __REGEX_REMAP_DIRECTIVE__'

Run t3c and observe the regex_remap plugin *after* the uri-manip.so plugin.

To negatively test, leave the regex remap text field blank, run again and ensure no regex_remap.so plugin directives exist.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
