### PR TITLE
Improve the blur on 'private' text fields

### DIFF
--- a/traffic_portal/app/src/common/modules/form/_form.scss
+++ b/traffic_portal/app/src/common/modules/form/_form.scss
@@ -365,7 +365,7 @@ input:checked + .slider::before {
 	color: transparent;
 	text-shadow: 0 0 8px rgba(0,0,0,0.5);
 
-	&:active, &:hover {
+	&:focus {
 		color: inherit;
 		text-shadow: none;
 	}


### PR DESCRIPTION
Instead of un-blurring on mouse-over, it now un-blurs on focus; i.e. while the text box is selected.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Click on a blurred text box (e.g. DS private SSL key)

## PR submission checklist
- [x] This PR is sufficiently covered by existing tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**