### PR TITLE
t3c: strategies.yaml hash_key only for consistent_hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7137](https://github.com/apache/trafficcontrol/pull/7137) *Traffic Control Cache Config (t3c)* parent.config simulate topology for non topo delivery services.
 - [#7153](https://github.com/apache/trafficcontrol/pull/7153) *Traffic Control Cache Config (t3c)* Adds an extra T3C check for validity of an ssl cert (crash fix).
 - [#3965](https://github.com/apache/trafficcontrol/pull/3965) *Traffic Router* Traffic Router now always includes a `Content-Length` header in the response.
-- [#7182](https://github.com/apache/trafficcontrol/pull/7182) Sort peers used in strategy.yaml to prevent false positive for reload.
 - [#6533](https://github.com/apache/trafficcontrol/issues/6533) *TR should not rename/recreate log files on rollover
 - [#7182](https://github.com/apache/trafficcontrol/pull/7182) *Traffic Control Cache Config (t3c)* Sort peers used in strategy.yaml to prevent false positive for reload.
 - [#7204](https://github.com/apache/trafficcontrol/pull/7204) *Traffic Control Cache Config (t3c)* strategies.yaml hash_key only for consistent_hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7137](https://github.com/apache/trafficcontrol/pull/7137) *Traffic Control Cache Config (t3c)* parent.config simulate topology for non topo delivery services.
 - [#7153](https://github.com/apache/trafficcontrol/pull/7153) *Traffic Control Cache Config (t3c)* Adds an extra T3C check for validity of an ssl cert (crash fix).
 - [#3965](https://github.com/apache/trafficcontrol/pull/3965) *Traffic Router* Traffic Router now always includes a `Content-Length` header in the response.
-<<<<<<< HEAD
 - [#7182](https://github.com/apache/trafficcontrol/pull/7182) Sort peers used in strategy.yaml to prevent false positive for reload.
 - [#6533](https://github.com/apache/trafficcontrol/issues/6533) *TR should not rename/recreate log files on rollover
 - [#7182](https://github.com/apache/trafficcontrol/pull/7182) *Traffic Control Cache Config (t3c)* Sort peers used in strategy.yaml to prevent false positive for reload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7137](https://github.com/apache/trafficcontrol/pull/7137) *Traffic Control Cache Config (t3c)* parent.config simulate topology for non topo delivery services.
 - [#7153](https://github.com/apache/trafficcontrol/pull/7153) *Traffic Control Cache Config (t3c)* Adds an extra T3C check for validity of an ssl cert (crash fix).
 - [#3965](https://github.com/apache/trafficcontrol/pull/3965) *Traffic Router* Traffic Router now always includes a `Content-Length` header in the response.
+<<<<<<< HEAD
 - [#7182](https://github.com/apache/trafficcontrol/pull/7182) Sort peers used in strategy.yaml to prevent false positive for reload.
 - [#6533](https://github.com/apache/trafficcontrol/issues/6533) *TR should not rename/recreate log files on rollover
+- [#7182](https://github.com/apache/trafficcontrol/pull/7182) *Traffic Control Cache Config (t3c)* Sort peers used in strategy.yaml to prevent false positive for reload.
+- [#7204](https://github.com/apache/trafficcontrol/pull/7204) *Traffic Control Cache Config (t3c)* strategies.yaml hash_key only for consistent_hash
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/lib/go-atscfg/strategiesdotconfig.go
+++ b/lib/go-atscfg/strategiesdotconfig.go
@@ -200,10 +200,12 @@ func getStrategyStrategiesSection(pa *ParentAbstraction) string {
 	for _, svc := range pa.Services {
 		txt += "\n" + `  - strategy: '` + getStrategyName(svc.Name) + `'`
 		txt += "\n" + `    policy: ` + getStrategyPolicy(svc.RetryPolicy)
-		if !svc.IgnoreQueryStringInParentSelection {
-			txt += "\n" + `    hash_key: path+query`
-		} else {
-			txt += "\n" + `    hash_key: path`
+		if svc.RetryPolicy == ParentAbstractionServiceRetryPolicyConsistentHash {
+			if !svc.IgnoreQueryStringInParentSelection {
+				txt += "\n" + `    hash_key: path+query`
+			} else {
+				txt += "\n" + `    hash_key: path`
+			}
 		}
 		txt += "\n" + `    go_direct: ` + strconv.FormatBool(svc.GoDirect)
 		if getStrategySecondaryMode(svc.SecondaryMode) == "peering_ring" {

--- a/lib/go-atscfg/strategiesdotconfig_test.go
+++ b/lib/go-atscfg/strategiesdotconfig_test.go
@@ -1485,6 +1485,15 @@ func TestMakeStrategiesDotYAMLFirstLastNoTopoParams(t *testing.T) {
 		if 0 < len(missing) {
 			t.Errorf("Missing required string(s) from ds/line: %s/%v\n%v", *ds.XMLID, missing, txt)
 		}
+
+		excludes := []string{
+			`hash_key`,
+		}
+
+		excluding := missingFrom(txt, excludes)
+		if 1 != len(excludes) {
+			t.Errorf("Excluded required string(s) from ds/line: %s/%v\n%v", *ds.XMLID, excluding, txt)
+		}
 	}
 }
 
@@ -1783,6 +1792,7 @@ func TestMakeStrategiesDotYAMLFirstInnerLastParams(t *testing.T) {
 
 		needs := []string{
 			` policy: consistent_hash`,
+			` hash_key: path`,
 			` go_direct: false`,
 			` max_simple_retries: 12`,
 			` max_unavailable_retries: 22`,
@@ -1809,6 +1819,7 @@ func TestMakeStrategiesDotYAMLFirstInnerLastParams(t *testing.T) {
 
 		needs := []string{
 			` policy: consistent_hash`,
+			` hash_key: path`,
 			` go_direct: false`,
 			` max_simple_retries: 13`,
 			` max_unavailable_retries: 23`,
@@ -1845,6 +1856,15 @@ func TestMakeStrategiesDotYAMLFirstInnerLastParams(t *testing.T) {
 		missing := missingFrom(txt, needs)
 		if 0 < len(missing) {
 			t.Errorf("Missing required string(s) from line: %v\n%v", missing, txt)
+		}
+
+		excludes := []string{
+			`hash_key`,
+		}
+
+		excluding := missingFrom(txt, excludes)
+		if 1 != len(excludes) {
+			t.Errorf("Excluded required string(s) from ds/line: %s/%v\n%v", *ds.XMLID, excluding, txt)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

The t3c strategies.yaml file when generating a strategy always populates the hash_key yaml field although it only applies to consistent_hash policy.

Currently with this configuration ATS 9.2 will bump into the unexpected hash_key field for non consistent_hash policy and abort loading the strategies file entirely.

Note the ATS docs here where hash_key only applies to consistent_hash policy.
https://docs.trafficserver.apache.org/en/latest/admin-guide/files/strategies.yaml.en.html?highlight=strategies#strategies-definitions

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Create DS services, one with consistent_hash and another with round robin.
Run t3c to generate strategies.yaml
Ensure that the DS with consistent_hash policy also has a hash_key key/value
Ensure that the DS with round robin (rr_strict or rr_ip) does not have a hash_key entry.

As a bonus, drop the strategies.yaml file into an ats config directory, fire up ATS9.2 and verify that the strategies.yaml file loads without generating an error.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
7.1.0

## PR submission checklist
- [x] This PR has tests
- [ ] ~~This PR has documentation~~ bug fix
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
