### PR TITLE
Revert setting `PGPASSWORD` for entire db/admin binary

### DIFF
--- a/.github/workflows/cache-config-tests.yml
+++ b/.github/workflows/cache-config-tests.yml
@@ -26,41 +26,47 @@ on:
   workflow_dispatch:
   push:
     paths:
+      - cache-config/**.go
+      - cache-config/testing/**
+      - .github/actions/build-ats-test-rpm/**
+      - .github/actions/cache-config-integration-tests/**
+      - .github/actions/repo-info/**
       - .github/workflows/cache-config-tests.yml
       - go.mod
       - go.sum
       - GO_VERSION
-      - lib/go-atscfg/**.go
-      - traffic_ops/*client/**.go
-      - traffic_ops/toclientlib/**.go
       - lib/atscfg-go/**.go
+      - lib/go-atscfg/**.go
+      - 'traffic_ops/app/db/**'
+      - '!traffic_ops/app/db/**.md'
+      - traffic_ops/*client/**.go
+      - 'traffic_ops/install/**'
+      - traffic_ops/toclientlib/**.go
       - traffic_ops/traffic_ops_golang/**.go
-      - cache-config/**.go
-      - cache-config/testing/**
       - vendor/**.go
       - vendor/modules.txt
-      - .github/actions/build-ats-test-rpm/**
-      - .github/actions/repo-info/**
-      - .github/actions/cache-config-integration-tests/**
   create:
   pull_request:
     paths:
+      - cache-config/**.go
+      - cache-config/testing/**
+      - .github/actions/build-ats-test-rpm/**
+      - .github/actions/cache-config-integration-tests/**
+      - .github/actions/repo-info/**
       - .github/workflows/cache-config-tests.yml
       - go.mod
       - go.sum
       - GO_VERSION
-      - lib/go-atscfg/**.go
-      - traffic_ops/*client/**.go
-      - traffic_ops/toclientlib/**.go
       - lib/atscfg-go/**.go
+      - lib/go-atscfg/**.go
+      - 'traffic_ops/app/db/**'
+      - '!traffic_ops/app/db/**.md'
+      - traffic_ops/*client/**.go
+      - 'traffic_ops/install/**'
+      - traffic_ops/toclientlib/**.go
       - traffic_ops/traffic_ops_golang/**.go
-      - cache-config/**.go
-      - cache-config/testing/**
       - vendor/**.go
       - vendor/modules.txt
-      - .github/actions/build-ats-test-rpm/**
-      - .github/actions/repo-info/**
-      - .github/actions/cache-config-integration-tests/**
     types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:

--- a/traffic_ops/app/db/admin.go
+++ b/traffic_ops/app/db/admin.go
@@ -466,6 +466,7 @@ func seed() {
 	}
 	cmd := exec.Command("psql", "-h", hostIP, "-p", hostPort, "-d", dbName, "-U", dbUser, "-e", "-v", "ON_ERROR_STOP=1")
 	cmd.Stdin = bytes.NewBuffer(seedsBytes)
+	cmd.Env = append(os.Environ(), "PGPASSWORD="+dbPassword)
 	out, err := cmd.CombinedOutput()
 	fmt.Println(string(out))
 	if err != nil {
@@ -485,6 +486,7 @@ func loadSchema() {
 	}
 	cmd := exec.Command("psql", "-h", hostIP, "-p", hostPort, "-d", dbName, "-U", dbUser, "-e", "-v", "ON_ERROR_STOP=1")
 	cmd.Stdin = bytes.NewBuffer(schemaBytes)
+	cmd.Env = append(os.Environ(), "PGPASSWORD="+dbPassword)
 	out, err := cmd.CombinedOutput()
 	fmt.Println(string(out))
 	if err != nil {
@@ -503,6 +505,7 @@ func patch() {
 	}
 	cmd := exec.Command("psql", "-h", hostIP, "-p", hostPort, "-d", dbName, "-U", dbUser, "-e", "-v", "ON_ERROR_STOP=1")
 	cmd.Stdin = bytes.NewBuffer(patchesBytes)
+	cmd.Env = append(os.Environ(), "PGPASSWORD="+dbPassword)
 	out, err := cmd.CombinedOutput()
 	fmt.Printf(string(out))
 	if err != nil {
@@ -658,10 +661,6 @@ func main() {
 	if err := parseDBConfig(); err != nil {
 		die(err.Error())
 	}
-	if err := os.Setenv("PGPASSWORD", dbPassword); err != nil {
-		die("Setting PGPASSWORD: " + err.Error())
-	}
-
 	commands := make(map[string]func())
 
 	commands[cmdCreateDB] = createDB


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR reverts [`25483428a5`](https://github.com/apache/trafficcontrol/pull/7142/commits/25483428a53b3a2f0fdc1ca5e28f7992b91cb716), a commit in #7142 that set the `PGPASSWORD` environment variable for the entire `db/admin`, rather than only setting it for specific `psql` subprocesses. This has the effect of no longer breaking the *T3C Integration Tests* GHA workflow.

#7198 breaks Traffic Ops in CDN in a Box for Developers, so hopefully we can come up with a different solution that will work for both CDN in a Box for Developers and the T3C integration tests, like fixing #4954.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT) - integration tests
- Traffic Ops `app/db`

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Verify the T3C Integration Tests GHA workflow passes

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->