### PR TITLE
Remove reference to removed endpoint from TO API docs

### DIFF
--- a/docs/source/api/v3/deliveryservices_id_servers.rst
+++ b/docs/source/api/v3/deliveryservices_id_servers.rst
@@ -18,7 +18,6 @@
 ***********************************
 ``deliveryservices/{{ID}}/servers``
 ***********************************
-.. caution:: It's often much easier to use :ref:`to-api-v3-deliveryservices-xmlid-servers` instead
 
 ``GET``
 =======

--- a/docs/source/api/v4/deliveryservices_id_servers.rst
+++ b/docs/source/api/v4/deliveryservices_id_servers.rst
@@ -18,7 +18,6 @@
 ***********************************
 ``deliveryservices/{{ID}}/servers``
 ***********************************
-.. caution:: It's often much easier to use :ref:`to-api-deliveryservices-xmlid-servers` instead
 
 ``GET``
 =======

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -113,7 +113,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -962,7 +962,7 @@ Naturally, this assumes that each redundant server is exactly identical, from re
 	| :abbr:`MSO (Multi-Site Origin)` | In documentation and used heavily in discussion in Slack, mailing list etc. | unchanged (usually only used where implicitly ``true``) |
 	+---------------------------------+-----------------------------------------------------------------------------+---------------------------------------------------------+
 
-A Delivery Service Profile_ can have :term:`Parameters` that affect Multi-Site Origin configuration. These are detailed in `Parameters that Affect Multi-Site Origin`_.
+A Delivery Service Profile_ can have :term:`Parameters` that affect Multi-Site Origin configuration. These are detailed in `Parameters that Affect Multi-Site Origin and Parent Down Behavior`_.
 
 .. seealso:: A quick guide on setting up Multi-Site Origins is given in :ref:`multi-site-origin-qht`.
 
@@ -1020,9 +1020,9 @@ The following :term:`Parameters` must have the :ref:`Config File <parameter-conf
 	.. deprecated:: ATCv6.2
 		In :ref:`to-api` version 4 (unstable at the time of this writing), TLS versions should be configured using the `TLS Versions`_ property of the Delivery Service, and support for this :term:`Parameter` will be removed at some point after the stabilization of :ref:`to-api` version 4.
 
-Parameters that Affect Multi-Site Origin and inside a CDN
-'''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-Each :term:`Parameter` directly corresponds to a field in a line of the :abbr:`ATS (Apache Traffic Server)` `parent.config file <https://docs.trafficserver.apache.org/en/7.1.x/admin-guide/files/parent.config.en.html>`_ (usually by almost the same name), and documentation for these fields is provided in the form of links to their entries in the :abbr:`ATS (Apache Traffic Server)` documentation.
+Parameters that Affect Multi-Site Origin and Parent Down Behavior
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Each :term:`Parameter` directly corresponds to a field in a line of the :abbr:`ATS (Apache Traffic Server)` `parent.config file <https://docs.trafficserver.apache.org/en/9.1.x/admin-guide/files/parent.config.en.html>`_ (usually by almost the same name), and documentation for these fields is provided in the form of links to their entries in the :abbr:`ATS (Apache Traffic Server)` documentation.
 
 .. _round_robin: https://docs.trafficserver.apache.org/en/9.1.x/admin-guide/files/parent.config.en.html#parent-config-format-round-robin
 .. _max_simple_retries: https://docs.trafficserver.apache.org/en/9.1.x/admin-guide/files/parent.config.en.html#parent-config-format-max-simple-retries
@@ -1059,7 +1059,7 @@ Each :term:`Parameter` directly corresponds to a field in a line of the :abbr:`A
 	|                                         |                                                            | currently "unavailable".                                                            |
 	+-----------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+
 
-The above :term:`Parameters` are supported for ``first``, ``inner`` and ``last`` tiers by specifying prefixes ``first.``, ``inner.`` and ``last.``, applicable to both topology and non topology.  This allows fine tuning of markdown and retry behavior inside a CDN.
+The above :term:`Parameters` are supported for ``first``, ``inner`` and ``last`` tiers by specifying prefixes ``first.``, ``inner.`` and ``last.``, applicable to both topology and non topology. This allows fine tuning of marking parents "down" and retry behavior inside a CDN.
 
 .. deprecated:: The ``mso.`` prefix is deprecated.  ``last.`` prefix should be preferred although no prefix can also be used.
 


### PR DESCRIPTION
The documentation for `/deliveryservices/{{ID}}/servers` currently has a "caution"-level admonition advising users to use `/deliveryservices/{{XML ID}}/servers` instead. However, those endpoints' purposes don't actually overlap (unfortunately). The original admonition advised users to instead use `/deliveryservices/xmlId/{{XML ID}}/servers` and was erroneously updated to its current content when that endpoint was removed (I think). This PR removes the admonition from both v3 and v4 docs.

Also, the docs build on master currently has a warning caused by a broken link, which is a bug introduced by #6859, and this PR fixes that.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Read the docs

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR needs no tests
- [x] This PR is documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**