### PR TITLE
Remove expired cookie and bad signature cookie errors from error.log

### DIFF
--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -1082,9 +1082,9 @@ func GetUserFromReq(w http.ResponseWriter, r *http.Request, secret string) (auth
 		return auth.CurrentUser{}, errors.New("unauthorized, please log in."), nil, http.StatusUnauthorized
 	}
 
-	oldCookie, err := tocookie.Parse(secret, cookie.Value)
-	if err != nil {
-		return auth.CurrentUser{}, errors.New("unauthorized, please log in."), errors.New("error parsing cookie: " + err.Error()), http.StatusUnauthorized
+	oldCookie, userErr, sysErr := tocookie.Parse(secret, cookie.Value)
+	if userErr != nil || sysErr != nil {
+		return auth.CurrentUser{}, userErr, sysErr, http.StatusUnauthorized
 	}
 
 	username := oldCookie.AuthData

--- a/traffic_ops/traffic_ops_golang/login/logout_test.go
+++ b/traffic_ops/traffic_ops_golang/login/logout_test.go
@@ -133,9 +133,9 @@ func TestLogout(t *testing.T) {
 			break
 		}
 
-		parsedCookie, err := tocookie.Parse("test", c.Value)
-		if err != nil {
-			t.Errorf("Failed to parse cookie value: %v", err)
+		parsedCookie, _, sysErr := tocookie.Parse("test", c.Value)
+		if sysErr != nil {
+			t.Errorf("Failed to parse cookie value: %v", sysErr)
 			break
 		}
 

--- a/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
+++ b/traffic_ops/traffic_ops_golang/routing/middleware/wrappers.go
@@ -197,8 +197,8 @@ func WrapAccessLog(secret string, h http.Handler) http.HandlerFunc {
 		user := "-"
 		cookie, err := r.Cookie(tocookie.Name)
 		if err == nil && cookie != nil {
-			cookie, err := tocookie.Parse(secret, cookie.Value)
-			if err == nil {
+			cookie, userErr, sysErr := tocookie.Parse(secret, cookie.Value)
+			if userErr == nil && sysErr == nil {
 				user = cookie.AuthData
 			}
 		}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #7134

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

- Build CiaB
- Inspect the cdn-in-a-box_edge_1 contianer
  - create a copy of the current cookie:
 ```shell 
cd /var/lib/trafficcontrol-cache-config
cp admin.cookie admin-old.cookie
```
  - You will have to wait an hour as that is when this old cookie will expire
  - Once it has expired you will need to first change the TO password that t3c uses so it doesn't simply overwrite the cookie:
```vi /etc/cron.d/traffic_ops_ort-cron```
Change the password to anything else, then go ahead and replace the new cookie with the old:
```
rm the `admin.cookie` file
cp admin-old.cookie admin.cookie
```
t3c will run again (runs every minute) If you look at the ort logs: ```tail -f /var/log/ort.log```
You will see:
```
ERROR: t3c-request.go:68: 2022-10-13T22:47:01.876373173Z: writing data: getting server 'edge' update status: 
getting server update status: getting uncached: getting server update status from Traffic Ops '': 
error requesting Traffic Ops: path 'https://trafficops.infra.ciab.test:443/api/4.1/servers/edge/update_status' 
gave HTTP error 401 Unauthorized - error-level alerts: signature expired - unauthorized, please log in
````

If you also inspect the `cdn-in-a-box_trafficops_1` and check the error.log `(tail -f /var/log/traffic_ops/error.log)` you will not see that error logged.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
