### PR TITLE
Fix duplicate labels in the documentation

### DIFF
--- a/docs/source/api/v4/deliveryservice_stats.rst
+++ b/docs/source/api/v4/deliveryservice_stats.rst
@@ -77,7 +77,7 @@ Request Structure
 	|                     |                   | Epoch, or in the same, proprietary format as the ``lastUpdated`` fields prevalent throughout the Traffic Ops API                                                                          |
 	+---------------------+-------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-.. _deliveryservice_stats-get-request-example:
+.. _v4-deliveryservice_stats-get-request-example:
 .. code-block:: http
 	:caption: Request Example
 
@@ -90,7 +90,7 @@ Request Structure
 
 Content Format
 """"""""""""""
-It's important to note in :ref:`deliveryservice_stats-get-request-example` the use of a complex "Accept" header. This endpoint accepts two special media types in the "Accept" header that instruct it on how to format the timestamps associated with the returned data. Specifically, Traffic Ops will recognize the special, optional, non-standard parameter of :mimetype:`application/json`: ``timestamp``. The values of this parameter are restricted to one of
+It's important to note in :ref:`v4-deliveryservice_stats-get-request-example` the use of a complex "Accept" header. This endpoint accepts two special media types in the "Accept" header that instruct it on how to format the timestamps associated with the returned data. Specifically, Traffic Ops will recognize the special, optional, non-standard parameter of :mimetype:`application/json`: ``timestamp``. The values of this parameter are restricted to one of
 
 rfc
 	Returned timestamps will be formatted according to :rfc:`3339` (no sub-second precision).

--- a/docs/source/api/v4/osversions.rst
+++ b/docs/source/api/v4/osversions.rst
@@ -33,8 +33,6 @@ Request Structure
 -----------------
 No parameters available.
 
-.. _response-structure:
-
 Response Structure
 ------------------
 This endpoint has no constant keys in its ``response``. Instead, each key in the ``response`` object is the name of an OS, and the value is a string that names the directory where the ISO source can be found. These directories sit under ``/var/www/files/`` on the Traffic Ops host machine by default, or at the location defined by the ``kickstart.files.location`` :term:`Parameter` of the Traffic Ops server's :term:`Profile`, if it is defined.
@@ -64,7 +62,7 @@ Configuration File
 The data returned from the endpoint comes directly from a configuration file. By default, the file is located at ``/var/www/files/osversions.json``.
 The **directory** of the file can be changed by creating a specific :term:`Parameter` named ``kickstart.files.location`` in configuration file ``mkisofs``.
 
-The format of the file is a JSON object as described in :ref:`response-structure`.
+The format of the file is a JSON object as described in `Response Structure`_.
 
 .. code-block:: json
 	:caption: Example osversions.json file

--- a/docs/source/api/v5/osversions.rst
+++ b/docs/source/api/v5/osversions.rst
@@ -33,8 +33,6 @@ Request Structure
 -----------------
 No parameters available.
 
-.. _response-structure:
-
 Response Structure
 ------------------
 This endpoint has no constant keys in its ``response``. Instead, each key in the ``response`` object is the name of an OS, and the value is a string that names the directory where the ISO source can be found. These directories sit under ``/var/www/files/`` on the Traffic Ops host machine by default, or at the location defined by the ``kickstart.files.location`` :term:`Parameter` of the Traffic Ops server's :term:`Profile`, if it is defined.
@@ -64,7 +62,7 @@ Configuration File
 The data returned from the endpoint comes directly from a configuration file. By default, the file is located at ``/var/www/files/osversions.json``.
 The **directory** of the file can be changed by creating a specific :term:`Parameter` named ``kickstart.files.location`` in configuration file ``mkisofs``.
 
-The format of the file is a JSON object as described in :ref:`response-structure`.
+The format of the file is a JSON object as described in `Response Structure`_.
 
 .. code-block:: json
 	:caption: Example osversions.json file


### PR DESCRIPTION
This PR fixes some duplicate labels which were resulting in broken or incorrect links since #7063 introduced them.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build generates no warnings.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR needs no tests
- [x] This PR has documentation
- [x] This PR needs no CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**