### PR TITLE
Retract versions v1.1.0 through v1.1.5 from Go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,7 +107,7 @@ require (
 // v0.0.0-20201118150121-817a702a9de6
 // See https://pkg.go.dev/cmd/go@go1.15.15#hdr-Module_compatibility_and_semantic_versioning for details.
 retract (
-	v1.1.5
+	v1.1.5-retractions
 	v1.1.4
 	v1.1.3
 	v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,18 @@ require (
 	gopkg.in/jcmturner/gokrb5.v7 v7.5.0 // indirect
 	gopkg.in/jcmturner/rpc.v1 v1.1.0 // indirect
 )
+
+// Although the Apache Traffic Control considers v7.0.1 stable, Go modules consider it unstable because its major version
+// is greater than 1, and without these retractions, a commit like 817a702a9de6 will have a computed vesion of
+// v1.1.4-0.20201118150121-817a702a9de6
+// With these retractions, the same commit will have a computed version of
+// v0.0.0-20201118150121-817a702a9de6
+// See https://pkg.go.dev/cmd/go@go1.15.15#hdr-Module_compatibility_and_semantic_versioning for details.
+retract (
+	v1.1.5
+	v1.1.4
+	v1.1.3
+	v1.1.2
+	v1.1.1
+	v1.1.0
+)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR retracts `v1.1.0`, `v1.1.1`, `v1.1.2`, `v1.1.3`, `v1.1.4`, and `v1.1.5-retractions` from Go modules. If this PR is merged, it should be tagged version `v1.1.5-retractions`.

Without this PR and tag `v1.1.5-retractions`, a user running

```shell
go mod init my-module
go get github.com/apache/trafficcontrol@817a702a9de6
```
will retrieve dependency `github.com/apache/trafficcontrol` at version `v1.1.4-0.20201118150121-817a702a9de6`. With this PR merged and tagged `v1.1.5-retractions`, the same `go get` command will yield version `v0.0.0-20201118150121-817a702a9de6`.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- go.mod

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
```shell
git clone https://github.com/apache/trafficcontrol
cd trafficcontrol
# create github.com:my-username/nonfork using the GitHub UI
git remote add nonfork git@github.com:my-username/nonfork.git
git push nonfork --all
git push nonfork --tags
sed -i 's|github\.com/apache/trafficcontrol|github.com/my-username/nonfork|' go.mod
git add go.mod
git commit -m 'Update module path to github.com/my-username/nonfork'
git push nonfork HEAD:master
```

In a different window, try getting a 4.1.x commit:
```shell
mkdir my-project
cd my-project
go mod init my-project
go get github.com/my-fork/nonfork@817a702a9d
```

Expected computed version: `v1.1.4-0.20201118150121-817a702a9de6`

Back in the first window, retract v1:
```shell
<<'APPEND' cat >> go.mod
// Although the Apache Traffic Control considers v7.0.1 stable, Go modules consider it unstable because its major version
// is greater than 1, and without these retractions, a commit like 817a702a9de6 will have a computed vesion of
// v1.1.4-0.20201118150121-817a702a9de6
// With these retractions, the same commit will have a computed version of
// v0.0.0-20201118150121-817a702a9de6
// See https://pkg.go.dev/cmd/go@go1.15.15#hdr-Module_compatibility_and_semantic_versioning for details.
retract (
	v1.1.5-retractions
	v1.1.4
	v1.1.3
	v1.1.2
	v1.1.1
	v1.1.0
)
APPEND
git add go.mod
git commit -m 'Retract v1'
git tag v1.1.5-retractions
git push nonfork HEAD:master v1.1.5-retractions
```

Back in the `my-project` window, try importing the 4.1.x commit again:
```shell
sudo rm -rf ${GOPATH}/pkg
go get github.com/my-username/nonfork@817a702a9de6
```

Expected computed version: `v0.0.0-20201118150121-817a702a9de6`

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has comments <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->