### PR TITLE
Fix t3c multiple profile generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7021](https://github.com/apache/trafficcontrol/issues/7021) *Cache Config* Fixed cache config for Delivery Services with IP Origins.
 - [#7043](https://github.com/apache/trafficcontrol/issues/7043) Fixed cache config missing retry parameters for non-topology MSO Delivery Services going direct from edge to origin.
 - [#7047](https://github.com/apache/trafficcontrol/issues/7047) *Traffic Ops* allow `apply_time` query parameters on the `servers/{id-name}/update` when the CDN is locked.
+- [#7163](https://github.com/apache/trafficcontrol/issues/7163) Fix cache config for multiple profiles
 - [#7048](https://github.com/apache/trafficcontrol/issues/7048) *Traffic Stats* Add configuration value to set the client request timeout for calls to Traffic Ops.
 - Updated Apache Tomcat from 9.0.43 to 9.0.67
 - [#7125](https://github.com/apache/trafficcontrol/issues/7125) *Docs* Reflect implementation and deprecation notice for `letsencrypt/autorenew` endpoint.

--- a/cache-config/t3cutil/getdatacfg.go
+++ b/cache-config/t3cutil/getdatacfg.go
@@ -517,7 +517,8 @@ func GetConfigData(toClient *toreq.TOClient, disableProxy bool, cacheHostName st
 			return nil
 		}
 		serverParamsFs := []func() error{}
-		for _, profileName := range server.ProfileNames {
+		for _, profileNamePtr := range server.ProfileNames {
+			profileName := profileNamePtr // must copy, because Go for-loops overwrite the variable every iteration
 			serverParamsFs = append(serverParamsFs, func() error { return serverParamsF(atscfg.ProfileName(profileName)) })
 		}
 


### PR DESCRIPTION
Fixes t3c generation when servers have multiple profiles. The bug was a shared loop variable being overwritten in the TO request.

This is a 1-line fix, but it can't be unit tested because the bug was in the actual TO request, and the t3c Integration Tests are still on TO API v3 which doesn't have multiple Profiles. So testing this required updating the framework to v4, which is done in https://github.com/apache/trafficcontrol/pull/7167 .

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
Run tests. Generate config on a server with multiple profiles, verify config is as-expected and all profiles have their parameters applied as-expected.

## If this is a bugfix, which Traffic Control versions contained the bug?
- 7.0.x

## PR submission checklist
- ~[ ] This PR has tests~ tests can't be written until the t3c integration framework is upgraded to v3, which is a considerable amount of work <!-- If not, please delete this text and explain why this PR does not need tests. -->
- ~[ ] This PR has documentation~ no docs, no interface change <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
