### PR TITLE
t3c: sort peers in strategies.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7137](https://github.com/apache/trafficcontrol/pull/7137) *Traffic Control Cache Config (t3c)* parent.config simulate topology for non topo delivery services.
 - [#7153](https://github.com/apache/trafficcontrol/pull/7153) *Traffic Control Cache Config (t3c)* Adds an extra T3C check for validity of an ssl cert (crash fix).
 - [#3965](https://github.com/apache/trafficcontrol/pull/3965) *Traffic Router* Traffic Router now always includes a `Content-Length` header in the response.
+- [#7182](https://github.com/apache/trafficcontrol/pull/7182) Sort peers used in strategy.yaml to prevent false positive for reload.
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/lib/go-atscfg/parentabstraction.go
+++ b/lib/go-atscfg/parentabstraction.go
@@ -232,6 +232,12 @@ func (sp ParentAbstractionServiceParent) Key() string {
 	return sp.FQDN + ":" + strconv.Itoa(sp.Port)
 }
 
+type peersSort []*ParentAbstractionServiceParent
+
+func (a peersSort) Len() int           { return len(a) }
+func (a peersSort) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a peersSort) Less(i, j int) bool { return a[i].Key() < a[j].Key() }
+
 func RemoveParentDuplicates(inputs []*ParentAbstractionServiceParent, seens map[string]struct{}) ([]*ParentAbstractionServiceParent, map[string]struct{}) {
 	if seens == nil {
 		seens = make(map[string]struct{})

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -402,6 +402,8 @@ func makeParentDotConfigData(
 		parentAbstraction.Peers = append(parentAbstraction.Peers, peer)
 	}
 
+	sort.Sort(peersSort(parentAbstraction.Peers))
+
 	cgServerIDs := map[int]struct{}{}
 	for serverID, _ := range cgServers {
 		cgServerIDs[serverID] = struct{}{}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

During T3C strategy.yaml generation, make sure the peers are sorted by key before writing out.  This can cause false positives for reloading ATS.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

With old t3c:

Run t3c.  Change a delivery service (header rewrite value, etc).
Rerun t3c.  Observe that the strategies.yaml changes due to arbitrary sort order of peers.

Run the same with new t3c and note the peers are now sorted and that a new strategies.yaml file isn't installed by t3c.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->

7.1.0

## PR submission checklist
- ~~[ ] This PR has tests:~~  bug fix
- ~~[ ] This PR has documentation:~~ bug fix
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
