### PR TITLE
Add t3c flag to skip confirming reload or restart

### DIFF
--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -191,6 +191,11 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
     Whether to not use a cache and make conditional requests to
     Traffic Ops. Default is false: use cache.
 
+-\-no-confirm-service-action
+
+    Whether to skip waiting and confirming the service action succeeded (reload or
+    restart) via t3c-tail. Default is false.
+
 -o, -\-report-only
 
     Log information about necessary files and actions, but take

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -108,7 +108,9 @@ type Cfg struct {
 	TsHome          string
 	TsConfigDir     string
 
-	ServiceAction     t3cutil.ApplyServiceActionFlag
+	ServiceAction          t3cutil.ApplyServiceActionFlag
+	NoConfirmServiceAction bool
+
 	ReportOnly        bool
 	Files             t3cutil.ApplyFilesFlag
 	InstallPackages   bool
@@ -258,6 +260,9 @@ func GetCfg(appVersion string, gitRevision string) (Cfg, error) {
 	const serviceActionFlagName = "service-action"
 	const defaultServiceAction = t3cutil.ApplyServiceActionFlagReload
 	serviceActionPtr := getopt.EnumLong(serviceActionFlagName, 'a', []string{string(t3cutil.ApplyServiceActionFlagReload), string(t3cutil.ApplyServiceActionFlagRestart), string(t3cutil.ApplyServiceActionFlagNone), ""}, "", "action to perform on Traffic Server and other system services. Only reloads if necessary, but always restarts. Default is 'reload'")
+
+	const noConfirmServiceActionFlagName = "no-confirm-service-action"
+	noConfirmServiceAction := getopt.BoolLong(noConfirmServiceActionFlagName, 0, "Whether to skip waiting and confirming the service action succeeded (reload or restart) via t3c-tail. Default is false.")
 
 	const reportOnlyFlagName = "report-only"
 	reportOnlyPtr := getopt.BoolLong(reportOnlyFlagName, 'o', "Log information about necessary files and actions, but take no action. Default is false")
@@ -544,16 +549,16 @@ If any of the related flags are also set, they override the mode's default behav
 		MaxMindLocation:             maxmindLocation,
 		TsHome:                      TSHome,
 		TsConfigDir:                 tsConfigDir,
-
-		ServiceAction:     t3cutil.ApplyServiceActionFlag(*serviceActionPtr),
-		ReportOnly:        *reportOnlyPtr,
-		Files:             t3cutil.ApplyFilesFlag(*filesPtr),
-		InstallPackages:   *installPackagesPtr,
-		IgnoreUpdateFlag:  *ignoreUpdateFlagPtr,
-		NoUnsetUpdateFlag: *noUnsetUpdateFlagPtr,
-		Version:           appVersion,
-		GitRevision:       gitRevision,
-		LocalATSVersion:   atsVersionStr,
+		ServiceAction:               t3cutil.ApplyServiceActionFlag(*serviceActionPtr),
+		NoConfirmServiceAction:      *noConfirmServiceAction,
+		ReportOnly:                  *reportOnlyPtr,
+		Files:                       t3cutil.ApplyFilesFlag(*filesPtr),
+		InstallPackages:             *installPackagesPtr,
+		IgnoreUpdateFlag:            *ignoreUpdateFlagPtr,
+		NoUnsetUpdateFlag:           *noUnsetUpdateFlagPtr,
+		Version:                     appVersion,
+		GitRevision:                 gitRevision,
+		LocalATSVersion:             atsVersionStr,
 	}
 
 	if err = log.InitCfg(cfg); err != nil {
@@ -654,6 +659,8 @@ func printConfig(cfg Cfg) {
 	log.Debugf("TSHome: %s\n", TSHome)
 	log.Debugf("LocalATSVersion: %s\n", cfg.LocalATSVersion)
 	log.Debugf("WaitForParents: %v\n", cfg.WaitForParents)
+	log.Debugf("ServiceAction: %v\n", cfg.ServiceAction)
+	log.Debugf("NoConfirmServiceAction: %v\n", cfg.NoConfirmServiceAction)
 	log.Debugf("YumOptions: %s\n", cfg.YumOptions)
 	log.Debugf("MaxmindLocation: %s\n", cfg.MaxMindLocation)
 }

--- a/cache-config/t3c-apply/torequest/torequest.go
+++ b/cache-config/t3c-apply/torequest/torequest.go
@@ -1120,8 +1120,14 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus, metaData *t3cu
 		}
 		t3cutil.WriteActionLog(t3cutil.ActionLogActionATSRestart, t3cutil.ActionLogStatusSuccess, metaData)
 		log.Infoln("trafficserver has been " + startStr + "ed")
-		if err := doTail(r.Cfg, TailDiagsLogRelative, ".*", tailRestartEnd, TailRestartTimeOutMS); err != nil {
-			log.Errorln("error running tail")
+
+		if !r.Cfg.NoConfirmServiceAction {
+			log.Infoln("confirming ATS restart succeeded")
+			if err := doTail(r.Cfg, TailDiagsLogRelative, ".*", tailRestartEnd, TailRestartTimeOutMS); err != nil {
+				log.Errorln("error running tail")
+			}
+		} else {
+			log.Infoln("skipping ATS restart success confirmation")
 		}
 		if *syncdsUpdate == UpdateTropsNeeded {
 			*syncdsUpdate = UpdateTropsSuccessful
@@ -1149,8 +1155,14 @@ func (r *TrafficOpsReq) StartServices(syncdsUpdate *UpdateStatus, metaData *t3cu
 				*syncdsUpdate = UpdateTropsSuccessful
 			}
 			log.Infoln("ATS 'traffic_ctl config reload' was successful")
-			if err := doTail(r.Cfg, TailDiagsLogRelative, tailMatch, tailReloadEnd, TailReloadTimeOutMS); err != nil {
-				log.Errorln("error running tail: ", err)
+
+			if !r.Cfg.NoConfirmServiceAction {
+				log.Infoln("confirming ATS reload succeeded")
+				if err := doTail(r.Cfg, TailDiagsLogRelative, tailMatch, tailReloadEnd, TailReloadTimeOutMS); err != nil {
+					log.Errorln("error running tail: ", err)
+				}
+			} else {
+				log.Infoln("skipping ATS reload success confirmation")
 			}
 		}
 		if *syncdsUpdate == UpdateTropsNeeded {

--- a/cache-config/testing/ort-tests/t3c-apply-unset-update_test.go
+++ b/cache-config/testing/ort-tests/t3c-apply-unset-update_test.go
@@ -139,6 +139,7 @@ func TestT3cUnsetsUpdateFlag(t *testing.T) {
 func t3cUpdateUnsetFlag(host string, runMode string) (string, int) {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-apply-wait-for-parents_test.go
+++ b/cache-config/testing/ort-tests/t3c-apply-wait-for-parents_test.go
@@ -320,6 +320,7 @@ func getUpdateStatus(hostName string) (atscfg.ServerUpdateStatus, error) {
 func t3cUpdateWaitForParents(host string, runMode string, waitForParents *string) (string, error) {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
+++ b/cache-config/testing/ort-tests/t3c-create-empty-file_test.go
@@ -68,6 +68,7 @@ func TestT3cCreateEmptyFile(t *testing.T) {
 func t3cUpdateCreateEmptyFile(host string, run_mode string) error {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-dns-local-bind_test.go
+++ b/cache-config/testing/ort-tests/t3c-dns-local-bind_test.go
@@ -55,6 +55,7 @@ func TestT3CDNSLocalBind(t *testing.T) {
 func t3cUpdateDNSLocalBind(host string, run_mode string) error {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-git_test.go
+++ b/cache-config/testing/ort-tests/t3c-git_test.go
@@ -126,6 +126,7 @@ func gitLogOneline(dir string) (string, error) {
 func t3cUpdateGit(host string, run_mode string) error {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-ims_test.go
+++ b/cache-config/testing/ort-tests/t3c-ims_test.go
@@ -162,6 +162,7 @@ func doTestIMSChangedCDN(t *testing.T) {
 func t3cApplyCache(host string, noCache bool) (string, int) {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-no-outgoing-ip-flag_test.go
+++ b/cache-config/testing/ort-tests/t3c-no-outgoing-ip-flag_test.go
@@ -69,6 +69,7 @@ func TestT3CNoOutgoingIP(t *testing.T) {
 func t3cUpdateNoOutgoingIP(host string, noOutgoingIP *bool) error {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-os-hostname-short_test.go
+++ b/cache-config/testing/ort-tests/t3c-os-hostname-short_test.go
@@ -108,6 +108,7 @@ func getHostName() (string, int) {
 func t3cApplyNoHost() (string, int) {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-reload_test.go
+++ b/cache-config/testing/ort-tests/t3c-reload_test.go
@@ -195,6 +195,7 @@ func doTestT3cReloadState(t *testing.T) {
 func t3cUpdateReload(host string, runMode string) (string, int) {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,

--- a/cache-config/testing/ort-tests/t3c-tail_test.go
+++ b/cache-config/testing/ort-tests/t3c-tail_test.go
@@ -1,0 +1,99 @@
+package orttest
+
+/*
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/testing/ort-tests/tcdata"
+)
+
+func TestT3cTail(t *testing.T) {
+	// t3c must create semantically blank files. Failing to do so will cause other config files that reference them to fail.
+	tcd.WithObjs(t, []tcdata.TCObj{
+		tcdata.CDNs, tcdata.Types, tcdata.Tenants, tcdata.Parameters,
+		tcdata.Profiles, tcdata.ProfileParameters,
+		tcdata.Divisions, tcdata.Regions, tcdata.PhysLocations,
+		tcdata.CacheGroups, tcdata.Servers, tcdata.Topologies,
+		tcdata.DeliveryServices}, func() {
+
+		t.Run("confirm default flags run t3c-tail ATS restart confirmation", func(t *testing.T) {
+			stdErr, err := t3cUpdateWithTail(DefaultCacheHostName, "badass", true)
+			if err != nil {
+				t.Fatalf("t3c badass failed: %v", err)
+			}
+
+			if !bytes.Contains(stdErr, []byte(`confirming ATS restart succeeded`)) {
+				t.Errorf("expected t3c log to have confirmed ATS restart (t3c-tail), actual: %v", string(stdErr))
+			}
+
+			if bytes.Contains(stdErr, []byte(`skipping ATS restart success confirmation`)) {
+				t.Errorf("expected t3c log to not have skipped ATS restart (t3c-tail), actual: %v", string(stdErr))
+			}
+
+		})
+
+		t.Run("confirm t3c-apply --no-confirm-service-action does not t3c-tail for ATS restart confirmation", func(t *testing.T) {
+			stdErr, err := t3cUpdateWithTail(DefaultCacheHostName, "badass", false)
+			if err != nil {
+				t.Fatalf("t3c badass failed: %v", err)
+			}
+
+			if bytes.Contains(stdErr, []byte(`confirming ATS restart succeeded`)) {
+				t.Errorf("expected t3c --no-confirm-service-action flag log to not confirm ATS restart (t3c-tail), actual: %v", string(stdErr))
+			}
+
+			if !bytes.Contains(stdErr, []byte(`skipping ATS restart success confirmation`)) {
+				t.Errorf("expected t3c --no-confirm-service-action flag to log not confirming ATS restart (t3c-tail), actual: %v", string(stdErr))
+			}
+
+		})
+
+	})
+}
+
+func t3cUpdateWithTail(host string, runMode string, withTail bool) ([]byte, error) {
+	args := []string{
+		"apply",
+		"--traffic-ops-insecure=true",
+		"--traffic-ops-timeout-milliseconds=3000",
+		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,
+		"--traffic-ops-password=" + tcd.Config.TrafficOps.UserPassword,
+		"--traffic-ops-url=" + tcd.Config.TrafficOps.URL,
+		"--cache-host-name=" + host,
+		"-vv",
+		"--omit-via-string-release=true",
+		"--run-mode=" + runMode,
+		"--git=no",
+	}
+
+	if !withTail {
+		args = append(args, "--no-confirm-service-action")
+	}
+
+	cmd := exec.Command("t3c", args...)
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err := cmd.Run()
+	if err != nil {
+		return nil, errors.New(err.Error() + ": " + "stdout: " + out.String() + " stderr: " + errOut.String())
+	}
+	return errOut.Bytes(), nil
+}

--- a/cache-config/testing/ort-tests/traffic_ops_ort_test.go
+++ b/cache-config/testing/ort-tests/traffic_ops_ort_test.go
@@ -162,6 +162,7 @@ func runRequest(host string, getData string) ([]byte, error) {
 func runApply(host string, run_mode string) error {
 	args := []string{
 		"apply",
+		"--no-confirm-service-action",
 		"--traffic-ops-insecure=true",
 		"--traffic-ops-timeout-milliseconds=3000",
 		"--traffic-ops-user=" + tcd.Config.TrafficOps.Users.Admin,


### PR DESCRIPTION
Adds a flag to skip the t3c-tail reload/restart confirmation.

The primary motivation for this is tests. Waiting for ATS to completely start with every test makes the tests take so long they timeout and fail. Production systems shouldn't ever need to skip the confirmation. But it's still a good feature-flag to have, in case there are ever issues.

I added a test to verify the logs for enabling vs disabling the check. The actual t3c-tail run can't really be verified because it has no side-effects. I'm not a fan of tests that don't actually test the real behavior; but I'm also not a fan of features not having tests. Not sure which is really better here.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
There's no good way to really verify whether the confirmation happened. I did add info logs you can look for, `confirming ATS reload|restart succeeded` and `skipping ATS reload success confirmation`. But the tail itself has no side-effects, so it can't really be verified to have occurred.

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix.


## PR submission checklist
- [x] This PR has tests
- [x] This PR has documentation 
- ~[x] This PR has a CHANGELOG.md entry~ t3c-tail already has a changelog entry 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
