### PR TITLE
Fix Health Client nil panic on blank parent.config lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6834](https://github.com/apache/trafficcontrol/issues/6834) - In API 4.0, fixed `GET` for `/servers` to display all profiles irrespective of the index position. Also, replaced query param `profileId` with `profileName`.
 - [#6299](https://github.com/apache/trafficcontrol/issues/6299) User representations don't match
 - [#6896](https://github.com/apache/trafficcontrol/issues/6896) Fixed the `POST api/cachegroups/id/queue_updates` endpoint so that it doesn't give an internal server error anymore.
+- [#6994](https://github.com/apache/trafficcontrol/issues/6994) Fixed the Health Client to not crash if parent.config has a blank line.
 - [#6933](https://github.com/apache/trafficcontrol/issues/6933) Fixed tc-health-client to handle credentials files with special characters in variables
 - [#6776](https://github.com/apache/trafficcontrol/issues/6776) User properties only required sometimes
 - Fixed TO API `GET /deliveryservicesserver` causing error when an IMS request is made with the `cdn` and `maxRevalDurationDays` parameters set.

--- a/tc-health-client/tmagent/test_files/etc/parent.config
+++ b/tc-health-client/tmagent/test_files/etc/parent.config
@@ -17,5 +17,6 @@
 # under the License.
 #
 dest_domain=foo.com port=80 parent="cdn-mid-01.bar.net:80|1.0;cdn-mid-02.bar.net:80|1.0;cdn-mid-03.bar.net:80|1.0;cdn-mid-04.bar.net:80|1.0;" round_robin=consistent_hash go_direct=false qstring=consider go_direct=true
+
 #
 dest_domain=foo.com port=80 parent="cdn-mid-05.foo.net:80|1.0;cdn-mid-06.foo.net:80|1.0;cdn-mid-07.foo.net:80|1.0;cdn-mid-08.foo.net:80|1.0;" round_robin=consistent_hash go_direct=false qstring=ignore go_direct=false

--- a/tc-health-client/tmagent/tmagent.go
+++ b/tc-health-client/tmagent/tmagent.go
@@ -744,6 +744,10 @@ func (c *ParentInfo) readParentConfig(parentStatus map[string]ParentStatus) erro
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		sbytes := scanner.Bytes()
+		sbytes = bytes.TrimSpace(sbytes)
+		if len(sbytes) == 0 {
+			continue // skip blank lines
+		}
 		if sbytes[0] == 35 { // skip comment lines, 35 is a '#'.
 			continue
 		}


### PR DESCRIPTION
Fixes the Health Client to not panic and crash if parent.config has a blank line. 

The current `t3c` will always insert a blank line after the header comment, to make it possible to programmatically distinguish the header comment from line comments. Thus, the Health Client will always crash with a parent.config generated by `t3c` from the same latest Traffic Control version.

## Which Traffic Control components are affected by this PR?
- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?
Run the Health Client with a parent.config with any blank line in it.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.1.0
- 7.0.0 (RC2)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[x] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
