### PR TITLE
Do not include non-TR profile params in CRConfig "config" section

### DIFF
--- a/traffic_ops/traffic_ops_golang/crconfig/config_test.go
+++ b/traffic_ops/traffic_ops_golang/crconfig/config_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/trafficcontrol/lib/go-tc"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
@@ -46,7 +47,7 @@ func MockGetConfigParams(mock sqlmock.Sqlmock, expected []CRConfigConfigParamete
 		v := param.Value
 		rows = rows.AddRow(n, v)
 	}
-	mock.ExpectQuery("select").WithArgs(cdn).WillReturnRows(rows)
+	mock.ExpectQuery("select").WithArgs(cdn, tc.RouterTypeName).WillReturnRows(rows)
 }
 
 func TestGetConfigParams(t *testing.T) {


### PR DESCRIPTION
Instead of querying all profile parameters with the config file "CRConfig.json" for any servers of any type that belong to a given CDN, query only profile params assigned to profiles of CCR-type servers for the given CDN.

Fixes #3974.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
ATS profiles will generally have a "weight" parameter assigned (with config_file = CRConfig.json), and this will tend to show up in the CRConfig "config" section like so:
```
"config": {
    "weight": "0.8",
```
With this PR, snapshotting that CDN should remove that "weight" parameter from the CRConfig's "config" section.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] minor tech debt, no docs needed <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] minor tech debt, no changelog needed <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
