### PR TITLE
Add health client parent health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7023](https://github.com/apache/trafficcontrol/pull/7023) *Traffic Ops* Added the `ASN` field in TO Server struct, which provides the ability to query servers by `ASN`.
 - [#2101](https://github.com/apache/trafficcontrol/issues/2101) *Traffic Portal* Added the ability to tell if a Delivery Service is the target of another steering DS.
 - [#6033](https://github.com/apache/trafficcontrol/issues/6033) *Traffic Ops, Traffic Portal* Added ability to assign multiple server capabilities to a server.
+- [#7096](https://github.com/apache/trafficcontrol/issues/7096) [Health Client] Added health client parent health
 - [#7032](https://github.com/apache/trafficcontrol/issues/7032) *Cache Config* Add t3c-apply flag to use local ATS version for config generation rather than Server package Parameter, to allow managing the ATS OS package via external tools. See 'man t3c-apply' and 'man t3c-generate' for details.
 
 ### Changed

--- a/lib/go-llog/llog.go
+++ b/lib/go-llog/llog.go
@@ -1,0 +1,173 @@
+// Package llog provides logging utilities for library packages.
+//
+// This allows libraries to log if desired, while still allowing
+// the library functions to have no side effects and not use
+// global loggers, which may be different than the application's
+// primary log library.
+//
+// This also allows users of the library to decide their logging
+// level for this particular library. For example, an application
+// may wish to generally log at the debug level, but not log
+// debug messages for some particular library.
+//
+// Or, a user may wish to log warning messages from a library
+// as errors. Setting two log levels to the same io.Writer
+// is permissible.
+//
+// This is not itself a logging library. Rather, it allows
+// applications using any log library to interface with libraries
+// using llog, by constructing a Loggers object from their own
+// logger.
+package llog
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"io"
+)
+
+// Log is an interface which library functions may accept
+// in order to log without side effects, if the caller desires.
+//
+// Applications using a library which uses Log may use
+// NewLog, or may themselves implement the interface.
+//
+// Library functions should immediately call DefaultIfNil to allow callers to
+// pass a nil Log. Importantly, this allows applications using the library
+// to avoid importing llog, if they don't want the library to log.
+type Log interface {
+	Errorf(format string, v ...interface{})
+	Errorln(v ...interface{})
+	Warnf(format string, v ...interface{})
+	Warnln(v ...interface{})
+	Infof(format string, v ...interface{})
+	Infoln(v ...interface{})
+	Debugf(format string, v ...interface{})
+	Debugln(v ...interface{})
+}
+
+// LibInit initializes the Log for libraries.
+//
+// All public functions in Libraries using llog should immediately call LibInit.
+// The return value should be assigned, like `log = llog.LibInit(log)`
+//
+// Applications creating a Log to pass to a library func should never call LibInit.
+//
+// This creates a Nop Log if the passed lg is nil, which allows applications
+// to pass a nil Log.
+//
+// It may do other things in the future.
+func LibInit(lg Log) Log {
+	if lg == nil {
+		return Nop()
+	}
+	return lg
+}
+
+// Nop returns a Log that never logs.
+// Applications which don't want a library to log can pass Nop
+// to libraries that take a Log.
+func Nop() Log { return &loggers{} }
+
+// New creates a new Log.
+//
+// Applications can use New to create a Log from their own internal log
+// libraries and writers, to pass to libraries using liblog.
+//
+// Standard log example:
+//
+//	errLog := log.New(os.Stdout, "ERROR: ", log.Ldate|log.Ltime|log.Lshortfile)
+//	mylib.MyFunc(liblog.New(errLog, nil, nil, nil), myArg)
+//
+// github.com/apache/trafficcontrol/lib/go-log example:
+//
+//	import("github.com/apache/trafficcontrol/lib/go-log")
+//
+//	log.Init(nil, os.Stderr, os.Stderr, nil, nil)
+//
+//	lLog := log.LLog() // lib/go-tc has a built-in llog helper
+//
+//	// alternatively, what the lib/go-log helper is doing internally:
+//	ltow := func(lg *log.Logger) io.Writer {
+//	  return llog.WriterFunc(func(p []byte) (n int, err error) {
+//	  Logln(lg, string(p))
+//	})
+//	lLog = llog.New(ltow(Error), ltow(Warning), ltow(Info), ltow(Debug))
+//
+//	mylib.MyFunc(lLog, myArg)
+//
+// zap example:
+//
+//	import("go.uber.org/zap")
+//
+//	func main() {
+//	  logger, _ := zap.NewProduction()
+//	  sugar := logger.Sugar()
+//	  zapErrLog := liblog.WriterFunc(func(p []byte) (n int, err error){
+//	    logger.Sugar().Error(string(p))
+//	  })
+//	  mylib.MyFunc(liblog.New(zapErrLog, nil, nil, nil), myArg)
+//	}
+func New(err io.Writer, warn io.Writer, info io.Writer, debug io.Writer) Log {
+	return &loggers{
+		err:  err,
+		warn: warn,
+		inf:  info,
+		dbg:  debug,
+	}
+}
+
+// WriterFunc is an adapter to allow the use of ordinary functions as io.Writers.
+// This behaves similar to http.HandlerFunc for http.Handler.
+type WriterFunc func(p []byte) (n int, err error)
+
+// Write implements io.Writer.
+func (wf WriterFunc) Write(p []byte) (n int, err error) { return wf(p) }
+
+type loggers struct {
+	err  io.Writer
+	warn io.Writer
+	inf  io.Writer
+	dbg  io.Writer
+}
+
+func (ls *loggers) Errorf(format string, v ...interface{}) { logf(ls.err, format, v...) }
+func (ls *loggers) Errorln(v ...interface{})               { logln(ls.err, v...) }
+func (ls *loggers) Warnf(format string, v ...interface{})  { logf(ls.warn, format, v...) }
+func (ls *loggers) Warnln(v ...interface{})                { logln(ls.warn, v...) }
+func (ls *loggers) Infof(format string, v ...interface{})  { logf(ls.inf, format, v...) }
+func (ls *loggers) Infoln(v ...interface{})                { logln(ls.inf, v...) }
+func (ls *loggers) Debugf(format string, v ...interface{}) { logf(ls.dbg, format, v...) }
+func (ls *loggers) Debugln(v ...interface{})               { logln(ls.dbg, v...) }
+
+func logf(wr io.Writer, format string, v ...interface{}) {
+	if wr == nil {
+		return
+	}
+	fmt.Fprintf(wr, format, v...)
+}
+
+func logln(wr io.Writer, v ...interface{}) {
+	if wr == nil {
+		return
+	}
+	fmt.Fprintln(wr, v...)
+}

--- a/tc-health-client/README.md
+++ b/tc-health-client/README.md
@@ -69,26 +69,28 @@ Requires Apache TrafficServer 8.1.0 or later.
 
 # OPTIONS
 
--f, -\-config-file=config-file 
-  
-Specify the config file to use.  
-Defaults to /etc/trafficcontro-health-client/tc-health-client.json
+-f, -\-config-file=config-file
 
--h, -\-help 
+  Specify the config file to use.
+  Defaults to /etc/trafficcontro-health-client/tc-health-client.json
 
-Prints command line usage and exits
+-h, -\-help
+
+  Prints command line usage and exits
 
 -l, -\-logging-dir=logging-directory
 
-Specify the directory where log files are kept.  The default location
-is **/var/log/trafficcontrol/**
+  Specify the directory where log files are kept.  The default location
+  is **/var/log/trafficcontrol/**
+
+-l, -\-logging-dir=logging-directory
 
 -v, -\-verbose
 
-Logging verbosity.  Errors are logged to the default log file 
-**/var/log/trafficcontrol/tc-health-client.log**
-To add Warnings, use -v.  To add Warnings and Informational 
-logging, use -vv.  Finally you may add Debug logging using -vvv.
+  Logging verbosity.  Errors are logged to the default log file
+  **/var/log/trafficcontrol/tc-health-client.log**
+  To add Warnings, use -v.  To add Warnings and Informational
+  logging, use -vv.  Finally you may add Debug logging using -vvv.
 
 # CONFIGURATION
 
@@ -103,21 +105,28 @@ Sample configuarion file:
     "enable-active-markdowns": false,
     "reason-code": "active",
     "to-credential-file": "/etc/credentials",
-    "to-url": "https://tp.cdn.com:443", 
+    "to-url": "https://tp.cdn.com:443",
     "to-request-timeout-seconds": "5s",
     "tm-poll-interval-seconds": "60s",
-    "tm-proxy-url", "http://sample-http-proxy.cdn.net:80",
+    "tm-proxy-url": "http://sample-http-proxy.cdn.net:80",
     "to-login-dispersion-factor": 90,
     "unavailable-poll-threshold": 2,
     "markup-poll-threshold": 1,
     "trafficserver-config-dir": "/opt/trafficserver/etc/trafficserver",
     "trafficserver-bin-dir": "/opt/trafficserver/bin",
     "poll-state-json-log": "/var/log/trafficcontrol/poll-state.json",
-    "enable-poll-state-log": false
+    "enable-poll-state-log": false,
+    "parent-health-poll-ms": 10000,
+    "serve-parent-health": true,
+    "parent-health-service-port": 31337,
+    "parent-health-log-location": "/var/log/trafficcontrol/tc-health-client_parent-health.log",
+    "health-methods": ["traffic-monitor", "parent-l4", "parent-l7", "parent-service"],
+    "markdown-methods": ["traffic-monitor", "parent-l4", "parent-l7", "parent-service"],
+    "hostname": ""
   }
 ```
 
-### cdn-name 
+### cdn-name
 
 The name of the CDN that the Traffic Server host is a member of.
 
@@ -135,7 +144,7 @@ hosts in the Traffic Server **HostStatus** subsystem.
 
 ### to-credential-file
 
-The file where **Traffic Ops** credentials are read.  The file should define the 
+The file where **Traffic Ops** credentials are read.  The file should define the
 following variables:
 
 * TO_URL="https://trafficops.cdn.com"
@@ -185,7 +194,7 @@ with the parent reported as healthy.  The default threshold is 1.
 
 ### trafficserver-config-dir
 
-The location on the host where **Traffic Server** configuration files are 
+The location on the host where **Traffic Server** configuration files are
 located.
 
 ### trafficserver-bin-dir
@@ -195,7 +204,7 @@ be found.
 
 ### poll-state-json-log ###
 
-The full path to the polling state file which contains information 
+The full path to the polling state file which contains information
 about the current status of parents and the health client configuration.
 Polling state data is written to this file after each polling cycle when
 enabled, see **enable-poll-state-log**
@@ -204,6 +213,54 @@ enabled, see **enable-poll-state-log**
 
 Enable writing the Polling state to the **poll-state-json-log** after
 eache polling cycle.  Default **false**, disabled
+
+### markdown-min-interval-ms ###
+
+Minimum interval between markdown processing in milliseconds. When health polls finish, they automatically signal the markdown service to mark down accordingly. This is the minimum time to wait between processing, to avoid too much processing. To always process markdowns as soon as every health poll finishes, set to 0. Default is 5 seconds.
+
+### parent-health-l4-poll-ms ###
+
+Interval to poll for parent health via L4 in milliseconds.
+
+### parent-health-l7-poll-ms ###
+
+Interval to poll for parent health via L7 in milliseconds.
+
+### parent-health-service-poll-ms ###
+
+Interval to poll for parent health from parents' health service in milliseconds.
+
+### parent-health-service-port ###
+
+The port to serve the JSON parent health data over HTTP. To disable serving, set to < 1. Default is 0, disabled.
+
+### parent-health-log-location ###
+
+The location to log parent health changes. May be stdout, stderr, null, or a file path.
+
+### health-methods ###
+
+The health methods to poll. Options are 'traffic-monitor', 'parent-l4', 'parent-l7', and 'parent-service'.
+
+Traffic Monitor requests Traffic Monitor and uses its boolean CRStates API for health.
+
+Parent L4 polls all parents via a HTTP request. Any valid response, including HTTP error codes, is considered a success. Only a failed HTTP request is considered unhealthy.
+
+Parent L7 polls all parents via a TCP SYN. Any valid TCP ACK response within the timeout is considered healthy. Failure to receive an ACK before the timeout is considered unhealthy. Note this also sends a TCP Reset to aid the host in quickly releasing resources.
+
+Parent Service polls the tc-health-client parent service, on the same port as this host's parent service, and uses a heuristic of the parent's own available parents to determine health. The heuristic is currently 50%, but that may change or be made configurable in the future. That is, if more than 50% of a parent cache's own parents are unavailable, the parent is unhealthy.
+
+### markdown-methods ###
+
+Markdown methods are the health methods to consider when marking down parents. See health-methods. Hence, a method may be polled via health-methods and logged and served for informational purposes, without using that method to mark down parents.
+
+### num-health-workers ###
+
+The number of worker microthreads (goroutines) per health poll method.
+
+Note this only applies to Parent L4, Parent L7, and Parent Service health; the Traffic Monitor health poll is a single HTTP request and thus doesn't need workers.
+
+### hostname ###
 
 # Files
 
@@ -215,4 +272,3 @@ eache polling cycle.  Default **false**, disabled
 * Traffic Server **parent.config**
 * Traffic Server **strategies.yaml**
 * Traffic Server **traffic_ctl** command
-  

--- a/tc-health-client/config/config.go
+++ b/tc-health-client/config/config.go
@@ -36,15 +36,13 @@ import (
 	"github.com/apache/trafficcontrol/cache-config/t3cutil"
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/tc-health-client/util"
-	toclient "github.com/apache/trafficcontrol/traffic_ops/v3-client"
 
 	"github.com/pborman/getopt/v2"
 )
 
-var userAgent = "tc-health-client/1.0"
-var tmPollingInterval time.Duration
-var toRequestTimeout time.Duration
-var toSession *toclient.Session = nil
+// userAgent is the UA used by this service in HTTP requests.
+// TODO dynamically add Version from RPM build.
+const userAgent = "tc-health-client/1.0"
 
 const (
 	DefaultPollStateJSONLog         = "/var/log/trafficcontrol/poll-state.json"
@@ -58,28 +56,106 @@ const (
 	DefaultMarkupPollThreshold      = 1
 )
 
+// NewCfgPtr is a convenience func for NewAtomicPtr(cfg).
+func NewCfgPtr(cfg *Cfg) *util.AtomicPtr[Cfg] {
+	return util.NewAtomicPtr(cfg)
+}
+
+type HealthMethod string
+
+const (
+	HealthMethodTrafficMonitor = HealthMethod("traffic-monitor")
+	HealthMethodParentL4       = HealthMethod("parent-l4")
+	HealthMethodParentL7       = HealthMethod("parent-l7")
+	HealthMethodParentService  = HealthMethod("parent-service")
+)
+
+var DefaultHealthMethods = []HealthMethod{HealthMethodTrafficMonitor}
+var DefaultMarkdownMethods = []HealthMethod{HealthMethodTrafficMonitor}
+
 type Cfg struct {
-	CDNName                  string          `json:"cdn-name"`
-	EnableActiveMarkdowns    bool            `json:"enable-active-markdowns"`
-	ReasonCode               string          `json:"reason-code"`
-	TOCredentialFile         string          `json:"to-credential-file"`
-	TORequestTimeOutSeconds  string          `json:"to-request-timeout-seconds"`
-	TOPass                   string          `json:"to-pass"`
-	TOUrl                    string          `json:"to-url"`
-	TOUser                   string          `json:"to-user"`
-	TmProxyURL               string          `json:"tm-proxy-url"`
-	TmPollIntervalSeconds    string          `json:"tm-poll-interval-seconds"`
-	TOLoginDispersionFactor  int             `json:"to-login-dispersion-factor"`
-	UnavailablePollThreshold int             `json:"unavailable-poll-threshold"`
-	MarkUpPollThreshold      int             `json:"markup-poll-threshold"`
-	TrafficServerConfigDir   string          `json:"trafficserver-config-dir"`
-	TrafficServerBinDir      string          `json:"trafficserver-bin-dir"`
-	PollStateJSONLog         string          `json:"poll-state-json-log"`
-	EnablePollStateLog       bool            `json:"enable-poll-state-log"`
-	TrafficMonitors          map[string]bool `json:"trafficmonitors,omitempty"`
+	// TODO fix to not take CDN name, so it can't be wrong.
+	//      If this is wrong, the health client runs but just can't find tons of stuff,
+	//      resulting in strange not-obvious errors.
+	// Infer from server somehow (config header comment? t3c metadata? hostname -s?)
+	CDNName                  string `json:"cdn-name"`
+	EnableActiveMarkdowns    bool   `json:"enable-active-markdowns"`
+	ReasonCode               string `json:"reason-code"`
+	TOCredentialFile         string `json:"to-credential-file"`
+	TORequestTimeOutSeconds  string `json:"to-request-timeout-seconds"`
+	TOPass                   string `json:"to-pass"`
+	TOUrl                    string `json:"to-url"`
+	TOUser                   string `json:"to-user"`
+	TmProxyURL               string `json:"tm-proxy-url"`
+	TmPollIntervalSeconds    string `json:"tm-poll-interval-seconds"`
+	TOLoginDispersionFactor  int    `json:"to-login-dispersion-factor"`
+	UnavailablePollThreshold int    `json:"unavailable-poll-threshold"`
+	MarkUpPollThreshold      int    `json:"markup-poll-threshold"`
+	TrafficServerConfigDir   string `json:"trafficserver-config-dir"`
+	TrafficServerBinDir      string `json:"trafficserver-bin-dir"`
+	PollStateJSONLog         string `json:"poll-state-json-log"`
+	EnablePollStateLog       bool   `json:"enable-poll-state-log"`
 	HealthClientConfigFile   util.ConfigFile
 	CredentialFile           util.ConfigFile
 	ParsedProxyURL           *url.URL
+
+	MarkdownMinIntervalMS     *uint64 `json:"markdown-min-interval-ms"`
+	ParentHealthL4PollMS      uint64  `json:"parent-health-l4-poll-ms"`
+	ParentHealthL7PollMS      uint64  `json:"parent-health-l7-poll-ms"`
+	ParentHealthServicePollMS uint64  `json:"parent-health-service-poll-ms"`
+
+	// ParentHealthServicePort is the port to serve parent health on. To disable serving parent health, set to 0.
+	ParentHealthServicePort int `json:"parent-health-service-port"`
+
+	// ParentHealthLogLocation may be a file path, stdout, stderr, or null (the empty string is equivalent to null)
+	ParentHealthLogLocation string `json:"parent-health-log-location"`
+
+	// HealthMethods are the types of health to poll. If omitted, Traffic Monitor health will be used.
+	HealthMethods *[]HealthMethod `json:"health-methods"`
+
+	// MarkdownMethods are the types of health to consider when marking down parents.
+	// This may be empty or omitted, to never marking down parents.
+	MarkdownMethods *[]HealthMethod `json:"markdown-methods"`
+
+	// NumHealthWorkers is the number of worker microthreads (goroutines) per health poll method.
+	// Note this only applies to Parent L4, Parent L7, and Parent Service health; the Traffic
+	// Monitor health poll is a single HTTP request and thus doesn't need workers.
+	NumHealthWorkers int `json:"num-health-workers"`
+
+	TMPollingInterval time.Duration
+	TORequestTimeout  time.Duration
+
+	UserAgent string
+	// HostName is this host's short hostname.
+	// If empty, the system's hostname will be used.
+	HostName string
+}
+
+func (cfg *Cfg) Clone() *Cfg {
+	newCfg := *cfg
+	newCfg.ParsedProxyURL = nil
+	if cfg.ParsedProxyURL != nil {
+		urlCopy := *cfg.ParsedProxyURL
+		newCfg.ParsedProxyURL = &urlCopy
+	}
+
+	if cfg.HealthMethods != nil {
+		healthMethods := make([]HealthMethod, len(*cfg.HealthMethods), len(*cfg.HealthMethods))
+		copy(healthMethods, *cfg.HealthMethods)
+		newCfg.HealthMethods = &healthMethods
+	} else {
+		newCfg.HealthMethods = &[]HealthMethod{}
+	}
+
+	if cfg.MarkdownMethods != nil {
+		markdownMethods := make([]HealthMethod, len(*cfg.MarkdownMethods), len(*cfg.MarkdownMethods))
+		copy(markdownMethods, *cfg.MarkdownMethods)
+		newCfg.MarkdownMethods = &markdownMethods
+	} else {
+		newCfg.MarkdownMethods = &[]HealthMethod{}
+	}
+
+	return &newCfg
 }
 
 type LogCfg struct {
@@ -145,7 +221,7 @@ func ReadCredentials(cfg *Cfg, updating bool) error {
 	return nil
 }
 
-func GetConfig() (Cfg, error, bool) {
+func GetConfig() (*Cfg, error, bool) {
 	var err error
 	var configFile string
 	var logLocationErr = log.LogLocationStderr
@@ -185,7 +261,7 @@ func GetConfig() (Cfg, error, bool) {
 
 	if help := *helpPtr; help == true {
 		Usage()
-		return Cfg{}, nil, true
+		return nil, nil, true
 	}
 
 	lcfg := LogCfg{
@@ -196,7 +272,7 @@ func GetConfig() (Cfg, error, bool) {
 	}
 
 	if err := log.InitCfg(&lcfg); err != nil {
-		return Cfg{}, errors.New("initializing loggers: " + err.Error() + "\n"), false
+		return nil, errors.New("initializing loggers: " + err.Error() + "\n"), false
 	}
 
 	cf := util.ConfigFile{
@@ -204,68 +280,29 @@ func GetConfig() (Cfg, error, bool) {
 		LastModifyTime: 0,
 	}
 
-	cfg := Cfg{
+	cfg := &Cfg{
 		HealthClientConfigFile: cf,
 		CredentialFile:         util.ConfigFile{},
+		UserAgent:              userAgent,
 	}
 
-	if _, err = LoadConfig(&cfg); err != nil {
-		return Cfg{}, errors.New(err.Error() + "\n"), false
+	if _, err = LoadConfig(cfg); err != nil {
+		return nil, errors.New(err.Error() + "\n"), false
 	}
 
-	if err = ReadCredentials(&cfg, false); err != nil {
+	if err = ReadCredentials(cfg, false); err != nil {
 		return cfg, err, false
 	}
 
-	dispersion := GetTOLoginDispersion(cfg.TOLoginDispersionFactor)
+	dispersion := GetTOLoginDispersion(cfg.TMPollingInterval, cfg.TOLoginDispersionFactor)
 	log.Infof("waiting %v seconds before logging into TrafficOps", dispersion.Seconds())
 	time.Sleep(dispersion)
-	err = GetTrafficMonitors(&cfg)
-	if err != nil {
-		return cfg, err, false
-	}
 
 	return cfg, nil, false
 }
 
-func GetTrafficMonitors(cfg *Cfg) error {
-	qry := &url.Values{}
-	qry.Add("type", "RASCAL")
-	qry.Add("status", "ONLINE")
-
-	// login to traffic ops.
-	if toSession == nil {
-		session, _, err := toclient.LoginWithAgent(cfg.TOUrl, cfg.TOUser, cfg.TOPass, true, userAgent, false, GetRequestTimeout())
-		if err != nil {
-			return fmt.Errorf("could not establish a TrafficOps session: %w", err)
-		} else {
-			toSession = session
-		}
-	}
-	srvs, _, err := toSession.GetServersWithHdr(qry, nil)
-	if err != nil {
-		// next time we'll login again and get a new session.
-		toSession = nil
-		return errors.New("error fetching Trafficmonitor server list: " + err.Error())
-	}
-
-	cfg.TrafficMonitors = make(map[string]bool, 0)
-	for _, v := range srvs.Response {
-		if *v.CDNName == cfg.CDNName && *v.Status == "ONLINE" {
-			hostname := *v.HostName + "." + *v.DomainName
-			cfg.TrafficMonitors[hostname] = true
-		}
-	}
-
-	return nil
-}
-
-func GetTMPollingInterval() time.Duration {
-	return tmPollingInterval
-}
-
-func GetTOLoginDispersion(dispersionFactor int) time.Duration {
-	dispersionSeconds := uint64(tmPollingInterval.Seconds()) * uint64(dispersionFactor)
+func GetTOLoginDispersion(pollingInterval time.Duration, dispersionFactor int) time.Duration {
+	dispersionSeconds := uint64(pollingInterval.Seconds()) * uint64(dispersionFactor)
 	hostName, err := os.Hostname()
 	if err != nil {
 		log.Errorf("the OS hostname is not set, cannot continue: %s", err.Error())
@@ -274,108 +311,129 @@ func GetTOLoginDispersion(dispersionFactor int) time.Duration {
 	md5hash := md5.Sum([]byte(hostName))
 	sl := md5hash[0:8]
 	disp := (binary.BigEndian.Uint64(sl) % dispersionSeconds)
-	if disp < uint64(tmPollingInterval.Seconds()*2) {
-		disp = ((disp * 2) + uint64(tmPollingInterval.Seconds()))
+	if disp < uint64(pollingInterval.Seconds()*2) {
+		disp = ((disp * 2) + uint64(pollingInterval.Seconds()))
 	}
 	return time.Duration(disp) * time.Second
 }
 
-func GetRequestTimeout() time.Duration {
-	return toRequestTimeout
-}
+const DefaultParentHealthL4PollMS = 30000
+const DefaultParentHealthL7PollMS = 30000
+const ParentHealthServicePollMS = 30000
+const DefaultMarkdownMinIntervalMS = 5000
 
+// LoadConfig returns whether the config was updated and any error.
+//
+// Note the cfg may be modified, even if the returned updated is false.
+// Users should create and pass a copy of Cfg if changes on error are not acceptable.
 func LoadConfig(cfg *Cfg) (bool, error) {
-	updated := false
 	configFile := cfg.HealthClientConfigFile.Filename
 	modTime, err := util.GetFileModificationTime(configFile)
 	if err != nil {
-		return updated, errors.New(err.Error())
+		return false, errors.New(err.Error())
 	}
 
-	if modTime > cfg.HealthClientConfigFile.LastModifyTime {
-		log.Infoln("Loading a new config file.")
-		content, err := ioutil.ReadFile(configFile)
-		if err != nil {
-			return updated, errors.New(err.Error())
-		}
-		err = json.Unmarshal(content, cfg)
-		if err != nil {
-			return updated, fmt.Errorf("config parsing failed: %w", err)
-		}
-		tmPollingInterval, err = time.ParseDuration(cfg.TmPollIntervalSeconds)
-		if err != nil {
-			return updated, errors.New("parsing TMPollingIntervalSeconds: " + err.Error())
-		}
-		if cfg.TOLoginDispersionFactor == 0 {
-			cfg.TOLoginDispersionFactor = DefaultTOLoginDispersionFactor
-		}
-		toRequestTimeout, err = time.ParseDuration(cfg.TORequestTimeOutSeconds)
-		if err != nil {
-			return updated, errors.New("parsing TORequestTimeOutSeconds: " + err.Error())
-		}
-		if cfg.ReasonCode != "active" && cfg.ReasonCode != "local" {
-			return updated, errors.New("invalid reason-code: " + cfg.ReasonCode + ", valid reason codes are 'active' or 'local'")
-		}
-		if cfg.TrafficServerConfigDir == "" {
-			cfg.TrafficServerConfigDir = DefaultTrafficServerConfigDir
-		}
-		if cfg.TrafficServerBinDir == "" {
-			cfg.TrafficServerBinDir = DefaultTrafficServerBinDir
-		}
-		if cfg.UnavailablePollThreshold == 0 {
-			cfg.UnavailablePollThreshold = DefaultUnavailablePollThreshold
-		}
-		if cfg.PollStateJSONLog == "" {
-			cfg.PollStateJSONLog = DefaultPollStateJSONLog
-		}
-
-		cfg.HealthClientConfigFile.LastModifyTime = modTime
-
-		if cfg.TOCredentialFile != "" {
-			cfg.CredentialFile.Filename = cfg.TOCredentialFile
-		}
-
-		// if tm-proxy-url is set in the config, verify the proxy
-		// url
-		if cfg.TmProxyURL != "" {
-			if cfg.ParsedProxyURL, err = url.Parse(cfg.TmProxyURL); err != nil {
-				cfg.ParsedProxyURL = nil
-				return false, errors.New("parsing TmProxyUrl: " + err.Error())
-			}
-			if cfg.ParsedProxyURL.Port() == "" {
-				cfg.ParsedProxyURL = nil
-				return false, errors.New("TmProxyUrl invalid port specified")
-			}
-			log.Infof("TM queries will use the proxy: %s", cfg.TmProxyURL)
-		} else {
-			cfg.ParsedProxyURL = nil
-		}
-		updated = true
+	if modTime <= cfg.HealthClientConfigFile.LastModifyTime {
+		return false, nil
 	}
-	return updated, nil
-}
 
-func UpdateConfig(cfg *Cfg, newCfg *Cfg) {
-	cfg.CDNName = newCfg.CDNName
-	cfg.EnableActiveMarkdowns = newCfg.EnableActiveMarkdowns
-	cfg.ReasonCode = newCfg.ReasonCode
-	cfg.TOCredentialFile = newCfg.TOCredentialFile
-	cfg.TORequestTimeOutSeconds = newCfg.TORequestTimeOutSeconds
-	cfg.TOPass = newCfg.TOPass
-	cfg.TOUrl = newCfg.TOUrl
-	cfg.TOUser = newCfg.TOUser
-	cfg.TmPollIntervalSeconds = newCfg.TmPollIntervalSeconds
-	cfg.TOLoginDispersionFactor = newCfg.TOLoginDispersionFactor
+	log.Infoln("Loading a new config file.")
+	content, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return false, errors.New(err.Error())
+	}
+	err = json.Unmarshal(content, cfg)
+	if err != nil {
+		return false, fmt.Errorf("config parsing failed: %w", err)
+	}
+	cfg.TMPollingInterval, err = time.ParseDuration(cfg.TmPollIntervalSeconds)
+	if err != nil {
+		return false, errors.New("parsing TMPollingIntervalSeconds: " + err.Error())
+	}
 	if cfg.TOLoginDispersionFactor == 0 {
 		cfg.TOLoginDispersionFactor = DefaultTOLoginDispersionFactor
 	}
-	cfg.UnavailablePollThreshold = newCfg.UnavailablePollThreshold
-	cfg.TrafficServerConfigDir = newCfg.TrafficServerConfigDir
-	cfg.TrafficServerBinDir = newCfg.TrafficServerBinDir
-	cfg.TrafficMonitors = newCfg.TrafficMonitors
-	cfg.HealthClientConfigFile = newCfg.HealthClientConfigFile
-	cfg.PollStateJSONLog = newCfg.PollStateJSONLog
-	cfg.EnablePollStateLog = newCfg.EnablePollStateLog
+	cfg.TORequestTimeout, err = time.ParseDuration(cfg.TORequestTimeOutSeconds)
+	if err != nil {
+		return false, errors.New("parsing TORequestTimeOutSeconds: " + err.Error())
+	}
+	if cfg.ReasonCode != "active" && cfg.ReasonCode != "local" {
+		return false, errors.New("invalid reason-code: " + cfg.ReasonCode + ", valid reason codes are 'active' or 'local'")
+	}
+	if cfg.TrafficServerConfigDir == "" {
+		cfg.TrafficServerConfigDir = DefaultTrafficServerConfigDir
+	}
+	if cfg.TrafficServerBinDir == "" {
+		cfg.TrafficServerBinDir = DefaultTrafficServerBinDir
+	}
+	if cfg.UnavailablePollThreshold == 0 {
+		cfg.UnavailablePollThreshold = DefaultUnavailablePollThreshold
+	}
+	if cfg.PollStateJSONLog == "" {
+		cfg.PollStateJSONLog = DefaultPollStateJSONLog
+	}
+
+	cfg.HealthClientConfigFile.LastModifyTime = modTime
+
+	if cfg.TOCredentialFile != "" {
+		cfg.CredentialFile.Filename = cfg.TOCredentialFile
+	}
+
+	// if tm-proxy-url is set in the config, verify the proxy
+	// url
+	if cfg.TmProxyURL != "" {
+		if cfg.ParsedProxyURL, err = url.Parse(cfg.TmProxyURL); err != nil {
+			cfg.ParsedProxyURL = nil
+			return false, errors.New("parsing TmProxyUrl: " + err.Error())
+		}
+		if cfg.ParsedProxyURL.Port() == "" {
+			cfg.ParsedProxyURL = nil
+			return false, errors.New("TmProxyUrl invalid port specified")
+		}
+		log.Infof("TM queries will use the proxy: %s", cfg.TmProxyURL)
+	} else {
+		cfg.ParsedProxyURL = nil
+	}
+
+	if cfg.HostName == "" {
+		hostName, err := os.Hostname()
+		if err != nil {
+			return false, errors.New("No hostname configured, getting from OS: " + err.Error())
+		}
+		cfg.HostName = util.HostNameToShort(hostName)
+	}
+
+	if cfg.HealthMethods == nil {
+		healthMethods := make([]HealthMethod, len(DefaultHealthMethods), len(DefaultHealthMethods))
+		copy(healthMethods, DefaultHealthMethods)
+		cfg.HealthMethods = &healthMethods
+	}
+
+	if cfg.MarkdownMethods == nil {
+		markdownMethods := make([]HealthMethod, len(DefaultMarkdownMethods), len(DefaultMarkdownMethods))
+		copy(markdownMethods, DefaultMarkdownMethods)
+		cfg.MarkdownMethods = &markdownMethods
+	}
+
+	if cfg.NumHealthWorkers < 1 {
+		cfg.NumHealthWorkers = 1
+	}
+
+	if cfg.MarkdownMinIntervalMS == nil {
+		mi := uint64(DefaultMarkdownMinIntervalMS)
+		cfg.MarkdownMinIntervalMS = &mi
+	}
+	if cfg.ParentHealthL4PollMS <= 0 {
+		cfg.ParentHealthL4PollMS = DefaultParentHealthL4PollMS
+	}
+	if cfg.ParentHealthL7PollMS <= 0 {
+		cfg.ParentHealthL7PollMS = DefaultParentHealthL7PollMS
+	}
+	if cfg.ParentHealthServicePollMS <= 0 {
+		cfg.ParentHealthServicePollMS = ParentHealthServicePollMS
+	}
+
+	return true, nil
 }
 
 func Usage() {

--- a/tc-health-client/config/config_test.go
+++ b/tc-health-client/config/config_test.go
@@ -37,7 +37,6 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	cfg := Cfg{
-		TrafficMonitors:        make(map[string]bool, 0),
 		HealthClientConfigFile: cf,
 	}
 

--- a/tc-health-client/sar/ephemeralportholder.go
+++ b/tc-health-client/sar/ephemeralportholder.go
@@ -1,0 +1,77 @@
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net"
+	"strconv"
+)
+
+// EphemeralPortHolder serves 2 purposes: it gets an ephemeral TCP port, and it holds
+// onto the port so the OS doesn't assign it to any other app.
+//
+// It listens on :0 thereby getting a socket on an ephemeral port.
+// It continues listening but never reading from the socket until Close is called.
+type EphemeralPortHolder struct {
+	listener net.Listener
+	port     int
+}
+
+// GetAndHoldEphemeralPort gets an ephemeral port, and listens on it to prevent
+// the OS assigning the port to other apps.
+// Close must be called on the returned EphemeralPortHolder to stop listening.
+func GetAndHoldEphemeralPort(addr string) (*EphemeralPortHolder, error) {
+	addr += ":0"
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, errors.New("listening: " + err.Error())
+	}
+
+	// get the port now, so EphemeralPortHolder.Port() doesn't need to return an error
+
+	listenAddr := listener.Addr().String()
+	ipPort := SplitLast(listenAddr, ":")
+	if len(ipPort) < 1 {
+		return nil, errors.New("malformed addr '" + listenAddr + "', should have been ip:port") // should never happen
+	}
+	portStr := ipPort[1]
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, errors.New("malformed addr '" + listenAddr + "' port was not an integer") // should never happen
+	}
+	if port > 65535 || port < 0 {
+		return nil, errors.New("malformed addr '" + listenAddr + "' port was outside bounds") // should never happen
+	}
+
+	return &EphemeralPortHolder{listener: listener, port: port}, nil
+}
+
+func (ph *EphemeralPortHolder) Close() error {
+	return ph.listener.Close()
+}
+
+func (ph *EphemeralPortHolder) Addr() net.Addr {
+	return ph.listener.Addr()
+}
+
+func (ph *EphemeralPortHolder) Port() int {
+	return ph.port
+}

--- a/tc-health-client/sar/multisar.go
+++ b/tc-health-client/sar/multisar.go
@@ -1,0 +1,388 @@
+// package sar implements a syn-ack-rst health ping.
+// It sends a TCP SYN, waits for an ACK, then immediately sends an RST to kill the connection.
+// The primary purpose of this is as a health check, to verify the remote host is reachable, and able and willing to respond.
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-llog"
+)
+
+type HostPort struct {
+	Host string
+	Port int
+}
+
+type SARResult struct {
+	Host string
+	Port int
+	RTT  time.Duration
+	Err  error
+}
+
+// MultiSAR is like SAR for multiple requests.
+// SAR has to listen on a raw IP port without a TCP socket, which is relatively inexpensive for a single request,
+// but expensive for large numbers of requests.
+// MultiSAR uses a single listener on an ephemeral local port for all SAR requests, significantly reducing
+// resource costs.
+func MultiSAR(log llog.Log, hosts []HostPort, timeout time.Duration) ([]SARResult, error) {
+	log = llog.LibInit(log)
+
+	localAddrStr, err := GetLocalAddr()
+	if err != nil {
+		return nil, errors.New("getting local address: " + err.Error())
+	}
+
+	localAddr := net.ParseIP(localAddrStr)
+	if localAddr == nil {
+		return nil, errors.New("failed to parse local addr '" + localAddrStr + "' as IP")
+	}
+	if v4 := localAddr.To4(); v4 != nil {
+		localAddr = v4
+	}
+
+	ephemeralPortHolder, err := GetAndHoldEphemeralPort(localAddrStr)
+	if err != nil {
+		return nil, errors.New("failed to listen on ephemeral port: " + err.Error())
+	}
+	defer ephemeralPortHolder.Close()
+
+	srcPort := ephemeralPortHolder.Port()
+
+	// pre-construct all the packets, so we listen for as little time as possible
+
+	// TODO implement Initial Sequence Number ISN per RFC9293§3.4.1? It might be faster to use the same seq num for all packets
+	seqNum := uint32(42)
+
+	type HostPortPacket struct {
+		HostPort
+		TCPHdr TCPHdr
+	}
+
+	packets := []HostPortPacket{}
+
+	hostAddr := map[string]string{}    // map[host]addr - note hosts may be IPs, in which case host and addr will be the same
+	addrHosts := map[string][]string{} // map[addr][]host - note multiple FQDNs may have the same IP
+
+	results := []SARResult{}
+
+	for _, host := range hosts {
+		makeHostErrResult := func(err error) SARResult {
+			return SARResult{
+				Host: host.Host,
+				Port: host.Port,
+				RTT:  0,
+				Err:  err,
+			}
+		}
+
+		remoteAddr := net.ParseIP(host.Host)
+		if remoteAddr != nil {
+			// host is IP
+			hostAddr[host.Host] = host.Host
+			addrHosts[host.Host] = append(addrHosts[host.Host], host.Host)
+		} else {
+			// host isn't an IP, assume FQDN
+			addrs, err := net.LookupHost(host.Host)
+			if err != nil {
+				results = append(results, makeHostErrResult(errors.New("lookup up host '"+host.Host+"': "+err.Error())))
+				continue
+			}
+			if len(addrs) == 0 {
+				results = append(results, makeHostErrResult(errors.New("looking up host '"+host.Host+"' succeeded, but no addresses were found.")))
+				continue
+			}
+			remoteAddr = net.ParseIP(addrs[0])
+			if remoteAddr == nil {
+				results = append(results, makeHostErrResult(errors.New("failed to parse addr '"+host.Host+"' ip '"+addrs[0]+"' as IP")))
+				continue
+			}
+
+			hostAddr[host.Host] = addrs[0]
+			addrHosts[addrs[0]] = append(addrHosts[addrs[0]], host.Host)
+		}
+
+		if v4 := remoteAddr.To4(); v4 != nil {
+			remoteAddr = v4
+		}
+
+		// TODO handle IPv6
+
+		window := 256 * 10
+		destPort := host.Port
+		dataOffset := 5 // because we have no options?
+		native := TCPHdrNative{
+			SrcPort:    uint16(srcPort),
+			DestPort:   uint16(destPort),
+			SeqNum:     seqNum,
+			DataOffset: uint8(dataOffset), // 4 bits
+			SYN:        true,
+			Window:     uint16(window),
+		}
+		hdrBts, err := TCPHdrFromNative(native)
+		if err != nil {
+			return nil, errors.New("converting native header to byte: " + err.Error())
+		}
+		hdrBts.SetChecksum(MakeTCPChecksum(hdrBts, localAddr, remoteAddr))
+		packets = append(packets, HostPortPacket{HostPort: host, TCPHdr: hdrBts})
+	}
+
+	remoteInf := []sarRemoteInf{}
+	// Note we need to iterate over hostAddr, *not* hosts.
+	// The hosts has all, but we may have failed to resolve some, in which case they won't be sent and we must not listen for their responses.
+	for _, host := range hosts {
+		addr, ok := hostAddr[host.Host]
+		if !ok {
+			continue // if it's not in hostAddr, we already added an error result and we won't send a packet, so don't listen for it
+		}
+		remoteInf = append(remoteInf, sarRemoteInf{
+			Host:   host.Host,
+			Addr:   addr,
+			Port:   host.Port,
+			AckNum: seqNum + 1,
+		})
+	}
+
+	sarListenerResp := []sarListenerResp{}
+	sarListenerErr := error(nil)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	doneSending := make(chan struct{}, 1) // we don't want to start the timeout until after we send the last packet. Buffer 1, the main sending thread doesn't block
+	go func() {
+		sarListenerResp, sarListenerErr = sarListener(log, localAddrStr, localAddr, remoteInf, timeout, srcPort, doneSending)
+		ephemeralPortHolder.Close() // this isn't strictly necessary, the defer will close this shortly. But this closes it ASAP
+		wg.Done()
+	}()
+
+	sendTimes := map[HostPort]time.Time{}
+
+	packetSendStart := time.Now()
+	for _, packet := range packets {
+		sendTime, err := SendPacket(packet.TCPHdr, packet.HostPort.Host)
+		if err != nil {
+			return nil, errors.New("sending packet: " + err.Error())
+		}
+		sendTimes[packet.HostPort] = sendTime
+	}
+
+	log.Infof("multisar main thread sent %v packets in %vms\n", len(packets), time.Since(packetSendStart)/time.Millisecond)
+
+	doneSending <- struct{}{} // send the doneSending message to the listener, so it sets the timeout
+	wg.Wait()                 // wait for the listener to return and set sarListenerResp and sarListenerErr
+
+	if sarListenerErr != nil {
+		return nil, errors.New("listening for ACKs: " + sarListenerErr.Error())
+	}
+
+	for _, listenResp := range sarListenerResp {
+		hosts := addrHosts[listenResp.Addr] // multiple FQDNs may have the same IP, but at L4 we only care about the behavior of the IP
+		for _, host := range hosts {
+			sendTime, ok := sendTimes[HostPort{Host: host, Port: listenResp.Port}]
+			if !ok {
+				log.Errorf("SAR listener got packet that was never sent somehow! Should never happen! Response: %+v\n", listenResp)
+				continue
+			}
+			roundTripTime := time.Duration(0)
+			if listenResp.Err == nil {
+				// this check shouldn't be necessary, the caller should never look at duration if err!=nil. This just makes it easier to debug if they do
+				roundTripTime = listenResp.RespTime.Sub(sendTime)
+			}
+			results = append(results, SARResult{
+				Host: host,
+				Port: listenResp.Port,
+				RTT:  roundTripTime,
+				Err:  listenResp.Err,
+			})
+		}
+	}
+	return results, nil
+}
+
+type sarRemoteInf struct {
+	Host   string
+	Addr   string
+	Port   int
+	AckNum uint32
+}
+
+type sarListenerResp struct {
+	Addr     string
+	Port     int
+	RespTime time.Time
+	Err      error
+}
+
+func sarListener(log llog.Log, localAddrStr string, localAddrIP net.IP, remoteArr []sarRemoteInf, timeout time.Duration, srcPort int, doneSending <-chan struct{}) ([]sarListenerResp, error) {
+
+	localAddr, err := net.ResolveIPAddr("ip4", localAddrStr)
+	if err != nil {
+		return nil, errors.New("resolving local address: " + err.Error())
+	}
+
+	// remotes is used to quickly, progressively match multiple requests
+	remotes := map[string]map[int]uint32{} // map[remoteAddr][port]acknum
+	for _, remote := range remoteArr {
+		if _, ok := remotes[remote.Addr]; !ok {
+			remotes[remote.Addr] = map[int]uint32{}
+		}
+		remotes[remote.Addr][remote.Port] = remote.AckNum
+	}
+
+	// listen on the local IP for the SynAck
+	// TODO should this ListenPacket, to let Go automatically choose the port for us?
+	conn, err := net.ListenIP("ip4:tcp", localAddr)
+	if err != nil {
+		return nil, errors.New("listening for syn-ack response: " + err.Error())
+	}
+	defer conn.Close()
+
+	// TODO listen on "sent everything" chan, and don't set timeout until everything was sent,
+	// to prevent timing out before some things are even sent
+
+	responses := []sarListenerResp{}
+
+	// the max TCP Header size is 60 bytes (IPv4 is variable up to 60, IPv6 is always 40)
+	// This means the buffer here won't be just the header, it may also contain part of the payload.
+	// We don't care here, our header parsing will stop after reading the final End Of Option List option.
+	// But if this were changed to do something with the body, that would need taken into account.
+	buf := make([]byte, 60)
+	for {
+		// after the main thread is done sending all packets, set the timeout
+		select {
+		case <-doneSending:
+			log.Infof("multisar listener got doneSending, setting timeout '%v'\n", timeout)
+			// Note this sets the absolute deadline, for all read packets.
+			// If we wanted to set the timeout for each individual packet read,
+			// we could call conn.SetDeadline inside the for-loop immediately before each conn.ReadFrom call.
+			if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+				return nil, errors.New("setting deadline timeout to listen for syn-ack response: " + err.Error())
+			}
+		default:
+		}
+
+		numBts, readRemoteAddr, err := conn.ReadFrom(buf)
+		readTime := time.Now()
+		if err != nil {
+			if errors.Is(err, os.ErrDeadlineExceeded) {
+				// after we time out, we need to add everything still in remotes into responses as an error
+				for remoteAddr, portMap := range remotes {
+					for port, _ := range portMap {
+						responses = append(responses, sarListenerResp{
+							Addr: remoteAddr,
+							Port: port,
+							Err:  err,
+						})
+					}
+				}
+				return responses, nil
+			}
+
+			// wasn't a read deadline error, some other kind of error
+			return nil, errors.New("reading response: " + err.Error())
+		}
+		if numBts < 14 { // 14 because the last data we need to look at, the flags, are at index 13
+			// log.Warnf("receiveSAR got malformed packet, too short")
+			continue
+		}
+
+		tcpHdrRaw := TCPHdr(buf[:numBts])
+
+		if int(tcpHdrRaw.DestPort()) != srcPort {
+			// log.Warnf("receiveSAR got mismatched dest port %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.DestPort(), srcPort)
+			continue
+		}
+
+		remoteAddr := readRemoteAddr.String()
+		addrMap, ok := remotes[remoteAddr]
+		if !ok {
+			// this is normal. Listening to an IP makes us receive all packets for all apps using that local IP.
+			// They're duplicated to us, so we're not causing anyone else to lose packets.
+			// We just need to ignore them
+			continue
+		}
+
+		// note we swap src and dest ports. The source for the packet we sent is the dest we recieve, and vice versa.
+
+		destPort := int(tcpHdrRaw.SrcPort()) // source of packet is dest for our request
+		ackNum, ok := addrMap[destPort]
+		if !ok {
+			// log.Warnf("receiveSAR got mismatched source port %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.SrcPort(), dstPort)
+			continue
+		}
+
+		if tcpHdrRaw.AckNum() != ackNum {
+			// log.Warnf("receiveSAR got mismatched ack num %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.AckNum(), ackNum)
+			continue
+		}
+
+		if tcpHdrRaw.SYN() && tcpHdrRaw.ACK() {
+			// Note the sendRST below is commented because it isn't necessary:
+			// the Linux kernel, even though we're listening on the port, will respond with an RST.
+			//
+			// Presumably because the kernel knows an ACK for something it doesn't know it sent
+			// is malformed, and also because the AckNum doesn't match anything.
+			//
+			// I'm leaving the below sendRST commented to make it clear that an RST should be sent
+			// to help the remote host free resources quickly;
+			// but we don't need to, the kernel is doing it for us.
+
+			// if err := sendRST(log, remoteAddr, localAddrIP, remoteAddrIP, int(tcpHdr.AckNum), srcPort, dstPort); err != nil {
+			// 	log.Errorln("receiveSAR sendRST error: " + err.Error())
+			// 	// don't fail. The RST is just to help the remote host close the connection gracefully.
+			// 	// We still succeeded with sending a syn and getting a syn-ack, which is all we need on our end
+			// }
+		} else if tcpHdrRaw.RST() {
+			// We're expecting either a Reset or a Syn-Ack
+		} else {
+			log.Warnln("receiveSAR got packet that wasn't an rst or a synack, but matched the ports and AckNum. Very strange!")
+			continue // packet wasn't a Rest or a Syn-Ack, ignore it
+		}
+
+		// We found a match for an addr+port+acknum in our requests, that was either a Reset or Syn-Ack response.
+
+		// So now add the time to the response array, remove the request from remoteMap,
+		// and return if remoteMap is empty
+
+		responses = append(responses, sarListenerResp{
+			Addr:     remoteAddr,
+			Port:     destPort,
+			RespTime: readTime,
+		})
+
+		delete(addrMap, destPort)
+		if len(addrMap) == 0 {
+			delete(remotes, remoteAddr)
+		}
+
+		// log.Warnf("multisar got packet, still have %v remotes\n", len(remotes))
+
+		// if we read all the packets we were expecting, return
+		if len(remotes) == 0 {
+			return responses, nil
+		}
+	}
+}

--- a/tc-health-client/sar/sar.go
+++ b/tc-health-client/sar/sar.go
@@ -1,0 +1,348 @@
+// package sar implements a syn-ack-rst health ping.
+// It sends a TCP SYN, waits for an ACK, then immediately sends an RST to kill the connection.
+// The primary purpose of this is as a health check, to verify the remote host is reachable, and able and willing to respond.
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-llog"
+)
+
+// SAR calls SARAddr if host is an IP address, or SARHost if host is an FQDN.
+func SAR(log llog.Log, host string, port int, timeout time.Duration) (time.Duration, error) {
+	log = llog.LibInit(log)
+	if ip := net.ParseIP(host); ip != nil {
+		return SARAddr(log, host, port, timeout)
+	}
+	return SARHost(log, host, port, timeout)
+}
+
+// SARAddr sends a syn-ack-reset to the given addr.
+// The addr must be an IP.
+// On success, the round-trip time to receive the Ack is returned, with a nil error.
+// The addr is a string representation of an IPv4 or IPv6 address.
+// TODO add optional local addr param
+func SARAddr(log llog.Log, addr string, port int, timeout time.Duration) (time.Duration, error) {
+	log = llog.LibInit(log)
+	remoteAddr := net.ParseIP(addr)
+	if remoteAddr == nil {
+		return 0, errors.New("failed to parse addr '" + addr + "' as IP")
+	}
+	if v4 := remoteAddr.To4(); v4 != nil {
+		remoteAddr = v4
+	}
+
+	localAddrStr, err := GetLocalAddr()
+	if err != nil {
+		return 0, errors.New("getting local address: " + err.Error())
+	}
+
+	localAddr := net.ParseIP(localAddrStr)
+	if localAddr == nil {
+		return 0, errors.New("failed to parse local addr '" + localAddrStr + "' as IP")
+	}
+	if v4 := localAddr.To4(); v4 != nil {
+		localAddr = v4
+	}
+
+	ephemeralPortHolder, err := GetAndHoldEphemeralPort(localAddrStr)
+	if err != nil {
+		return 0, errors.New("failed to listen on ephemeral port: " + err.Error())
+	}
+	defer ephemeralPortHolder.Close()
+
+	srcPort := ephemeralPortHolder.Port()
+
+	// TODO implement Initial Sequence Number ISN per RFC9293§3.4.1
+	seqNum := uint32(42)
+	window := 256 * 10
+	destPort := port
+	dataOffset := 5 // because we have no options?
+
+	native := TCPHdrNative{
+		SrcPort:    uint16(srcPort),
+		DestPort:   uint16(destPort),
+		SeqNum:     seqNum,
+		DataOffset: uint8(dataOffset), // 4 bits
+		SYN:        true,
+		Window:     uint16(window),
+	}
+	hdrBts, err := TCPHdrFromNative(native)
+	if err != nil {
+		return 0, errors.New("converting native header to byte: " + err.Error())
+	}
+	// the hdrBts packet is still missing the checksum, since we couldn't compute that until we had the marshalled bytes of the packet
+
+	checksum := MakeTCPChecksum(hdrBts, localAddr, remoteAddr)
+
+	hdrBts.SetChecksum(checksum)
+
+	// wait for the recieving SAR goroutine to finish
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	receiveTime := time.Time{}
+	receiveSARErr := error(nil)
+	// have to receive in a goroutine, because listening doesn't return, and we need to start listening before we send
+	// (or else the response could get to our machine and be discarded between the send and listen)
+	go func() {
+		remoteAddrStr := addr
+		localAddrStr := localAddr.String()
+		receiveTime, receiveSARErr = receiveSAR(log, localAddrStr, remoteAddrStr, localAddr, remoteAddr, timeout, srcPort, destPort, int(seqNum+1))
+		ephemeralPortHolder.Close() // this isn't strictly necessary, the defer will close this shortly. But this closes it ASAP
+		wg.Done()
+	}()
+
+	sendTime, err := SendPacket(hdrBts, remoteAddr.String())
+	if err != nil {
+		return 0, errors.New("sending packet: " + err.Error())
+	}
+
+	wg.Wait()
+
+	if receiveSARErr != nil {
+		return 0, errors.New("receiving SAR: " + receiveSARErr.Error())
+	}
+
+	return receiveTime.Sub(sendTime), nil
+}
+
+// SARHost sends a syn-ack-reset to the given hostname.
+// It looks up the hostname, and calls SendAddr on the first returned address.
+// See SendAddr.
+func SARHost(log llog.Log, host string, port int, timeout time.Duration) (time.Duration, error) {
+	log = llog.LibInit(log)
+	addrs, err := net.LookupHost(host)
+	if err != nil {
+		return 0, errors.New("lookup up host: " + err.Error())
+	} else if len(addrs) == 0 {
+		return 0, errors.New("looking up host succeeded, but no addresses were found.")
+	}
+	return SARAddr(log, addrs[0], port, timeout)
+}
+
+// GetLocalAddr gets a local IP, which this package will set as the TCP packet
+// source, and then listen on this address to get the syn-ack response.
+func GetLocalAddr() (string, error) {
+	_, localAddr, err := FindNetInterfaceAddr()
+	if err != nil {
+		return "", errors.New("finding interface and address: " + err.Error())
+	}
+	laddr := strings.Split(localAddr.String(), "/")[0] // remove any CIDR
+	return laddr, nil
+}
+
+// FindNetInterfaceAddr selects a local network interface to use.
+// It picks the first interface that isn't loopback, is up, and has addresses.
+// It then picks the first address in that interface.
+// Returns the selected interface name, the selected address, and any error.
+func FindNetInterfaceAddr() (string, net.Addr, error) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return "", nil, errors.New("getting interfaces: " + err.Error())
+	}
+	if len(interfaces) == 0 {
+		return "", nil, errors.New("no interfaces found")
+	}
+
+	errs := []string{}
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			errs = append(errs, err.Error())
+			continue
+		} else if len(addrs) == 0 {
+			errs = append(errs, "interface '"+iface.Name+"' had no addresses")
+			continue
+		}
+		return iface.Name, addrs[0], nil
+	}
+	return "", nil, errors.New("no interface found. Errors: " + strings.Join(errs, ", "))
+}
+
+// SendPacket sends the given packet to the given address and port.
+//
+// Note this doesn't take the local IP:port, which will be the source, which the destination will reply to,
+// Because those must already be included in the packet.
+//
+// Returns the time immediately before the packet was sent, and any error.
+func SendPacket(packet TCPHdr, addr string) (time.Time, error) {
+	// TODO handle IPv6
+
+	// Note this doesn't include the port. When dialing tcp, net.Dial addr must include the port.
+	// But when dialing ip, the addr must not include the port.
+	// Rather, the port will be determined from the dest port in the packet.
+	conn, err := net.Dial("ip4:tcp", addr)
+	if err != nil {
+		return time.Time{}, errors.New("dialing address: " + err.Error())
+	}
+	defer conn.Close()
+
+	sendTime := time.Now()
+	numBtsSent, err := conn.Write(packet)
+	if err != nil {
+		return time.Time{}, errors.New("writing: " + err.Error())
+	}
+	if numBtsSent != len(packet) {
+		return time.Time{}, fmt.Errorf("tried to write %v bytes, but only %v sent but no error", len(packet), numBtsSent)
+	}
+	return sendTime, nil
+}
+
+// receiveSAR receives the Syn-Ack in response to the Syn, with the given timeout.
+// Upon receiving a SynAck, it sends a RST to help the remote discard the connection quickly, and stops caring.
+// The srcPort, dstPort, and ackNum are used to match the SYNACK packet.
+// Returns the time that the SynAck was received.
+func receiveSAR(log llog.Log, localAddrStr string, remoteAddr string, localAddrIP net.IP, remoteAddrIP net.IP, timeout time.Duration, srcPort int, dstPort int, ackNum int) (time.Time, error) {
+	localAddr, err := net.ResolveIPAddr("ip4", localAddrStr)
+	if err != nil {
+		return time.Time{}, errors.New("resolving local address: " + err.Error())
+	}
+	// listen on the local IP for the SynAck
+	// TODO should this ListenPacket, to let Go automatically choose the port for us?
+	conn, err := net.ListenIP("ip4:tcp", localAddr)
+	if err != nil {
+		return time.Time{}, errors.New("listening for syn-ack response: " + err.Error())
+	}
+	defer conn.Close()
+
+	// Note this sets the absolute deadline, for all read packets.
+	// If we wanted to set the timeout for each individual packet read,
+	// we could call conn.SetDeadline inside the for-loop immediately before each conn.ReadFrom call.
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return time.Time{}, errors.New("setting deadline timeout to listen for syn-ack response: " + err.Error())
+	}
+
+	for {
+		// the max TCP Header size is 60 bytes (IPv4 is variable up to 60, IPv6 is always 40)
+		// This means the buffer here won't be just the header, it may also contain part of the payload.
+		// We don't care here, our header parsing will stop after reading the final End Of Option List option.
+		// But if this were changed to do something with the body, that would need taken into account.
+		buf := make([]byte, 60)
+
+		numBts, readRemoteAddr, err := conn.ReadFrom(buf)
+		readTime := time.Now()
+		if err != nil {
+			return time.Time{}, errors.New("reading response: " + err.Error())
+		}
+
+		if readRemoteAddr.String() != remoteAddr {
+			// this is normal. Listening to an IP makes us receive all packets for all apps using that local IP.
+			// They're duplicated to us, so we're not causing anyone else to lose packets.
+			// We just need to ignore them
+			continue
+		}
+
+		tcpHdrRaw := TCPHdr(buf[:numBts])
+
+		// note we swap src and dest ports. The source for the packet we sent is the dest we recieve, and vice versa.
+
+		if int(tcpHdrRaw.SrcPort()) != dstPort {
+			// log.Warnf("receiveSAR got mismatched source port %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.SrcPort(), dstPort)
+			continue
+		}
+		if int(tcpHdrRaw.DestPort()) != srcPort {
+			// log.Warnf("receiveSAR got mismatched dest port %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.DestPort(), srcPort)
+			continue
+		}
+		if int(tcpHdrRaw.AckNum()) != ackNum {
+			// log.Warnf("receiveSAR got mismatched ack num %+v expecting %v, ignoring and continuing to listen\n", tcpHdrRaw.AckNum(), ackNum)
+			continue
+		}
+
+		tcpHdr, err := TCPHdrToNative(tcpHdrRaw)
+		if err != nil {
+			return time.Time{}, errors.New("decoding tcp header: " + err.Error())
+		}
+
+		if tcpHdr.RST {
+			return readTime, nil // TODO should this return an error? We were expecting a syn-ack, not a reset
+		}
+		if tcpHdr.SYN && tcpHdr.ACK {
+
+			// Note the sendRST below is commented because it isn't necessary:
+			// the Linux kernel, even though we're listening on the port, will respond with an RST.
+			//
+			// Presumably because the kernel knows an ACK for something it doesn't know it sent
+			// is malformed, and also because the AckNum doesn't match anything.
+			//
+			// I'm leaving the below sendRST commented to make it clear that an RST should be sent
+			// to help the remote host free resources quickly;
+			// but we don't need to, the kernel is doing it for us.
+
+			// if err := sendRST(log, remoteAddr, localAddrIP, remoteAddrIP, int(tcpHdr.AckNum), srcPort, dstPort); err != nil {
+			// 	log.Errorln("receiveSAR sendRST error: " + err.Error())
+			// 	// don't fail. The RST is just to help the remote host close the connection gracefully.
+			// 	// We still succeeded with sending a syn and getting a syn-ack, which is all we need on our end
+			// }
+
+			return readTime, nil
+		}
+
+		log.Warnln("receiveSAR got packet that wasn't an rst or a synack, but matched the ports and AckNum. Very strange!")
+	}
+}
+
+// sendRST sends a tcp reset. This is designed to be called immediately after getting the syn-ack
+// for the syn-ack-rst health check, to help the remote host close the connection quickly and gracefully.
+//
+// The seqNum must be the sequence number of the original syn packet plus 1.
+func sendRST(log llog.Log, remoteAddrStr string, localAddr net.IP, remoteAddr net.IP, seqNum int, srcPort int, dstPort int) error {
+	window := 43690 // TODO change
+
+	dataOffset := 5 // because we have no options?
+	native := TCPHdrNative{
+		SrcPort:    uint16(srcPort),
+		DestPort:   uint16(dstPort),
+		SeqNum:     uint32(seqNum),
+		DataOffset: uint8(dataOffset), // 4 bits
+		RST:        true,
+		Window:     uint16(window),
+	}
+	hdrBts, err := TCPHdrFromNative(native)
+	if err != nil {
+		return errors.New("converting native header to byte: " + err.Error())
+	}
+	// the hdrBts packet is still missing the checksum, since we couldn't compute that until we had the marshalled bytes of the packet
+
+	checksum := MakeTCPChecksum(hdrBts, localAddr, remoteAddr)
+
+	hdrBts.SetChecksum(checksum)
+
+	if _, err := SendPacket(hdrBts, remoteAddrStr); err != nil {
+		return errors.New("sending packet: " + err.Error())
+	}
+	return nil
+}

--- a/tc-health-client/sar/sar_test.go
+++ b/tc-health-client/sar/sar_test.go
@@ -1,0 +1,52 @@
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitLast(t *testing.T) {
+
+	type InputExpected struct {
+		InputStr   string
+		InputDelim string
+		Expected   []string
+	}
+
+	inputExpecteds := []InputExpected{
+		{"", ":", []string{""}},
+		{":", ":", []string{"", ""}},
+		{"192.168.2.1:42", ":", []string{"192.168.2.1", "42"}},
+		{"2001:DB8::1:42", ":", []string{"2001:DB8::1", "42"}},
+		{"[2001:DB8::1]:42", ":", []string{"[2001:DB8::1]", "42"}},
+	}
+
+	for _, ie := range inputExpecteds {
+		actual := SplitLast(ie.InputStr, ie.InputDelim)
+		if !reflect.DeepEqual(ie.Expected, actual) {
+			for _, actual := range actual {
+				t.Errorf("actual '" + actual + "'")
+			}
+			t.Errorf("input '%v' delim '%v' expected '%v' actual '%v'", ie.InputStr, ie.InputDelim, ie.Expected, actual)
+		}
+	}
+}

--- a/tc-health-client/sar/tcphdr.go
+++ b/tc-health-client/sar/tcphdr.go
@@ -1,0 +1,234 @@
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/binary"
+)
+
+// TCPHdr is a TCP header
+//
+// TCPHdr should always be constructed with at least 20 bytes, the minimum TCP header size.
+// Users constructing a TCPHdr and giving it to a trusting caller must ensure it is at least 20 bytes and valid.
+// Users receiving an untrusted TCPHdr must check it is at least 20 bytes.
+// This type and its functions do not check size or validity, for performance reasons, and therefore may
+// panic if the TCPHdr is too small or otherwise malformed.
+//
+// Note TCPHdr does no validation of any kind, and is completely unaware of the contents of the packet,
+// including the semantics of any TCP Options.
+//
+// For a more convenient but slower implementation, use TCPHdrDecoded (TODO implement)
+//
+// See Valid.
+type TCPHdr []byte
+
+func (th TCPHdr) SrcPort() uint16 { return binary.BigEndian.Uint16(th[:2]) }
+
+func (th TCPHdr) DestPort() uint16 { return binary.BigEndian.Uint16(th[2:4]) }
+
+func (th TCPHdr) SeqNum() uint32 {
+	return binary.BigEndian.Uint32(th[4:8])
+}
+
+func (th TCPHdr) AckNum() uint32 {
+	return binary.BigEndian.Uint32(th[8:12])
+}
+
+// DataOffset is the DOffset TCP field. See RFC9293§3.1.
+//
+// Note the Data Offset field is 4 bits; unfortunately, uint8 is the smallest Go type.
+// Therefore, the most significant 4 bits will be unused and are not part of the field.
+func (th TCPHdr) DataOffset() uint8 {
+	do := th[12]         // don't need an Endian convertion, it's just a single byte
+	do = do & 0b00001111 // We could just not do this mask. Callers shouldn't be looking at the higher bits anyway. Is this ever a security issue?
+	return do
+}
+
+// Reserved is the reserved TCP field. See RFC9293§3.1.
+//
+// Note the Reserved field is 4 bits; unfortunately, uint8 is the smallest Go type.
+// Therefore, the most significant 4 bits will be unused and are not part of the field.
+func (th TCPHdr) Reserved() uint8 {
+	do := th[12] // don't need an Endian convertion, it's just a single byte
+	do = do >> 4
+	return do
+}
+
+// Control is the control flag TCP fields: CWR, ECE, URG, ACK, PSH, RST, SYN, FIN.
+//
+// This provided for convenience and performance, when bit-shifting is faster or more convenient
+// than using booleans. Each control flag is also available via individual boolean funcs.
+func (th TCPHdr) Control() uint8 {
+	return th[13]
+}
+
+// CWR is the Congestion Window Reduced flag, part of the ECN Explicit Congestion Notification.
+// See RFC3168§6.1, RFC9293§3.1.
+func (th TCPHdr) CWR() bool {
+	return th[13]&0b10000000 != 0
+}
+
+// ECE is the ECN-Echo flag, part of the ECN Explicit Congestion Notification.
+// See RFC3168§6.1, RFC9293§3.1.
+func (th TCPHdr) ECE() bool {
+	return th[13]&0b01000000 != 0
+}
+
+// URG is the Urgent flag. See RFC9293§3.1.
+func (th TCPHdr) URG() bool {
+	return th[13]&0b00100000 != 0
+}
+
+// ACK is the Acknowledgement flag. See RFC9293§3.1.
+func (th TCPHdr) ACK() bool {
+	return th[13]&0b00010000 != 0
+}
+
+// PSH is the Push flag. See RFC9293§3.1, RFC9293§3.9.1
+func (th TCPHdr) PSH() bool {
+	return th[13]&0b00001000 != 0
+}
+
+// RST is the connection Reset flag. See RFC9293§3.1.
+func (th TCPHdr) RST() bool {
+	return th[13]&0b00000100 != 0
+}
+
+// SYN is the synchronize sequence numbers flag. See RFC9293§3.1.
+func (th TCPHdr) SYN() bool {
+	return th[13]&0b00000010 != 0
+}
+
+// FIN is the finish connection flag. See RFC9293§3.1.
+func (th TCPHdr) FIN() bool {
+	return th[13]&0b00000001 != 0
+}
+
+func (th TCPHdr) Window() uint16 {
+	return binary.BigEndian.Uint16(th[14:16])
+}
+
+func (th TCPHdr) Checksum() uint16 {
+	return binary.BigEndian.Uint16(th[16:18])
+}
+
+func (th TCPHdr) SetChecksum(cs uint16) {
+	binary.BigEndian.PutUint16(th[16:18], cs)
+}
+
+func (th TCPHdr) Urgent() uint16 {
+	return binary.BigEndian.Uint16(th[18:20])
+}
+
+// OptionKind returns the kind of the nth option. See RFC9293§3.2.
+//
+// The prevSize is the sum of the sizes of all options less than n.
+// This is necessary to find the next option.
+//
+// Note the End of Option List the last option is of kind 0. So to iterate over all options, continuously request Option(prevSize, n) (tracking the sum of the previous sizes)
+// until the returned option Kind is 0.
+//
+// Note per RFC9293§3.2 all options except kind 0 (End of Option) and kind 1 (No Operation) have lengths. Callers must detect this and not query OptionLength for Kind 0 or 1.
+//
+// See RFC9293§3.2 for more details.
+func (th TCPHdr) OptionKind(prevSize int, n int) uint8 {
+	return th[prevSize] // single byte, no Endian conversion
+}
+
+// OptionLen returns the kind of the nth option. See RFC9293§3.2.
+//
+// The prevSize is the sum of the sizes of all options less than n.
+// This is necessary to find the next option.
+//
+// Note per RFC9293§3.2 all options except kind 0 (End of Option) and kind 1 (No Operation) have lengths. Callers must detect this and not query OptionLen for Kind 0 or 1.
+//
+// See RFC9293§3.2 for more details.
+func (th TCPHdr) OptionLen(prevSize int, n int) uint8 {
+	return th[prevSize+1] // single byte, no Endian conversion
+}
+
+// OptionData returns the data of the nth option. See RFC9293§3.2.
+//
+// The prevSize is the sum of the sizes of all options less than n.
+// This is necessary to find the next option.
+//
+// Note per RFC9293§3.2 all options except kind 0 (End of Option) and kind 1 (No Operation) have lengths. Callers must detect this and not query OptionLength or OptionData for Kind 0 or 1.
+// Note the Option Length includes the Kind and Length fields, each 1 octet. Therefore, options of length 2 have no data. Options of length <=2 must not call OptionData.
+//
+// The optionLen is the Length field. Note the Option Length includes the Kind and Length. The optionLen must not be the length of the data, it must be the Option Length field.
+// Therefore, the returned data will be 2 octets less than optionLen.
+//
+// Note the OptionLength includes padding. Therefore, the data returned by this func will include padding, in addition to the semantic option data. This func is unaware of the semantics
+// of any options.
+//
+// Note the OptionsData bytes are returned in network byte order (Big Endian), not machine byte order (frequently Little Endian).
+// Because TCPHdr doesn't know about options, it lacks the context to know the sizes and locations of integers inside particular options,
+// and therefore cannot convert byte order. Callers must convert byte order as necessary. See the binary package.
+//
+// See RFC9293§3.2 for more details.
+func (th TCPHdr) OptionData(prevSize int, optionLen int, n int) []byte {
+	return th[prevSize+2 : optionLen-2]
+}
+
+const TCPHdrOptionEndOfOptionList = 0
+const TCPHdrOptionNoOperation = 1
+
+// ProtocolNumberTCP is the protocol number for TCP.
+// See IANA Protocol Numbers, RFC791.
+const ProtocolNumberTCP = 6
+
+// MakeTCPChecksum creates the TCP packet checksum. See RFC9293§3.1
+// TODO handle IPv6
+func MakeTCPChecksum(data []byte, sourceIP []byte, destIP []byte) uint16 {
+	// TODO validate sourceIP and destIP are either 4 or 16 len?
+	// TODO handle IPv6
+
+	// TCP Checksum includes an IP "psuedo-header" (to protect against mis-routed packets). See RFC9293§3.1.
+	pseudoHdr := []byte{
+		sourceIP[0], sourceIP[1], sourceIP[2], sourceIP[3],
+		destIP[0], destIP[1], destIP[2], destIP[3],
+		0, // defined to be zero, see RFC9293§3.1.
+		ProtocolNumberTCP,
+		0, // tcp segment length, will calculate below
+		0, // tcp segment length, will calculate below
+	}
+	binary.BigEndian.PutUint16(pseudoHdr[10:12], uint16(len(data))) // tcp segment length
+	// TODO pad pseudoHdr?
+
+	btsToSum := append(pseudoHdr, data...)
+
+	lenBtsToSum := len(btsToSum)
+	nextWord := uint16(0)
+	sum := uint32(0)
+	for i := 0; i+1 < lenBtsToSum; i += 2 {
+		nextWord = uint16(btsToSum[i])<<8 | uint16(btsToSum[i+1])
+		sum += uint32(nextWord)
+	}
+	if lenBtsToSum%2 != 0 { // is there an odd byte?
+		sum += uint32(btsToSum[len(btsToSum)-1])
+	}
+
+	// add carry (if any), which itself may have a carry so add that too (if any)
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum = sum + (sum >> 16)
+
+	// bitwise complement
+	return uint16(^sum)
+}

--- a/tc-health-client/sar/tcphdrnative.go
+++ b/tc-health-client/sar/tcphdrnative.go
@@ -1,0 +1,170 @@
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// TCPHdrNative is a convenience struct containing deserialized TCP Header data.
+// This is more convenient but less efficient than TCPHdr.
+type TCPHdrNative struct {
+	SrcPort    uint16
+	DestPort   uint16
+	SeqNum     uint32
+	AckNum     uint32
+	DataOffset uint8 // 4 bits
+	Reserved   uint8 // 4 bits
+	CWR        bool
+	ECE        bool
+	URG        bool
+	ACK        bool
+	PSH        bool
+	RST        bool
+	SYN        bool
+	FIN        bool
+	Window     uint16
+	Checksum   uint16 // Kernel will set this if it's 0
+	Urgent     uint16
+	Options    []TCPHdrNativeOption
+}
+
+type TCPHdrNativeOption struct {
+	Kind int
+	Len  int
+	Data []byte
+}
+
+// TCPHdrToNative creates a TCPHdrNative from a TCPHdr.
+func TCPHdrToNative(hdr TCPHdr) (TCPHdrNative, error) {
+	native := TCPHdrNative{}
+	const minTCPHdrSize = 20
+	if len(hdr) < minTCPHdrSize {
+		return TCPHdrNative{}, fmt.Errorf("malformed header, minimum TCP header size is %v but hdr was %v bytes", minTCPHdrSize, len(hdr))
+	}
+
+	native.SrcPort = hdr.SrcPort()
+	native.DestPort = hdr.DestPort()
+	native.SeqNum = hdr.SeqNum()
+	native.AckNum = hdr.AckNum()
+	native.DataOffset = hdr.DataOffset()
+	native.Reserved = hdr.Reserved()
+	native.CWR = hdr.CWR()
+	native.ECE = hdr.ECE()
+	native.URG = hdr.URG()
+	native.ACK = hdr.ACK()
+	native.PSH = hdr.PSH()
+	native.RST = hdr.RST()
+	native.SYN = hdr.SYN()
+	native.FIN = hdr.FIN()
+	native.Window = hdr.Window()
+	native.Checksum = hdr.Checksum()
+	native.Urgent = hdr.Urgent()
+	native.Options = []TCPHdrNativeOption{}
+
+	if native.DataOffset < 5 {
+		return native, nil // no options
+	}
+
+	prevOptionsSize := 0
+	optionNum := 0
+	for {
+		// TODO add bounds checking, for malformed options
+
+		option := TCPHdrNativeOption{}
+		option.Kind = int(hdr.OptionKind(prevOptionsSize, 0))
+		if option.Kind == TCPHdrOptionEndOfOptionList {
+			// EoOL is length 1, no length octet and no data octets
+			native.Options = append(native.Options, option)
+			prevOptionsSize += 1
+			optionNum++
+			break
+		}
+
+		if option.Kind == TCPHdrOptionNoOperation {
+			// NoOp is length 1, no length octet and no data octets
+			native.Options = append(native.Options, option)
+			prevOptionsSize += 1
+			optionNum++
+			continue
+		}
+
+		option.Len = int(hdr.OptionLen(prevOptionsSize, optionNum))
+		option.Data = hdr.OptionData(prevOptionsSize, option.Len, optionNum)
+		native.Options = append(native.Options, option)
+		prevOptionsSize += option.Len
+		optionNum++
+	}
+	return native, nil
+}
+
+// TCPHdrFromNative creates a TCPHdr bytes from a TCPHdrNative.
+// The created TCPHdr is ready to send over the wire.
+func TCPHdrFromNative(native TCPHdrNative) (TCPHdr, error) {
+	// TODO pre-calculate and allocate options size
+	hdr := TCPHdr(make([]byte, 20, 20)) // allocate the mandatory 20 bytes up front
+
+	binary.BigEndian.PutUint16(hdr[0:2], uint16(native.SrcPort))
+	binary.BigEndian.PutUint16(hdr[2:4], uint16(native.DestPort))
+	binary.BigEndian.PutUint32(hdr[4:8], uint32(native.SeqNum))
+	binary.BigEndian.PutUint32(hdr[8:12], uint32(native.AckNum))
+
+	// TODO write a single uint32 for offset+reserved+control+window? Should be faster
+
+	hdr[12] = (native.DataOffset << 4) | (native.Reserved) // single byte so no endian byte order conversion. offset is 4 bits and reserved is 4 bits
+
+	// TODO this is terribly inefficient. Go has no way to convert bool to int without a conditional.
+	//      The TCPHdr is designed to be efficient, and TCPHdrNative is designed to be convenient if less efficient,
+	//      But it shouldn't be *that* inefficient. Maybe we should just use uint8?
+
+	boolToByte := func(b bool) byte {
+		if b {
+			return 1
+		}
+		return 0
+	}
+
+	cwr := boolToByte(native.CWR)
+	ece := boolToByte(native.ECE)
+	urg := boolToByte(native.URG)
+	ack := boolToByte(native.ACK)
+	psh := boolToByte(native.PSH)
+	rst := boolToByte(native.RST)
+	syn := boolToByte(native.SYN)
+	fin := boolToByte(native.FIN)
+
+	hdr[13] = cwr | (ece << 1) | (urg << 2) | (ack << 3) | (psh << 4) | (rst << 5) | (syn << 6) | (fin << 7)
+
+	hdr[13] = (cwr << 7) | (ece << 6) | (urg << 5) | (ack << 4) | (psh << 3) | (rst << 2) | (syn << 1) | (fin)
+	binary.BigEndian.PutUint16(hdr[14:16], native.Window)
+	binary.BigEndian.PutUint16(hdr[16:18], native.Checksum)
+	binary.BigEndian.PutUint16(hdr[18:20], native.Urgent)
+
+	for _, opt := range native.Options {
+		hdr = append(hdr, uint8(opt.Kind)) // uint8, no endian byte order conversion
+		if opt.Len == 0 {
+			continue
+		}
+		hdr = append(hdr, uint8(opt.Len))
+		hdr = append(hdr, opt.Data[:opt.Len-2]...) // -2 because Len includes the 1-octet kind and 1-octet length fields.
+	}
+	return hdr, nil
+}

--- a/tc-health-client/sar/util.go
+++ b/tc-health-client/sar/util.go
@@ -1,0 +1,35 @@
+package sar
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"strings"
+)
+
+// SplitLast splits on the last occurence of delim.
+// The returned slice will always have at least one element.
+// If str contains delim, the returned slice will have 2 elements.
+func SplitLast(str string, delim string) []string {
+	i := strings.LastIndex(str, delim)
+	if i < 0 {
+		return []string{str}
+	}
+	return []string{str[:i], str[i+1:]}
+}

--- a/tc-health-client/tc-health-client.go
+++ b/tc-health-client/tc-health-client.go
@@ -20,12 +20,20 @@ package main
  */
 
 import (
+	"context"
+	"math/rand"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"strconv"
+	"time"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 	"github.com/apache/trafficcontrol/tc-health-client/config"
 	"github.com/apache/trafficcontrol/tc-health-client/tmagent"
+	"github.com/apache/trafficcontrol/tc-health-client/util"
 )
 
 const (
@@ -43,20 +51,28 @@ var (
 )
 
 func main() {
+	rand.Seed(time.Now().UnixNano()) // TODO make deterministic. Seed hostname?
+
 	cfg, err, helpflag := config.GetConfig()
 	if err != nil {
 		log.Errorln(err.Error())
 		os.Exit(ConfigError)
 	}
+	cfgPtr := config.NewCfgPtr(cfg)
 
 	if helpflag { // user used --help option
 		os.Exit(Success)
 	}
 
-	log.Infof("Polling interval: %v seconds\n", config.GetTMPollingInterval().Seconds())
-	tmInfo, err := tmagent.NewParentInfo(cfg)
+	log.Infof("Polling interval: %v seconds\n", cfg.TMPollingInterval.Seconds())
+	tmInfo, err := tmagent.NewParentInfo(cfgPtr)
 	if err != nil {
 		log.Errorf("startup could not initialize parent info, check that trafficserver is running: %s\n", err.Error())
+		os.Exit(RunTimeError)
+	}
+
+	if err := tmInfo.GetTOData(cfg); err != nil {
+		log.Errorln("startup could not get data from Traffic Ops: " + err.Error())
 		os.Exit(RunTimeError)
 	}
 
@@ -69,5 +85,160 @@ func main() {
 
 	log.Infof("startup complete, version: %s, built: %s\n", Version, BuildTimestamp)
 
-	tmInfo.PollAndUpdateCacheStatus()
+	// TODO: make configurable
+	cfg.ParentHealthLogLocation = filepath.Join(config.DefaultLogDirectory, "parent-health.log")
+
+	switch cfg.ParentHealthLogLocation {
+	case "":
+		fallthrough
+	case "null":
+		tmInfo.ParentHealthLog = util.NopWriter{}
+		log.Infoln("Logging parent health to /dev/null")
+	case "stdout":
+		tmInfo.ParentHealthLog = util.MakeNoCloser(os.Stdout)
+		log.Infoln("Logging parent health to out")
+	case "stderr":
+		tmInfo.ParentHealthLog = util.MakeNoCloser(os.Stderr)
+		log.Infoln("Logging parent health to stderr")
+	default:
+		logFi, err := os.OpenFile(cfg.ParentHealthLogLocation, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		if err != nil {
+			log.Errorf("Opening parent health log file '" + cfg.ParentHealthLogLocation + "': " + err.Error())
+			os.Exit(RunTimeError)
+		}
+		log.Infoln("Logging parent health to file '" + cfg.ParentHealthLogLocation + "'")
+		tmInfo.ParentHealthLog = logFi
+	}
+
+	// start goroutines
+
+	log.Infoln("Starting Internal Services")
+
+	log.Infof("Health Methods: %+v\n", cfg.HealthMethods)
+	log.Infof("Markdown Methods: %+v\n", cfg.HealthMethods)
+	log.Infof("Num Health Workers: %+v\n", cfg.NumHealthWorkers)
+	log.Infof("Parent Health L4 Poll MS: %+v\n", cfg.ParentHealthL4PollMS)
+	log.Infof("Parent Health L7 Poll MS: %+v\n", cfg.ParentHealthL7PollMS)
+	log.Infof("Parent Health Sv Poll MS: %+v\n", cfg.ParentHealthServicePollMS)
+
+	parentHealthL4PollInterval := time.Duration(cfg.ParentHealthL4PollMS) * time.Millisecond
+	parentHealthL7PollInterval := time.Duration(cfg.ParentHealthL7PollMS) * time.Millisecond
+	parentHealthServicePollInterval := time.Duration(cfg.ParentHealthServicePollMS) * time.Millisecond
+	markdownMinInterval := time.Duration(*cfg.MarkdownMinIntervalMS) * time.Millisecond
+
+	markdownSvc := tmagent.StartMarkdownService(tmInfo, markdownMinInterval)
+
+	parentHealthL4DoneChan := make(chan<- struct{}, 1)
+	if _, use := tmInfo.HealthMethods[config.HealthMethodParentL4]; use {
+		parentHealthL4DoneChan, err = tmagent.StartParentHealthPoller(tmInfo, cfg.NumHealthWorkers, parentHealthL4PollInterval, tmagent.ParentHealthPollTypeL4, markdownSvc.UpdateHealth)
+		if err != nil {
+			log.Errorln("starting parent health poller l4 failed: " + err.Error())
+			os.Exit(RunTimeError)
+		}
+	}
+
+	parentHealthL7DoneChan := make(chan<- struct{}, 1)
+	if _, use := tmInfo.HealthMethods[config.HealthMethodParentL7]; use {
+		parentHealthL7DoneChan, err = tmagent.StartParentHealthPoller(tmInfo, cfg.NumHealthWorkers, parentHealthL7PollInterval, tmagent.ParentHealthPollTypeL7, markdownSvc.UpdateHealth)
+		if err != nil {
+			log.Errorln("starting parent health poller l7 failed: " + err.Error())
+			os.Exit(RunTimeError)
+		}
+	}
+
+	tmHealthDoneChan := make(chan<- struct{}, 1)
+	if _, use := tmInfo.HealthMethods[config.HealthMethodTrafficMonitor]; use {
+		tmHealthDoneChan = tmagent.StartTrafficMonitorHealthPoller(tmInfo, markdownSvc.UpdateHealth)
+	}
+
+	parentServiceHealthDoneChan := make(chan<- struct{}, 1)
+	if _, use := tmInfo.HealthMethods[config.HealthMethodParentService]; use {
+		parentServiceHealthDoneChan = tmagent.StartParentServiceHealthPoller(tmInfo, cfg.NumHealthWorkers, parentHealthServicePollInterval, markdownSvc.UpdateHealth)
+	}
+
+	const parentHealthServiceTimeout = time.Second * 30 // TODO make configurable
+
+	parentHealthSvc := &tmagent.ParentHealthServer{}
+	if cfg.ParentHealthServicePort > 0 {
+		parentHealthSvc = tmagent.StartParentHealthService(tmInfo, cfg.ParentHealthServicePort, parentHealthServiceTimeout)
+	}
+
+	terminate := func() {
+		log.Infoln("Received SIGTERM signal, terminating")
+		parentHealthSvc.Shutdown(context.Background()) // TODO timeout context?
+		parentHealthL4DoneChan <- struct{}{}
+		parentHealthL7DoneChan <- struct{}{}
+		parentServiceHealthDoneChan <- struct{}{}
+		tmHealthDoneChan <- struct{}{}
+		markdownSvc.Shutdown <- struct{}{}
+		if err := tmInfo.ParentHealthLog.Close(); err != nil {
+			log.Errorln("Closing Parent Health Log: " + err.Error())
+		}
+		os.Exit(0)
+	}
+
+	go signalReloader(unix.SIGHUP, func() { reloadConfig(tmInfo) })
+	signalReloader(unix.SIGTERM, terminate)
+}
+
+func signalReloader(sig os.Signal, f func()) {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, sig)
+	for range c {
+		f()
+	}
+}
+
+// reloadConfig reloads the config if necessary, and puts the new config in cfgGetter.
+func reloadConfig(pi *tmagent.ParentInfo) {
+	cfg := pi.Cfg.Get()
+
+	newCfg := &config.Cfg{
+		HealthClientConfigFile: cfg.HealthClientConfigFile,
+	}
+
+	isNew, err := config.LoadConfig(newCfg)
+	if err != nil {
+		log.Errorf("error reading changed config file %s: %s\n", cfg.HealthClientConfigFile.Filename, err.Error())
+		return
+	}
+
+	if isNew {
+		if err = config.ReadCredentials(newCfg, false); err != nil {
+			log.Errorln("could not load credentials for config updates, keeping the old config")
+			return
+		}
+		if err = pi.GetTOData(newCfg); err != nil {
+			log.Errorln("could not update the list of trafficmonitors, keeping the old config")
+		} else {
+			// TODO this was calling a custom copy func that wasn't copying:
+			//      MarkUpPollThreshold, TmProxyURL, CredentialFile, ParsedProxyURL
+			//      Verify that was a bug, and none of those need to not be updated
+			pi.Cfg.Set(newCfg)
+			log.Infoln("the configuration has been successfully updated")
+		}
+		return
+	}
+
+	// check for updates to the credentials file
+	if cfg.CredentialFile.Filename != "" {
+		modTime, err := util.GetFileModificationTime(cfg.CredentialFile.Filename)
+		if err != nil {
+			log.Errorf("could not stat the credential file '" + cfg.CredentialFile.Filename + "', considering modified! Error: " + err.Error())
+			// There's no good option here. If we fail to get the modify time,
+			// we can either end up never updating, or update every time.
+			// Since this is only ever called on a user-initiated HUP, it's probably ok
+			// to always refresh.
+			modTime = cfg.CredentialFile.LastModifyTime + 1 // fake it as modified, so we update
+		}
+		if modTime > cfg.CredentialFile.LastModifyTime {
+			log.Infoln("the credential file has changed, loading new credentials")
+			newCfg := cfg.Clone()
+			if err = config.ReadCredentials(newCfg, true); err != nil {
+				log.Errorf("could not load credentials from the updated credential file: %s", newCfg.CredentialFile.Filename)
+			} else {
+				pi.Cfg.Set(newCfg)
+			}
+		}
+	}
 }

--- a/tc-health-client/testing/tests/health-client-startup_test.go
+++ b/tc-health-client/testing/tests/health-client-startup_test.go
@@ -95,14 +95,19 @@ func TestHealthClientStartup(t *testing.T) {
 
 		// we marked down mids, now test that the health client read the ATS
 		// Host Status and see's that they are down.
-		parents := cfg.Parents
-		p := parents[atlantaMid]
+		p, ok := cfg.LoadParentStatus(atlantaMid)
+		if !ok {
+			t.Fatalf("Expected %s to be in parents but it's not", atlantaMid)
+		}
 		if p.ActiveReason != false {
 			t.Fatalf("Expected %s to be marked down but it's not", atlantaMid)
 		} else {
 			fmt.Fprintf(os.Stdout, "%s is available: %v\n", atlantaMid, p.ActiveReason)
 		}
-		p = parents[dtrcMid]
+		p, ok = cfg.LoadParentStatus(dtrcMid)
+		if !ok {
+			t.Fatalf("Expected %s to be in parents but it's not", dtrcMid)
+		}
 		if p.ActiveReason != false {
 			t.Fatalf("Expected %s to be marked down but it's not", dtrcMid)
 		} else {
@@ -111,11 +116,11 @@ func TestHealthClientStartup(t *testing.T) {
 
 		// verify that the health-client was able to poll and get an available
 		// traffic monitor from TrafficOps
-		av := cfg.Cfg.TrafficMonitors[rascal]
-		if av != true {
+		_, ok = cfg.TOData.Get().Monitors[rascal]
+		if !ok {
 			t.Fatalf("Expected %s to be available but it's not", rascal)
 		} else {
-			fmt.Fprintf(os.Stdout, "%s is available: %v\n", rascal, av)
+			fmt.Fprintf(os.Stdout, "%s is available: true\n", rascal)
 		}
 
 		fmt.Fprintf(os.Stdout, "Stopping the tc-health-client\n")

--- a/tc-health-client/tmagent/markdownservice.go
+++ b/tc-health-client/tmagent/markdownservice.go
@@ -1,0 +1,483 @@
+package tmagent
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"github.com/apache/trafficcontrol/tc-health-client/config"
+)
+
+// ParentStatus contains the trafficserver 'HostStatus' fields that
+// are necessary to interface with the trafficserver 'traffic_ctl' command.
+type ParentStatus struct {
+	Fqdn                 string
+	ActiveReason         bool
+	LocalReason          bool
+	ManualReason         bool
+	LastTmPoll           int64
+	UnavailablePollCount int
+	MarkUpPollCount      int
+}
+
+// used to get the overall parent availablity from the
+// HostStatus markdown reasons.  all markdown reasons
+// must be true for a parent to be considered available.
+func (p ParentStatus) available(reasonCode string) bool {
+	rc := false
+
+	switch reasonCode {
+	case "active":
+		rc = p.ActiveReason
+	case "local":
+		rc = p.LocalReason
+	case "manual":
+		rc = p.ManualReason
+	}
+	return rc
+}
+
+// used to log that a parent's status is either UP or
+// DOWN based upon the HostStatus reason codes.  to
+// be considered UP, all reason codes must be 'true'.
+func (p ParentStatus) Status() string {
+	if !p.ActiveReason {
+		return "DOWN"
+	} else if !p.LocalReason {
+		return "DOWN"
+	} else if !p.ManualReason {
+		return "DOWN"
+	}
+	return "UP"
+}
+
+type StatusReason int
+
+// these are the HostStatus reason codes used within
+// trafficserver.
+const (
+	ACTIVE StatusReason = iota
+	LOCAL
+	MANUAL
+)
+
+// used for logging a parent's HostStatus reason code
+// setting.
+func (s StatusReason) String() string {
+	switch s {
+	case ACTIVE:
+		return "ACTIVE"
+	case LOCAL:
+		return "LOCAL"
+	case MANUAL:
+		return "MANUAL"
+	}
+	return "UNDEFINED"
+}
+
+// MarkdownServer contains symbols for manipulating a running MarkdownService
+// started by StartMarkdownService.
+type MarkdownServer struct {
+	// Shutdown signals the MarkdownService to stop its goroutines and release all resources.
+	//
+	// It is not buffered. Writes will block until the markdown service is done with any
+	// ongoing markdown operation. Once a write returns, the MarkdownService will begin
+	// shutdown.
+	// TODO: add signal to callers when shutdown has finished.
+	Shutdown chan<- struct{}
+
+	// UpdateHealth signals to the markdown service that health status has changed, and it should process markdowns again.
+	UpdateHealth func()
+}
+
+func StartMarkdownService(pi *ParentInfo, pollInterval time.Duration) *MarkdownServer {
+	doneCh := make(chan struct{})
+	updateCh := make(chan struct{})
+	updateHealthF := func() {
+		select {
+		case updateCh <- struct{}{}:
+		default:
+		}
+	}
+
+	go markdownServicePoll(pi, pollInterval, doneCh, updateCh)
+	return &MarkdownServer{Shutdown: doneCh, UpdateHealth: updateHealthF}
+}
+
+func markdownServicePoll(pi *ParentInfo, pollInterval time.Duration, doneChan <-chan struct{}, updateChan <-chan struct{}) {
+	for {
+		select {
+		case <-doneChan:
+			return
+		default:
+			<-updateChan
+			start := time.Now()
+			doMarkdown(pi)
+			log.Infof("poll-status poll=markdown ms=%v\n", int(time.Since(start)/time.Millisecond))
+			time.Sleep(pollInterval)
+		}
+	}
+}
+
+// decideHealthy is the algorithm for deciding whether a cache is healthy.
+// It takes the cache hostname, and all health results, and returns a single boolean decision.
+func decideHealthy(
+	markdownMethods map[config.HealthMethod]struct{},
+	parentFQDN string,
+	tmHealth *TrafficMonitorHealth,
+	parentHealthL4 *ParentHealth,
+	parentHealthL7 *ParentHealth,
+	parentServiceHealth *ParentServiceHealth,
+) bool {
+	// TODO use hostname:port? Parents can be healthy on one port/service but not another.
+	// The ATS markdown command can't mark down per-port as of this writing, but
+	// we can at least calculate it, to log that data, and be able to easily
+	// mark down host:port when ATS adds that.
+
+	// note the CacheStatuses has v4 and v6 data,
+	// but ATS also can't mark down hosts per IP version yet,
+	// so we just use the generic/old non-IP-versioned IsAvailable field.
+
+	// TODO make decision algorithm/pessimism/ratio/etc configurable
+
+	tmHealthy := (*bool)(nil)
+	l4Healthy := (*bool)(nil)
+	l7Healthy := (*bool)(nil)
+	recursiveHealthy := (*bool)(nil)
+
+	l4Health, hasL4Health := parentHealthL4.ParentHealthPollResults[parentFQDN]
+	l7Health, hasL7Health := parentHealthL7.ParentHealthPollResults[parentFQDN]
+
+	if _, use := markdownMethods[config.HealthMethodTrafficMonitor]; use && tmHealth.CacheStatuses != nil {
+		parentHostName := parseFqdn(parentFQDN)
+		tmHealthy = util.BoolPtr(tmHealth.CacheStatuses[tc.CacheName(parentHostName)].IsAvailable)
+	}
+	if _, use := markdownMethods[config.HealthMethodParentL4]; use && parentHealthL4 != nil && hasL4Health && len(parentHealthL4.ParentHealthPollResults) > 0 {
+		l4Healthy = util.BoolPtr(l4Health.Healthy)
+	}
+	if _, use := markdownMethods[config.HealthMethodParentL7]; use && parentHealthL7 != nil && hasL7Health && len(parentHealthL7.ParentHealthPollResults) > 0 {
+		l7Healthy = util.BoolPtr(l7Health.Healthy)
+	}
+	if _, use := markdownMethods[config.HealthMethodParentService]; use && parentServiceHealth != nil && parentServiceHealth.ParentServiceHealthPollResults != nil {
+		recursiveHealthy = util.BoolPtr(decideRecursiveHealthy(parentServiceHealth.ParentServiceHealthPollResults[parentFQDN].ParentServiceHealth))
+	}
+
+	printbp := func(bp *bool) string {
+		if bp == nil {
+			return "nil"
+		}
+		return strconv.FormatBool(*bp)
+	}
+
+	// TODO wait for all polls to have results, before marking down?
+	//      Maybe it doesn't matter for pessimistic health?
+
+	log.Infof("decide-healthy host=%v tm=%v l4=%v l7=%v svc=%v\n", parentFQDN, printbp(tmHealthy), printbp(l4Healthy), printbp(l7Healthy), printbp(recursiveHealthy))
+
+	// nilOrTrue is a helper func that returns true if the given *bool is nil or true.
+	// This is used for pessimistic health, but if the health doesn't exist for the parent
+	// for a particular health type poller, we don't want to mark it unhealthy.
+	nilOrTrue := func(bp *bool) bool {
+		return bp == nil || *bp
+	}
+
+	// pessimistic: if any health mechanism is unhealthy, consider the host unhealthy
+	return nilOrTrue(tmHealthy) && nilOrTrue(l4Healthy) && nilOrTrue(l7Healthy) && nilOrTrue(recursiveHealthy)
+}
+
+// decideRecursiveHealthy is the algorithm for deciding whether a parent is healthy,
+// based on a heuristic of whether it can get to most parents
+// It takes the cache hostname, and all health results, and returns a single boolean decision.
+//
+// Note this is a heuristic because ATS doesn't currently have the ability to mark down
+// a parent hostname for a single remap.
+// If and when ATS has the ability to mark down parents per-remap, we can mark down parents
+// just for remaps whose origins aren't available on that parent.
+func decideRecursiveHealthy(parentServiceHealth *ParentServiceHealth) bool {
+	// TODO get direct vs final parent data from strategies.yaml and parent.config
+	//      Because we really want to heuristically check only the final parents (i.e. origins)
+	//      are available on our direct parent, not any other origins it has that aren't assigned
+	//      to this cache.
+
+	// TODO make configurable
+	const ratioToConsiderHealthy = 0.5
+
+	parentHealthy := map[string]bool{}
+
+	// TODO this is currently pessimistic: if any health mechanism is unhealthy, consider unhealthy.
+	//      make health decision configurable.
+
+	if parentServiceHealth == nil || parentServiceHealth.ParentServiceHealthPollResults == nil {
+		log.Warnln("decideRecursiveHealthy got nil parents, returning healthy")
+		return true
+	}
+
+	for parentFQDN, recursiveHealth := range parentServiceHealth.ParentServiceHealthPollResults {
+		if recursiveHealth.ParentHealthL4 != nil && !recursiveHealth.ParentHealthL4.Healthy {
+			parentHealthy[parentFQDN] = false
+			continue
+		}
+		if recursiveHealth.ParentHealthL7 != nil && !recursiveHealth.ParentHealthL7.Healthy {
+			parentHealthy[parentFQDN] = false
+			continue
+		}
+		if !decideRecursiveHealthy(recursiveHealth.ParentServiceHealth.ParentServiceHealthPollResults[parentFQDN].ParentServiceHealth) {
+			parentHealthy[parentFQDN] = false
+			continue
+		}
+		parentHealthy[parentFQDN] = true
+	}
+
+	numParents := 0
+	numParentsHealthy := 0
+	for _, healthy := range parentHealthy {
+		numParents++
+		if healthy {
+			numParentsHealthy++
+		}
+	}
+	healthyRatio := float64(numParentsHealthy) / float64(numParents)
+	return healthyRatio >= ratioToConsiderHealthy
+}
+
+type parent struct {
+	host string
+	fqdn string
+}
+
+// getParentFQDNs returns the FQDN of all parents in all health types.
+// This is necessary, because some health polls might not have parents, so we need to combine them all
+func getParentFQDNs(pi *ParentInfo, tmh *TrafficMonitorHealth, l4h *ParentHealth, l7h *ParentHealth, sh *ParentServiceHealth) []string {
+
+	// put FQDns in a set first, to remove duplicates
+	fqdnSet := map[string]struct{}{}
+
+	for cacheName, _ := range tmh.CacheStatuses {
+		hostName := string(cacheName)
+		fqdn, ok := pi.ParentHostFQDNs.Load(hostName)
+		if !ok {
+			// this should be normal. Many parents in TM won't be parents of this cache
+			continue
+		}
+		fqdnSet[fqdn] = struct{}{}
+	}
+
+	for fqdn, _ := range l4h.ParentHealthPollResults {
+		fqdnSet[fqdn] = struct{}{}
+	}
+	for fqdn, _ := range l7h.ParentHealthPollResults {
+		fqdnSet[fqdn] = struct{}{}
+	}
+	for fqdn, _ := range sh.ParentServiceHealthPollResults {
+		// we don't need recursive health, just the direct parent. We only need direct parents to mark down.
+		fqdnSet[fqdn] = struct{}{}
+	}
+
+	fqdns := make([]string, 0, len(fqdnSet))
+	for fqdn, _ := range fqdnSet {
+		fqdns = append(fqdns, fqdn)
+	}
+	return fqdns
+}
+
+// HealthSafetyRatio is the ratio of unhealthy parents after which no parents will be marked down.
+//
+// This is a safety mechanism: if for any reason most or all parents are marked down, something
+// is seriously wrong, possibly with the health code itself, and therefore don't mark any parents down,
+const HealthSafetyRatio = 0.3 // TODO make configurable?
+
+func doMarkdown(pi *ParentInfo) {
+	cfg := pi.Cfg.Get()
+
+	tmHealth := pi.TrafficMonitorHealth.Get()
+	parentHealthL4 := pi.ParentHealthL4.Get()
+	parentHealthL7 := pi.ParentHealthL7.Get()
+	parentServiceHealth := pi.ParentServiceHealth.Get()
+
+	parentFQDNs := getParentFQDNs(pi, tmHealth, parentHealthL4, parentHealthL7, parentServiceHealth)
+	unhealthyNum := 0
+	newCacheHealth := map[string]bool{} // map[fqdn]healthy
+	for _, fqdn := range parentFQDNs {
+		newAvailable := decideHealthy(pi.MarkdownMethods, fqdn, tmHealth, parentHealthL4, parentHealthL7, parentServiceHealth)
+		if !newAvailable {
+			unhealthyNum++
+		}
+		newCacheHealth[fqdn] = newAvailable
+	}
+
+	unhealthyParentsExceedSafetyRatio := (float64(unhealthyNum) / float64(len(newCacheHealth))) > HealthSafetyRatio
+	log.Infof("markdown Unhealthy parents %v/%v safety ratio %v\n", unhealthyNum, len(newCacheHealth), HealthSafetyRatio)
+	if unhealthyParentsExceedSafetyRatio {
+		log.Errorf("Unhealthy parents %v/%v exceed safety ratio %v!! Marking all parents up!!\n", unhealthyNum, len(newCacheHealth), HealthSafetyRatio)
+	}
+
+	for _, fqdn := range parentFQDNs {
+		isAvailable := tc.IsAvailable{}
+		{
+			hostName := parseFqdn(fqdn)
+			isAvailable = tmHealth.CacheStatuses[tc.CacheName(hostName)]
+		}
+		parentStatus, ok := pi.LoadParentStatus(fqdn)
+		if !ok {
+			continue // TODO warn? error? is this normal?
+		}
+
+		// update the polling time
+		parentStatus.LastTmPoll = tmHealth.PollTime.Unix()
+
+		newAvailable := newCacheHealth[fqdn]
+		if unhealthyParentsExceedSafetyRatio {
+			newAvailable = true
+		}
+		// newAvailable := isAvailable.IsAvailable
+		oldAvailable := parentStatus.available(cfg.ReasonCode)
+		if oldAvailable != newAvailable {
+			// do not mark down if the configuration disables mark downs.
+			if !cfg.EnableActiveMarkdowns && !newAvailable {
+				log.Infof("TM reports that %s is not available and should be marked DOWN but, mark downs are disabled by configuration", fqdn)
+			} else {
+				if newParentStatus, err := markParent(cfg, parentStatus, isAvailable.Status, newAvailable); err != nil {
+					log.Errorln(err.Error())
+				} else {
+					log.Infoln("TM reports that '" + parentStatus.Fqdn + "' is not available so marked DOWN")
+					parentStatus = newParentStatus
+				}
+			}
+		}
+
+		// if the host is available clear the unavailable poll count if not 0.
+		if oldAvailable && newAvailable {
+			if parentStatus.UnavailablePollCount > 0 {
+				log.Debugf("resetting the UnavailablePollCount for '%s' from %d to 0",
+					fqdn, parentStatus.UnavailablePollCount)
+				parentStatus.UnavailablePollCount = 0
+			}
+		}
+
+		{
+			parentHostName := parseFqdn(parentStatus.Fqdn)
+			pi.ParentHostFQDNs.Store(parentHostName, parentStatus.Fqdn)
+		}
+
+		// even if the status wasn't updated, we always need to update the poll time on the ParentStatus
+		pi.StoreParentStatus(parentStatus.Fqdn, parentStatus)
+	}
+
+}
+
+// markParent is used to mark a parent as up or down in the trafficserver HostStatus subsystem.
+// It takes a parent, modifies it by marking available and setting reasons and other data,
+// and returns the modified/marked parent.
+func markParent(cfg *config.Cfg, pv ParentStatus, cacheStatus string, available bool) (ParentStatus, error) {
+	var hostAvailable bool
+
+	hostName := parseFqdn(pv.Fqdn)
+
+	activeReason := pv.ActiveReason
+	localReason := pv.LocalReason
+	unavailablePollCount := pv.UnavailablePollCount
+	markUpPollCount := pv.MarkUpPollCount
+
+	log.Debugf("hostName: %s, UnavailablePollCount: %d, available: %v", hostName, unavailablePollCount, available)
+
+	if !available { // unavailable
+		unavailablePollCount += 1
+		if unavailablePollCount < cfg.UnavailablePollThreshold {
+			log.Infof("TM indicates %s is unavailable but the UnavailablePollThreshold has not been reached", hostName)
+			hostAvailable = true
+		} else {
+			// marking the host down
+			if err := execTrafficCtl(pv.Fqdn, false, cfg.ReasonCode, cfg.TrafficServerBinDir); err != nil {
+				log.Errorln(err)
+				return ParentStatus{}, err
+			}
+
+			hostAvailable = false
+			// reset the poll counts
+			markUpPollCount = 0
+			unavailablePollCount = 0
+			log.Infof("marked parent %s DOWN, cache status was: %s\n", hostName, cacheStatus)
+		}
+	} else { // available
+		// marking the host up
+		markUpPollCount += 1
+		if markUpPollCount < cfg.MarkUpPollThreshold {
+			log.Infof("TM indicates %s is available but the MarkUpPollThreshold has not been reached", hostName)
+			hostAvailable = false
+		} else {
+			if err := execTrafficCtl(pv.Fqdn, true, cfg.ReasonCode, cfg.TrafficServerBinDir); err != nil {
+				log.Errorln(err)
+				return ParentStatus{}, err
+			}
+			hostAvailable = true
+			// reset the poll counts
+			unavailablePollCount = 0
+			markUpPollCount = 0
+			log.Infof("marked parent %s UP, cache status was: %s\n", hostName, cacheStatus)
+		}
+	}
+
+	// update parent info
+	reason := cfg.ReasonCode
+	switch reason {
+	case "active":
+		activeReason = hostAvailable
+	case "local":
+		localReason = hostAvailable
+	}
+	// save updates
+	pv.ActiveReason = activeReason
+	pv.LocalReason = localReason
+	pv.UnavailablePollCount = unavailablePollCount
+	pv.MarkUpPollCount = markUpPollCount
+	log.Debugf("Updated parent status: %v", pv)
+	return pv, nil
+}
+
+func execTrafficCtl(fqdn string, available bool, reason string, atsBinDir string) error {
+	tc := filepath.Join(atsBinDir, TrafficCtl)
+
+	var status string
+	if available {
+		status = "up"
+	} else {
+		status = "down"
+	}
+
+	cmd := exec.Command(tc, "host", status, "--reason", reason, fqdn)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err != nil {
+		return errors.New("marking " + fqdn + " " + status + ": " + TrafficCtl + " error: " + err.Error())
+	}
+
+	return nil
+}

--- a/tc-health-client/tmagent/parenthealth.go
+++ b/tc-health-client/tmagent/parenthealth.go
@@ -1,0 +1,350 @@
+package tmagent
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/tc-health-client/sar"
+	"github.com/apache/trafficcontrol/tc-health-client/util"
+)
+
+const ParentHealthVersion = "1.0"
+
+type ParentHealth struct {
+	// Version is the direct version of this parent health, which applies to
+	// direct RecursiveParentHealth which are ParentHealth.
+	//
+	// This does not apply to RecursiveParentHealth which are ParentServiceHealth;
+	// rather, their own Version applies.
+	//
+	// Note this is the version of the service sending the result, not the service doing the polling.
+	Version string `json:"version"`
+
+	// Since is the RFC3339Nano-formatted time that this health result was polled.
+	// Note this is the time of the service doing the polling, not the service sending the result.
+	Since string `json:"since"`
+
+	ParentHealthPollResults map[string]ParentHealthPollResult `json:"parent_health_poll_results"`
+}
+
+// ParentHealthPollResult is the health data from polling a parent.
+// This is currently just a boolean, but may include other data in the future.
+type ParentHealthPollResult struct {
+	Healthy bool `json:"healthy"`
+	// UnhealthyReason is a human-readable string as to why the parent was unhealthy.
+	// This will be empty if Healthy is true.
+	UnhealthyReason string `json:"unhealthy_reason,omitempty"` // TODO rename to HealthChangeReason?
+	// TODO add poll type (L4 vs L7)?
+}
+
+func NewParentHealth() *ParentHealth {
+	return &ParentHealth{
+		Version:                 ParentHealthVersion,
+		ParentHealthPollResults: map[string]ParentHealthPollResult{},
+	}
+}
+
+// Serialize serializes the ParentHealth for network or disk output.
+func (ph *ParentHealth) Serialize(prettyPrint bool) ([]byte, error) {
+	if prettyPrint {
+		return json.MarshalIndent(ph, "", "  ")
+	}
+	return json.Marshal(ph)
+}
+
+// DeserializeParentHealth deserializes the ParentHealth from network or disk output,
+// as previously serialized with Serialize.
+func DeserializeParentHealth(bts []byte) (*ParentHealth, error) {
+	ph := &ParentHealth{}
+	err := json.Unmarshal(bts, ph)
+	if err != nil {
+		return nil, errors.New("unmarshalling json: " + err.Error())
+	}
+
+	// this can be smarter if and when we have a new version that can be converted from an old.
+	if ph.Version != ParentHealthVersion {
+		return nil, errors.New("incompatible version '" + ph.Version + "'")
+	}
+
+	return ph, nil
+}
+
+// NewParentHealthPtr is a convenience func for NewAtomicPtr(NewParentHealth()).
+func NewParentHealthPtr() *util.AtomicPtr[ParentHealth] {
+	return util.NewAtomicPtr(NewParentHealth())
+}
+
+type ParentHealthPollType string
+
+const ParentHealthPollTypeL4 = ParentHealthPollType("l4")
+const ParentHealthPollTypeL7 = ParentHealthPollType("l7")
+const ParentHealthPollTypeInvalid = ParentHealthPollType("")
+
+func (pt ParentHealthPollType) String() string { return string(pt) }
+
+func ParentHealthPollTypeFromStr(st string) ParentHealthPollType {
+	switch st {
+	case string(ParentHealthPollTypeL4):
+		return ParentHealthPollTypeL4
+	case string(ParentHealthPollTypeL7):
+		return ParentHealthPollTypeL7
+	default:
+		return ParentHealthPollTypeInvalid
+	}
+}
+
+// StartParentHealthPoller polls parents for health every pollInterval.
+// Returns a done channel, which will terminate the polling loop when written to.
+func StartParentHealthPoller(pi *ParentInfo, numWorkers int, pollInterval time.Duration, pollType ParentHealthPollType, updateHealthSignal func()) (chan<- struct{}, error) {
+	// validate pollType immediately so we can assume it's valid in the rest of the poller
+	if ParentHealthPollTypeFromStr(pollType.String()) == ParentHealthPollTypeInvalid {
+		return nil, errors.New("invalid poll type")
+	}
+
+	// TODO dynamically get pollInterval every loop
+	//      Which will require atomic/safe config loading
+	doneChan := make(chan struct{})
+	go parentHealthPoll(pi, pollInterval, pollType, numWorkers, doneChan, updateHealthSignal)
+	return doneChan, nil
+}
+
+// startWorker starts a worker goroutine, which reads from workCh and calls the function it passes.
+// The goroutine stops when workCh is closed.
+func startWorker(workCh <-chan func()) {
+	go func() {
+		for f := range workCh {
+			f()
+		}
+	}()
+}
+
+// const numParentHealthPollWorkers = 10 // TODO make configurable?
+
+func parentHealthPoll(pi *ParentInfo, pollInterval time.Duration, pollType ParentHealthPollType, numWorkers int, doneChan <-chan struct{}, updateHealthSignal func()) {
+	for {
+		select {
+		case <-doneChan:
+			return
+		default:
+			break
+		}
+
+		start := time.Now()
+		workCh := make(chan func(), 10) // TODO make buffer configurable?
+		for i := 0; i < numWorkers; i++ {
+			startWorker(workCh)
+		}
+		doPollParentHealth(workCh, pi, pollInterval, pollType)
+		close(workCh) // closing the channel will cause the worker goroutines to return and stop
+		updateHealthSignal()
+		log.Infof("poll-status poll=parent-health-"+pollType.String()+" ms=%v\n", int(time.Since(start)/time.Millisecond))
+		time.Sleep(pollInterval)
+	}
+}
+
+func doPollParentHealth(workCh chan func(), pi *ParentInfo, pollInterval time.Duration, pollType ParentHealthPollType) {
+	parentFQDNs := pi.GetParents()
+	newParentHealth := pollParents(workCh, parentFQDNs, pollType)
+	parentHealthPtr := pi.ParentHealthL4
+	if pollType == ParentHealthPollTypeL7 {
+		parentHealthPtr = pi.ParentHealthL7
+	}
+
+	logParentHealthChanges(pi.ParentHealthLog, pollType, parentHealthPtr.Get(), newParentHealth)
+
+	if pollType == ParentHealthPollTypeL4 {
+		pi.ParentHealthL4.Set(newParentHealth)
+	} else if pollType == ParentHealthPollTypeL7 {
+		pi.ParentHealthL7.Set(newParentHealth)
+	}
+}
+
+// logParentHealthChanges writes parent health changes to plog.
+func logParentHealthChanges(plog io.Writer, pollType ParentHealthPollType, oldPH *ParentHealth, newPH *ParentHealth) {
+	for parentFQDN, newHealth := range newPH.ParentHealthPollResults {
+		oldHealth, ok := oldPH.ParentHealthPollResults[parentFQDN]
+		// We could remove this if check, if the user needed to log every poll,
+		// even if it was the same (for example, if their logging system needed that).
+		// TODO add config option?
+		// TODO add event log to config
+		if !ok || oldHealth.Healthy != newHealth.Healthy {
+			logStr := time.Now().UTC().Format(time.RFC3339) + ` ParentHealth type=` + pollType.String() + ` parent=` + parentFQDN + ` healthy=` + strconv.FormatBool(newHealth.Healthy) + ` reason='` + newHealth.UnhealthyReason + `'` + "\n"
+			bytesWritten, err := io.WriteString(plog, logStr)
+			if err != nil {
+				log.Errorln("writing to parent health log: " + err.Error())
+			} else if bytesWritten != len(logStr) {
+				log.Errorf("writing to parent health log: no error but wrote %v/%v bytes\n", bytesWritten, len(logStr))
+			}
+		}
+	}
+}
+
+type ParentHealthPollResultAndFQDN struct {
+	ParentHealthPollResult
+	ParentFQDN string
+}
+
+func pollParents(workCh chan func(), parentFQDNs []string, pollType ParentHealthPollType) *ParentHealth {
+	if pollType == ParentHealthPollTypeL4 {
+		return pollParentsL4(workCh, parentFQDNs, pollType)
+	}
+	if pollType == ParentHealthPollTypeL7 {
+		return pollParentsL7(workCh, parentFQDNs, pollType)
+	}
+	// should never happen, the poll start function should validate the poll type
+	log.Errorf("pollParent got unknown poll type '%v', defaulting to L7!\n", pollType)
+	return pollParentsL7(workCh, parentFQDNs, pollType)
+}
+
+func pollParentsL7(workCh chan func(), parentFQDNs []string, pollType ParentHealthPollType) *ParentHealth {
+	var timeout = 2 * time.Second // TODO make configurable.
+	const parentPort = 80         // TODO make configurable
+
+	// Note this could be made parallel with a pool of goroutine workers
+	// if it mattered for performance
+	results := map[string]ParentHealthPollResult{}
+
+	resultCh := make(chan ParentHealthPollResultAndFQDN) // TODO buffer?
+
+	// writing the work to workers needs to be in its own goroutine,
+	// because the channel buffer isn't large enough to hold all parents,
+	// and we don't know how many parents there are when workers are created and need passed the work chan.
+	// So, we need this writing goroutine to happen while we concurrently read work as it finishes in this thread.
+	go func() {
+		for _, parentFQDN := range parentFQDNs {
+			workCh <- func() {
+				resultCh <- pollParentL7(parentFQDN, parentPort, timeout)
+			}
+		}
+	}()
+
+	// read work as it finishes
+	for i := 0; i < len(parentFQDNs); i++ {
+		resultFQDN := <-resultCh
+		results[resultFQDN.ParentFQDN] = resultFQDN.ParentHealthPollResult
+	}
+	return &ParentHealth{ParentHealthPollResults: results}
+}
+
+func pollParentL7(parentFQDN string, parentPort int, timeout time.Duration) ParentHealthPollResultAndFQDN {
+	// TODO add service port, instead of assuming 80/443
+	// TODO reuse http.Client
+
+	httpClient := http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// TODO more granular timeout options?
+			// ConnectTimeout:        ParentPollTimeout,
+			// RequestTimeout:        ParentPollTimeout,
+			ResponseHeaderTimeout: timeout,
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://"+parentFQDN+":"+strconv.Itoa(parentPort), nil)
+	if err != nil {
+		// TODO log?
+		return ParentHealthPollResultAndFQDN{
+			ParentHealthPollResult: ParentHealthPollResult{
+				Healthy:         false,
+				UnhealthyReason: "error making request: " + err.Error(),
+			},
+			ParentFQDN: parentFQDN,
+		}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return ParentHealthPollResultAndFQDN{
+			ParentHealthPollResult: ParentHealthPollResult{
+				Healthy:         false,
+				UnhealthyReason: "error requesting: " + err.Error(),
+			},
+			ParentFQDN: parentFQDN,
+		}
+	}
+	// Immediately close the body, we don't care what was in it.
+	// But we do care that we're able to successfully stream the entire HTTP response.
+	if err := resp.Body.Close(); err != nil {
+		return ParentHealthPollResultAndFQDN{
+			ParentHealthPollResult: ParentHealthPollResult{
+				Healthy:         false,
+				UnhealthyReason: "error reading body: " + err.Error(),
+			},
+			ParentFQDN: parentFQDN,
+		}
+	}
+
+	return ParentHealthPollResultAndFQDN{
+		ParentHealthPollResult: ParentHealthPollResult{
+			Healthy: true,
+		},
+		ParentFQDN: parentFQDN,
+	}
+}
+
+func pollParentsL4(workCh chan func(), parentFQDNs []string, pollType ParentHealthPollType) *ParentHealth {
+	timeout := 2 * time.Second // TODO make configurable.
+	parentPort := 80           // TODO make configurable
+
+	// Note this could be made parallel with a pool of goroutine workers
+	// if it mattered for performance
+	results := map[string]ParentHealthPollResult{}
+
+	hosts := []sar.HostPort{}
+	for _, parentFQDN := range parentFQDNs {
+		hosts = append(hosts, sar.HostPort{Host: parentFQDN, Port: parentPort})
+	}
+
+	sarResults, err := sar.MultiSAR(log.LLog(), hosts, timeout)
+	if err != nil {
+		for _, parentFQDN := range parentFQDNs {
+			results[parentFQDN] = ParentHealthPollResult{
+				Healthy:         false,
+				UnhealthyReason: "l4 SAR error: " + err.Error(),
+			}
+		}
+		return &ParentHealth{
+			ParentHealthPollResults: results,
+		}
+	}
+
+	for _, rs := range sarResults {
+		if rs.Err != nil {
+			results[rs.Host] = ParentHealthPollResult{
+				Healthy:         false,
+				UnhealthyReason: rs.Err.Error(),
+			}
+			continue
+		}
+		results[rs.Host] = ParentHealthPollResult{
+			Healthy: true,
+		}
+	}
+	return &ParentHealth{
+		ParentHealthPollResults: results,
+	}
+}

--- a/tc-health-client/tmagent/parenthealthservice.go
+++ b/tc-health-client/tmagent/parenthealthservice.go
@@ -1,0 +1,100 @@
+package tmagent
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-rfc"
+)
+
+type ParentHealthServer struct {
+	parentInfo *ParentInfo
+	httpServer *http.Server
+}
+
+// StartParentHealthService is a helper function that calls NewParentHealthServer, runs ListenAndServe in a goroutine, and returns the ParentHealthServer.
+// If ListenAndServe returns an error, it's logged to the error log.
+func StartParentHealthService(pi *ParentInfo, port int, readTimeout time.Duration) *ParentHealthServer {
+	sv := NewParentHealthServer(pi, ":"+strconv.Itoa(port), readTimeout)
+	go func() {
+		if err := sv.ListenAndServe(); err != nil {
+			log.Errorln("Parent Health Service returned: " + err.Error())
+		}
+	}()
+	return sv
+}
+
+func NewParentHealthServer(pi *ParentInfo, addr string, readTimeout time.Duration) *ParentHealthServer {
+	sv := &ParentHealthServer{
+		parentInfo: pi,
+		httpServer: &http.Server{
+			Addr:        addr,
+			ReadTimeout: readTimeout,
+		},
+	}
+	sv.httpServer.Handler = sv
+	return sv
+}
+
+func (sv *ParentHealthServer) ListenAndServe() error {
+	return sv.httpServer.ListenAndServe()
+}
+
+func (sv *ParentHealthServer) ListenAndServeTLS(certFile, keyFile string) error {
+	return sv.httpServer.ListenAndServeTLS(certFile, keyFile)
+}
+
+func (sv *ParentHealthServer) Shutdown(ctx context.Context) error {
+	if sv.httpServer == nil {
+		return nil // allow Shutdown on a default-initialized ParentHealthServer as a no-op.
+	}
+	return sv.httpServer.Shutdown(ctx)
+}
+
+func (sv *ParentHealthServer) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	// TODO implement io.Reader/+io.WriterTo?
+	// TODO add 1s cache
+
+	parentHealthL4 := sv.parentInfo.ParentHealthL4.Get()
+	parentHealthL7 := sv.parentInfo.ParentHealthL7.Get()
+	parentSvcHealth := sv.parentInfo.ParentServiceHealth.Get()
+	combinedHealth := CombineParentHealth(parentHealthL4, parentHealthL7, parentSvcHealth)
+
+	parentHealthBts, err := combinedHealth.Serialize(false)
+	if err != nil {
+		const code = http.StatusInternalServerError
+		w.WriteHeader(code)
+		w.Write([]byte(http.StatusText(code)))
+		return
+	}
+
+	w.Header().Set(rfc.ContentType, rfc.ApplicationJSON)
+	w.Write(parentHealthBts)
+
+	// Append a newline so the response is a valid POSIX file.
+	// Not strictly necessary, but may be useful to clients, and it's still valid JSON,
+	// there's no reason not to.
+	w.Write([]byte("\n"))
+}

--- a/tc-health-client/tmagent/parentservicehealth.go
+++ b/tc-health-client/tmagent/parentservicehealth.go
@@ -1,0 +1,292 @@
+package tmagent
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/tc-health-client/config"
+	"github.com/apache/trafficcontrol/tc-health-client/util"
+)
+
+// ParentServiceHealth is the recursive parent health polled from other
+// Parent Health Services.
+//
+// Parents will be recursively polled.
+// If a parent is a cache, its Parent Health Service will be polled and the result
+// placed in its map key.
+// If a parent is not a cache, its ordinary Parent Health will be placed in its map key.
+// See StartParentHealthPoller.
+type ParentServiceHealth struct {
+	// Version is the direct version of this parent health, which applies to
+	// direct RecursiveParentHealth which are ParentHealth.
+	//
+	// This does not apply to RecursiveParentHealth which are ParentServiceHealth;
+	// rather, their own Version applies.
+	Version string `json:"version"`
+	// ParentServiceHealthPollResults map[HostName]RecursiveParentHealth `json:"parent_health_poll_results"`
+
+	ParentServiceHealthPollResults map[string]RecursiveParentHealth `json:"parent_service_health_poll_results"`
+
+	// Since is the RFC3339Nano-formatted time that this health result was polled.
+	// Note this is the time of the service doing the polling, not the service sending the result.
+	Since time.Time `json:"since"`
+}
+
+// RecursiveParentHealth is either a poll from a direct parent poll of a non-cache
+// or a ParentServiceHealth from a parent service poll of a cache.
+//
+// Either ParentHealth or ParentServiceHealth will not be nil, but never both.
+//
+// This would be more elegant as an interface, but a struct with two pointers is easier to deserialize.
+type RecursiveParentHealth struct {
+	ParentHealthL4      *ParentHealthPollResult `json:"parent_health_l4"`
+	ParentHealthL7      *ParentHealthPollResult `json:"parent_health_l7"`
+	ParentServiceHealth *ParentServiceHealth    `json:"parent_service_health"` // debug
+}
+
+func NewParentServiceHealth() *ParentServiceHealth {
+	return &ParentServiceHealth{
+		Version:                        ParentHealthVersion,
+		ParentServiceHealthPollResults: map[string]RecursiveParentHealth{},
+	}
+}
+
+// Serialize serializes the ParentServiceHealth for network or disk output.
+func (ph *ParentServiceHealth) Serialize(prettyPrint bool) ([]byte, error) {
+	if prettyPrint {
+		return json.MarshalIndent(ph, "", "  ")
+	}
+	return json.Marshal(ph)
+}
+
+// DeserializeParentServiceHealth deserializes the ParentHealth from network or disk output,
+// as previously serialized with Serialize.
+func DeserializeParentServiceHealth(bts []byte) (*ParentServiceHealth, error) {
+	ph := &ParentServiceHealth{}
+	err := json.Unmarshal(bts, ph)
+	if err != nil {
+		return nil, errors.New("unmarshalling json: " + err.Error())
+	}
+
+	// this can be smarter if and when we have a new version that can be converted from an old.
+	if ph.Version != ParentHealthVersion {
+		return nil, errors.New("incompatible version '" + ph.Version + "'")
+	}
+
+	return ph, nil
+}
+
+// NewParentServiceHealthPtr is a convenience func for NewAtomicPtr(NewParentServiceHealth()).
+func NewParentServiceHealthPtr() *util.AtomicPtr[ParentServiceHealth] {
+	return util.NewAtomicPtr(NewParentServiceHealth())
+}
+
+// StartParentServiceHealthPoller polls parents for health every pollInterval.
+// Note only parents which are caches are polled.
+// Returns a done channel, which will terminate the polling loop when written to.
+func StartParentServiceHealthPoller(pi *ParentInfo, numWorkers int, pollInterval time.Duration, updateHealthSignal func()) chan<- struct{} {
+	// TODO share HTTP client, which should reuse connections
+
+	// TODO dynamically get pollInterval every loop
+	//      Which will require atomic/safe config loading
+	doneChan := make(chan struct{})
+	go parentServiceHealthPoll(pi, numWorkers, pollInterval, doneChan, updateHealthSignal)
+	return doneChan
+}
+
+func parentServiceHealthPoll(pi *ParentInfo, numWorkers int, pollInterval time.Duration, doneChan <-chan struct{}, updateHealthSignal func()) {
+	for {
+		select {
+		case <-doneChan:
+			return
+		default:
+			break
+		}
+
+		start := time.Now()
+		workCh := make(chan func(), 10) // TODO make buffer configurable?
+		for i := 0; i < numWorkers; i++ {
+			startWorker(workCh)
+		}
+		doPollParentServiceHealth(workCh, pi, pollInterval)
+		close(workCh) // closing the channel will cause the worker goroutines to return and stop
+		updateHealthSignal()
+		log.Infof("poll-status poll=parent-health-service ms=%v\n", int(time.Since(start)/time.Millisecond))
+		time.Sleep(pollInterval)
+	}
+}
+
+func doPollParentServiceHealth(workCh chan func(), pi *ParentInfo, pollInterval time.Duration) {
+	log.Debugf("doPollParentHealth starting\n")
+	// TODO add config to not poll at all
+
+	cfg := pi.Cfg.Get()
+	parentFQDNs := pi.GetCacheParents()
+
+	log.Debugf("about to poll service cache parents: %+v\n", parentFQDNs)
+
+	newParentServiceHealth := pollParentServices(workCh, cfg, parentFQDNs)
+
+	// logParentServiceHealthChanges(pi.ParentServiceHealthLog, pi.ParentserviceHealthPtr.Get(), newParentServiceHealth)
+
+	pi.ParentServiceHealth.Set(newParentServiceHealth)
+}
+
+// logParentServiceHealthChanges writes parent health changes to the Event log.
+// func logParentServiceHealthChanges(plog io.Writer, oldPH *ParentServiceHealth, newPH *ParentServiceHealth) {
+// 	for parentFQDN, newHealth := range newPH.ParentServiceHealthPollResults {
+// 		oldHealth, ok := oldPH.ParentServiceHealthPollResults[parentFQDN]
+// 		// We could remove this if check, if the user needed to log every poll,
+// 		// even if it was the same (for example, if their logging system needed that).
+// 		// TODO add config option?
+// 		// TODO add event log to config
+// 		if !ok || oldHealth.Healthy != newHealth.Healthy {
+// 			logStr := time.Now().UTC().Format(time.RFC3339) + ` ParentHealth '` + parentFQDN + `' healthy=` + strconv.FormatBool(newHealth.Healthy) + ` reason='` + newHealth.UnhealthyReason + `'` + "\n"
+// 			bytesWritten, err := io.WriteString(plog, logStr)
+// 			if err != nil {
+// 				log.Errorln("writing to parent health log: " + err.Error())
+// 			} else if bytesWritten != len(logStr) {
+// 				log.Errorf("writing to parent health log: no error but wrote %v/%v bytes\n", bytesWritten, len(logStr))
+// 			}
+// 		}
+// 	}
+
+// 	// Healthy bool
+// 	// UnhealthyReason string
+// }
+
+// ParentServicePollTimeoutService is the timeout for PollParent.
+// TODO make configurable.
+var ParentServicePollTimeoutService = 2 * time.Second
+
+// ParentServiceHealthPollResult is the health data from polling a parent.
+// This is currently just a boolean, but may include other data in the future.
+// TODO delete
+type ParentServiceHealthPollResult struct {
+	Healthy bool
+	// UnhealthyReason is a human-readable string as to why the parent was unhealthy.
+	// This will be empty if Healthy is true.
+	UnhealthyReason string // TODO rename to HealthChangeReason?
+	// TODO add poll type (L4 vs L7)?
+}
+
+// ParentServiceHealthErrFQDN contains the health, any error, and the parent fqdn.
+// This is used to return on a result chan from a poll worker.
+type ParentServiceHealthErrFQDN struct {
+	Health RecursiveParentHealth
+	Err    error
+	FQDN   string
+}
+
+func pollParentServices(workCh chan func(), cfg *config.Cfg, parentFQDNs []string) *ParentServiceHealth {
+	// Note this could be made parallel with a pool of goroutine workers
+	// if it mattered for performance
+	results := map[string]RecursiveParentHealth{}
+
+	resultCh := make(chan ParentServiceHealthErrFQDN) // TODO buffer?
+
+	// write to work chan in a goroutine, because the work chan buffer won't be large enough that it'll block before we can start reading from it
+	go func() {
+		for _, parentFQDN := range parentFQDNs {
+			if parentShortHostName := util.HostNameToShort(parentFQDN); parentShortHostName == cfg.HostName {
+				// log.Debugf("pollParentServices got self %+v (%v), not polling self\n", parentFQDN, parentShortHostName)
+				continue
+			}
+
+			workCh <- func() {
+				const scheme = "http" // TODO always https and support client certs? Or make configurable?
+				parentURI := scheme + `://` + parentFQDN + `:` + strconv.Itoa(cfg.ParentHealthServicePort)
+				parentServiceHealth, err := pollParentService(parentURI, ParentServicePollTimeoutService)
+				resultCh <- ParentServiceHealthErrFQDN{
+					Health: RecursiveParentHealth{ParentServiceHealth: parentServiceHealth},
+					Err:    err,
+					FQDN:   parentFQDN,
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < len(parentFQDNs); i++ {
+		result := <-resultCh
+		if result.Err != nil {
+			log.Errorln("parent service health poll for '" + result.FQDN + "' failed, parent health will be determined purely from native parent health; error: " + result.Err.Error())
+		} else {
+			results[result.FQDN] = result.Health
+		}
+	}
+
+	return &ParentServiceHealth{
+		ParentServiceHealthPollResults: results,
+	}
+}
+
+func pollParentService(parentURI string, timeout time.Duration) (*ParentServiceHealth, error) {
+	// TODO reuse http.Client
+
+	httpClient := http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			// TODO more granular timeout options?
+			// ConnectTimeout:        ParentPollTimeout,
+			// RequestTimeout:        ParentPollTimeout,
+			ResponseHeaderTimeout: timeout,
+		},
+	}
+
+	req, err := http.NewRequest(http.MethodGet, parentURI, nil)
+	if err != nil {
+		// TODO log?
+		return nil, errors.New("making request: " + err.Error())
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, errors.New("requesting: " + err.Error())
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bts, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, errors.New("code " + strconv.Itoa(resp.StatusCode) + " reading: " + err.Error())
+		}
+		bts = bytes.ReplaceAll(bts, []byte("\n"), []byte(`\n`)) // we don't want newlines in the error log
+		return nil, errors.New("code " + strconv.Itoa(resp.StatusCode) + " body: " + string(bts))
+	}
+
+	parentServiceHealth := &ParentServiceHealth{}
+	if err := json.NewDecoder(resp.Body).Decode(parentServiceHealth); err != nil {
+		return nil, errors.New("code " + strconv.Itoa(resp.StatusCode) + " decoding: " + err.Error())
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, errors.New("closing body: " + err.Error())
+	}
+
+	return parentServiceHealth, nil
+}

--- a/tc-health-client/tmagent/tmhealthservice.go
+++ b/tc-health-client/tmagent/tmhealthservice.go
@@ -1,0 +1,166 @@
+package tmagent
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/apache/trafficcontrol/lib/go-log"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/tc-health-client/config"
+	"github.com/apache/trafficcontrol/traffic_monitor/tmclient"
+)
+
+type TrafficMonitorHealth struct {
+	// PollTime is the local time this TM health was obtained
+	PollTime      time.Time
+	CacheStatuses map[tc.CacheName]tc.IsAvailable
+}
+
+func NewTrafficMonitorHealth() *TrafficMonitorHealth {
+	return &TrafficMonitorHealth{
+		CacheStatuses: map[tc.CacheName]tc.IsAvailable{},
+	}
+}
+
+// StartTrafficMonitorHealthPoller
+// The main polling function that keeps the parents list current if
+// with any changes to the trafficserver 'parent.config' or 'strategies.yaml'.
+// Also, it keeps parent status current with the the trafficserver HostStatus
+// subsystem.  Finally, on each poll cycle a trafficmonitor is queried to check
+// that all parents used by this trafficserver are available for use based upon
+// the trafficmonitors idea from it's health protocol.  Parents are marked up or
+// down in the trafficserver subsystem based upon that hosts current status and
+// the status that trafficmonitor health protocol has determined for a parent.
+func StartTrafficMonitorHealthPoller(pi *ParentInfo, updateHealthSignal func()) chan<- struct{} {
+	log.Infoln("Traffic Monitor Health Poller started")
+	doneChan := make(chan struct{})
+	go loopPollAndUpdateCacheStatus(pi, doneChan, updateHealthSignal)
+	return doneChan
+}
+
+func loopPollAndUpdateCacheStatus(pi *ParentInfo, doneChan <-chan struct{}, updateHealthSignal func()) {
+	cfg := pi.Cfg.Get()
+	toLoginDispersion := config.GetTOLoginDispersion(cfg.TMPollingInterval, cfg.TOLoginDispersionFactor)
+	for {
+		select {
+		case <-doneChan:
+			return
+		default:
+			break
+		}
+
+		pollingInterval := pi.Cfg.Get().TMPollingInterval
+		if toLoginDispersion <= 0 {
+			cfg := pi.Cfg.Get()
+			toLoginDispersion = config.GetTOLoginDispersion(cfg.TMPollingInterval, cfg.TOLoginDispersionFactor)
+		} else {
+			toLoginDispersion -= pollingInterval
+		}
+		doTrafficOpsReq := toLoginDispersion <= 0
+
+		log.Infoln("service-status tm-health starting")
+		start := time.Now()
+		doPollAndUpdateCacheStatus(pi, doTrafficOpsReq)
+		updateHealthSignal()
+		log.Infof("poll-status poll=tm-health ms=%v\n", int(time.Since(start)/time.Millisecond))
+		time.Sleep(pollingInterval)
+	}
+}
+
+func doPollAndUpdateCacheStatus(pi *ParentInfo, doTrafficOpsReq bool) {
+	cfg := pi.Cfg.Get()
+
+	// check for parent and strategies config file updates, and trafficserver
+	// host status changes.  If an error is encountered reading data the current
+	// parents lists and hoststatus remains unchanged.
+	// TODO move reading ATS config files to its own poller service
+	if err := pi.UpdateParentInfo(cfg); err != nil {
+		log.Errorf("could not load new ATS parent info: %s\n", err.Error())
+	} else {
+		// log.Debugf("updated parent info, total number of parents: %d\n", len(pi.Parents))
+		// TODO track map len
+		log.Debugf("updated parent info, total number of parents: x\n")
+	}
+
+	// read traffic manager cache statuses.
+	crStates, err := pi.GetCacheStatuses()
+	now := time.Now() // get the current poll time
+	if err != nil {
+		log.Errorf("error in TrafficMonitor polling: %s\n", err.Error())
+		if err := pi.GetTOData(cfg); err != nil {
+			log.Errorln("could not update the list of trafficmonitors, keeping the old config")
+		} else {
+			log.Infoln("updated TrafficMonitor statuses from TrafficOps")
+		}
+
+		// log the poll state data if enabled
+		if cfg.EnablePollStateLog {
+			err = pi.WritePollState()
+			if err != nil {
+				log.Errorf("could not write the poll state log: %s\n", err.Error())
+			}
+		}
+		return
+	}
+
+	pi.TrafficMonitorHealth.Set(&TrafficMonitorHealth{
+		PollTime:      now,
+		CacheStatuses: crStates.Caches,
+	})
+
+	// periodically update the TrafficMonitor list and statuses
+	if doTrafficOpsReq {
+		// TODO move to its own TO poller
+		if err = pi.GetTOData(cfg); err != nil {
+			log.Errorln("could not update the list of trafficmonitors, keeping the old config")
+		} else {
+			log.Infoln("updated TrafficMonitor statuses from TrafficOps")
+		}
+	}
+
+	// log the poll state data if enabled
+	if cfg.EnablePollStateLog {
+		if err = pi.WritePollState(); err != nil {
+			log.Errorf("could not write the poll state log: %s\n", err.Error())
+		}
+	}
+}
+
+// Queries a traffic monitor that is monitoring the trafficserver instance running on a host to
+// obtain the availability, health, of a parent used by trafficserver.
+func (pi *ParentInfo) GetCacheStatuses() (tc.CRStates, error) {
+	cfg := pi.Cfg.Get()
+
+	tmHostName, err := pi.findATrafficMonitor()
+	if err != nil {
+		return tc.CRStates{}, errors.New("finding a trafficmonitor: " + err.Error())
+	}
+	tmc := tmclient.New("http://"+tmHostName, cfg.TORequestTimeout)
+
+	// Use a proxy to query TM if the ProxyURL is set
+	if cfg.ParsedProxyURL != nil {
+		tmc.Transport = &http.Transport{Proxy: http.ProxyURL(cfg.ParsedProxyURL)}
+	}
+
+	return tmc.CRStates(false)
+}

--- a/tc-health-client/util/util.go
+++ b/tc-health-client/util/util.go
@@ -21,7 +21,12 @@ package util
 
 import (
 	"errors"
+	"io"
 	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
 )
 
 type ConfigFile struct {
@@ -42,4 +47,105 @@ func GetFileModificationTime(fn string) (int64, error) {
 		return 0, errors.New("unable to get file status for " + fn + ": " + err.Error())
 	}
 	return finfo.ModTime().UnixNano(), nil
+}
+
+// NopWriter is a no-op io.WriteCloser.
+// It always returns the length of the given bytes as written.
+// Writes to this go nowhere. Close may be called, and is also a no-op.
+type NopWriter struct{}
+
+// Write implements io.Writer.
+// It always returns the length of the given bytes as written.
+func (nw NopWriter) Write(p []byte) (n int, err error) { return len(p), nil }
+func (nw NopWriter) Close() error                      { return nil }
+
+// WriteNoCloser wraps an io.Writer and returns an io.WriteCloser for which Close will be a no-op.
+//
+// This allows for passing a WriteCloser to something that ordinarily takes ownership and closes,
+// Without that Close() closing the real Writer. For example, to prevent closing os.Stdout.
+//
+// This can also be used to turn an io.Writer into an io.WriteCloser.
+type NoCloser struct {
+	wr io.Writer
+}
+
+func MakeNoCloser(wr io.Writer) io.WriteCloser        { return NoCloser{wr: wr} }
+func (nc NoCloser) Write(p []byte) (n int, err error) { return nc.wr.Write(p) }
+func (nw NoCloser) Close() error                      { return nil }
+
+// AtomicPtr provides atomic getting and setting of a pointer.
+// It may be default-constructed or via NewAtomicPtr.
+// It must not be copied after first use.
+//
+// No further synchronization is provided, besides the atomic pointer exchange.
+// If value pointed to is modified concurrently, users must perform their own synchronization.
+type AtomicPtr[T any] struct {
+	up *unsafe.Pointer
+}
+
+// NewAtomicPtr creates a new AtomicPtr[T] initialized with ptr.
+func NewAtomicPtr[T any](ptr *T) *AtomicPtr[T] {
+	up := (unsafe.Pointer)(ptr)
+	return &AtomicPtr[T]{up: &up}
+}
+
+// Get returns the pointer.
+// This is safe for multiple concurrent goroutines.
+//
+// No further synchronization is provided, besides the atomic pointer exchange.
+// If the returned object is modified concurrently, users must perform their own synchronization.
+func (ag *AtomicPtr[T]) Get() *T {
+	return (*T)(atomic.LoadPointer(ag.up))
+}
+
+// Set sets the AtomicPtr's pointer.
+// This is safe for multiple concurrent goroutines.
+//
+// No further synchronization is provided, besides the atomic pointer exchange.
+// If the set object is modified concurrently, users must perform their own synchronization
+func (ag *AtomicPtr[T]) Set(ptr *T) {
+	up := (unsafe.Pointer)(ptr)
+	atomic.StorePointer(ag.up, up)
+}
+
+// SyncMap is a strongly-typed sync.Map.
+type SyncMap[KT any, VT any] struct {
+	m sync.Map
+}
+
+func (sm *SyncMap[KT, VT]) Load(key KT) (VT, bool) {
+	iVal, ok := sm.m.Load(key)
+	if !ok {
+		var vt VT
+		return vt, false
+	}
+	return iVal.(VT), true
+}
+
+func (sm *SyncMap[KT, VT]) Store(key KT, val VT) {
+	sm.m.Store(key, val)
+}
+
+func (sm *SyncMap[KT, VT]) Range(f func(key KT, value VT) bool) {
+	sm.m.Range(func(iKey, iVal interface{}) bool {
+		key := iKey.(KT)
+		val := iVal.(VT)
+		return f(key, val)
+	})
+}
+
+func (sm *SyncMap[KT, VT]) LoadOrStore(key KT, val VT) (actual VT, loaded bool) {
+	iVal, loaded := sm.m.LoadOrStore(key, val)
+	return iVal.(VT), loaded
+}
+
+// HostNameToShort takes a hostname which may be a Fully Qualified Domain Name or a short hostname,
+// and returns the short hostname.
+// If host is already a short hostname, it is returned unmodified.
+func HostNameToShort(host string) string {
+	dotPos := strings.Index(host, ".")
+	if dotPos < 0 {
+		return host
+	}
+	return host[:dotPos]
 }

--- a/tc-health-client/util/util_test.go
+++ b/tc-health-client/util/util_test.go
@@ -1,0 +1,52 @@
+package util
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"testing"
+)
+
+func TestHostNameToShort(t *testing.T) {
+	type InputExpected struct {
+		Input    string
+		Expected string
+	}
+
+	inputs := []InputExpected{
+		{"", ""},
+		{".", ""},
+		{".foo", ""},
+		{"foo", "foo"},
+		{"foo.", "foo"},
+		{"foo.bar", "foo"},
+		{"foo.bar.", "foo"},
+		{"foo.bar.baz", "foo"},
+		{"foo.bar.baz.", "foo"},
+		{`!@#$%^&*()_+{}|:"<>?.bar.baz`, `!@#$%^&*()_+{}|:"<>?`},
+		{"`.bar.baz", "`"},
+	}
+
+	for _, ie := range inputs {
+		actual := HostNameToShort(ie.Input)
+		if actual != ie.Expected {
+			t.Errorf("HostNameToShort(%v) expected '%v' actual '%v'", ie.Input, ie.Expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Adds parent health to the health client.

This allows caches to log and markdown parent health based on whether the cache can directly request its parents, in addition to the existing Traffic Monitor health.

Intra-datacenter network issues can cause a child cache to be unable to get to its parent, even though externally both are accessible to the Traffic Monitor. When this happens, we implicitly rely on the ATS parent health and markdown system, which is reactive and typically leads to client timeouts before a markdown and retry of a different parent can be completed. Direct parent health provides faster proactive markdown during these intra-datacenter network events.

This also significantly refactors the health client. It was a single thread with a loop to reload config, refresh TO data, get TM health, and markdown. This makes all operations their own goroutine/microthread service, as the single-threaded work loop just wasn't feasible with the size of work for parent health polling.

It adds 3 health mechanisms: L4 health (a TCP syn-ack-rst), L7 health (a successful HTTP response), and a meta-parent poll which polls the parent's own health client parent health and uses a heuristic of unavailable parents on the parent.

All new parent health mechanisms default to disabled, and should be considered experimental.

## Which Traffic Control components are affected by this PR?
- Traffic Control Health Client (tc-health-client)

## What is the best way to verify this PR?
Enable parent health on the health client, observe logs and markdowns

## If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
