### PR TITLE
Traffic Stats: reuse http influx client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - [#6033](https://github.com/apache/trafficcontrol/issues/6033) Added ability to assign multiple server capabilities to a server.
 
+### Fixed
+- Traffic Stats: Reuse InfluxDB client handle to prevent potential connection leaks
+
 ### Changed
 - Traffic Portal now obscures sensitive text in Delivery Service "Raw Remap" fields, private SSL keys, "Header Rewrite" rules, and ILO interface passwords by default.
 

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -1041,6 +1041,18 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		host := hosts[n]
 		hosts = append(hosts[:n], hosts[n+1:]...)
 		parsedURL, _ := url.Parse(host.URL)
+		if host.InfluxClient != nil && parsedURL.Scheme == "http" {
+			// NOTE: closing an http client just closes idle connections -- the client can still make new requests
+			if err := host.InfluxClient.Close(); err != nil {
+				errorf("closing http influx client: %s", err)
+			}
+			_, _, err := host.InfluxClient.Ping(10)
+			if err != nil {
+				warnf("pinging InfluxDB: %v", err)
+				continue
+			}
+			return host.InfluxClient, nil
+		}
 		if parsedURL.Scheme == "udp" {
 			conf := influx.UDPConfig{
 				Addr: parsedURL.Host,
@@ -1063,12 +1075,6 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 			errorf("An error occurred creating InfluxDB HTTP client: %v", err)
 			continue
 		}
-		//Close old connections explicitly
-		if host.InfluxClient != nil {
-			if err := host.InfluxClient.Close(); err != nil {
-				errorf("closing influx client: %s", err)
-			}
-		}
 		host.InfluxClient = con
 		_, _, err = con.Ping(10)
 		if err != nil {
@@ -1077,7 +1083,7 @@ func influxConnect(config StartupConfig) (influx.Client, error) {
 		}
 		return con, nil
 	}
-	err := errors.New("Could not connect to any of the InfluxDb servers defined in the influxUrls config.")
+	err := errors.New("could not connect to any of the InfluxDb servers defined in the influxUrls config")
 	return nil, err
 }
 


### PR DESCRIPTION
Instead of creating a new http influx client with each request, reuse
the existing client. This should prevent connection leaks when an old
client is discarded for a new one but connections are still active on
the old one (and therefore not closed by the `Close` function).

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run Traffic Stats and watch the number of open connections to influxdb. The connection counts should remain steady without climbing indefinitely.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master
- 7.x
- 6.x

## PR submission checklist
- [x] not really unit testable
- [x] bug fix, no docs needed
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
