### PR TITLE
Run tests against Apache Traffic Server 9.1

### DIFF
--- a/.github/actions/repo-info/README.md
+++ b/.github/actions/repo-info/README.md
@@ -56,5 +56,5 @@ jobs:
           with:
             - owner: apache
             - repo: trafficserver
-            - branch: 8.1.x
+            - branch: 9.1.x
 ```

--- a/.github/actions/repo-info/action.yml
+++ b/.github/actions/repo-info/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'The owners github repository ie, "trafficcontrol"'
     required: true
   branch:
-    description: 'The repository branch to query ie, "8.1.0-branch"'
+    description: 'The repository branch to query ie, "9.1.3-branch"'
     required: true
 outputs:
   expected-rpm-name:

--- a/.github/workflows/cache-config-tests.yml
+++ b/.github/workflows/cache-config-tests.yml
@@ -18,7 +18,7 @@
 name: T3C Integration Tests
 
 env:
-  ATS_VERSION: 8.1.x
+  ATS_VERSION: 9.1.x
   RHEL_VERSION: 8
   TARGET_ARCH: x86_64
 

--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -257,7 +257,7 @@ jobs:
         with:
           owner: apache
           repo: trafficserver
-          branch: 8.1.x
+          branch: 9.1.x
         id: repo-info
       - name: Check Cache
         id: ats-rpm-cache

--- a/.github/workflows/health-client-tests.yml
+++ b/.github/workflows/health-client-tests.yml
@@ -18,7 +18,7 @@
 name: TC Health Client Integration Tests
 
 env:
-  ATS_VERSION: 8.1.x
+  ATS_VERSION: 9.1.x
   RHEL_VERSION: 8
   TARGET_ARCH: x86_64
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#4654](https://github.com/apache/trafficcontrol/pull/4654) *Traffic Ops, Traffic Portal* Switched Delivery Service active state to a three-value system, adding a state that will be used to prevent cache servers from deploying DS configuration.
 - [#7242](https://github.com/apache/trafficcontrol/pull/7276) *Traffic Portal* Now depends on NodeJS version 16 or later.
 - [#7120](https://github.com/apache/trafficcontrol/pull/7120) *Docs* Update t3c documentation regarding parent.config parent_retry.
+- [#7044](https://github.com/apache/trafficcontrol/issues/7044) *CDN in a Box* [CDN in a Box, the t3c integration tests, and the tc health client integration tests now use Apache Traffic Server 9.1.
 
 ### Fixed
 - [#5557](https://github.com/apache/trafficcontrol/issues/5557) *Traffic Portal* Moved `Fair Queueing Pacing Rate Bps` DS field to `Cache Configuration Settings` section.

--- a/cache-config/testing/docker/variables.env
+++ b/cache-config/testing/docker/variables.env
@@ -57,7 +57,7 @@ TV_USER_PASS=twelve
 X509_CA_PERSIST_DIR=/ca
 X509_CA_PERSIST_ENV_FILE=/ca/environment
 # trafficserver build variables
-ATS_VERSION=8.1.x
+ATS_VERSION=9.1.x
 CJOSE_URL=https://github.com/cisco/cjose
 CJOSE_TAG=latest
 JANSSON_URL=https://github.com/akheron/jansson

--- a/docs/source/admin/quick_howto/ciab.rst
+++ b/docs/source/admin/quick_howto/ciab.rst
@@ -65,11 +65,11 @@ In a typical scenario, if the steps in `Building`_ have been followed, all that'
 	+=================================+====================================================================+=======================================+===========================================+
 	| DNS                             | DNS name resolution on 9353                                        | N/A                                   | N/A                                       |
 	+---------------------------------+--------------------------------------------------------------------+---------------------------------------+-------------------------------------------+
-	| Edge Tier Cache                 | Apache Trafficserver 8.1 HTTP caching reverse proxy on port 9000   | N/A                                   | N/A                                       |
+	| Edge Tier Cache                 | Apache Trafficserver 9.1 HTTP caching reverse proxy on port 9000   | N/A                                   | N/A                                       |
 	+---------------------------------+--------------------------------------------------------------------+---------------------------------------+-------------------------------------------+
-	| Mid Tier Cache                  | Apache Trafficserver 8.1 HTTP caching forward proxy on port 9100   | N/A                                   | N/A                                       |
+	| Mid Tier Cache                  | Apache Trafficserver 9.1 HTTP caching forward proxy on port 9100   | N/A                                   | N/A                                       |
 	+---------------------------------+--------------------------------------------------------------------+---------------------------------------+-------------------------------------------+
-	| Second Mid-Tier Cache (parent   | Apache Trafficserver 8.1 HTTP caching forward proxy on port 9100   | N/A                                   | N/A                                       |
+	| Second Mid-Tier Cache (parent   | Apache Trafficserver 9.1 HTTP caching forward proxy on port 9100   | N/A                                   | N/A                                       |
 	| of the first Mid-Tier Cache)    |                                                                    |                                       |                                           |
 	+---------------------------------+--------------------------------------------------------------------+---------------------------------------+-------------------------------------------+
 	| Mock Origin Server              | Example web page served on port 9200                               | N/A                                   | N/A                                       |

--- a/tc-health-client/testing/docker/health-check-test/Dockerfile
+++ b/tc-health-client/testing/docker/health-check-test/Dockerfile
@@ -38,7 +38,10 @@ EXPOSE 80 443
 # no checks required at this time.
 RUN yum install -y epel-release && yum repolist && \
   yum install -y brotli initscripts jansson jansson-devel \
-    git gcc hwloc jq lua luajit man-db tcl && \
+    git gcc hwloc jq lua luajit man-db tcl \
+    # libmaxminddb is required by trafficserver
+    libmaxminddb \
+    && \
   yum clean all
 
 RUN echo "Using Image ${OS_DISTRO}:${OS_VERSION}"


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR closes #7044 by making t3c integration tests, the tc-health-client integration tests, and CDN in a Box use ATS 9.1.x instead of what they currently use, ATS 8.1.x.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT) - tests
- Traffic Control Health Client (tc-health-client) - tests
- CDN in a Box - ATS version used by Edge and Mid caches
- Automation - GitHub Actions<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Verify that the GitHub Actions for CDN in a Box, the t3c integration tests, and the tc-health-client integration tests pass

## PR submission checklist
- [x] This PR affects tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)