### PR TITLE
fix missing lastUpdated property in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7037](https://github.com/apache/trafficcontrol/pull/7037) *Traffic Router* Uses Traffic Ops API 4.0 by default
 
 ### Fixed
+- [#7131](https://github.com/apache/trafficcontrol/issues/7131) *Docs* Fixed Docs for staticdnsentries API endpoint missing lastUpdated response property description in APIv3, APIv4 and APIv5.
 - [#6947](https://github.com/apache/trafficcontrol/issues/6947) *Docs* Fixed docs for `cdns/{{name}}/federations` in APIv3, APIv4 and APIv5.
 - [#6903](https://github.com/apache/trafficcontrol/issues/6903), [#6903](https://github.com/apache/trafficcontrol/issues/6903) *Docs* Fixed docs for /cdns/dnsseckeys/refresh in APIv4 and APIv5.
 - [#7049](https://github.com/apache/trafficcontrol/issues/7049), [#7052](https://github.com/apache/trafficcontrol/issues/7052) *Traffic Portal* Fixed server table's quick search and filter option for multiple profiles.

--- a/docs/source/api/v3/staticdnsentries.rst
+++ b/docs/source/api/v3/staticdnsentries.rst
@@ -88,6 +88,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the type of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -177,6 +178,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -278,6 +280,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the :abbr:`FQDN (Fully Qualified Domain Name)` which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry

--- a/docs/source/api/v4/staticdnsentries.rst
+++ b/docs/source/api/v4/staticdnsentries.rst
@@ -89,6 +89,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the type of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -179,6 +180,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -281,6 +283,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the :abbr:`FQDN (Fully Qualified Domain Name)` which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry

--- a/docs/source/api/v5/staticdnsentries.rst
+++ b/docs/source/api/v5/staticdnsentries.rst
@@ -89,6 +89,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the type of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -179,6 +180,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
@@ -281,6 +283,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the :abbr:`FQDN (Fully Qualified Domain Name)` which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
+:lastUpdated:       The date and time at which this static DNS entry was last updated
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the :term:`Type` of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry


### PR DESCRIPTION
Closes #7131 by adding the missing property description to the API documentation.

<hr/>

## Which Traffic Control components are affected by this PR?

- Documentation

## What is the best way to verify this PR?
Go to the link below and verify the response description.
- https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/staticdnsentries.html
- https://traffic-control-cdn.readthedocs.io/en/latest/api/v4/staticdnsentries.html
- https://traffic-control-cdn.readthedocs.io/en/latest/api/v3/staticdnsentries.html


## If this is a bugfix, which Traffic Control versions contained the bug?
- historical/legacy/EoL versions
- 6.x
- 7.x
- master


## PR submission checklist
- [x] This PR needs no tests, it is a minor documentation change.
- [x] This PR itself is a documentation fix.
- [x] This PR has a CHANGELOG.md entry 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**