### PR TITLE
Remove imports from Traffic Router source files that were never used

### DIFF
--- a/traffic_router/connector/src/main/java/org/apache/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
+++ b/traffic_router/connector/src/main/java/org/apache/traffic_control/traffic_router/protocol/RouterNioEndpoint.java
@@ -20,14 +20,9 @@ import org.apache.traffic_control.traffic_router.secure.HandshakeData;
 import org.apache.traffic_control.traffic_router.secure.KeyManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.tomcat.jni.SSL;
-import org.apache.tomcat.util.net.NioChannel;
 import org.apache.tomcat.util.net.NioEndpoint;
 import org.apache.tomcat.util.net.SSLHostConfig;
 import org.apache.tomcat.util.net.SSLHostConfigCertificate;
-import org.apache.tomcat.util.net.SocketEvent;
-import org.apache.tomcat.util.net.SocketProcessorBase;
-import org.apache.tomcat.util.net.SocketWrapperBase;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -137,4 +132,3 @@ public class RouterNioEndpoint extends NioEndpoint {
 	}
 
 }
-

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 
-import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.io.File;

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/dns/protocol/AbstractProtocolTest.java
@@ -35,7 +35,6 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.util.Random;
 
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/ExternalTestSuite.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/ExternalTestSuite.java
@@ -22,7 +22,6 @@ import org.apache.catalina.LifecycleException;
 import org.apache.logging.log4j.core.appender.ConsoleAppender;
 import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.experimental.categories.Category;

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/StatsTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/StatsTest.java
@@ -28,8 +28,6 @@ import org.apache.http.util.EntityUtils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.fail;
 
 import org.junit.After;
@@ -52,20 +50,20 @@ public class StatsTest {
 	public void before() throws LifecycleException {
 		httpClient = HttpClientBuilder.create().build();
 	}
-	
+
 	@After
 	public void after() throws Exception {
 		if (httpClient != null) httpClient.close();
 	}
-	
+
 	@Test
 	public void itGetsApplicationStats() throws Exception {
 		HttpGet httpGet = new HttpGet("http://localhost:3333/crs/stats");
 
 		CloseableHttpResponse httpResponse = null;
-		
+
 		try {
-			
+
 			httpResponse = httpClient.execute(httpGet);
 			String responseContent = EntityUtils.toString(httpResponse.getEntity());
 
@@ -116,7 +114,7 @@ public class StatsTest {
 		HttpGet httpGet = new HttpGet("http://localhost:3333/crs/stats/ip/8.8.8.8");
 
 		CloseableHttpResponse response = null;
-		
+
 		try {
 			response = httpClient.execute(httpGet);
 			String actual = EntityUtils.toString(response.getEntity());

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/hashing/ConsistentHasherTest.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/secure/CertificatesClientTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/secure/CertificatesClientTest.java
@@ -19,8 +19,6 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.core.IsNull.nullValue;
 
 
 public class CertificatesClientTest {

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/secure/Pkcs1Test.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/secure/Pkcs1Test.java
@@ -26,7 +26,6 @@ import java.security.spec.KeySpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class Pkcs1Test {

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/util/FetcherTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/util/FetcherTest.java
@@ -25,7 +25,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.lang.ClassCastException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.net.URL;

--- a/traffic_router/shared/src/main/java/org/apache/traffic_control/traffic_router/shared/ZoneTestRecords.java
+++ b/traffic_router/shared/src/main/java/org/apache/traffic_control/traffic_router/shared/ZoneTestRecords.java
@@ -22,7 +22,6 @@ import org.xbill.DNS.*;
 import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.KeyFactory;
 import java.security.KeyPair;

--- a/traffic_router/shared/src/test/java/shared/DeliveryServiceCertificatesTest.java
+++ b/traffic_router/shared/src/test/java/shared/DeliveryServiceCertificatesTest.java
@@ -35,7 +35,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DeliveryServiceCertificates.class, System.class})


### PR DESCRIPTION
This just removes some imports that were never used from some Java files.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Router

## What is the best way to verify this PR?
Make sure all existing tests still pass. If anything was actually needed I'd expect compilation to fail.

## PR submission checklist
- [x] This PR utilizes existing tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**