### PR TITLE
Add configuration setting for TO client request timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7021](https://github.com/apache/trafficcontrol/issues/7021) *Cache Config* Fixed cache config for Delivery Services with IP Origins.
 - [#7043](https://github.com/apache/trafficcontrol/issues/7043) Fixed cache config missing retry parameters for non-topology MSO Delivery Services going direct from edge to origin.
 - [#7047](https://github.com/apache/trafficcontrol/issues/7047) *Traffic Ops* allow `apply_time` query parameters on the `servers/{id-name}/update` when the CDN is locked.
+- [#7048](https://github.com/apache/trafficcontrol/issues/7048) *Traffic Stats* Add configuration value to set the client request timeout for calls to Traffic Ops.
 - Updated Apache Tomcat from 9.0.43 to 9.0.67
 
 ## [7.0.0] - 2022-07-19

--- a/docs/source/admin/traffic_stats.rst
+++ b/docs/source/admin/traffic_stats.rst
@@ -50,6 +50,7 @@ Traffic Stats's configuration file can be found in :file:`/opt/traffic_stats/con
 :toUser: The username of the user as whom to connect to Traffic Ops
 :toPasswd: The password to use when authenticating with Traffic Ops
 :toUrl: The URL of the Traffic Ops server used by Traffic Stats
+:toRequestTimeout: The time, in seconds, before a client request to Traffic Ops is canceled. Defaults to 10 if no value provided
 :influxUser: Optionally specify the user to use when connecting to InfluxDB (if InfluxDB is not configured to require authentication, has no effect)
 :influxPassword: Optionally specify the password to use when connecting to InfluxDB (if InfluxDB is not configured to require authentication, has no effect)
 :pollingInterval: The interval in seconds for which Traffic Monitor will wait between polling for stats and storing them in InfluxDB

--- a/infrastructure/ansible/roles/traffic_stats/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_stats/defaults/main.yml
@@ -28,6 +28,7 @@ ts_install_logdir: "{{ ts_install_basedir }}/var/log/traffic_stats"
 ts_toUser:
 ts_toPasswd:
 ts_toUrl: https://kabletown.invalid
+ts_toRequestTimeout: 10
 
 # InfluxDB credentials
 ts_influxUser: influxUser

--- a/infrastructure/ansible/roles/traffic_stats/templates/traffic_stats.cfg.j2
+++ b/infrastructure/ansible/roles/traffic_stats/templates/traffic_stats.cfg.j2
@@ -15,6 +15,7 @@
         "toUser": "{{ ts_toUser }}",
         "toPasswd": "{{ ts_toPasswd }}",
         "toUrl": "{{ ts_toUrl }}",
+        "toRequestTimeout": "{{ ts_toRequestTimeout }}",
         "influxUser": "{{ ts_influxUser }}",
         "influxPassword": "{{ ts_influxPassword }}",
         "pollingInterval": {{ ts_pollingInterval }},

--- a/infrastructure/cdn-in-a-box/traffic_stats/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_stats/run.sh
@@ -75,7 +75,7 @@ cat <<-EOF >$TSCONF
 	"toUser": "$TO_ADMIN_USER",
 	"toPasswd": "$TO_ADMIN_PASSWORD",
 	"toUrl": "$TO_URL",
-  "toRequestTimeout": 10,
+	"toRequestTimeout": 10,
 	"influxUser": "$INFLUXDB_ADMIN_USER",
 	"influxPassword": "$INFLUXDB_ADMIN_PASSWORD",
 	"pollingInterval": 10,

--- a/infrastructure/cdn-in-a-box/traffic_stats/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_stats/run.sh
@@ -75,6 +75,7 @@ cat <<-EOF >$TSCONF
 	"toUser": "$TO_ADMIN_USER",
 	"toPasswd": "$TO_ADMIN_PASSWORD",
 	"toUrl": "$TO_URL",
+  "toRequestTimeout": 10,
 	"influxUser": "$INFLUXDB_ADMIN_USER",
 	"influxPassword": "$INFLUXDB_ADMIN_PASSWORD",
 	"pollingInterval": 10,

--- a/traffic_stats/traffic_stats.cfg
+++ b/traffic_stats/traffic_stats.cfg
@@ -2,6 +2,7 @@
 	"toUser": "admin",
 	"toPasswd": "",
 	"toUrl": "https://localhost",
+	"toRequestTimeout": 10,
 	"disableInflux": false,
 	"influxUser": "influxUser",
 	"influxPassword": "",

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -726,7 +726,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
-	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds))
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds)*time.Second)
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		errorln(newErr)
@@ -740,7 +740,7 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds))
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds)*time.Second)
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -48,9 +48,9 @@ import (
 )
 
 const UserAgent = "traffic-stats"
-const TrafficOpsRequestTimeout = time.Second * time.Duration(10)
 
 const (
+	defaultTrafficOpsRequestTimeout    = 10
 	defaultPollingInterval             = 10
 	defaultDailySummaryPollingInterval = 60
 	defaultConfigInterval              = 300
@@ -95,6 +95,7 @@ type StartupConfig struct {
 	ToUser                      string   `json:"toUser"`
 	ToPasswd                    string   `json:"toPasswd"`
 	ToURL                       string   `json:"toUrl"`
+	ToRequestTimeoutSeconds     int      `json:"toRequestTimeout"`
 	DisableInflux               bool     `json:"disableInflux"`
 	InfluxUser                  string   `json:"influxUser"`
 	InfluxPassword              string   `json:"influxPassword"`
@@ -516,6 +517,10 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 		config.MaxPublishSize = defaultMaxPublishSize
 	}
 
+	if config.ToRequestTimeoutSeconds == 0 {
+		config.ToRequestTimeoutSeconds = defaultTrafficOpsRequestTimeout
+	}
+
 	if config.LogConfig != nil {
 		if err = log.InitCfg(config.LogConfig); err != nil {
 			return config, fmt.Errorf("initializing logging configuration: %w", err)
@@ -721,7 +726,7 @@ func queryDB(con influx.Client, cmd string, database string) (res []influx.Resul
 }
 
 func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
-	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds))
 	if err != nil {
 		newErr := fmt.Errorf("Could not store summary stats! Error logging in to %v: %v", config.ToURL, err)
 		errorln(newErr)
@@ -735,7 +740,7 @@ func writeSummaryStats(config StartupConfig, statsSummary tc.StatsSummary) {
 
 func getToData(config StartupConfig, init bool, configChan chan RunningConfig) {
 	var runningConfig RunningConfig
-	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, TrafficOpsRequestTimeout)
+	to, _, err := client.LoginWithAgent(config.ToURL, config.ToUser, config.ToPasswd, true, UserAgent, false, time.Duration(config.ToRequestTimeoutSeconds))
 	if err != nil {
 		msg := fmt.Sprintf("Error logging in to %v: %v", config.ToURL, err)
 		if init {

--- a/traffic_stats/traffic_stats.go
+++ b/traffic_stats/traffic_stats.go
@@ -517,7 +517,7 @@ func loadStartupConfig(configFile string, oldConfig StartupConfig) (StartupConfi
 		config.MaxPublishSize = defaultMaxPublishSize
 	}
 
-	if config.ToRequestTimeoutSeconds == 0 {
+	if config.ToRequestTimeoutSeconds <= 0 {
 		config.ToRequestTimeoutSeconds = defaultTrafficOpsRequestTimeout
 	}
 


### PR DESCRIPTION
Closes: #7048 

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Ensure the all tests (especially CDN-in-a-box) continues to work and run. Traffic Stats should run whether the configuration value is present or not. It will default to the previous hard coded 10 seconds. However, now it should also accept the new "toRequestTimeout" value in the .cfg file.

As this requires an unresponsive/slow TO instance, testing can be difficult. This can be done locally with a debug build and breakpoints. You can put a breakpoint at the beginning of the TO GET v3.1/servers endpoint and waiting longer the alloted time (be it the 10 second default or whatever custom value you place) which will prevent Traffic Stats from receiving a response in time and cause the error to appear in the log. The error is:

```
[ERROR] 2022-08-30 14:36:10 Error getting server list from https://{{traffic_ops_url}}/: Get "https://{{traffic_ops_url}}/api/3.1/servers": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The next time through you can remove the breakpoint and allow it to proceed normally. The error will not appear and TS will function normally.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests - Traffic Stats has minimal testing support and would require significant refactoring for this test.
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
