### PR TITLE
Add t3-tail to .gitignore

### DIFF
--- a/cache-config/.gitignore
+++ b/cache-config/.gitignore
@@ -26,6 +26,7 @@ t3c-diff/t3c-diff
 t3c-generate/t3c-generate
 t3c-preprocess/t3c-preprocess
 t3c-request/t3c-request
+t3c-tail/t3c-tail
 t3c-update/t3c-update
 
 # generated documentation


### PR DESCRIPTION
Adds the built `t3c-tail` binary to the list of git-ignored files.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Build t3c-tail then run `git status`


## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**