### PR TITLE
t3c integration tests to not modify config file

### DIFF
--- a/cache-config/testing/docker/ort_test/run.sh
+++ b/cache-config/testing/docker/ort_test/run.sh
@@ -77,8 +77,8 @@ else
   echo "$(</ort-tests/tc-fixtures.json jq --arg ATS_RPM "$ATS_RPM" '.profiles[] |= (
     select(.params != null).params[] |= (
       select(.configFile == "package" and .name == "trafficserver").value = $ATS_RPM
-    ))')" >/ort-tests/tc-fixtures.json
-  if ! </ort-tests/tc-fixtures.json jq -r --arg ATS_RPM "$ATS_RPM" '.profiles[] |
+    ))')" >/ort-tests/tc-fixtures.json.tmp
+  if ! </ort-tests/tc-fixtures.json.tmp jq -r --arg ATS_RPM "$ATS_RPM" '.profiles[] |
     select(.params != null).params[] |
     select(.configFile == "package" and .name == "trafficserver")
     .value' |
@@ -106,7 +106,7 @@ while ! nc $TO_HOSTNAME $TO_PORT </dev/null; do
   fi
 done
 
-cp /ort-tests/tc-fixtures.json /tc-fixtures.json
+mv /ort-tests/tc-fixtures.json.tmp /tc-fixtures.json
 (touch test.log && chmod a+rw test.log && tail -f test.log)&
 
 go test --cfg=conf/docker-edge-cache.conf 2>&1 >> test.log
@@ -114,7 +114,5 @@ if [[ $? != 0 ]]; then
   echo "ERROR: ORT tests failure"
   exit 3
 fi
-
-cp /tc-fixtures.json /ort-tests/tc-fixtures.json
 
 exit 0

--- a/cache-config/testing/ort-tests/traffic_ops_ort_test.go
+++ b/cache-config/testing/ort-tests/traffic_ops_ort_test.go
@@ -51,7 +51,7 @@ const cfgFmt = `Using Config values:
 func TestMain(m *testing.M) {
 	tcd = tcdata.NewTCData()
 	configFileName := flag.String("cfg", "conf/traffic-ops-test.conf", "The config file path")
-	tcFixturesFileName := flag.String("fixtures", "tc-fixtures.json", "The test fixtures for the API test tool")
+	tcFixturesFileName := flag.String("fixtures", "/tc-fixtures.json", "The test fixtures for the API test tool")
 	cliIncludeSystemTests := *flag.Bool("includeSystemTests", false, "Whether to enable tests that have environment dependencies beyond a database")
 	flag.Parse()
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Currently, the Cache Config Integration Test framework modifies cache-config/ort-tests/tc-fixtures.json with the ATS RPM version before running. Because this file is checked into git, this creates a git change. It means developers have to revert the file before committing, commit -A, can accidentally commit the file with the injected RPM info, etc.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run t3c integration tests and see that tc-fixtures.json is not modified. 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
Not a bug fix.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
