### PR TITLE
Consider DS Regional field for MaxOriginConnections of Edge Caches

### DIFF
--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -372,16 +372,16 @@ func getAssignedMids(
 	serverCGs := map[tc.CacheGroupName]struct{}{}
 	for _, sv := range servers {
 		if sv.CDNName == nil {
-			warnings = append(warnings, "TO returned Servers server with missing CDNName, skipping!")
+			warnings = append(warnings, "TO returned Servers sv with missing CDNName, skipping!")
 			continue
 		} else if sv.ID == nil {
-			warnings = append(warnings, "TO returned Servers server with missing ID, skipping!")
+			warnings = append(warnings, "TO returned Servers sv with missing ID, skipping!")
 			continue
 		} else if sv.Status == nil {
-			warnings = append(warnings, "TO returned Servers server with missing Status, skipping!")
+			warnings = append(warnings, "TO returned Servers sv with missing Status, skipping!")
 			continue
 		} else if sv.Cachegroup == nil {
-			warnings = append(warnings, "TO returned Servers server with missing Cachegroup, skipping!")
+			warnings = append(warnings, "TO returned Servers sv with missing Cachegroup, skipping!")
 			continue
 		}
 
@@ -392,9 +392,6 @@ func getAssignedMids(
 			continue
 		}
 		if tc.CacheStatus(*sv.Status) != tc.CacheStatusReported && tc.CacheStatus(*sv.Status) != tc.CacheStatusOnline {
-			continue
-		}
-		if ds != nil && ds.Regional && *sv.Cachegroup != *server.Cachegroup {
 			continue
 		}
 		serverCGs[tc.CacheGroupName(*sv.Cachegroup)] = struct{}{}
@@ -416,22 +413,25 @@ func getAssignedMids(
 	}
 
 	assignedMids := []Server{}
-	for _, server := range servers {
-		if server.CDNName == nil {
+	for _, sv := range servers {
+		if sv.CDNName == nil {
 			warnings = append(warnings, "TO returned Servers server with missing CDNName, skipping!")
 			continue
 		}
-		if server.Cachegroup == nil {
+		if sv.Cachegroup == nil {
 			warnings = append(warnings, "TO returned Servers server with missing Cachegroup, skipping!")
 			continue
 		}
-		if *server.CDNName != *ds.CDNName {
+		if *sv.CDNName != *ds.CDNName {
 			continue
 		}
-		if _, ok := parentCGs[*server.Cachegroup]; !ok {
+		if _, ok := parentCGs[*sv.Cachegroup]; !ok {
 			continue
 		}
-		assignedMids = append(assignedMids, server)
+		if ds != nil && ds.Regional && *sv.Cachegroup != *server.Cachegroup {
+			continue
+		}
+		assignedMids = append(assignedMids, sv)
 	}
 
 	return assignedMids, warnings

--- a/lib/go-atscfg/headerrewritedotconfig.go
+++ b/lib/go-atscfg/headerrewritedotconfig.go
@@ -329,11 +329,11 @@ func getAssignedEdges(
 	assignedEdges := []Server{}
 	for _, sv := range servers {
 		if sv.CDNName == nil {
-			warnings = append(warnings, "servers had sv with missing cdnName, skipping!")
+			warnings = append(warnings, "servers had server with missing cdnName, skipping!")
 			continue
 		}
 		if sv.ID == nil {
-			warnings = append(warnings, "servers had sv with missing id, skipping!")
+			warnings = append(warnings, "servers had server with missing id, skipping!")
 			continue
 		}
 		if *sv.CDNName != *ds.CDNName {

--- a/lib/go-atscfg/headerrewritedotconfig_test.go
+++ b/lib/go-atscfg/headerrewritedotconfig_test.go
@@ -427,7 +427,6 @@ func TestGetAssignedTierPeers(t *testing.T) {
 		},
 	}
 	allServers := append(edges, mids...)
-	_ = allServers
 
 	topology := tc.Topology{
 		Name: "mytopology",
@@ -445,7 +444,6 @@ func TestGetAssignedTierPeers(t *testing.T) {
 			},
 		},
 	}
-	_ = topology
 
 	allDeliveryServices := []DeliveryService{{}, {}, {}, {}}
 	allDeliveryServices[0].ID = util.Ptr(1)

--- a/lib/go-atscfg/headerrewritedotconfig_test.go
+++ b/lib/go-atscfg/headerrewritedotconfig_test.go
@@ -415,6 +415,7 @@ func TestGetAssignedTierPeers(t *testing.T) {
 			HostName:   util.Ptr("midCache1"),
 			ID:         util.Ptr(3),
 			Status:     util.Ptr(string(tc.CacheStatusReported)),
+			Type:       tc.MidTypePrefix,
 		},
 		{
 			Cachegroup: util.Ptr("mid2"),
@@ -422,6 +423,7 @@ func TestGetAssignedTierPeers(t *testing.T) {
 			HostName:   util.Ptr("midCache2"),
 			ID:         util.Ptr(4),
 			Status:     util.Ptr(string(tc.CacheStatusReported)),
+			Type:       tc.MidTypePrefix,
 		},
 	}
 	allServers := append(edges, mids...)
@@ -489,9 +491,9 @@ func TestGetAssignedTierPeers(t *testing.T) {
 		},
 		// mid
 		{
-			server:  &mids[0],
+			server:  &allServers[2],
 			ds:      &allDeliveryServices[0],
-			servers: mids,
+			servers: allServers,
 			deliveryServiceServers: []DeliveryServiceServer{
 				{
 					Server:          1,
@@ -515,9 +517,9 @@ func TestGetAssignedTierPeers(t *testing.T) {
 			expectedHostnames: []string{"midCache1", "midCache2"},
 		},
 		{
-			server:  &mids[0],
+			server:  &allServers[2],
 			ds:      &allDeliveryServices[1],
-			servers: mids,
+			servers: allServers,
 			deliveryServiceServers: []DeliveryServiceServer{
 				{
 					Server:          1,


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes a bug where MaxOriginConnections for a *Regional* Delivery Service was not divided over a Server's own Cache Group in the case of Edge Caches directly parented by the Origin.

This PR also fixes the logic for the *Regional* MaxOriginConnections for Mid Caches by moving it to the correct block and updating tests.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run the t3c integration tests and the t3c and `lib/go-atscfg` integration tests

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master (994119d23b)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] Intended behavior unchanged, existing docs are suficient <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] Existing *Regional* Delivery Service field changelog entry is sufficient<!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->