### PR TITLE
Divide MaxOriginConnections over a Server's own Cache Group if DS Regional field is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6021](https://github.com/apache/trafficcontrol/issues/6021) *Traffic Portal* Added the ability to view a change logs message in it's entirety by clicking on it.
 - [#6033](https://github.com/apache/trafficcontrol/issues/6033) *Traffic Ops, Traffic Portal* Added ability to assign multiple server capabilities to a server.
 - [#7032](https://github.com/apache/trafficcontrol/issues/7032) *Cache Config* Add t3c-apply flag to use local ATS version for config generation rather than Server package Parameter, to allow managing the ATS OS package via external tools. See 'man t3c-apply' and 'man t3c-generate' for details.
-- [#7097](https://github.com/apache/trafficcontrol/issues/7097) *Traffic Ops, Traffic Portal* Added the `regional` field to Delivery Services, which indicates whether `maxOriginConnections` should be per Cache Group
+- [#7097](https://github.com/apache/trafficcontrol/issues/7097) *Traffic Ops, Traffic Portal, t3c* Added the `regional` field to Delivery Services, which affects whether `maxOriginConnections` should be per Cache Group
 
 ### Changed
 - [#7063](https://github.com/apache/trafficcontrol/pull/7063) *Traffic Ops* Python client now uses Traffic Ops API 4.1 by default.

--- a/lib/go-atscfg/headerrewritedotconfig_test.go
+++ b/lib/go-atscfg/headerrewritedotconfig_test.go
@@ -364,6 +364,238 @@ func TestGetCachegroupsInSameTopologyTier(t *testing.T) {
 	}
 }
 
+func TestGetTopologyTierServers(t *testing.T) {
+	allCachegroups := []tc.CacheGroupNullable{
+		{
+			Name: util.StrPtr("edge1"),
+			Type: util.StrPtr(tc.CacheGroupEdgeTypeName),
+		},
+		{
+			Name: util.StrPtr("edge2"),
+			Type: util.StrPtr(tc.CacheGroupEdgeTypeName),
+		},
+		{
+			Name: util.StrPtr("org1"),
+			Type: util.StrPtr(tc.CacheGroupOriginTypeName),
+		},
+	}
+
+	allServers := []Server{
+		{
+			Cachegroup: util.Ptr("edge1"),
+			HostName:   util.Ptr("edgeCache1"),
+			ID:         util.Ptr(0),
+		},
+		{
+			Cachegroup: util.Ptr("edge2"),
+			HostName:   util.Ptr("edgeCache2"),
+			ID:         util.Ptr(0),
+		},
+	}
+
+	topology := tc.Topology{
+		Nodes: []tc.TopologyNode{
+			{
+				Cachegroup: "edge1",
+				Parents:    []int{2},
+			},
+			{
+				Cachegroup: "edge2",
+				Parents:    []int{2},
+			},
+			{
+				Cachegroup: "org1",
+			},
+		},
+	}
+
+	type testCase struct {
+		ds                     *DeliveryService
+		dsRequiredCapabilities map[ServerCapability]struct{}
+		cg                     tc.CacheGroupName
+		topology               tc.Topology
+		cacheGroups            []tc.CacheGroupNullable
+		servers                []Server
+		serverCapabilities     map[int]map[ServerCapability]struct{}
+
+		expectedHostnames []string
+	}
+	testCases := []testCase{
+		{
+			ds:          &DeliveryService{},
+			cg:          tc.CacheGroupName("edge1"),
+			topology:    topology,
+			cacheGroups: allCachegroups,
+			servers:     allServers,
+
+			expectedHostnames: []string{"edgeCache1", "edgeCache2"},
+		},
+		{
+			ds:          &DeliveryService{Regional: true},
+			cg:          tc.CacheGroupName("edge1"),
+			topology:    topology,
+			cacheGroups: allCachegroups,
+			servers:     allServers,
+
+			expectedHostnames: []string{"edgeCache1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		actualServers, _ := getTopologyTierServers(tc.ds, tc.dsRequiredCapabilities, tc.cg, tc.topology, tc.cacheGroups, tc.servers, tc.serverCapabilities)
+		actualHostnames := []string{}
+		for _, as := range actualServers {
+			actualHostnames = append(actualHostnames, *as.HostName)
+		}
+		if !reflect.DeepEqual(tc.expectedHostnames, actualHostnames) {
+			t.Errorf("getting servers in same topology tier -- expected: %v, actual: %v", tc.expectedHostnames, actualHostnames)
+		}
+	}
+}
+
+func TestGetAssignedMids(t *testing.T) {
+	allCachegroups := []tc.CacheGroupNullable{
+		{
+			Name:       util.StrPtr("edge1"),
+			ParentName: util.Ptr("mid1"),
+			Type:       util.StrPtr(tc.CacheGroupEdgeTypeName),
+		},
+		{
+			Name:       util.StrPtr("edge2"),
+			ParentName: util.Ptr("mid2"),
+			Type:       util.StrPtr(tc.CacheGroupEdgeTypeName),
+		},
+		{
+			Name:       util.StrPtr("mid1"),
+			ParentName: util.Ptr("org1"),
+			Type:       util.StrPtr(tc.CacheGroupMidTypeName),
+		},
+		{
+			Name:       util.StrPtr("mid2"),
+			ParentName: util.Ptr("org1"),
+			Type:       util.StrPtr(tc.CacheGroupMidTypeName),
+		},
+		{
+			Name: util.StrPtr("org1"),
+			Type: util.StrPtr(tc.CacheGroupOriginTypeName),
+		},
+	}
+
+	allServers := []Server{
+		{
+			Cachegroup: util.Ptr("edge1"),
+			CDNName:    util.Ptr("mycdn"),
+			HostName:   util.Ptr("edgeCache1"),
+			ID:         util.Ptr(1),
+			Status:     util.Ptr(string(tc.CacheStatusReported)),
+		},
+		{
+			Cachegroup: util.Ptr("edge2"),
+			CDNName:    util.Ptr("mycdn"),
+			HostName:   util.Ptr("edgeCache2"),
+			ID:         util.Ptr(2),
+			Status:     util.Ptr(string(tc.CacheStatusReported)),
+		},
+
+		{
+			Cachegroup: util.Ptr("mid1"),
+			CDNName:    util.Ptr("mycdn"),
+			HostName:   util.Ptr("midCache1"),
+			ID:         util.Ptr(3),
+			Status:     util.Ptr(string(tc.CacheStatusReported)),
+		},
+		{
+			Cachegroup: util.Ptr("mid2"),
+			CDNName:    util.Ptr("mycdn"),
+			HostName:   util.Ptr("midCache2"),
+			ID:         util.Ptr(4),
+			Status:     util.Ptr(string(tc.CacheStatusReported)),
+		},
+	}
+
+	allDeliveryServices := []DeliveryService{{}, {}}
+	allDeliveryServices[0].ID = util.Ptr(1)
+	allDeliveryServices[0].CDNName = util.Ptr("mycdn")
+	allDeliveryServices[1].ID = util.Ptr(2)
+	allDeliveryServices[1].Regional = true
+	allDeliveryServices[1].CDNName = util.Ptr("mycdn")
+
+	type testCase struct {
+		server                 *Server
+		ds                     *DeliveryService
+		deliveryServiceServers []DeliveryServiceServer
+		servers                []Server
+		cacheGroups            []tc.CacheGroupNullable
+
+		expectedHostnames []string
+	}
+	testCases := []testCase{
+		{
+			server:  &allServers[0],
+			ds:      &allDeliveryServices[0],
+			servers: allServers,
+			deliveryServiceServers: []DeliveryServiceServer{
+				{
+					Server:          1,
+					DeliveryService: 1,
+				},
+				{
+					Server:          2,
+					DeliveryService: 1,
+				},
+				{
+					Server:          3,
+					DeliveryService: 1,
+				},
+				{
+					Server:          4,
+					DeliveryService: 1,
+				},
+			},
+			cacheGroups: allCachegroups,
+
+			expectedHostnames: []string{"midCache1", "midCache2"},
+		},
+		{
+			server:  &allServers[0],
+			ds:      &allDeliveryServices[1],
+			servers: allServers,
+			deliveryServiceServers: []DeliveryServiceServer{
+				{
+					Server:          1,
+					DeliveryService: 2,
+				},
+				{
+					Server:          2,
+					DeliveryService: 2,
+				},
+				{
+					Server:          3,
+					DeliveryService: 2,
+				},
+				{
+					Server:          4,
+					DeliveryService: 2,
+				},
+			},
+			cacheGroups: allCachegroups,
+
+			expectedHostnames: []string{"midCache1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		actualServers, _ := getAssignedMids(tc.server, tc.ds, tc.servers, tc.deliveryServiceServers, tc.cacheGroups)
+		actualHostnames := []string{}
+		for _, as := range actualServers {
+			actualHostnames = append(actualHostnames, *as.HostName)
+		}
+		if !reflect.DeepEqual(tc.expectedHostnames, actualHostnames) {
+			t.Errorf("getting servers in same topology tier -- expected: %v, actual: %v", tc.expectedHostnames, actualHostnames)
+		}
+	}
+}
+
 func TestMakeHeaderRewriteMidDotConfig(t *testing.T) {
 	cdnName := "mycdn"
 	hdr := "myHeaderComment"

--- a/lib/go-atscfg/headerrewritedotconfig_test.go
+++ b/lib/go-atscfg/headerrewritedotconfig_test.go
@@ -591,7 +591,7 @@ func TestGetAssignedMids(t *testing.T) {
 			actualHostnames = append(actualHostnames, *as.HostName)
 		}
 		if !reflect.DeepEqual(tc.expectedHostnames, actualHostnames) {
-			t.Errorf("getting servers in same topology tier -- expected: %v, actual: %v", tc.expectedHostnames, actualHostnames)
+			t.Errorf("getting servers in same cachegroup tier -- expected: %v, actual: %v", tc.expectedHostnames, actualHostnames)
 		}
 	}
 }

--- a/lib/go-util/ptr.go
+++ b/lib/go-util/ptr.go
@@ -21,6 +21,10 @@ package util
 
 import "time"
 
+func Ptr[T any](v T) *T {
+	return &v
+}
+
 func StrPtr(str string) *string {
 	return &str
 }

--- a/lib/go-util/ptr_test.go
+++ b/lib/go-util/ptr_test.go
@@ -21,6 +21,12 @@ package util
 
 import "fmt"
 
+func ExamplePtr() {
+	ptr := Ptr("testquest")
+	fmt.Println(*ptr)
+	// Output: testquest
+}
+
 func ExampleStrPtr() {
 	ptr := StrPtr("testquest")
 	fmt.Println(*ptr)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR resolves #7097 by having `t3c` divide `MaxOriginConnections` over a Server's own Cache Group if the Delivery Service's `Regional` field is set.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
- Run the t3c integration tests
- Run the `lib/go-atscfg` unit tests

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
