### PR TITLE
Fix t3c for large number of added files

### DIFF
--- a/cache-config/t3c-apply/torequest/cmd.go
+++ b/cache-config/t3c-apply/torequest/cmd.go
@@ -390,9 +390,7 @@ func diff(cfg config.Cfg, newFile []byte, fileLocation string, reportOnly bool, 
 // The cfgFile should be the full text of either a plugin.config or remap.config.
 // Returns nil if t3c-check-refs returned no errors found, or the error found if any.
 func checkRefs(cfg config.Cfg, cfgFile []byte, filesAdding []string) error {
-	args := []string{`check`, `refs`,
-		"--files-adding=" + strings.Join(filesAdding, ","),
-	}
+	args := []string{`check`, `refs`, `--files-adding=input`}
 	if cfg.LogLocationErr == log.LogLocationNull {
 		args = append(args, "-s")
 	}
@@ -403,7 +401,12 @@ func checkRefs(cfg config.Cfg, cfgFile []byte, filesAdding []string) error {
 		args = append(args, "-v")
 	}
 
-	stdOut, stdErr, code := t3cutil.DoInput(cfgFile, t3cpath, args...)
+	inputBts, err := json.Marshal(&t3cutil.CheckRefsInputFileAndAdding{File: cfgFile, Adding: filesAdding})
+	if err != nil {
+		return errors.New("marshalling json input: " + err.Error())
+	}
+
+	stdOut, stdErr, code := t3cutil.DoInput(inputBts, t3cpath, args...)
 
 	if code != 0 {
 		logSubAppErr(t3cchkrefs+` stdout`, stdOut)

--- a/cache-config/t3c-check-refs/README.md
+++ b/cache-config/t3c-check-refs/README.md
@@ -71,6 +71,22 @@ supplied, t3c-check-refs reads its config file input from stdin.
     comma-delimited list of file names being added, to not fail
     to verify if they don't already exist.
 
+    Alternatively, this may be "input" in which case the input
+    (stdin or the passed argument filename) should be JSON of
+    the form:
+
+    {"file": "config-file-text", "adding": ["files-adding"]}
+
+    Where 'config-file-text' is the text of the config file to check
+    (which otherwise would have been passed to input unadorned),
+    and 'files-adding' is a JSON array of the files added
+    (which otherwise would have been passed to --files-adding).
+    and the full input is properly formed JSON, with the config
+    file escaped for JSON.
+
+    Callers are encouraged to use the --files-adding=input format
+    to avoid errors from operating system argument length limits.
+
 -h, -\-help
 
     Print usage information and exit

--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -438,3 +438,10 @@ func sortAndCombineStrs(as []string, bs []string) []string {
 	}
 	return combined
 }
+
+// CheckRefsInputFileAndAdding is the input (stdin or file) for t3c-check-refs if
+// --files-adding=input. If not, the input is simply the raw file to check.
+type CheckRefsInputFileAndAdding struct {
+	File   []byte   `json:"file"`
+	Adding []string `json:"adding"`
+}

--- a/lib/go-util/util.go
+++ b/lib/go-util/util.go
@@ -36,3 +36,13 @@ func Stacktrace() []byte {
 		buf = make([]byte, len(buf)*2)
 	}
 }
+
+// SliceToSet converts a slice to a map whose keys are the slice members, that is, a set.
+// Note duplicates will be lost, as is the nature of a set.
+func SliceToSet[T comparable](sl []T) map[T]struct{} {
+	st := map[T]struct{}{}
+	for _, val := range sl {
+		st[val] = struct{}{}
+	}
+	return st
+}


### PR DESCRIPTION
Fixes t3c-check-refs to accept the list of added files over stdin or the input file, instead of an arg.

Also changes the corresponding t3c-apply call of check-refs to pass the list as input.

Because many operating systems (including the supported CentOS Linux) have argument length limits, this caused t3c-check-refs and therefore t3c-apply to fail for large numbers of added files.

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Run t3c with a large number of newly-added files, verify it succeeds.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 6.0.0 and newer


## PR submission checklist
- ~[x] This PR has tests~ Functionality is tested in numerous existing tests.
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
