### PR TITLE
TP: Adds the ability to turn ACME on/off for generating SSL keys for a delivery service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6033](https://github.com/apache/trafficcontrol/issues/6033) [Traffic Ops, Traffic Portal] Added ability to assign multiple server capabilities to a server.
 - [#7032](https://github.com/apache/trafficcontrol/issues/7032) Add t3c-apply flag to use local ATS version for config generation rather than Server package Parameter, to allow managing the ATS OS package via external tools. See 'man t3c-apply' and 'man t3c-generate' for details.
 - [Traffic Monitor] Added logging for `ipv4Availability` and `ipv6Availability` in TM.
+- [Traffic Portal] Added the ability to turn ACME on/off when generating SSL keys for a delivery service. This change requires a change to TP's config file: traffic_portal_properties.json.
 
 ### Fixed
 - Traffic Stats: Reuse InfluxDB client handle to prevent potential connection leaks

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceSslKeys/generate/FormGenerateDeliveryServiceSslKeysController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceSslKeys/generate/FormGenerateDeliveryServiceSslKeysController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var FormGenerateDeliveryServiceSslKeysController = function(deliveryService, sslKeys, sslRequest, $scope, $uibModal, locationUtils, deliveryServiceSslKeysService, formUtils) {
+var FormGenerateDeliveryServiceSslKeysController = function(deliveryService, propertiesModel, sslKeys, sslRequest, $scope, $uibModal, locationUtils, deliveryServiceSslKeysService, formUtils) {
 
 	var setSSLRequest = function(sslRequest) {
 		if (!sslRequest.hostname) {
@@ -49,6 +49,8 @@ var FormGenerateDeliveryServiceSslKeysController = function(deliveryService, ssl
 			getAcmeProviders();
 		}
 	};
+
+	$scope.showAcme = propertiesModel.properties.deliveryServices.showAcme;
 
 	$scope.useAcme = false;
 	$scope.acmeProviders = [];
@@ -366,5 +368,5 @@ var FormGenerateDeliveryServiceSslKeysController = function(deliveryService, ssl
 
 };
 
-FormGenerateDeliveryServiceSslKeysController.$inject = ['deliveryService', 'sslKeys', 'sslRequest', '$scope', '$uibModal', 'locationUtils', 'deliveryServiceSslKeysService', 'formUtils'];
+FormGenerateDeliveryServiceSslKeysController.$inject = ['deliveryService', 'propertiesModel', 'sslKeys', 'sslRequest', '$scope', '$uibModal', 'locationUtils', 'deliveryServiceSslKeysService', 'formUtils'];
 module.exports = FormGenerateDeliveryServiceSslKeysController;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceSslKeys/generate/form.GenerateDeliveryServiceSslKeys.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceSslKeys/generate/form.GenerateDeliveryServiceSslKeys.tpl.html
@@ -30,11 +30,11 @@ under the License.
     <div class="x_content">
         <br>
         <form name="dsGenerateSslKeyForm" class="form-horizontal form-label-left" novalidate>
-            <div class="form-group">
+            <div class="form-group" ng-show="showAcme">
                 <label for="acmeSlider" class="control-label col-md-2 col-sm-2 col-xs-12">Use ACME</label>
                 <div class="col-md-10 col-sm-10 col-xs-12" style="padding-top: 10px">
                     <label class="switch">
-                        <input id="acmeSlider" type="checkbox" ng-model="useAcme" ng-change="loadAcmeProviders()">
+                        <input id="acmeSlider" type="checkbox" ng-model="useAcme" ng-change="loadAcmeProviders()" ng-disabled="!showAcme">
                         <span class="slider round"></span>
                     </label>
                 </div>

--- a/traffic_portal/app/src/traffic_portal_properties.json
+++ b/traffic_portal/app/src/traffic_portal_properties.json
@@ -181,6 +181,7 @@
           "ecsEnabled": false
         }
       },
+      "showAcme": true,
       "charts": {
         "_comment": "Delivery Service Charts",
         "autoRefresh": true,


### PR DESCRIPTION

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Portal

## What is the best way to verify this PR?
In TP, navigate to an HTTPS delivery service and select More > Manage SSL Keys then More > Generate SSL Keys. If in trafffic_portal_properties.json deliveryServices.showAcme=true, you will see the `Use ACME` slider, otherwise, you will not.

## PR submission checklist
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
