### PR TITLE
Add t3c flag for local ATS version for config gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## [unreleased]
 ### Added
 - [#6033](https://github.com/apache/trafficcontrol/issues/6033) [Traffic Ops, Traffic Portal] Added ability to assign multiple server capabilities to a server.
+- [#7032](https://github.com/apache/trafficcontrol/issues/7032) Add t3c-apply flag to use local ATS version for config generation rather than Server package Parameter, to allow managing the ATS OS package via external tools. See 'man t3c-apply' and 'man t3c-generate' for details.
 - [Traffic Monitor] Added logging for `ipv4Availability` and `ipv6Availability` in TM.
 
 ### Fixed

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -54,189 +54,207 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
 -2, -\-default-client-enable-h2
 
-                    Whether to enable HTTP/2 on Delivery Services by default, if
-                    they have no explicit Parameter. This is irrelevant if ATS
-                    records.config is not serving H2. If omitted, H2 is
-                    disabled.
+    Whether to enable HTTP/2 on Delivery Services by default, if
+    they have no explicit Parameter. This is irrelevant if ATS
+    records.config is not serving H2. If omitted, H2 is
+    disabled.
 
 -a, -\-service-action=value
 
-                    action to perform on Traffic Server and other system
-                    services. Only reloads if necessary, but always restarts.
-                    Default is 'reload'
+    The action to perform on Traffic Server and other system
+    services. Only reloads if necessary, but always restarts.
+    Default is 'reload'
 
 -A, -\-update-ipallow
 
-                    Whether ipallow file will be updated if necessary. This
-                    exists because ATS had a bug where reloading after changing
-                    ipallow would block everything. Default is false.
+    Whether ipallow file will be updated if necessary. This
+    exists because ATS had a bug where reloading after changing
+    ipallow would block everything. Default is false.
+
 -b, -\-dns-local-bind
 
-                    [true | false] whether to use the server's Service Addresses
-                    to set the ATS DNS local bind address
+    [true | false] whether to use the server's Service Addresses
+    to set the ATS DNS local bind address.
 
 -c, -\-disable-parent-config-comments
 
-                    Whether to disable verbose parent.config comments. Default
-                    false.
+    Whether to disable verbose parent.config comments. Default
+    false.
 
 -C, -\-skip-os-check
 
-                    [false | true] skip os check, default is false
+    [false | true] skip os check, default is false
 
 -d, -\-no-unset-update-flag
 
-                    Whether to not unset the update flag in Traffic Ops after
-                    applying files. This option makes it possible to generate
-                    test or debug configuration from a production Traffic Ops
-                    without un-setting queue or reval flags. Default is false.
+    Whether to not unset the update flag in Traffic Ops after
+    applying files. This option makes it possible to generate
+    test or debug configuration from a production Traffic Ops
+    without un-setting queue or reval flags. Default is false.
 
 -e, -\-omit-via-string-release
 
-                    Whether to set the records.config via header to the ATS
-                    release from the RPM. Default true.
+    Whether to set the records.config via header to the ATS
+    release from the RPM. Default true.
 
 -E, -\-version
 
-                    Print version information and exit.
+    Print version information and exit.
 
 -f, -\-files=value  [all | reval]
 
-                    Which files to generate. If reval, the Traffic
-                    Ops server reval_pending flag is used instead of the
-                    upd_pending flag. Default is 'all'
+    Which files to generate. If reval, the Traffic
+    Ops server reval_pending flag is used instead of the
+    upd_pending flag. Default is 'all'.
 
 -F, -\-ignore-update-flag
 
-                    Whether to ignore the upd_pending or reval_pending flag in
-                    Traffic Ops, and always generate and apply files. If true,
-                    the flag is still unset in Traffic Ops after files are
-                    applied. Default is false.
+    Whether to ignore the upd_pending or reval_pending flag in
+    Traffic Ops, and always generate and apply files. If true,
+    the flag is still unset in Traffic Ops after files are
+    applied. Default is false.
 
 -g, -\-git=value
-                    Create and use a git repo in the config directory. Options
-                    are yes, no, and auto. If yes, create and use. If auto, use
-                    if it exist. Default is auto. [auto]
+
+    Create and use a git repo in the config directory. Options
+    are yes, no, and auto. If yes, create and use. If auto, use
+    if it exist. Default is auto. [auto]
 
 -H, -\-cache-host-name=value
 
-                    Host name of the cache to generate config for. Must be the
-                    server host name in Traffic Ops, not a URL, and not the FQDN
+    Host name of the cache to generate config for. Must be the
+    server host name in Traffic Ops, not a URL, and not the FQDN
 
 -h, -\-help
 
-                    Print usage information and exit
+    Print usage information and exit
 
 -i, -\-no-outgoing-ip
 
-     Whether to not set the records.config outgoing IP to the
-     server's addresses in Traffic Ops. Default is false.
+    Whether to not set the records.config outgoing IP to the
+    server's addresses in Traffic Ops. Default is false.
 
 -I, -\-traffic-ops-insecure
 
-                    [true | false] ignore certificate errors from Traffic Ops
+    [true | false] ignore certificate errors from Traffic Ops
 
 -k, -\-install-packages
 
-                    Whether to install necessary packages. Default is false.
+    Whether to install necessary packages. Default is false.
+
+-\-local-ats-version
+
+    [true | false] whether to use the local installed ATS version
+    for config generation. If false, attempt to use the Server
+    Package Parameter and fall back to ATS 5. If true and the
+    local ATS version cannot be found, an error will be logged
+    and the version set to ATS 5. Default is false.
 
 -M, -\-maxmind-location=value
 
-                    URL of a maxmind gzipped database file, to be installed into
-                    the trafficserver etc directory.
+    URL of a maxmind gzipped database file, to be installed into
+    the trafficserver etc directory.
 
 -m, -\-run-mode=value
 
-                    [badass | report | revalidate | syncds] run mode. Optional, convenience flag which sets other flags for common usage scenarios.
-                    syncds     keeps the defaults:
-                                    --report-only=false
-                                    --files=all
-                                    --install-packages=false
-                                    --service-action=reload
-                                    --ignore-update-flag=false
-                                    --update-ipallow=false
-                                    --no-unset-update-flag=false
-                    revalidate sets --files=reval
-                                    --wait-for-parents=true
-                    badass     sets --install-packages=true
-                                    --service-action=restart
-                                    --ignore-update-flag=true
-                                    --update-ipallow=true
-                    report     sets --report-only=true
+    [badass | report | revalidate | syncds] run mode. Optional,
+    convenience flag which sets other flags for common usage
+    scenarios.
 
-                    Note the 'syncds' settings are all the flag defaults. Hence, if no mode is set, the default is effectively 'syncds'.
+        syncds     keeps the defaults:
+                        --report-only=false
+                        --files=all
+                        --install-packages=false
+                        --service-action=reload
+                        --ignore-update-flag=false
+                        --update-ipallow=false
+                        --no-unset-update-flag=false
 
-                    If any of the related flags are also set, they override the mode's default behavior.
+        revalidate sets --files=reval
+                        --wait-for-parents=true
 
- -n, -\-no-cache
+        badass     sets --install-packages=true
+                        --service-action=restart
+                        --ignore-update-flag=true
+                        --update-ipallow=true
+
+        report     sets --report-only=true
+
+    Note the 'syncds' settings are all the flag defaults. Hence,
+    if no mode is set, the default is effectively 'syncds'.
+
+    If any of the related flags are also set, they override the
+    mode's default behavior.
+
+-n, -\-no-cache
 
     Whether to not use a cache and make conditional requests to
     Traffic Ops. Default is false: use cache.
 
 -o, -\-report-only
 
-                    Log information about necessary files and actions, but take
-                    no action. Default is false
+    Log information about necessary files and actions, but take
+    no action. Default is false
 
 -p, -\-reverse-proxy-disable
 
-                    [false | true] bypass the reverse proxy even if one has been
-                    configured default is false
+    [false | true] bypass the reverse proxy even if one has been
+    configured default is false
 
 -P, -\-traffic-ops-password=value
 
-                    Traffic Ops password. Required. May also be set with the
-                    environment variable TO_PASS
+    Traffic Ops password. Required. May also be set with the
+    environment variable TO_PASS
 
 -r, -\-num-retries=value
 
-                    [number] retry connection to Traffic Ops URL [number] times,
-                    default is 3 [3]
+    [number] retry connection to Traffic Ops URL [number] times,
+    default is 3 [3]
 
 -R, -\-trafficserver-home=value
 
-                    Trafficserver Package directory. May also be set with the
-                    environment variable TS_HOME
+    Trafficserver Package directory. May also be set with the
+    environment variable TS_HOME
 
 -s, -\-silent
 
-                    Silent. Errors are not logged, and the 'verbose' flag is
-                    ignored. If a fatal error occurs, the return code will be
-                    non-zero but no text will be output to stderr
+    Silent. Errors are not logged, and the 'verbose' flag is
+    ignored. If a fatal error occurs, the return code will be
+    non-zero but no text will be output to stderr
 
 -t, -\-traffic-ops-timeout-milliseconds=value
 
-                    Timeout in milli-seconds for Traffic Ops requests, default
-                    is 30000 [30000]
+    Timeout in milli-seconds for Traffic Ops requests, default
+    is 30000 [30000]
 
 -u, -\-traffic-ops-url=value
 
-                    Traffic Ops URL. Must be the full URL, including the scheme.
-                    Required. May also be set with the environment variable
-                    TO_URL
+    Traffic Ops URL. Must be the full URL, including the scheme.
+    Required. May also be set with the environment variable
+    TO_URL
 
 -U, -\-traffic-ops-user=value
 
-                    Traffic Ops username. Required. May also be set with the
-                    environment variable TO_USER
+    Traffic Ops username. Required. May also be set with the
+    environment variable TO_USER
 
 -V, -\-default-client-tls-versions=value
 
-                    Comma-delimited list of default TLS versions for Delivery
-                    Services with no Parameter, e.g.
-                    --default-tls-versions='1.1,1.2,1.3'. If omitted, all
-                    versions are enabled.
+    Comma-delimited list of default TLS versions for Delivery
+    Services with no Parameter, e.g.
+    --default-tls-versions='1.1,1.2,1.3'. If omitted, all
+    versions are enabled.
 
 -v, -\-verbose
 
-                    Log verbosity. Logging is output to stderr. By default,
-                    errors are logged. To log warnings, pass '-v'. To log info,
-                    pass '-vv'. To omit error logging, see '-s' [0]
+    Log verbosity. Logging is output to stderr. By default,
+    errors are logged. To log warnings, pass '-v'. To log info,
+    pass '-vv'. To omit error logging, see '-s' [0]
 
 -W, -\-wait-for-parents
 
-                    [true | false] do not update if parent_pending = 1 in the
-                    update json. Default is false
+    [true | false] do not update if parent_pending = 1 in the
+    update json. Default is false
 
 # MODES
 

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -116,6 +117,7 @@ type Cfg struct {
 	UpdateIPAllow     bool
 	Version           string
 	GitRevision       string
+	LocalATSVersion   string
 }
 
 func (cfg Cfg) AppVersion() string { return t3cutil.VersionStr(AppName, cfg.Version, cfg.GitRevision) }
@@ -277,6 +279,9 @@ func GetCfg(appVersion string, gitRevision string) (Cfg, error) {
 	const useStrategiesFlagName = "use-strategies"
 	const defaultUseStrategies = t3cutil.UseStrategiesFlagFalse
 	useStrategiesPtr := getopt.EnumLong(useStrategiesFlagName, 0, []string{string(t3cutil.UseStrategiesFlagTrue), string(t3cutil.UseStrategiesFlagCore), string(t3cutil.UseStrategiesFlagCore), ""}, "", "[true | core| false] whether to generate config using strategies.yaml instead of parent.config. If true use the parent_select plugin, if 'core' use ATS core strategies, if false use parent.config.")
+
+	const useLocalATSVersionFlagName = "local-ats-version"
+	useLocalATSVersionPtr := getopt.BoolLong(useLocalATSVersionFlagName, 0, "[true | false] whether to use the local installed ATS version for config generation. If false, attempt to use the Server Package Parameter and fall back to ATS 5. If true and the local ATS version cannot be found, an error will be logged and the version set to ATS 5. Default is false")
 
 	const runModeFlagName = "run-mode"
 	runModePtr := getopt.StringLong(runModeFlagName, 'm', "", `[badass | report | revalidate | syncds] run mode. Optional, convenience flag which sets other flags for common usage scenarios.
@@ -475,6 +480,15 @@ If any of the related flags are also set, they override the mode's default behav
 		toInfoLog = append(toInfoLog, fmt.Sprintf("TSHome: %s, TSConfigDir: %s\n", TSHome, tsConfigDir))
 	}
 
+	atsVersionStr := ""
+	if *useLocalATSVersionPtr {
+		atsVersionStr, err = GetATSVersionStr(tsHome)
+		if err != nil {
+			return Cfg{}, errors.New("getting local ATS version: " + err.Error())
+		}
+	}
+	toInfoLog = append(toInfoLog, fmt.Sprintf("ATSVersionStr: '%s'\n", atsVersionStr))
+
 	usageStr := "basic usage: t3c-apply --traffic-ops-url=myurl --traffic-ops-user=myuser --traffic-ops-password=mypass --cache-host-name=my-cache"
 	if strings.TrimSpace(toURL) == "" {
 		return Cfg{}, errors.New("Missing required argument --traffic-ops-url or TO_URL environment variable. " + usageStr)
@@ -539,6 +553,7 @@ If any of the related flags are also set, they override the mode's default behav
 		NoUnsetUpdateFlag: *noUnsetUpdateFlagPtr,
 		Version:           appVersion,
 		GitRevision:       gitRevision,
+		LocalATSVersion:   atsVersionStr,
 	}
 
 	if err = log.InitCfg(cfg); err != nil {
@@ -604,6 +619,22 @@ func getOSSvcManagement() SvcManagement {
 	return _svcManager
 }
 
+func GetATSVersionStr(tsHome string) (string, error) {
+	tsPath := tsHome
+	tsPath = filepath.Join(tsPath, "bin")
+	tsPath = filepath.Join(tsPath, "traffic_server")
+
+	stdOut, stdErr, code := t3cutil.Do(`sh`, `-c`, `set -o pipefail && `+tsPath+` --version | head -1 | awk '{print $3}'`)
+	if code != 0 {
+		return "", fmt.Errorf("traffic_server --version returned code %v stderr '%v' stdout '%v'", code, string(stdErr), string(stdOut))
+	}
+	atsVersion := strings.TrimSpace(string(stdOut))
+	if atsVersion == "" {
+		return "", fmt.Errorf("traffic_server --version returned nothing, code %v stderr '%v' stdout '%v'", code, string(stdErr), string(stdOut))
+	}
+	return atsVersion, nil
+}
+
 func printConfig(cfg Cfg) {
 	// TODO add new flags
 	log.Debugf("LogLocationDebug: %s\n", cfg.LogLocationDebug)
@@ -621,6 +652,7 @@ func printConfig(cfg Cfg) {
 	log.Debugf("TOPass: Pass len: '%d'\n", len(cfg.TOPass))
 	log.Debugf("TOURL: %s\n", cfg.TOURL)
 	log.Debugf("TSHome: %s\n", TSHome)
+	log.Debugf("LocalATSVersion: %s\n", cfg.LocalATSVersion)
 	log.Debugf("WaitForParents: %v\n", cfg.WaitForParents)
 	log.Debugf("YumOptions: %s\n", cfg.YumOptions)
 	log.Debugf("MaxmindLocation: %s\n", cfg.MaxMindLocation)

--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -94,6 +94,9 @@ func generate(cfg config.Cfg) ([]t3cutil.ATSConfigFile, error) {
 	if cfg.Files == t3cutil.ApplyFilesFlagReval {
 		args = append(args, "--revalidate-only")
 	}
+	if cfg.LocalATSVersion != "" {
+		args = append(args, "--ats-version="+cfg.LocalATSVersion)
+	}
 	args = append(args, "--via-string-release="+strconv.FormatBool(!cfg.OmitViaStringRelease))
 	args = append(args, "--no-outgoing-ip="+strconv.FormatBool(cfg.NoOutgoingIP))
 	args = append(args, "--disable-parent-config-comments="+strconv.FormatBool(cfg.DisableParentConfigComments))

--- a/cache-config/t3c-generate/README.md
+++ b/cache-config/t3c-generate/README.md
@@ -61,6 +61,13 @@ The output is a JSON array of objects containing the file and its metadata.
     records.config is not serving H2. If omitted, H2 is
     disabled.
 
+-a, -\-ats-version
+
+    The ATS version, e.g. 9.1.2-42.abc123.el7.x86_64. If omitted
+    generation will attempt to get the ATS version from the
+    Server Profile Parameters, and fall back to
+    lib/go-atscfg.DefaultATSVersion.
+
 -b, -\-dns-local-bind
 
     Whether to use the server's Service Addresses to set the ATS

--- a/cache-config/t3c-generate/cfgfile/all.go
+++ b/cache-config/t3c-generate/cfgfile/all.go
@@ -42,7 +42,7 @@ func GetAllConfigs(
 		return nil, errors.New("server hostname is nil")
 	}
 
-	configFiles, warnings, err := MakeConfigFilesList(toData, cfg.Dir)
+	configFiles, warnings, err := MakeConfigFilesList(toData, cfg.Dir, cfg.ATSMajorVersion)
 	logWarnings("generating config files list: ", warnings)
 	if err != nil {
 		return nil, errors.New("creating meta: " + err.Error())

--- a/lib/go-atscfg/atscfg_test.go
+++ b/lib/go-atscfg/atscfg_test.go
@@ -76,7 +76,7 @@ func TestTrimParamUnderscoreNumSuffix(t *testing.T) {
 }
 
 func TestGetATSMajorVersionFromATSVersion(t *testing.T) {
-	inputExpected := map[string]int{
+	inputExpected := map[string]uint{
 		`7.1.2-34.56abcde.el7.centos.x86_64`:    7,
 		`8`:                                     8,
 		`8.1`:                                   8,
@@ -98,14 +98,14 @@ func TestGetATSMajorVersionFromATSVersion(t *testing.T) {
 	}
 
 	for input, expected := range inputExpected {
-		if actual, err := getATSMajorVersionFromATSVersion(input); err != nil {
+		if actual, err := GetATSMajorVersionFromATSVersion(input); err != nil {
 			t.Errorf("expected %v actual: error '%v'", expected, err)
 		} else if actual != expected {
 			t.Errorf("expected %v actual: %v", expected, actual)
 		}
 	}
 	for _, input := range errExpected {
-		if actual, err := getATSMajorVersionFromATSVersion(input); err == nil {
+		if actual, err := GetATSMajorVersionFromATSVersion(input); err == nil {
 			t.Errorf("input %v expected: error, actual: nil error '%v'", input, actual)
 		}
 	}

--- a/lib/go-atscfg/parentabstraction.go
+++ b/lib/go-atscfg/parentabstraction.go
@@ -273,7 +273,7 @@ var DefaultUnavailableServerRetryCodes = []int{503}
 
 const DefaultIgnoreQueryStringInParentSelection = false
 
-func parentAbstractionToParentDotConfig(pa *ParentAbstraction, opt *ParentConfigOpts, atsMajorVersion int) (string, []string, error) {
+func parentAbstractionToParentDotConfig(pa *ParentAbstraction, opt *ParentConfigOpts, atsMajorVersion uint) (string, []string, error) {
 	warnings := []string{}
 	txt := ""
 
@@ -301,7 +301,7 @@ func parentAbstractionToParentDotConfig(pa *ParentAbstraction, opt *ParentConfig
 	return txt, warnings, nil
 }
 
-func (svc *ParentAbstractionService) ToParentDotConfigLine(opt *ParentConfigOpts, atsMajorVersion int) (string, []string, error) {
+func (svc *ParentAbstractionService) ToParentDotConfigLine(opt *ParentConfigOpts, atsMajorVersion uint) (string, []string, error) {
 	warnings := []string{}
 	txt := ""
 	if opt.AddComments && svc.Comment != "" {
@@ -371,7 +371,7 @@ func (svc *ParentAbstractionService) ToParentDotConfigLine(opt *ParentConfigOpts
 		if atsMajorVersion >= 9 {
 			txt += ` simple_server_retry_responses="` + strings.Join(intsToStrs(svc.ErrorResponseCodes), `,`) + `"`
 		} else {
-			warnings = append(warnings, "Service '"+svc.Name+"' had simple retry codes '"+strings.Join(intsToStrs(svc.ErrorResponseCodes), ",")+"' but ATS version "+strconv.Itoa(atsMajorVersion)+" < 9 does not support custom simple retry codes, omitting!")
+			warnings = append(warnings, "Service '"+svc.Name+"' had simple retry codes '"+strings.Join(intsToStrs(svc.ErrorResponseCodes), ",")+"' but ATS version "+strconv.FormatUint(uint64(atsMajorVersion), 10)+" < 9 does not support custom simple retry codes, omitting!")
 		}
 	}
 

--- a/lib/go-atscfg/strategiesdotconfig.go
+++ b/lib/go-atscfg/strategiesdotconfig.go
@@ -41,6 +41,14 @@ type StrategiesYAMLOpts struct {
 	// This should be the text desired, without comment syntax (like # or //). The file's comment syntax will be added.
 	// To omit the header comment, pass the empty string.
 	HdrComment string
+
+	// ATSMajorVersion is the integral major version of Apache Traffic server,
+	// used to generate the proper config for the proper version.
+	//
+	// If omitted or 0, the major version will be read from the Server's Profile Parameter config file 'package' name 'trafficserver'. If no such Parameter exists, the ATS version will default to 5.
+	// This was the old Traffic Control behavior, before the version was specifiable externally.
+	//
+	ATSMajorVersion uint
 }
 
 func MakeStrategiesDotYAML(
@@ -57,10 +65,14 @@ func MakeStrategiesDotYAML(
 	cdn *tc.CDN,
 	opt *StrategiesYAMLOpts,
 ) (Cfg, error) {
+	warnings := []string{}
 	if opt == nil {
 		opt = &StrategiesYAMLOpts{}
 	}
-	parentAbstraction, warnings, err := makeParentDotConfigData(
+
+	atsMajorVersion := getATSMajorVersion(opt.ATSMajorVersion, tcServerParams, &warnings)
+
+	parentAbstraction, dataWarns, err := makeParentDotConfigData(
 		dses,
 		server,
 		servers,
@@ -73,18 +85,18 @@ func MakeStrategiesDotYAML(
 		dss,
 		cdn,
 		&ParentConfigOpts{
-			AddComments: opt.VerboseComments,
-			HdrComment:  opt.HdrComment,
+			AddComments:     opt.VerboseComments,
+			HdrComment:      opt.HdrComment,
+			ATSMajorVersion: opt.ATSMajorVersion,
 		}, // TODO change makeParentDotConfigData to its own opt?
+		atsMajorVersion,
 	)
+	warnings = append(warnings, dataWarns...)
 	if err != nil {
 		return Cfg{}, makeErr(warnings, err.Error())
 	}
 
-	atsMajorVer, verWarns := getATSMajorVersion(tcServerParams)
-	warnings = append(warnings, verWarns...)
-
-	text, paWarns, err := parentAbstractionToStrategiesDotYaml(parentAbstraction, opt, atsMajorVer)
+	text, paWarns, err := parentAbstractionToStrategiesDotYaml(parentAbstraction, opt, atsMajorVersion)
 	warnings = append(warnings, paWarns...)
 	if err != nil {
 		return Cfg{}, makeErr(warnings, err.Error())
@@ -107,7 +119,7 @@ func MakeStrategiesDotYAML(
 const YAMLDocumentStart = "---"
 const YAMLDocumentEnd = "..."
 
-func parentAbstractionToStrategiesDotYaml(pa *ParentAbstraction, opt *StrategiesYAMLOpts, atsMajorVersion int) (string, []string, error) {
+func parentAbstractionToStrategiesDotYaml(pa *ParentAbstraction, opt *StrategiesYAMLOpts, atsMajorVersion uint) (string, []string, error) {
 	warnings := []string{}
 	txt := YAMLDocumentStart +
 		getStrategyHostsSection(pa) +


### PR DESCRIPTION
Adds a new `t3c-apply` `--local-ats-version` flag to discover and use the local installed ATS version for config generation, rather than the Traffic Ops Server `package` Parameter. 

This, combined with the existing `--install-packages=false` flag, allows users to manage the ATS operating system package with an external tool (e.g. Ansible, Puppet, etc).

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c-apply with the new `--local-ats-version` flag with a local installed Traffic server major version different from any Server Package Parameter, verify local ATS version is used to generate rather than package Parameter.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
