### PR TITLE
Use tonistiigi/binfmt to emulate arm64

### DIFF
--- a/.github/workflows/container-trafficserver-alpine.yml
+++ b/.github/workflows/container-trafficserver-alpine.yml
@@ -66,9 +66,7 @@ jobs:
         run: echo 'IMAGE_NAME=${{ env.CONTAINER }}:${{ env.ATS_VERSION }}-${{ matrix.platform }}' >> '${{ github.env }}'
       - name: Install aarch64 emulator
         if: ${{ env.SHOULD_RUN == '1' && matrix.platform == 'arm64' }}
-        # Updated 2020-02-07 but we're still using docker/binfmt instead of tonistiigi/binfmt@qemu-v6.2.0
-        # because tonistiigi/binfmt@qemu-v6.2.0 fails on building trafficserver after about an hour
-        run: docker run --rm --privileged docker/binfmt:a7996909642ee92942dcd6cff44b9b95f08dad64
+        run: docker run --rm --privileged tonistiigi/binfmt:qemu-v6.2.0 --install arm64
       - name: Make a Docker Buildx builder
         if: ${{ env.SHOULD_RUN == '1' && matrix.platform == 'arm64' }}
         run: docker buildx create --name arm64-builder --use


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR updates the `ghcr.io/apache/trafficcontrol/ci/trafficserver-alpine`-building workflow to use tonistiigi/binfmt to emulate aarch64, which saves an hour of build time.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - GitHub Actions<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Verify the workflow passes for both linux/amd64 and linux/arm64

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->