### PR TITLE
APIv5 Delivery Service updates for Traffic Portal

### DIFF
--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -17,137 +17,208 @@
  * under the License.
  */
 
+/**
+ * This is a minimal definition of a DSR. Add to it as necessary.
+ *
+ * @typedef DeliveryServiceRequest
+ * @property {number} id
+ * @property {?import("./DeliveryServiceService").DeliveryService} requested
+ */
+
+/**
+ * The allowed values for a DSR's status.
+ * @typedef {"draft" | "submitted" | "rejected" | "pending" | "complete"} DSRStatus
+ */
+
+/**
+ * Represents a comment on a DSR.
+ *
+ * @typedef DSRComment
+ * @property {number} authorId
+ * @property {string} author
+ * @property {number} deliveryServiceRequestId
+ * @property {number} id
+ * @property {string} lastUpdated
+ * @property {string} value
+ * @property {string} xmlId
+ */
+
+/**
+ * DeliveryServiceRequestService provides methods for interacting with the parts
+ * of the Traffic Ops API that relate to Delivery Service Requests.
+ *
+ * @param {import("angular").IHttpService} $http Angular HTTP service.
+ * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
+ * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
+ */
 var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 
-	this.getDeliveryServiceRequests = function(queryParams) {
-		return $http.get(ENV.api.unstable + 'deliveryservice_requests', {params: queryParams}).then(
-			function(result) {
-				return result.data.response;
-			},
-			function(err) {
-				throw err;
-			}
-		);
+	const apiVersion = ENV.api.next;
+
+	/**
+	 * Get Delivery Service Requests.
+	 *
+	 * @param {Record<PropertyKey, unknown>} params
+	 * @returns {Promise<DeliveryServiceRequest[]>}
+	 */
+	this.getDeliveryServiceRequests = async function(params) {
+		const result = await $http.get(`${apiVersion}/deliveryservice_requests`, {params});
+		return result.data.response;
 	};
 
-	this.createDeliveryServiceRequest = function(dsRequest) {
+	/**
+	 * Creates a new DSR.
+	 *
+	 * @param {DeliveryServiceRequest} dsRequest The DSR to be create.
+	 * @returns {Promise<DeliveryServiceRequest>} The newly created DSR.
+	 */
+	this.createDeliveryServiceRequest = async function(dsRequest) {
 
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		if (dsRequest.requested) {
-			dsRequest.requested.consistentHashQueryParams = Array.from(new Set(dsRequest.requested.consistentHashQueryParams)).filter(function(i){return i;});
+			dsRequest.requested.consistentHashQueryParams = Array.from(new Set(dsRequest.requested.consistentHashQueryParams)).filter(i => i);
 		}
 
-		return $http.post(ENV.api.unstable + "deliveryservice_requests", dsRequest).then(
-			function(result) {
-				return result.data.response;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+		try {
+			const result = await $http.post(`${apiVersion}/deliveryservice_requests`, dsRequest);
+			return result.data.response;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.updateDeliveryServiceRequest = function(id, dsRequest) {
+	/**
+	 * Replaces an existing DSR with the provided, new definition.
+	 *
+	 * @param {number} id The ID of the DSR being modified.
+	 * @param {DeliveryServiceRequest} dsRequest The new, desired definition of the DSR.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
+	 */
+	this.updateDeliveryServiceRequest = async function(id, dsRequest) {
 
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		if (dsRequest.requested) {
-			dsRequest.requested.consistentHashQueryParams = Array.from(new Set(dsRequest.requested.consistentHashQueryParams)).filter(function(i){return i;});
+			dsRequest.requested.consistentHashQueryParams = Array.from(new Set(dsRequest.requested.consistentHashQueryParams)).filter(i => i);
 		}
 
-		return $http.put(ENV.api.unstable + "deliveryservice_requests", dsRequest, {params: {id: id}}).then(
-			function(result) {
-				return result;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+		try {
+			const result = await $http.put(`${apiVersion}deliveryservice_requests`, dsRequest, {params: {id}});
+			return result.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.deleteDeliveryServiceRequest = function(id, delay) {
-		return $http.delete(ENV.api.unstable + "deliveryservice_requests", {params: {id: id}}).then(
-			function(response) {
-				return response;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+	/**
+	 * Deletes the identified DSR.
+	 *
+	 * @param {number} id The ID of the DSR to be deleted.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
+	 */
+	this.deleteDeliveryServiceRequest = async function(id) {
+		try {
+			const response = await $http.delete(`${apiVersion}deliveryservice_requests`, {params: {id}});
+			return response.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.assignDeliveryServiceRequest = function(id, username) {
-		return $http.put(ENV.api.unstable + "deliveryservice_requests/" + id + "/assign", { assignee: username }).then(
-			function(result) {
-				return result;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+	/**
+	 * Assigns a DS to a user.
+	 *
+	 * @param {number} id The ID of the DSR being assigned.
+	 * @param {string} assignee The username of the user to whom the DSR is being assigned.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
+	 */
+	this.assignDeliveryServiceRequest = async function(id, assignee) {
+		try {
+			const result = await $http.put(`${apiVersion}deliveryservice_requests/${id}/assign`, { assignee });
+			return result.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.updateDeliveryServiceRequestStatus = function(id, status) {
-		return $http.put(ENV.api.unstable + "deliveryservice_requests/" + id + "/status", { status: status }).then(
-			function(result) {
-				return result;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+	/**
+	 * Sets the status of a DSR.
+	 *
+	 * @param {number} id The ID of the DSR being modified.
+	 * @param {DSRStatus} status The new status of the DSR.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
+	 */
+	this.updateDeliveryServiceRequestStatus = async function(id, status) {
+		try {
+			const result = await $http.put(`${apiVersion}deliveryservice_requests/${id}/status`, { status });
+			return result.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.getDeliveryServiceRequestComments = function(queryParams) {
-		return $http.get(ENV.api.unstable + 'deliveryservice_request_comments', {params: queryParams}).then(
-			function(result) {
-				return result.data.response;
-			},
-			function(err) {
-				throw err;
-			}
-		);
+	/**
+	 * Gets the comments associated with DSRs.
+	 *
+	 * @param {Record<PropertyKey, unknown>} params Any and all query string parameters for the request.
+	 * @returns {Promise<DSRComment[]>} The requested comments.
+	 */
+	this.getDeliveryServiceRequestComments = async function(params) {
+		try {
+			const result = await $http.get(`${apiVersion}deliveryservice_request_comments`, {params});
+			return result.data.response;
+		} catch(err) {
+			throw err;
+		}
 	};
 
-	this.createDeliveryServiceRequestComment = function(comment) {
-		return $http.post(ENV.api.unstable + "deliveryservice_request_comments", comment).then(
-			function(response) {
-				return response;
-			},
-			function(err) {
-				throw err;
-			}
-		);
+	/**
+	 * Creates a new comment on a DSR.
+	 *
+	 * @param {DSRComment} comment The new comment to be created.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DSRComment}>} The full API response.
+	 */
+	this.createDeliveryServiceRequestComment = async function(comment) {
+		const response = await  $http.post(`${apiVersion}deliveryservice_request_comments`, comment);
+		return response.data;
 	};
 
-	this.updateDeliveryServiceRequestComment = function(comment) {
-		return $http.put(ENV.api.unstable + "deliveryservice_request_comments", comment, {params: {id: comment.id}}).then(
-				function(result) {
-					return result;
-				},
-				function(err) {
-					messageModel.setMessages(err.data.alerts, false);
-					throw err;
-				}
-			);
+	/**
+	 * Updates an existing comment on a DSR.
+	 *
+	 * @param {DSRComment} comment The comment as desired.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DSRComment}>} The full API response.
+	 */
+	this.updateDeliveryServiceRequestComment = async function(comment) {
+		try {
+			const result = await $http.put(`${apiVersion}deliveryservice_request_comments`, comment, {params: {id: comment.id}});
+			return result.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 
-	this.deleteDeliveryServiceRequestComment = function(comment) {
-		return $http.delete(ENV.api.unstable + "deliveryservice_request_comments", {params: {id: comment.id}}).then(
-			function(response) {
-				return response;
-			},
-			function(err) {
-				messageModel.setMessages(err.data.alerts, false);
-				throw err;
-			}
-		);
+	/**
+	 * Removes a comment from its DSR.
+	 *
+	 * @param {DSRComment} comment The comment to be deleted.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
+	 */
+	this.deleteDeliveryServiceRequestComment = async function(comment) {
+		try {
+			const response = await $http.delete(`${apiVersion}deliveryservice_request_comments`, {params: {id: comment.id}});
+			return response.data;
+		} catch (err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
 	};
 };
 
-DeliveryServiceRequestService.$inject = ['$http', 'messageModel', 'ENV'];
+DeliveryServiceRequestService.$inject = ["$http", "messageModel", "ENV"];
 module.exports = DeliveryServiceRequestService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -21,8 +21,9 @@
  * This is a minimal definition of a DSR. Add to it as necessary.
  *
  * @typedef DeliveryServiceRequest
- * @property {number} id
- * @property {?import("./DeliveryServiceService").DeliveryService} requested
+ * @property {number} [id]
+ * @property {import("./DeliveryServiceService").DeliveryService} [original]
+ * @property {import("./DeliveryServiceService").DeliveryService} [requested]
  */
 
 /**
@@ -34,13 +35,13 @@
  * Represents a comment on a DSR.
  *
  * @typedef DSRComment
- * @property {number} authorId
- * @property {string} author
+ * @property {number} [authorId]
+ * @property {string} [author]
  * @property {number} deliveryServiceRequestId
- * @property {number} id
- * @property {string} lastUpdated
+ * @property {number} [id]
+ * @property {string} [lastUpdated]
  * @property {string} value
- * @property {string} xmlId
+ * @property {string} [xmlId]
  */
 
 /**
@@ -84,7 +85,7 @@ class DeliveryServiceRequestService {
 	 * Creates a new DSR.
 	 *
 	 * @param {DeliveryServiceRequest} dsRequest The DSR to be create.
-	 * @returns {Promise<DeliveryServiceRequest>} The newly created DSR.
+	 * @returns {Promise<DeliveryServiceRequest & {id: number}>} The newly created DSR.
 	 */
 	async createDeliveryServiceRequest(dsRequest) {
 

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -21,6 +21,7 @@
  * This is a minimal definition of a DSR. Add to it as necessary.
  *
  * @typedef DeliveryServiceRequest
+ * @property {string} changeType
  * @property {number} [id]
  * @property {import("./DeliveryServiceService").DeliveryService} [original]
  * @property {import("./DeliveryServiceService").DeliveryService} [requested]

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -62,7 +62,6 @@ class DeliveryServiceRequestService {
 	 * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
 	 */
 	constructor($http, messageModel, ENV) {
-
 		this.apiVersion = ENV.api.next;
 		this.$http = $http;
 		this.messageModel = messageModel;
@@ -75,7 +74,7 @@ class DeliveryServiceRequestService {
 	 * @returns {Promise<DeliveryServiceRequest[]>}
 	 */
 	async getDeliveryServiceRequests(params) {
-		const result = await this.$http.get(`${this.apiVersion}/deliveryservice_requests`, { params });
+		const result = await this.$http.get(`${this.apiVersion}deliveryservice_requests`, { params });
 		return result.data.response;
 	}
 
@@ -93,7 +92,7 @@ class DeliveryServiceRequestService {
 		}
 
 		try {
-			const result = await this.$http.post(`${this.apiVersion}/deliveryservice_requests`, dsRequest);
+			const result = await this.$http.post(`${this.apiVersion}deliveryservice_requests`, dsRequest);
 			return result.data.response;
 		} catch (err) {
 			this.messageModel.setMessages(err.data.alerts, false);

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -22,14 +22,11 @@
  *
  * @typedef DeliveryServiceRequest
  * @property {string} changeType
+ * @property {string} [createdAt]
  * @property {number} [id]
+ * @property {string} [lastUpdated]
  * @property {import("./DeliveryServiceService").DeliveryService} [original]
  * @property {import("./DeliveryServiceService").DeliveryService} [requested]
- */
-
-/**
- * The allowed values for a DSR's status.
- * @typedef {"draft" | "submitted" | "rejected" | "pending" | "complete"} DSRStatus
  */
 
 /**
@@ -164,7 +161,7 @@ class DeliveryServiceRequestService {
 	 * Sets the status of a DSR.
 	 *
 	 * @param {number} id The ID of the DSR being modified.
-	 * @param {DSRStatus} status The new status of the DSR.
+	 * @param {string} status The new status of the DSR.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
 	 */
 	async updateDeliveryServiceRequestStatus(id, status) {

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var DeliveryServiceRequestService = function($http, locationUtils, messageModel, ENV) {
+var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 
 	this.getDeliveryServiceRequests = function(queryParams) {
 		return $http.get(ENV.api.unstable + 'deliveryservice_requests', {params: queryParams}).then(
@@ -149,5 +149,5 @@ var DeliveryServiceRequestService = function($http, locationUtils, messageModel,
 	};
 };
 
-DeliveryServiceRequestService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
+DeliveryServiceRequestService.$inject = ['$http', 'messageModel', 'ENV'];
 module.exports = DeliveryServiceRequestService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceRequestService.js
@@ -46,14 +46,28 @@
 /**
  * DeliveryServiceRequestService provides methods for interacting with the parts
  * of the Traffic Ops API that relate to Delivery Service Requests.
- *
- * @param {import("angular").IHttpService} $http Angular HTTP service.
- * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
- * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
  */
-var DeliveryServiceRequestService = function($http, messageModel, ENV) {
+class DeliveryServiceRequestService {
 
-	const apiVersion = ENV.api.next;
+	/**
+	 * @type {string}
+	 * @readonly
+	 * @private
+	 */
+	apiVersion;
+
+	/**
+	 *
+	 * @param {import("angular").IHttpService} $http Angular HTTP service.
+	 * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
+	 * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
+	 */
+	constructor($http, messageModel, ENV) {
+
+		this.apiVersion = ENV.api.next;
+		this.$http = $http;
+		this.messageModel = messageModel;
+	}
 
 	/**
 	 * Get Delivery Service Requests.
@@ -61,10 +75,10 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {Record<PropertyKey, unknown>} params
 	 * @returns {Promise<DeliveryServiceRequest[]>}
 	 */
-	this.getDeliveryServiceRequests = async function(params) {
-		const result = await $http.get(`${apiVersion}/deliveryservice_requests`, {params});
+	async getDeliveryServiceRequests(params) {
+		const result = await this.$http.get(`${this.apiVersion}/deliveryservice_requests`, { params });
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Creates a new DSR.
@@ -72,7 +86,7 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DeliveryServiceRequest} dsRequest The DSR to be create.
 	 * @returns {Promise<DeliveryServiceRequest>} The newly created DSR.
 	 */
-	this.createDeliveryServiceRequest = async function(dsRequest) {
+	async createDeliveryServiceRequest(dsRequest) {
 
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		if (dsRequest.requested) {
@@ -80,13 +94,13 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 		}
 
 		try {
-			const result = await $http.post(`${apiVersion}/deliveryservice_requests`, dsRequest);
+			const result = await this.$http.post(`${this.apiVersion}/deliveryservice_requests`, dsRequest);
 			return result.data.response;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Replaces an existing DSR with the provided, new definition.
@@ -95,7 +109,7 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DeliveryServiceRequest} dsRequest The new, desired definition of the DSR.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
 	 */
-	this.updateDeliveryServiceRequest = async function(id, dsRequest) {
+	async updateDeliveryServiceRequest(id, dsRequest) {
 
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		if (dsRequest.requested) {
@@ -103,13 +117,13 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 		}
 
 		try {
-			const result = await $http.put(`${apiVersion}deliveryservice_requests`, dsRequest, {params: {id}});
+			const result = await this.$http.put(`${this.apiVersion}deliveryservice_requests`, dsRequest, { params: { id } });
 			return result.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Deletes the identified DSR.
@@ -117,15 +131,15 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {number} id The ID of the DSR to be deleted.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
 	 */
-	this.deleteDeliveryServiceRequest = async function(id) {
+	async deleteDeliveryServiceRequest(id) {
 		try {
-			const response = await $http.delete(`${apiVersion}deliveryservice_requests`, {params: {id}});
+			const response = await this.$http.delete(`${this.apiVersion}deliveryservice_requests`, { params: { id } });
 			return response.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Assigns a DS to a user.
@@ -134,15 +148,15 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {string} assignee The username of the user to whom the DSR is being assigned.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
 	 */
-	this.assignDeliveryServiceRequest = async function(id, assignee) {
+	async assignDeliveryServiceRequest(id, assignee) {
 		try {
-			const result = await $http.put(`${apiVersion}deliveryservice_requests/${id}/assign`, { assignee });
+			const result = await this.$http.put(`${this.apiVersion}deliveryservice_requests/${id}/assign`, { assignee });
 			return result.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Sets the status of a DSR.
@@ -151,15 +165,15 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DSRStatus} status The new status of the DSR.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DeliveryServiceRequest}>} The full API response.
 	 */
-	this.updateDeliveryServiceRequestStatus = async function(id, status) {
+	async updateDeliveryServiceRequestStatus(id, status) {
 		try {
-			const result = await $http.put(`${apiVersion}deliveryservice_requests/${id}/status`, { status });
+			const result = await this.$http.put(`${this.apiVersion}deliveryservice_requests/${id}/status`, { status });
 			return result.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Gets the comments associated with DSRs.
@@ -167,14 +181,14 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {Record<PropertyKey, unknown>} params Any and all query string parameters for the request.
 	 * @returns {Promise<DSRComment[]>} The requested comments.
 	 */
-	this.getDeliveryServiceRequestComments = async function(params) {
+	async getDeliveryServiceRequestComments(params) {
 		try {
-			const result = await $http.get(`${apiVersion}deliveryservice_request_comments`, {params});
+			const result = await this.$http.get(`${this.apiVersion}deliveryservice_request_comments`, { params });
 			return result.data.response;
-		} catch(err) {
+		} catch (err) {
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Creates a new comment on a DSR.
@@ -182,10 +196,10 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DSRComment} comment The new comment to be created.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DSRComment}>} The full API response.
 	 */
-	this.createDeliveryServiceRequestComment = async function(comment) {
-		const response = await  $http.post(`${apiVersion}deliveryservice_request_comments`, comment);
+	async createDeliveryServiceRequestComment(comment) {
+		const response = await this.$http.post(`${this.apiVersion}deliveryservice_request_comments`, comment);
 		return response.data;
-	};
+	}
 
 	/**
 	 * Updates an existing comment on a DSR.
@@ -193,15 +207,15 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DSRComment} comment The comment as desired.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: DSRComment}>} The full API response.
 	 */
-	this.updateDeliveryServiceRequestComment = async function(comment) {
+	async updateDeliveryServiceRequestComment(comment) {
 		try {
-			const result = await $http.put(`${apiVersion}deliveryservice_request_comments`, comment, {params: {id: comment.id}});
+			const result = await this.$http.put(`${this.apiVersion}deliveryservice_request_comments`, comment, { params: { id: comment.id } });
 			return result.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Removes a comment from its DSR.
@@ -209,16 +223,16 @@ var DeliveryServiceRequestService = function($http, messageModel, ENV) {
 	 * @param {DSRComment} comment The comment to be deleted.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
 	 */
-	this.deleteDeliveryServiceRequestComment = async function(comment) {
+	async deleteDeliveryServiceRequestComment(comment) {
 		try {
-			const response = await $http.delete(`${apiVersion}deliveryservice_request_comments`, {params: {id: comment.id}});
+			const response = await this.$http.delete(`${this.apiVersion}deliveryservice_request_comments`, { params: { id: comment.id } });
 			return response.data;
 		} catch (err) {
-			messageModel.setMessages(err.data.alerts, false);
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
-};
+	}
+}
 
 DeliveryServiceRequestService.$inject = ["$http", "messageModel", "ENV"];
 module.exports = DeliveryServiceRequestService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -22,15 +22,15 @@
  * @typedef DeliveryService
  * @property {number} cdnId
  * @property {string[]} consistentHashQueryParams
- * @property {string[]} exampleURLs
- * @property {?(number|null|undefined)} id
- * @property {string} lastUpdated
+ * @property {string[]} [exampleURLs]
+ * @property {number} [id]
+ * @property {string} [lastUpdated]
  * @property {string} routingName
  * @property {boolean} signed
- * @property {null|number} sslKeyVersion
+ * @property {null|number} [sslKeyVersion]
  * @property {null|[string, ...string[]]} tlsVersions
- * @property {?(string|null|undefined)} trResponseHeaders
- * @property {?(string|null|undefined)} type
+ * @property {string} [trResponseHeaders]
+ * @property {string|null|undefined} [type]
  * @property {number} typeId
  * @property {string} xmlId
  */
@@ -39,7 +39,7 @@
  * The type of elements in the array response to GET requests from `deliveryservices_required_capabilities`.
  * @typedef DSRequiredCapability
  * @property {number} deliveryServiceID
- * @property {string} lastUpdated
+ * @property {string} [lastUpdated]
  * @property {string} requiredCapability
  * @property {string} xmlId
  */

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -17,6 +17,61 @@
  * under the License.
  */
 
+/**
+ * This is a minimal type definition for Delivery Services. Expand as necessary.
+ * @typedef DeliveryService
+ * @property {string[]} consistentHashQueryParams
+ * @property {?number|null|undefined} id
+ * @property {null|[string, ...string[]]} tlsVersions
+ */
+
+/**
+ * The type of elements in the array response to GET requests from `deliveryservices_required_capabilities`.
+ * @typedef DSRequiredCapability
+ * @property {number} deliveryServiceID
+ * @property {string} lastUpdated
+ * @property {string} requiredCapability
+ * @property {string} xmlId
+ */
+
+/**
+ * The type of elements in the array response from `steering`.
+ * @typedef SteeringDefinition
+ * @property {string} deliveryService
+ * @property {boolean} clientSteering
+ * @property {{order: number; weight: number; deliveryService: string}[]} targets
+ * @property {{deliveryService: string; pattern: string}[]} filters
+ */
+
+/**
+ * A single target of a Delivery Service.
+ * @typedef SteeringTarget
+ * @property {string} deliveryService
+ * @property {number} deliveryServiceId
+ * @property {string} target
+ * @property {number} targetId
+ * @property {string} type
+ * @property {number} typeId
+ * @property {number} value
+ */
+
+/**
+ * The result of testing a consistent hashing regular expression against Traffic
+ * Router.
+ * @typedef ConsistentHashResponse
+ * @property {string} resultingPathToConsistentHash
+ * @property {string} consistentHashRegex
+ * @property {string} requestPath
+ */
+
+/**
+ * DeliveryServiceService handles API requests dealing with Delivery Services.
+ *
+ * @param {import("angular").IHttpService} $http Angular HTTP service.
+ * @param {import("../service/utils/LocationUtils")} locationUtils Utilities for manipulating Angular routing.
+ * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
+ * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
+ */
 var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 
     this.getDeliveryServices = function(queryParams) {

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -20,11 +20,14 @@
 /**
  * This is a minimal type definition for Delivery Services. Expand as necessary.
  * @typedef DeliveryService
+ * @property {number} cdnId
  * @property {string[]} consistentHashQueryParams
  * @property {string[]} exampleURLs
  * @property {?(number|null|undefined)} id
  * @property {string} lastUpdated
+ * @property {string} routingName
  * @property {boolean} signed
+ * @property {null|number} sslKeyVersion
  * @property {null|[string, ...string[]]} tlsVersions
  * @property {?(string|null|undefined)} trResponseHeaders
  * @property {?(string|null|undefined)} type

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -29,6 +29,7 @@
  * @property {boolean} signed
  * @property {null|number} [sslKeyVersion]
  * @property {null|[string, ...string[]]} tlsVersions
+ * @property {null|string} topology
  * @property {string} [trResponseHeaders]
  * @property {string|null|undefined} [type]
  * @property {number} typeId
@@ -93,7 +94,7 @@ class DeliveryServiceService {
 	/**
 	 * Get Delivery Services.
 	 *
-	 * @param {Record<string, unknown>} params Any and all query string parameters.
+	 * @param {Record<string, unknown>} [params] Any and all query string parameters.
 	 * @returns {Promise<DeliveryService[]>} The response property of the response.
 	 */
 	async getDeliveryServices(params) {

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -71,15 +71,21 @@
  * @property {string} requestPath
  */
 
-/**
- * DeliveryServiceService handles API requests dealing with Delivery Services.
- *
- * @param {import("angular").IHttpService} $http Angular HTTP service.
- * @param {import("../service/utils/LocationUtils")} locationUtils Utilities for manipulating Angular routing.
- * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
- * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
- */
-var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
+class DeliveryServiceService {
+	/**
+	 * DeliveryServiceService handles API requests dealing with Delivery Services.
+	 *
+	 * @param {import("angular").IHttpService} $http Angular HTTP service.
+	 * @param {import("../service/utils/LocationUtils")} locationUtils Utilities for manipulating Angular routing.
+	 * @param {import("../models/MessageModel")} messageModel Service for displaying messages/alerts.
+	 * @param {{api:{next: string; unstable: string; stable: string}}} ENV Environment configuration.
+	 */
+	constructor($http, locationUtils, messageModel, ENV) {
+		this.$http = $http;
+		this.locationUtils = locationUtils;
+		this.messageModel = messageModel;
+		this.ENV = ENV;
+	}
 
 	/**
 	 * Get Delivery Services.
@@ -87,10 +93,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {Record<string, unknown>} params Any and all query string parameters.
 	 * @returns {Promise<DeliveryService[]>} The response property of the response.
 	 */
-	this.getDeliveryServices = async function(params) {
-		const result = await $http.get(`${ENV.api.next}deliveryservices`, {params});
+	async getDeliveryServices(params) {
+		const result = await this.$http.get(`${this.ENV.api.next}deliveryservices`, { params });
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Get the Delivery Service with the given ID.
@@ -98,10 +104,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} id The ID of the desired Delivery Service.
 	 * @returns {Promise<DeliveryService>} The requested Delivery Service.
 	 */
-	this.getDeliveryService = async function(id) {
-		const result = await $http.get(`${ENV.api.next}deliveryservices`, {params: {id}});
+	async getDeliveryService(id) {
+		const result = await this.$http.get(`${this.ENV.api.next}deliveryservices`, { params: { id } });
 		return result.data.response[0];
-	};
+	}
 
 	/**
 	 * Creates the given Delivery Service.
@@ -109,13 +115,13 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {DeliveryService} ds The Delivery Service being created.
 	 * @returns {Promise<{alerts: {level: string; text: string}[], response: DeliveryService}>} The full API response.
 	 */
-	this.createDeliveryService = async function(ds) {
+	async createDeliveryService(ds) {
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(i => i);
 
-		const response = await $http.post(`${ENV.api.next}deliveryservices`, ds);
+		const response = await this.$http.post(`${this.ENV.api.next}deliveryservices`, ds);
 		return response.data;
-	};
+	}
 
 	/**
 	 * Replaces an existing Delivery Service with the new provided definition.
@@ -123,13 +129,13 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {DeliveryService & {id: number}} ds The Delivery Service being updated (ID MUST be specified).
 	 * @returns {Promise<{alerts: {level: string; text: string}[], response: DeliveryService}>} The full API response.
 	 */
-	this.updateDeliveryService = async function(ds) {
+	async updateDeliveryService(ds) {
 		// strip out any falsy values or duplicates from consistentHashQueryParams
 		ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(i => i);
 
-		const response = await $http.put(`${ENV.api.next}deliveryservices/${ds.id}`, ds);
+		const response = await this.$http.put(`${this.ENV.api.next}deliveryservices/${ds.id}`, ds);
 		return response.data;
-	};
+	}
 
 	/**
 	 * Deletes an existing Delivery Service.
@@ -137,10 +143,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {DeliveryService} ds The Delivery Service to be deleted.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response
 	 */
-	this.deleteDeliveryService = async function(ds) {
-		const response = await $http.delete(`${ENV.api.next}deliveryservices/${ds.id}`);
+	async deleteDeliveryService(ds) {
+		const response = await this.$http.delete(`${this.ENV.api.next}deliveryservices/${ds.id}`);
 		return response.data;
-	};
+	}
 
 	/**
 	 * Gets the server capabilities required by the identified Delivery Service.
@@ -148,8 +154,8 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} deliveryServiceID The ID of the Delivery Service in question.
 	 * @returns {Promise<DSRequiredCapability[]>} The Server Capabilities required by the DS with the given ID.
 	 */
-	this.getServerCapabilities = async function(deliveryServiceID) {
-		const result = await $http.get(`${ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID } });
+	async getServerCapabilities(deliveryServiceID) {
+		const result = await this.$http.get(`${this.ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID } });
 		return result.data.response;
 	};
 
@@ -157,7 +163,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * Gets steering information.
 	 * @returns {Promise<SteeringDefinition[]>}
 	 */
-	this.getSteering = async () => $http.get(`${ENV.api.unstable}steering/`).then(r => r.data.response);
+	async getSteering() {
+		const r = await this.$http.get(`${this.ENV.api.unstable}steering/`)
+		return r.data.response;
+	}
 
 	/**
 	 * Adds a Capability requirement to a Delivery Service.
@@ -165,17 +174,17 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {string} requiredCapability The name of the Capability being added as a requirement.
 	 * @returns {Promise<{alerts: {text: string; level: string}[]; response: {deliveryServiceID: number; lastUpdated: string; requiredCapability: string}}>} The full API response.
 	 */
-	this.addServerCapability = async function(deliveryServiceID, requiredCapability) {
+	async addServerCapability(deliveryServiceID, requiredCapability) {
 		try {
-			const result = await $http.post(`${ENV.api.unstable}deliveryservices_required_capabilities`, { deliveryServiceID, requiredCapability});
+			const result = await this.$http.post(`${this.ENV.api.unstable}deliveryservices_required_capabilities`, { deliveryServiceID, requiredCapability });
 			return result.data;
 		} catch (err) {
 			if (err.data && err.data.alerts) {
-				messageModel.setMessages(err.data.alerts, false);
+				this.messageModel.setMessages(err.data.alerts, false);
 			}
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Removes the requirement of a particular Capability from the identified Delivery Service.
@@ -184,17 +193,17 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {string} requiredCapability The name of the Capability being removed as a requirement.
 	 * @returns {Promise<{alerts: {text: string; level: string}[]}>} The full API response.
 	 */
-	this.removeServerCapability = async function(deliveryServiceID, requiredCapability) {
+	async removeServerCapability(deliveryServiceID, requiredCapability) {
 		try {
-			const result = await $http.delete(`${ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID, requiredCapability} });
+			const result = await this.$http.delete(`${this.ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID, requiredCapability } });
 			return result.data;
-		} catch(err) {
+		} catch (err) {
 			if (err.data && err.data.alerts) {
-				messageModel.setMessages(err.data.alerts, false);
+				this.messageModel.setMessages(err.data.alerts, false);
 			}
 			throw err;
 		}
-	};
+	}
 
 	/**
 	 * Get the Delivery Service for which the identified server is responsible for serving content.
@@ -204,10 +213,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} serverID The ID of the server in question.
 	 * @returns {Promise<DeliveryService[]>} The Delivery Services for which the identified server is responsible for serving content.
 	 */
-	this.getServerDeliveryServices = async function(serverID) {
-		const result = await $http.get(`${ENV.api.unstable}servers/${serverID}/deliveryservices`);
+	async getServerDeliveryServices(serverID) {
+		const result = await this.$http.get(`${this.ENV.api.unstable}servers/${serverID}/deliveryservices`);
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Gets the targets of the given steering Delivery Service.
@@ -215,10 +224,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} dsID The ID of the steering Delivery Service in question.
 	 * @returns {Promise<SteeringTarget[]>} The targets of the identified Delivery Service.
 	 */
-	this.getDeliveryServiceTargets = async function(dsID) {
-		const result = await $http.get(`${ENV.api.unstable}steering/${dsID}/targets`);
+	async getDeliveryServiceTargets(dsID) {
+		const result = await this.$http.get(`${this.ENV.api.unstable}steering/${dsID}/targets`);
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Gets a particular target definition for a Steering Delivery Service.
@@ -229,10 +238,10 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * target - or `undefined` if the target DS is not actually a target of the
 	 * steering DS.
 	 */
-	this.getDeliveryServiceTarget = async function(dsID, target) {
-		const result = await $http.get(`${ENV.api.unstable}steering/${dsID}/targets`, {params: {target}});
+	async getDeliveryServiceTarget(dsID, target) {
+		const result = await this.$http.get(`${this.ENV.api.unstable}steering/${dsID}/targets`, { params: { target } });
 		return result.data.response[0];
-	};
+	}
 
 	/**
 	 * Updates a particular target definition of a Steering Delivery Service.
@@ -242,18 +251,18 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {SteeringTarget} target The new, desired definition of the target.
 	 * @returns {Promise<SteeringTarget>} The steering target definition after update.
 	 */
-	this.updateDeliveryServiceTarget = async function(dsID, targetID, target) {
+	async updateDeliveryServiceTarget(dsID, targetID, target) {
 		let result;
 		try {
-			result = await $http.put(`${ENV.api.unstable}steering/${dsID}/targets/${targetID}`, target);
+			result = await this.$http.put(`${this.ENV.api.unstable}steering/${dsID}/targets/${targetID}`, target);
 		} catch (err) {
-			messageModel.setMessages(err.data.alerts, false);
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-		messageModel.setMessages(result.data.alerts, true);
-		locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
+		this.messageModel.setMessages(result.data.alerts, true);
+		this.locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Creates a new target definition for a Steering Delivery Service.
@@ -262,18 +271,18 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} target The definition of the new target.
 	 * @returns {Promise<SteeringTarget>} The newly created target definition.
 	 */
-	this.createDeliveryServiceTarget = async function(dsID, target) {
+	async createDeliveryServiceTarget(dsID, target) {
 		let result;
 		try {
-			result = await $http.post(`${ENV.api.unstable}steering/${dsID}/targets`, target);
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+			result = await this.$http.post(`${this.ENV.api.unstable}steering/${dsID}/targets`, target);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-		messageModel.setMessages(result.data.alerts, true);
-		locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
+		this.messageModel.setMessages(result.data.alerts, true);
+		this.locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
 		return result.data.response;
-	};
+	}
 
 	/**
 	 * Removes a target from a Steering Delivery Service.
@@ -282,18 +291,18 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} targetID The ID of the Delivery Service being removed as a target.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
 	 */
-	this.deleteDeliveryServiceTarget = async function(dsID, targetID) {
+	async deleteDeliveryServiceTarget(dsID, targetID) {
 		let result;
 		try {
-			result = await $http.delete(`${ENV.api.unstable}steering/${dsID}/targets/${targetID}`);
+			result = await this.$http.delete(`${this.ENV.api.unstable}steering/${dsID}/targets/${targetID}`);
 		} catch (err) {
-			messageModel.setMessages(err.data.alerts, true);
+			this.messageModel.setMessages(err.data.alerts, true);
 			throw err;
 		}
-		messageModel.setMessages(result.data.alerts, true);
-		locationUtils.navigateToPath('/delivery-services/' + dsID + '/targets');
+		this.messageModel.setMessages(result.data.alerts, true);
+		this.locationUtils.navigateToPath('/delivery-services/' + dsID + '/targets');
 		return result.data;
-	};
+	}
 
 	/**
 	 * Removes a server from a Delivery Service's directly assigned servers.
@@ -304,17 +313,17 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} serverID The ID of the server being removed.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
 	 */
-	this.deleteDeliveryServiceServer = async function(dsID, serverID) {
+	async deleteDeliveryServiceServer(dsID, serverID) {
 		let result;
 		try {
-			result = await $http.delete(`${ENV.api.unstable}deliveryserviceserver/${dsID}/${serverID}`);
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+			result = await this.$http.delete(`${this.ENV.api.unstable}deliveryserviceserver/${dsID}/${serverID}`);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-		messageModel.setMessages(result.data.alerts, false);
+		this.messageModel.setMessages(result.data.alerts, false);
 		return result.data;
-	};
+	}
 
 	/**
 	 * Assigns a set of servers to a Delivery Service *overriding any existing
@@ -326,17 +335,17 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number[]} servers The IDs of the servers being directly assigned to the Delivery Service.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: {dsId: number; replace: true; servers: number[]}}>} The full API response.
 	 */
-	this.assignDeliveryServiceServers = async function(dsId, servers) {
+	async assignDeliveryServiceServers(dsId, servers) {
 		let result;
 		try {
-			result = await $http.post(`${ENV.api.unstable}deliveryserviceserver`, { dsId, servers, replace: true } );
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+			result = await this.$http.post(`${this.ENV.api.unstable}deliveryserviceserver`, { dsId, servers, replace: true });
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-		messageModel.setMessages(result.data.alerts, false);
+		this.messageModel.setMessages(result.data.alerts, false);
 		return result.data;
-	};
+	}
 
 	/**
 	 * Tests a consistent hashing regular expression against Traffic Router, to
@@ -347,19 +356,19 @@ var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 	 * @param {number} cdnId The ID of the CDN within which the request is to be made.
 	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: ConsistentHashResponse}>} The full API response.
 	 */
-	this.getConsistentHashResult = async function (regex, requestPath, cdnId) {
-		const url = `${ENV.api.unstable}consistenthash`;
-		const params = {regex, requestPath, cdnId};
+	async getConsistentHashResult(regex, requestPath, cdnId) {
+		const url = `${this.ENV.api.unstable}consistenthash`;
+		const params = { regex, requestPath, cdnId };
 
 		try {
-			const result = await $http.post(url, params);
+			const result = await this.$http.post(url, params);
 			return result.data;
-		} catch(err) {
-			messageModel.setMessages(err.data.alerts, false);
+		} catch (err) {
+			this.messageModel.setMessages(err.data.alerts, false);
 			throw err;
 		}
-	};
-};
+	}
+}
 
 DeliveryServiceService.$inject = ["$http", "locationUtils", "messageModel", "ENV"];
 module.exports = DeliveryServiceService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -74,237 +74,285 @@
  */
 var DeliveryServiceService = function($http, locationUtils, messageModel, ENV) {
 
-    this.getDeliveryServices = function(queryParams) {
-        return $http.get(ENV.api.unstable + 'deliveryservices', {params: queryParams}).then(
-            function(result) {
-                return result.data.response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Get Delivery Services.
+	 *
+	 * @param {Record<string, unknown>} params Any and all query string parameters.
+	 * @returns {Promise<DeliveryService[]>} The response property of the response.
+	 */
+	this.getDeliveryServices = async function(params) {
+		const result = await $http.get(`${ENV.api.next}deliveryservices`, {params});
+		return result.data.response;
+	};
 
-    this.getDeliveryService = function(id) {
-        return $http.get(ENV.api.unstable + 'deliveryservices', {params: {id: id}}).then(
-            function(result) {
-                return result.data.response[0];
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Get the Delivery Service with the given ID.
+	 *
+	 * @param {number} id The ID of the desired Delivery Service.
+	 * @returns {Promise<DeliveryService>} The requested Delivery Service.
+	 */
+	this.getDeliveryService = async function(id) {
+		const result = await $http.get(`${ENV.api.next}deliveryservices`, {params: {id}});
+		return result.data.response[0];
+	};
 
-    this.createDeliveryService = function(ds) {
-        // strip out any falsy values or duplicates from consistentHashQueryParams
-        ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(function(i){return i;});
+	/**
+	 * Creates the given Delivery Service.
+	 *
+	 * @param {DeliveryService} ds The Delivery Service being created.
+	 * @returns {Promise<{alerts: {level: string; text: string}[], response: DeliveryService}>} The full API response.
+	 */
+	this.createDeliveryService = async function(ds) {
+		// strip out any falsy values or duplicates from consistentHashQueryParams
+		ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(i => i);
 
-        return $http.post(ENV.api.unstable + "deliveryservices", ds).then(
-            function(response) {
-                return response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+		const response = await $http.post(`${ENV.api.next}deliveryservices`, ds);
+		return response.data;
+	};
 
-    this.updateDeliveryService = function(ds) {
-        // strip out any falsy values or duplicates from consistentHashQueryParams
-        ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(function(i){return i;});
+	/**
+	 * Replaces an existing Delivery Service with the new provided definition.
+	 *
+	 * @param {DeliveryService & {id: number}} ds The Delivery Service being updated (ID MUST be specified).
+	 * @returns {Promise<{alerts: {level: string; text: string}[], response: DeliveryService}>} The full API response.
+	 */
+	this.updateDeliveryService = async function(ds) {
+		// strip out any falsy values or duplicates from consistentHashQueryParams
+		ds.consistentHashQueryParams = Array.from(new Set(ds.consistentHashQueryParams)).filter(i => i);
 
-        return $http.put(ENV.api.unstable + "deliveryservices/" + ds.id, ds).then(
-            function(response) {
-                return response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+		const response = await $http.put(`${ENV.api.next}deliveryservices/${ds.id}`, ds);
+		return response.data;
+	};
 
-    // todo: change to use query param when it is supported
-    this.deleteDeliveryService = function(ds) {
-        return $http.delete(ENV.api.unstable + "deliveryservices/" + ds.id).then(
-            function(response) {
-                return response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Deletes an existing Delivery Service.
+	 *
+	 * @param {DeliveryService} ds The Delivery Service to be deleted.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response
+	 */
+	this.deleteDeliveryService = async function(ds) {
+		const response = await $http.delete(`${ENV.api.next}deliveryservices/${ds.id}`);
+		return response.data;
+	};
 
-    this.getServerCapabilities = function(id) {
-        return $http.get(ENV.api.unstable + 'deliveryservices_required_capabilities', { params: { deliveryServiceID: id } }).then(
-            function (result) {
-                return result.data.response;
-            },
-            function (err) {
-                throw err;
-            }
-        )
-    };
+	/**
+	 * Gets the server capabilities required by the identified Delivery Service.
+	 *
+	 * @param {number} deliveryServiceID The ID of the Delivery Service in question.
+	 * @returns {Promise<DSRequiredCapability[]>} The Server Capabilities required by the DS with the given ID.
+	 */
+	this.getServerCapabilities = async function(deliveryServiceID) {
+		const result = await $http.get(`${ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID } });
+		return result.data.response;
+	};
 
-    this.getSteering = () => $http.get(`${ENV.api.unstable}steering/`).then(r => r.data.response);
+	/**
+	 * Gets steering information.
+	 * @returns {Promise<SteeringDefinition[]>}
+	 */
+	this.getSteering = async () => $http.get(`${ENV.api.unstable}steering/`).then(r => r.data.response);
 
-    this.addServerCapability = function(deliveryServiceId, capabilityName) {
-        return $http.post(ENV.api.unstable + 'deliveryservices_required_capabilities', { deliveryServiceID: deliveryServiceId, requiredCapability: capabilityName}).then(
-            function(result) {
-                return result.data;
-            },
-            function(err) {
-                if (err.data && err.data.alerts) {
-                    messageModel.setMessages(err.data.alerts, false);
-                }
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Adds a Capability requirement to a Delivery Service.
+	 * @param {number} deliveryServiceID The ID of the Delivery Service to which to add a Capability requirement.
+	 * @param {string} requiredCapability The name of the Capability being added as a requirement.
+	 * @returns {Promise<{alerts: {text: string; level: string}[]; response: {deliveryServiceID: number; lastUpdated: string; requiredCapability: string}}>} The full API response.
+	 */
+	this.addServerCapability = async function(deliveryServiceID, requiredCapability) {
+		try {
+			const result = await $http.post(`${ENV.api.unstable}deliveryservices_required_capabilities`, { deliveryServiceID, requiredCapability});
+			return result.data;
+		} catch (err) {
+			if (err.data && err.data.alerts) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+			throw err;
+		}
+	};
 
-    this.removeServerCapability = function(deliveryServiceId, capabilityName) {
-        return $http.delete(ENV.api.unstable + 'deliveryservices_required_capabilities', { params: { deliveryServiceID: deliveryServiceId, requiredCapability: capabilityName} }).then(
-            function(result) {
-                return result.data;
-            },
-            function(err) {
-                if (err.data && err.data.alerts) {
-                    messageModel.setMessages(err.data.alerts, false);
-                }
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Removes the requirement of a particular Capability from the identified Delivery Service.
+	 *
+	 * @param {number} deliveryServiceID The ID of the Delivery Service from which a Capability requirement will be removed.
+	 * @param {string} requiredCapability The name of the Capability being removed as a requirement.
+	 * @returns {Promise<{alerts: {text: string; level: string}[]}>} The full API response.
+	 */
+	this.removeServerCapability = async function(deliveryServiceID, requiredCapability) {
+		try {
+			const result = await $http.delete(`${ENV.api.unstable}deliveryservices_required_capabilities`, { params: { deliveryServiceID, requiredCapability} });
+			return result.data;
+		} catch(err) {
+			if (err.data && err.data.alerts) {
+				messageModel.setMessages(err.data.alerts, false);
+			}
+			throw err;
+		}
+	};
 
-    this.getServerDeliveryServices = function(serverId) {
-        return $http.get(ENV.api.unstable + 'servers/' + serverId + '/deliveryservices').then(
-            function(result) {
-                return result.data.response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Get the Delivery Service for which the identified server is responsible for serving content.
+	 *
+	 * This includes assignments through direct assignment as well as Topology ancestry.
+	 *
+	 * @param {number} serverID The ID of the server in question.
+	 * @returns {Promise<DeliveryService[]>} The Delivery Services for which the identified server is responsible for serving content.
+	 */
+	this.getServerDeliveryServices = async function(serverID) {
+		const result = await $http.get(`${ENV.api.unstable}servers/${serverID}/deliveryservices`);
+		return result.data.response;
+	};
 
-    this.getDeliveryServiceTargets = function(dsId) {
-        return $http.get(ENV.api.unstable + 'steering/' + dsId + '/targets').then(
-            function(result) {
-                return result.data.response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Gets the targets of the given steering Delivery Service.
+	 *
+	 * @param {number} dsID The ID of the steering Delivery Service in question.
+	 * @returns {Promise<SteeringTarget[]>} The targets of the identified Delivery Service.
+	 */
+	this.getDeliveryServiceTargets = async function(dsID) {
+		const result = await $http.get(`${ENV.api.unstable}steering/${dsID}/targets`);
+		return result.data.response;
+	};
 
-    this.getDeliveryServiceTarget = function(dsId, targetId) {
-        return $http.get(ENV.api.unstable + 'steering/' + dsId + '/targets', {params: {target: targetId}}).then(
-            function(result) {
-                return result.data.response[0];
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Gets a particular target definition for a Steering Delivery Service.
+	 *
+	 * @param {number} dsID The ID of the Steering Delivery Service in question.
+	 * @param {number} target The ID of the target Delivery Service.
+	 * @returns {Promise<SteeringTarget|undefined>} The definition of the requested
+	 * target - or `undefined` if the target DS is not actually a target of the
+	 * steering DS.
+	 */
+	this.getDeliveryServiceTarget = async function(dsID, target) {
+		const result = await $http.get(`${ENV.api.unstable}steering/${dsID}/targets`, {params: {target}});
+		return result.data.response[0];
+	};
 
-    this.updateDeliveryServiceTarget = function(dsId, targetId, target) {
-        return $http.put(ENV.api.unstable + "steering/" + dsId + "/targets/" + targetId, target).then(
-            function(result) {
-                messageModel.setMessages(result.data.alerts, true);
-                locationUtils.navigateToPath('/delivery-services/' + dsId + '/targets');
-                return result;
-            },
-            function(err) {
-                messageModel.setMessages(err.data.alerts, false);
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Updates a particular target definition of a Steering Delivery Service.
+	 *
+	 * @param {number} dsID The ID of the steering Delivery Service in question.
+	 * @param {number} targetID The ID of the Delivery Service for which the target definition will be updated.
+	 * @param {SteeringTarget} target The new, desired definition of the target.
+	 * @returns {Promise<SteeringTarget>} The steering target definition after update.
+	 */
+	this.updateDeliveryServiceTarget = async function(dsID, targetID, target) {
+		let result;
+		try {
+			result = await $http.put(`${ENV.api.unstable}steering/${dsID}/targets/${targetID}`, target);
+		} catch (err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
+		messageModel.setMessages(result.data.alerts, true);
+		locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
+		return result.data.response;
+	};
 
-    this.createDeliveryServiceTarget = function(dsId, target) {
-        return $http.post(ENV.api.unstable + 'steering/' + dsId + '/targets', target).then(
-            function(result) {
-                messageModel.setMessages(result.data.alerts, true);
-                locationUtils.navigateToPath('/delivery-services/' + dsId + '/targets');
-                return result;
-            },
-            function(err) {
-                messageModel.setMessages(err.data.alerts, false);
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Creates a new target definition for a Steering Delivery Service.
+	 *
+	 * @param {number} dsID The ID of the Steering Delivery Service in question.
+	 * @param {number} target The definition of the new target.
+	 * @returns {Promise<SteeringTarget>} The newly created target definition.
+	 */
+	this.createDeliveryServiceTarget = async function(dsID, target) {
+		let result;
+		try {
+			result = await $http.post(`${ENV.api.unstable}steering/${dsID}/targets`, target);
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
+		messageModel.setMessages(result.data.alerts, true);
+		locationUtils.navigateToPath(`/delivery-services/${dsID}/targets`);
+		return result.data.response;
+	};
 
-    this.deleteDeliveryServiceTarget = function(dsId, targetId) {
-        return $http.delete(ENV.api.unstable + 'steering/' + dsId + '/targets/' + targetId).then(
-            function(result) {
-                messageModel.setMessages(result.data.alerts, true);
-                locationUtils.navigateToPath('/delivery-services/' + dsId + '/targets');
-                return result;
-            },
-            function(err) {
-                messageModel.setMessages(err.data.alerts, true);
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Removes a target from a Steering Delivery Service.
+	 *
+	 * @param {number} dsID The ID of the Steering Delivery Service in question.
+	 * @param {number} targetID The ID of the Delivery Service being removed as a target.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
+	 */
+	this.deleteDeliveryServiceTarget = async function(dsID, targetID) {
+		let result;
+		try {
+			result = await $http.delete(`${ENV.api.unstable}steering/${dsID}/targets/${targetID}`);
+		} catch (err) {
+			messageModel.setMessages(err.data.alerts, true);
+			throw err;
+		}
+		messageModel.setMessages(result.data.alerts, true);
+		locationUtils.navigateToPath('/delivery-services/' + dsID + '/targets');
+		return result.data;
+	};
 
-    this.getUserDeliveryServices = function(userId) {
-        return $http.get(ENV.api.unstable + 'users/' + userId + '/deliveryservices').then(
-            function(result) {
-                return result.data.response;
-            },
-            function(err) {
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Removes a server from a Delivery Service's directly assigned servers.
+	 *
+	 * Cannot be used on a Delivery Service that uses a Topology.
+	 *
+	 * @param {number} dsID The ID of the Delivery Service in question.
+	 * @param {number} serverID The ID of the server being removed.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]}>} The full API response.
+	 */
+	this.deleteDeliveryServiceServer = async function(dsID, serverID) {
+		let result;
+		try {
+			result = await $http.delete(`${ENV.api.unstable}deliveryserviceserver/${dsID}/${serverID}`);
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
+		messageModel.setMessages(result.data.alerts, false);
+		return result.data;
+	};
 
-    this.deleteDeliveryServiceServer = function(dsId, serverId) {
-        return $http.delete(ENV.api.unstable + 'deliveryserviceserver/' + dsId + '/' + serverId).then(
-            function(result) {
-                messageModel.setMessages(result.data.alerts, false);
-                return result;
-            },
-            function(err) {
-                messageModel.setMessages(err.data.alerts, false);
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Assigns a set of servers to a Delivery Service *overriding any existing
+	 * direct assignments*.
+	 *
+	 * This cannot be used with a Delivery Service that uses a Topology.
+	 *
+	 * @param {number} dsId The ID of the Delivery Service in question.
+	 * @param {number[]} servers The IDs of the servers being directly assigned to the Delivery Service.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: {dsId: number; replace: true; servers: number[]}}>} The full API response.
+	 */
+	this.assignDeliveryServiceServers = async function(dsId, servers) {
+		let result;
+		try {
+			result = await $http.post(`${ENV.api.unstable}deliveryserviceserver`, { dsId, servers, replace: true } );
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
+		messageModel.setMessages(result.data.alerts, false);
+		return result.data;
+	};
 
-    this.assignDeliveryServiceServers = function(dsId, servers) {
-        return $http.post(ENV.api.unstable + 'deliveryserviceserver',{ dsId: dsId, servers: servers, replace: true } ).then(
-            function(result) {
-                messageModel.setMessages(result.data.alerts, false);
-                return result;
-            },
-            function(err) {
-                messageModel.setMessages(err.data.alerts, false);
-                throw err;
-            }
-        );
-    };
+	/**
+	 * Tests a consistent hashing regular expression against Traffic Router, to
+	 * see how it would be routed.
+	 *
+	 * @param {string|RegExp} regex The regular expression being tested.
+	 * @param {string} requestPath The sample client request path.
+	 * @param {number} cdnId The ID of the CDN within which the request is to be made.
+	 * @returns {Promise<{alerts: {level: string; text: string}[]; response: ConsistentHashResponse}>} The full API response.
+	 */
+	this.getConsistentHashResult = async function (regex, requestPath, cdnId) {
+		const url = `${ENV.api.unstable}consistenthash`;
+		const params = {regex, requestPath, cdnId};
 
-    this.getConsistentHashResult = function (regex, requestPath, cdnId) {
-        const url = ENV.api.unstable + "consistenthash";
-        const params = {regex: regex, requestPath: requestPath, cdnId: cdnId};
-
-        return $http.post(url, params).then(
-            function (result) {
-                return result.data;
-            },
-            function (err) {
-                messageModel.setMessages(err.data.alerts, false);
-                throw err;
-            }
-        );
-    };
-
+		try {
+			const result = await $http.post(url, params);
+			return result.data;
+		} catch(err) {
+			messageModel.setMessages(err.data.alerts, false);
+			throw err;
+		}
+	};
 };
 
-DeliveryServiceService.$inject = ['$http', 'locationUtils', 'messageModel', 'ENV'];
+DeliveryServiceService.$inject = ["$http", "locationUtils", "messageModel", "ENV"];
 module.exports = DeliveryServiceService;

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -21,8 +21,15 @@
  * This is a minimal type definition for Delivery Services. Expand as necessary.
  * @typedef DeliveryService
  * @property {string[]} consistentHashQueryParams
- * @property {?number|null|undefined} id
+ * @property {string[]} exampleURLs
+ * @property {?(number|null|undefined)} id
+ * @property {string} lastUpdated
+ * @property {boolean} signed
  * @property {null|[string, ...string[]]} tlsVersions
+ * @property {?(string|null|undefined)} trResponseHeaders
+ * @property {?(string|null|undefined)} type
+ * @property {number} typeId
+ * @property {string} xmlId
  */
 
 /**

--- a/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var ChartBPSController = function(deliveryService, $scope, $state, $timeout, $filter, $q, $interval, deliveryServiceService, deliveryServiceStatsService, dateUtils, locationUtils, numberUtils, propertiesModel) {
+var ChartBPSController = function(deliveryService, $scope, $timeout, $filter, $q, $interval, deliveryServiceStatsService, dateUtils, numberUtils, propertiesModel) {
 
 	var chartSeries,
 		chartOptions;
@@ -64,7 +64,7 @@ var ChartBPSController = function(deliveryService, $scope, $state, $timeout, $fi
 		if (angular.isDefined(series)) {
 			series.values.forEach(function(seriesItem) {
 				if (moment(seriesItem[0]).isSame(start) || moment(seriesItem[0]).isAfter(start)) {
-					normalizedChartData.push([ moment(seriesItem[0]).valueOf(), 
+					normalizedChartData.push([ moment(seriesItem[0]).valueOf(),
 						numberUtils.convertTo(seriesItem[1], $scope.unitSize) ]); // converts data to appropriate unit
 				}
 			});
@@ -165,5 +165,5 @@ var ChartBPSController = function(deliveryService, $scope, $state, $timeout, $fi
 
 };
 
-ChartBPSController.$inject = ['deliveryService', '$scope', '$state', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceService', 'deliveryServiceStatsService', 'dateUtils', 'locationUtils', 'numberUtils', 'propertiesModel'];
+ChartBPSController.$inject = ['deliveryService', '$scope', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceStatsService', 'dateUtils', 'numberUtils', 'propertiesModel'];
 module.exports = ChartBPSController;

--- a/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
+++ b/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var ChartHttpStatusController = function(deliveryService, $scope, $state, $timeout, $filter, $q, $interval, deliveryServiceService, deliveryServiceStatsService, dateUtils, locationUtils, numberUtils, propertiesModel) {
+var ChartHttpStatusController = function(deliveryService, $scope, $timeout, $filter, $q, $interval, deliveryServiceStatsService, dateUtils, propertiesModel) {
 
 	var chartSeries,
 		chartOptions;
@@ -197,5 +197,5 @@ var ChartHttpStatusController = function(deliveryService, $scope, $state, $timeo
 
 };
 
-ChartHttpStatusController.$inject = ['deliveryService', '$scope', '$state', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceService', 'deliveryServiceStatsService', 'dateUtils', 'locationUtils', 'numberUtils', 'propertiesModel'];
+ChartHttpStatusController.$inject = ['deliveryService', '$scope', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceStatsService', 'dateUtils', 'propertiesModel'];
 module.exports = ChartHttpStatusController;

--- a/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var ChartTPSController = function(deliveryService, $scope, $state, $timeout, $filter, $q, $interval, deliveryServiceService, deliveryServiceStatsService, dateUtils, locationUtils, numberUtils, propertiesModel) {
+var ChartTPSController = function(deliveryService, $scope, $timeout, $filter, $q, $interval, deliveryServiceStatsService, dateUtils, propertiesModel) {
 
 	var chartSeries,
 		chartOptions;
@@ -164,5 +164,5 @@ var ChartTPSController = function(deliveryService, $scope, $state, $timeout, $fi
 
 };
 
-ChartTPSController.$inject = ['deliveryService', '$scope', '$state', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceService', 'deliveryServiceStatsService', 'dateUtils', 'locationUtils', 'numberUtils', 'propertiesModel'];
+ChartTPSController.$inject = ['deliveryService', '$scope', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceStatsService', 'dateUtils', 'propertiesModel'];
 module.exports = ChartTPSController;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -60,7 +60,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 			cachedTLSVersions = null;
 		}
 
-		deliveryService.tlsVersions =  null;
+		deliveryService.tlsVersions = null;
 	}
 	$scope.toggleTLSRestrict = toggleTLSRestrict;
 
@@ -226,16 +226,6 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		}
 	};
 
-	$scope.falseTrue = [
-		{ value: true, label: 'true' },
-		{ value: false, label: 'false' }
-	];
-
-	$scope.activeInactive = [
-		{ value: true, label: 'Active' },
-		{ value: false, label: 'Not Active'}
-	];
-
 	$scope.signingAlgos = [
 		{ value: null, label: 'None' },
 		{ value: 'url_sig', label: 'URL Signature Keys' },
@@ -290,24 +280,6 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		{ value: 56, label: '56 - CS7' }
 	];
 
-	$scope.deepCachingTypes = [
-		{ value: 'NEVER', label: 'NEVER' },
-		{ value: 'ALWAYS', label: 'ALWAYS' }
-	];
-
-	$scope.dispersions = [
-		{ value: 1, label: '1 - OFF' },
-		{ value: 2, label: '2' },
-		{ value: 3, label: '3' },
-		{ value: 4, label: '4' },
-		{ value: 5, label: '5' },
-		{ value: 6, label: '6' },
-		{ value: 7, label: '7' },
-		{ value: 8, label: '8' },
-		{ value: 9, label: '9' },
-		{ value: 10, label: '10' }
-	];
-
 	$scope.rrhs = [
 		{ value: 0, label: "Don't cache Range Requests" },
 		{ value: 1, label: "Use the background_fetch plugin" },
@@ -323,9 +295,6 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		{ value: 4, label: "4 - Latch on Failover" }
 	];
 
-	$scope.clone = function(ds) {
-		locationUtils.navigateToPath('/delivery-services/' + ds.id + '/clone?dsType=' + ds.type);
-	};
 
 	$scope.changeSigningAlgorithm = function(signingAlgorithm) {
 		if (signingAlgorithm == null) {
@@ -357,52 +326,6 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		}
 		$scope.deliveryServiceForm.$pristine = false; // this enables the 'update' button in the ds form
 	};
-
-	$scope.viewTargets = function() {
-		$location.path($location.path() + '/targets');
-	};
-
-	$scope.viewCapabilities = function() {
-		$location.path($location.path() + '/required-server-capabilities');
-	};
-
-	$scope.viewOrigins = function() {
-		$location.path($location.path() + '/origins');
-	};
-
-	$scope.viewServers = function() {
-		$location.path($location.path() + '/servers');
-	};
-
-	$scope.viewRegexes = function() {
-		$location.path($location.path() + '/regexes');
-	};
-
-	$scope.viewJobs = function() {
-		$location.path($location.path() + '/jobs');
-	};
-
-	$scope.manageSslKeys = function() {
-		$location.path($location.path() + '/ssl-keys');
-	};
-
-	$scope.manageUrlSigKeys = function() {
-		$location.path($location.path() + '/url-sig-keys');
-	};
-
-	$scope.manageUriSigningKeys = function() {
-		$location.path($location.path() + '/uri-signing-keys');
-	};
-
-	$scope.viewStaticDnsEntries = function() {
-		$location.path($location.path() + '/static-dns-entries');
-	};
-
-	$scope.viewCharts = function() {
-		$location.path($location.path() + '/charts');
-	};
-
-	$scope.navigateToPath = locationUtils.navigateToPath;
 
 	$scope.hasError = formUtils.hasError;
 
@@ -454,22 +377,21 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		}
 	};
 
-	var init = function () {
-		getCDNs();
-		getProfiles();
-		getTenants();
-		getServiceCategories();
-		getSteeringTargets();
-		if (!deliveryService.consistentHashQueryParams || deliveryService.consistentHashQueryParams.length < 1) {
-			// add an empty one so the dynamic form widget is visible. empty strings get stripped out on save anyhow.
-			$scope.deliveryService.consistentHashQueryParams = [ '' ];
-		}
-		if (deliveryService.lastUpdated) {
-			deliveryService.lastUpdated = new Date(deliveryService.lastUpdated.replace("+00", "Z"));
-		}
-	};
-	init();
-
+	getCDNs();
+	getProfiles();
+	getTenants();
+	getServiceCategories();
+	getSteeringTargets();
+	if (!deliveryService.consistentHashQueryParams || deliveryService.consistentHashQueryParams.length < 1) {
+		// add an empty one so the dynamic form widget is visible. empty strings get stripped out on save anyhow.
+		$scope.deliveryService.consistentHashQueryParams = [ "" ];
+	}
+	if (deliveryService.lastUpdated) {
+		// TS checkers hate him for this one weird trick:
+		deliveryService.lastUpdated = new Date(deliveryService.lastUpdated.replace("+00", "Z"));
+		// ... the right way to do this is with an interceptor, but nobody
+		// wants to put in that kinda work on a legacy product.
+	}
 };
 
 FormDeliveryServiceController.$inject = ['deliveryService', 'dsCurrent', 'origin', 'topologies', 'type', 'types', '$scope', '$location', '$uibModal', '$window', 'formUtils', 'locationUtils', 'tenantUtils', 'deliveryServiceUtils', 'deliveryServiceService', 'cdnService', 'profileService', 'tenantService', 'propertiesModel', 'userModel', 'serviceCategoryService'];

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -19,457 +19,456 @@
 
 var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin, topologies, type, types, $scope, $location, $uibModal, $window, formUtils, locationUtils, tenantUtils, deliveryServiceUtils, deliveryServiceService, cdnService, profileService, tenantService, propertiesModel, userModel, serviceCategoryService) {
 
-    /**
-     * This is used to cache TLS version settings when the checkbox is toggled.
-     * @type null | [string, ...string[]]
-     */
-    let cachedTLSVersions = null;
+	/**
+	 * This is used to cache TLS version settings when the checkbox is toggled.
+	 * @type null | [string, ...string[]]
+	 */
+	let cachedTLSVersions = null;
 
 	$scope.showSensitive = false;
 
-
-    const knownVersions = new Set(["1.0", "1.1", "1.2", "1.3"]);
-    $scope.tlsVersionUnknown = v => v && !knownVersions.has(v);
-
-    const insecureVersions = new Set(["1.0", "1.1"]);
-    $scope.tlsVersionInsecure = v => v && insecureVersions.has(v);
-
-    /**
-     * This toggles whether TLS versions are restricted for the Delivery
-     * Service.
-     *
-     * It uses cachedTLSVersions to cache TLS version restrictions, so that the
-     * DS is always ready to submit without manipulation, but the UI "remembers"
-     * the TLS versions that existed on toggling restrictions off.
-     *
-     * This is called when the checkbox's 'change' event fires - that event is
-     * not handled here.
-     */
-    function toggleTLSRestrict() {
-        if ($scope.restrictTLS) {
-            if (cachedTLSVersions instanceof Array && cachedTLSVersions.length > 0) {
-                deliveryService.tlsVersions = cachedTLSVersions;
-            } else {
-                deliveryService.tlsVersions = [""];
-            }
-            cachedTLSVersions = null;
-            return;
-        }
-        if (deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0) {
-            cachedTLSVersions = deliveryService.tlsVersions;
-        } else {
-            cachedTLSVersions = null;
-        }
-
-        deliveryService.tlsVersions =  null;
-    }
-    $scope.toggleTLSRestrict = toggleTLSRestrict;
-
-    $scope.removeTLSVersion = function(index) {
-        deliveryService.tlsVersions.splice(index, 1);
-    };
-
-    $scope.addTLSVersion = function(index) {
-        deliveryService.tlsVersions.splice(index+1, 0, "");
-    };
-
-    /**
-     * This function is called on 'change' events for any and all TLS Version
-     * inputs, and sets validity states of duplicates.
-     *
-     * This can't use a normal validator because it depends on a value checking
-     * against a list containing itself. AngularJS sets values that fail
-     * validation to `undefined`, so if there's a set of TLS versions
-     * `["1.3", "1.3"]`, then the validator will set one of them to `undefined`.
-     * Now the set is `["1.3", undefined]`, so there are no more duplicates, so
-     * the set is marked as valid.
-     */
-    function validateTLS() {
-        if (!$scope.generalConfig || !($scope.deliveryService.tlsVersions instanceof Array)) {
-            return;
-        }
-
-        const verMap = new Map();
-        for (let i = 0; i < $scope.deliveryService.tlsVersions.length; ++i) {
-            const propName = `tlsVersion${i+1}`;
-            if (propName in $scope.generalConfig) {
-                $scope.generalConfig[propName].$setValidity("duplicates", true);
-            }
-
-            const ver = $scope.deliveryService.tlsVersions[i];
-            if (ver === undefined) {
-                continue;
-            }
-            const current = verMap.get(ver);
-            if (current) {
-                current.count++;
-                current.indices.push(i);
-            } else {
-                verMap.set(ver, {
-                    count: 1,
-                    indices: [i]
-                });
-            }
-        }
-
-        for (const index of Array.from(verMap).filter(v=>v[1].count>1).flatMap(v=>v[1].indices)) {
-            const propName = `tlsVersion${index+1}`;
-            if (propName in $scope.generalConfig) {
-                $scope.generalConfig[propName].$setValidity("duplicates", false);
-            }
-        }
-    }
-    $scope.validateTLS = validateTLS;
-
-    async function getSteeringTargets() {
-        if(type.indexOf("HTTP") > -1)  {
-            const configs = await deliveryServiceService.getSteering();
-            const dsTargets = deliveryServiceUtils.getSteeringTargetsForDS([deliveryService.xmlId], configs);
-            $scope.steeringTargetsFor = Array.from(dsTargets[deliveryService.xmlId]);
-        }
-    }
-
-    var getCDNs = function() {
-        cdnService.getCDNs()
-            .then(function(result) {
-                $scope.cdns = result;
-            });
-    };
-
-    var getProfiles = function() {
-        profileService.getProfiles({ orderby: 'name' })
-            .then(function(result) {
-                $scope.profiles = _.filter(result, function(profile) {
-                    return profile.type == 'DS_PROFILE';
-                });
-            });
-    };
-
-    var getTenants = function() {
-        tenantService.getTenant(userModel.user.tenantId)
-            .then(function(tenant) {
-                tenantService.getTenants()
-                    .then(function(tenants) {
-                        $scope.tenants = tenantUtils.hierarchySort(tenantUtils.groupTenantsByParent(tenants), tenant.parentId, []);
-                        tenantUtils.addLevels($scope.tenants);
-                    });
-            });
-    };
-
-    var getServiceCategories = function() {
-        serviceCategoryService.getServiceCategories({dsId: deliveryService.id })
-            .then(function(result) {
-                $scope.serviceCategories = result;
-            });
-    };
-
-    $scope.deliveryService = deliveryService;
-
-    $scope.showGeneralConfig = true;
-
-    $scope.showCacheConfig = true;
-
-    $scope.showRoutingConfig = true;
-
-    $scope.dsCurrent = dsCurrent; // this ds is used primarily for showing the diff between a ds request and the current DS
-
-    $scope.origin = origin[0];
-
-    $scope.topologies = topologies;
-
-    $scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
-
-    $scope.openCharts = deliveryServiceUtils.openCharts;
-
-    $scope.dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
-
-    $scope.edgeFQDNs = function(ds) {
-        return ds.exampleURLs.join('<br/>');
-    };
-
-    $scope.DRAFT = 0;
-    $scope.SUBMITTED = 1;
-    $scope.REJECTED = 2;
-    $scope.PENDING = 3;
-    $scope.COMPLETE = 4;
-
-    $scope.saveable = function() {
-        // this may be overriden in a child class. i.e. FormEditDeliveryServiceController
-        return true;
-    };
-
-    $scope.deletable = function() {
-        // this may be overriden in a child class. i.e. FormEditDeliveryServiceController
-        return true;
-    };
-
-    $scope.types = _.filter(types, function(currentType) {
-        var category;
-        if (type.indexOf('ANY_MAP') != -1) {
-            category = 'ANY_MAP';
-        } else if (type.indexOf('DNS') != -1) {
-            category = 'DNS';
-        } else if (type.indexOf('HTTP') != -1) {
-            category = 'HTTP';
-        } else if (type.indexOf('STEERING') != -1) {
-            category = 'STEERING';
-        }
-        return currentType.name.indexOf(category) != -1;
-    });
-
-    $scope.clientSteeringType = _.findWhere(types, {name: "CLIENT_STEERING"});
-    $scope.isClientSteering = function(ds) {
-        if (ds.typeId == $scope.clientSteeringType.id) {
-            return true;
-        } else {
-            ds.trResponseHeaders = "";
-            return false;
-        }
-    };
-
-    $scope.falseTrue = [
-        { value: true, label: 'true' },
-        { value: false, label: 'false' }
-    ];
-
-    $scope.activeInactive = [
-        { value: true, label: 'Active' },
-        { value: false, label: 'Not Active'}
-    ];
-
-    $scope.signingAlgos = [
-        { value: null, label: 'None' },
-        { value: 'url_sig', label: 'URL Signature Keys' },
-        { value: 'uri_signing', label: 'URI Signing Keys' }
-    ];
-
-    $scope.protocols = [
-        { value: 0, label: 'HTTP' },
-        { value: 1, label: 'HTTPS' },
-        { value: 2, label: 'HTTP AND HTTPS' },
-        { value: 3, label: 'HTTP TO HTTPS' }
-    ];
-
-    $scope.qStrings = [
-        { value: 0, label: 'Use query parameter strings in cache key and pass in upstream requests' },
-        { value: 1, label: 'Do not use query parameter strings in cache key, but do pass in upstream requests' },
-        { value: 2, label: 'Neither use query parameter strings in cache key, nor pass in upstream requests' }
-    ];
-
-    $scope.geoLimits = [
-        { value: 0, label: 'None' },
-        { value: 1, label: 'Coverage Zone File only' },
-        { value: 2, label: 'Coverage Zone File and Country Code(s)' }
-    ];
-
-    $scope.geoProviders = [
-        { value: 0, label: 'Maxmind' },
-        { value: 1, label: 'Neustar' }
-    ];
-
-    $scope.dscps = [
-        { value: 0, label: '0 - Best Effort' },
-        { value: 10, label: '10 - AF11' },
-        { value: 12, label: '12 - AF12' },
-        { value: 14, label: '14 - AF13' },
-        { value: 18, label: '18 - AF21' },
-        { value: 20, label: '20 - AF22' },
-        { value: 22, label: '22 - AF23' },
-        { value: 26, label: '26 - AF31' },
-        { value: 28, label: '28 - AF32' },
-        { value: 30, label: '30 - AF33' },
-        { value: 34, label: '34 - AF41' },
-        { value: 36, label: '36 - AF42' },
-        { value: 37, label: '37 - ' },
-        { value: 38, label: '38 - AF43' },
-        { value: 8, label: '8 - CS1' },
-        { value: 16, label: '16 - CS2' },
-        { value: 24, label: '24 - CS3' },
-        { value: 32, label: '32 - CS4' },
-        { value: 40, label: '40 - CS5' },
-        { value: 48, label: '48 - CS6' },
-        { value: 56, label: '56 - CS7' }
-    ];
-
-    $scope.deepCachingTypes = [
-        { value: 'NEVER', label: 'NEVER' },
-        { value: 'ALWAYS', label: 'ALWAYS' }
-    ];
-
-    $scope.dispersions = [
-        { value: 1, label: '1 - OFF' },
-        { value: 2, label: '2' },
-        { value: 3, label: '3' },
-        { value: 4, label: '4' },
-        { value: 5, label: '5' },
-        { value: 6, label: '6' },
-        { value: 7, label: '7' },
-        { value: 8, label: '8' },
-        { value: 9, label: '9' },
-        { value: 10, label: '10' }
-    ];
-
-    $scope.rrhs = [
-        { value: 0, label: "Don't cache Range Requests" },
-        { value: 1, label: "Use the background_fetch plugin" },
-        { value: 2, label: "Use the cache_range_requests plugin" },
-        { value: 3, label: "Use the slice plugin" }
-    ];
-
-    $scope.msoAlgos = [
-        { value: 0, label: "0 - Consistent Hash" },
-        { value: 1, label: "1 - Primary/Backup" },
-        { value: 2, label: "2 - Strict Round Robin" },
-        { value: 3, label: "3 - IP-based Round Robin" },
-        { value: 4, label: "4 - Latch on Failover" }
-    ];
-
-    $scope.clone = function(ds) {
-        locationUtils.navigateToPath('/delivery-services/' + ds.id + '/clone?dsType=' + ds.type);
-    };
-
-    $scope.changeSigningAlgorithm = function(signingAlgorithm) {
-        if (signingAlgorithm == null) {
-            deliveryService.signed = false;
-        } else {
-            deliveryService.signed = true;
-        }
-    };
-
-    $scope.encodeRegex = function(consistentHashRegex) {
-        if (consistentHashRegex != undefined) {
-            $scope.encodedRegex = encodeURIComponent(consistentHashRegex);
-        } else {
-            scope.encodedRegex = "";
-        }
-    };
-
-    $scope.addQueryParam = function() {
-        $scope.deliveryService.consistentHashQueryParams.push('');
-    };
-
-    $scope.removeQueryParam = function(index) {
-        if ($scope.deliveryService.consistentHashQueryParams.length > 1) {
-            $scope.deliveryService.consistentHashQueryParams.splice(index, 1);
-        } else {
-            // if only one query param is left, don't remove the item from the array. instead, just blank it out
-            // so the dynamic form widget will still be visible. empty strings get stripped out on save anyhow.
-            $scope.deliveryService.consistentHashQueryParams[index] = '';
-        }
-        $scope.deliveryServiceForm.$pristine = false; // this enables the 'update' button in the ds form
-    };
-
-    $scope.viewTargets = function() {
-        $location.path($location.path() + '/targets');
-    };
-
-    $scope.viewCapabilities = function() {
-        $location.path($location.path() + '/required-server-capabilities');
-    };
-
-    $scope.viewOrigins = function() {
-        $location.path($location.path() + '/origins');
-    };
-
-    $scope.viewServers = function() {
-        $location.path($location.path() + '/servers');
-    };
-
-    $scope.viewRegexes = function() {
-        $location.path($location.path() + '/regexes');
-    };
-
-    $scope.viewJobs = function() {
-        $location.path($location.path() + '/jobs');
-    };
-
-    $scope.manageSslKeys = function() {
-        $location.path($location.path() + '/ssl-keys');
-    };
-
-    $scope.manageUrlSigKeys = function() {
-        $location.path($location.path() + '/url-sig-keys');
-    };
-
-    $scope.manageUriSigningKeys = function() {
-        $location.path($location.path() + '/uri-signing-keys');
-    };
-
-    $scope.viewStaticDnsEntries = function() {
-        $location.path($location.path() + '/static-dns-entries');
-    };
-
-    $scope.viewCharts = function() {
-        $location.path($location.path() + '/charts');
-    };
-
-    $scope.navigateToPath = locationUtils.navigateToPath;
-
-    $scope.hasError = formUtils.hasError;
-
-    /**
-     * Checks if a TLS Version has a specific error.
-     *
-     * @param {number} index The index of the TLS Version to check into the
-     * form's Delivery Service's `tlsVersions` array.
-     * @param {string} property The name of the error to check.
-     * @returns {boolean} Whether or not the indicated TLS Version has the given
-     * error.
-     */
-    function tlsVersionHasPropertyError(index, property) {
-        if (!$scope.generalConfig) {
-            return false;
-        }
-        const propName = `tlsVersion${index+1}`;
-        if (!(propName in $scope.generalConfig)) {
-            return false;
-        }
-        return formUtils.hasPropertyError($scope.generalConfig[propName], property);
-    };
-    $scope.tlsVersionHasPropertyError = tlsVersionHasPropertyError;
-
-    /**
-     * Checks if a TLS Version has any error.
-     *
-     * @param {number} index The index of the TLS Version to check into the
-     * form's Delivery Service's `tlsVersions` array.
-     * @returns {boolean} Whether or not the indicated TLS Version has an error.
-     */
-     function tlsVersionHasError(index) {
-        if (!$scope.generalConfig) {
-            return false;
-        }
-        const propName = `tlsVersion${index+1}`;
-        if (!(propName in $scope.generalConfig)) {
-            return false;
-        }
-        return formUtils.hasError($scope.generalConfig[propName]);
-    };
-    $scope.tlsVersionHasError = tlsVersionHasError;
-
-    $scope.hasPropertyError = formUtils.hasPropertyError;
-
-    $scope.rangeRequestSelected = function() {
-        if ($scope.deliveryService.rangeRequestHandling != 3) {
-            $scope.deliveryService.rangeSliceBlockSize = null;
-        }
-    };
-
-    var init = function () {
-        getCDNs();
-        getProfiles();
-        getTenants();
-        getServiceCategories();
-        getSteeringTargets();
-        if (!deliveryService.consistentHashQueryParams || deliveryService.consistentHashQueryParams.length < 1) {
-            // add an empty one so the dynamic form widget is visible. empty strings get stripped out on save anyhow.
-            $scope.deliveryService.consistentHashQueryParams = [ '' ];
-        }
-        if (deliveryService.lastUpdated) {
-            deliveryService.lastUpdated = new Date(deliveryService.lastUpdated.replace("+00", "Z"));
-        }
-    };
-    init();
+	const knownVersions = new Set(["1.0", "1.1", "1.2", "1.3"]);
+	$scope.tlsVersionUnknown = v => v && !knownVersions.has(v);
+
+	const insecureVersions = new Set(["1.0", "1.1"]);
+	$scope.tlsVersionInsecure = v => v && insecureVersions.has(v);
+
+	/**
+	 * This toggles whether TLS versions are restricted for the Delivery
+	 * Service.
+	 *
+	 * It uses cachedTLSVersions to cache TLS version restrictions, so that the
+	 * DS is always ready to submit without manipulation, but the UI "remembers"
+	 * the TLS versions that existed on toggling restrictions off.
+	 *
+	 * This is called when the checkbox's 'change' event fires - that event is
+	 * not handled here.
+	 */
+	function toggleTLSRestrict() {
+		if ($scope.restrictTLS) {
+			if (cachedTLSVersions instanceof Array && cachedTLSVersions.length > 0) {
+				deliveryService.tlsVersions = cachedTLSVersions;
+			} else {
+				deliveryService.tlsVersions = [""];
+			}
+			cachedTLSVersions = null;
+			return;
+		}
+		if (deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0) {
+			cachedTLSVersions = deliveryService.tlsVersions;
+		} else {
+			cachedTLSVersions = null;
+		}
+
+		deliveryService.tlsVersions =  null;
+	}
+	$scope.toggleTLSRestrict = toggleTLSRestrict;
+
+	$scope.removeTLSVersion = function(index) {
+		deliveryService.tlsVersions.splice(index, 1);
+	};
+
+	$scope.addTLSVersion = function(index) {
+		deliveryService.tlsVersions.splice(index+1, 0, "");
+	};
+
+	/**
+	 * This function is called on 'change' events for any and all TLS Version
+	 * inputs, and sets validity states of duplicates.
+	 *
+	 * This can't use a normal validator because it depends on a value checking
+	 * against a list containing itself. AngularJS sets values that fail
+	 * validation to `undefined`, so if there's a set of TLS versions
+	 * `["1.3", "1.3"]`, then the validator will set one of them to `undefined`.
+	 * Now the set is `["1.3", undefined]`, so there are no more duplicates, so
+	 * the set is marked as valid.
+	 */
+	function validateTLS() {
+		if (!$scope.generalConfig || !($scope.deliveryService.tlsVersions instanceof Array)) {
+			return;
+		}
+
+		const verMap = new Map();
+		for (let i = 0; i < $scope.deliveryService.tlsVersions.length; ++i) {
+			const propName = `tlsVersion${i+1}`;
+			if (propName in $scope.generalConfig) {
+				$scope.generalConfig[propName].$setValidity("duplicates", true);
+			}
+
+			const ver = $scope.deliveryService.tlsVersions[i];
+			if (ver === undefined) {
+				continue;
+			}
+			const current = verMap.get(ver);
+			if (current) {
+				current.count++;
+				current.indices.push(i);
+			} else {
+				verMap.set(ver, {
+					count: 1,
+					indices: [i]
+				});
+			}
+		}
+
+		for (const index of Array.from(verMap).filter(v=>v[1].count>1).flatMap(v=>v[1].indices)) {
+			const propName = `tlsVersion${index+1}`;
+			if (propName in $scope.generalConfig) {
+				$scope.generalConfig[propName].$setValidity("duplicates", false);
+			}
+		}
+	}
+	$scope.validateTLS = validateTLS;
+
+	async function getSteeringTargets() {
+		if(type.indexOf("HTTP") > -1)  {
+			const configs = await deliveryServiceService.getSteering();
+			const dsTargets = deliveryServiceUtils.getSteeringTargetsForDS([deliveryService.xmlId], configs);
+			$scope.steeringTargetsFor = Array.from(dsTargets[deliveryService.xmlId]);
+		}
+	}
+
+	var getCDNs = function() {
+		cdnService.getCDNs()
+			.then(function(result) {
+				$scope.cdns = result;
+			});
+	};
+
+	var getProfiles = function() {
+		profileService.getProfiles({ orderby: 'name' })
+			.then(function(result) {
+				$scope.profiles = _.filter(result, function(profile) {
+					return profile.type == 'DS_PROFILE';
+				});
+			});
+	};
+
+	var getTenants = function() {
+		tenantService.getTenant(userModel.user.tenantId)
+			.then(function(tenant) {
+				tenantService.getTenants()
+					.then(function(tenants) {
+						$scope.tenants = tenantUtils.hierarchySort(tenantUtils.groupTenantsByParent(tenants), tenant.parentId, []);
+						tenantUtils.addLevels($scope.tenants);
+					});
+			});
+	};
+
+	var getServiceCategories = function() {
+		serviceCategoryService.getServiceCategories({dsId: deliveryService.id })
+			.then(function(result) {
+				$scope.serviceCategories = result;
+			});
+	};
+
+	$scope.deliveryService = deliveryService;
+
+	$scope.showGeneralConfig = true;
+
+	$scope.showCacheConfig = true;
+
+	$scope.showRoutingConfig = true;
+
+	$scope.dsCurrent = dsCurrent; // this ds is used primarily for showing the diff between a ds request and the current DS
+
+	$scope.origin = origin[0];
+
+	$scope.topologies = topologies;
+
+	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
+
+	$scope.openCharts = deliveryServiceUtils.openCharts;
+
+	$scope.dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
+
+	$scope.edgeFQDNs = function(ds) {
+		return ds.exampleURLs.join('<br/>');
+	};
+
+	$scope.DRAFT = 0;
+	$scope.SUBMITTED = 1;
+	$scope.REJECTED = 2;
+	$scope.PENDING = 3;
+	$scope.COMPLETE = 4;
+
+	$scope.saveable = function() {
+		// this may be overriden in a child class. i.e. FormEditDeliveryServiceController
+		return true;
+	};
+
+	$scope.deletable = function() {
+		// this may be overriden in a child class. i.e. FormEditDeliveryServiceController
+		return true;
+	};
+
+	$scope.types = _.filter(types, function(currentType) {
+		var category;
+		if (type.indexOf('ANY_MAP') != -1) {
+			category = 'ANY_MAP';
+		} else if (type.indexOf('DNS') != -1) {
+			category = 'DNS';
+		} else if (type.indexOf('HTTP') != -1) {
+			category = 'HTTP';
+		} else if (type.indexOf('STEERING') != -1) {
+			category = 'STEERING';
+		}
+		return currentType.name.indexOf(category) != -1;
+	});
+
+	$scope.clientSteeringType = _.findWhere(types, {name: "CLIENT_STEERING"});
+	$scope.isClientSteering = function(ds) {
+		if (ds.typeId == $scope.clientSteeringType.id) {
+			return true;
+		} else {
+			ds.trResponseHeaders = "";
+			return false;
+		}
+	};
+
+	$scope.falseTrue = [
+		{ value: true, label: 'true' },
+		{ value: false, label: 'false' }
+	];
+
+	$scope.activeInactive = [
+		{ value: true, label: 'Active' },
+		{ value: false, label: 'Not Active'}
+	];
+
+	$scope.signingAlgos = [
+		{ value: null, label: 'None' },
+		{ value: 'url_sig', label: 'URL Signature Keys' },
+		{ value: 'uri_signing', label: 'URI Signing Keys' }
+	];
+
+	$scope.protocols = [
+		{ value: 0, label: 'HTTP' },
+		{ value: 1, label: 'HTTPS' },
+		{ value: 2, label: 'HTTP AND HTTPS' },
+		{ value: 3, label: 'HTTP TO HTTPS' }
+	];
+
+	$scope.qStrings = [
+		{ value: 0, label: 'Use query parameter strings in cache key and pass in upstream requests' },
+		{ value: 1, label: 'Do not use query parameter strings in cache key, but do pass in upstream requests' },
+		{ value: 2, label: 'Neither use query parameter strings in cache key, nor pass in upstream requests' }
+	];
+
+	$scope.geoLimits = [
+		{ value: 0, label: 'None' },
+		{ value: 1, label: 'Coverage Zone File only' },
+		{ value: 2, label: 'Coverage Zone File and Country Code(s)' }
+	];
+
+	$scope.geoProviders = [
+		{ value: 0, label: 'Maxmind' },
+		{ value: 1, label: 'Neustar' }
+	];
+
+	$scope.dscps = [
+		{ value: 0, label: '0 - Best Effort' },
+		{ value: 10, label: '10 - AF11' },
+		{ value: 12, label: '12 - AF12' },
+		{ value: 14, label: '14 - AF13' },
+		{ value: 18, label: '18 - AF21' },
+		{ value: 20, label: '20 - AF22' },
+		{ value: 22, label: '22 - AF23' },
+		{ value: 26, label: '26 - AF31' },
+		{ value: 28, label: '28 - AF32' },
+		{ value: 30, label: '30 - AF33' },
+		{ value: 34, label: '34 - AF41' },
+		{ value: 36, label: '36 - AF42' },
+		{ value: 37, label: '37 - ' },
+		{ value: 38, label: '38 - AF43' },
+		{ value: 8, label: '8 - CS1' },
+		{ value: 16, label: '16 - CS2' },
+		{ value: 24, label: '24 - CS3' },
+		{ value: 32, label: '32 - CS4' },
+		{ value: 40, label: '40 - CS5' },
+		{ value: 48, label: '48 - CS6' },
+		{ value: 56, label: '56 - CS7' }
+	];
+
+	$scope.deepCachingTypes = [
+		{ value: 'NEVER', label: 'NEVER' },
+		{ value: 'ALWAYS', label: 'ALWAYS' }
+	];
+
+	$scope.dispersions = [
+		{ value: 1, label: '1 - OFF' },
+		{ value: 2, label: '2' },
+		{ value: 3, label: '3' },
+		{ value: 4, label: '4' },
+		{ value: 5, label: '5' },
+		{ value: 6, label: '6' },
+		{ value: 7, label: '7' },
+		{ value: 8, label: '8' },
+		{ value: 9, label: '9' },
+		{ value: 10, label: '10' }
+	];
+
+	$scope.rrhs = [
+		{ value: 0, label: "Don't cache Range Requests" },
+		{ value: 1, label: "Use the background_fetch plugin" },
+		{ value: 2, label: "Use the cache_range_requests plugin" },
+		{ value: 3, label: "Use the slice plugin" }
+	];
+
+	$scope.msoAlgos = [
+		{ value: 0, label: "0 - Consistent Hash" },
+		{ value: 1, label: "1 - Primary/Backup" },
+		{ value: 2, label: "2 - Strict Round Robin" },
+		{ value: 3, label: "3 - IP-based Round Robin" },
+		{ value: 4, label: "4 - Latch on Failover" }
+	];
+
+	$scope.clone = function(ds) {
+		locationUtils.navigateToPath('/delivery-services/' + ds.id + '/clone?dsType=' + ds.type);
+	};
+
+	$scope.changeSigningAlgorithm = function(signingAlgorithm) {
+		if (signingAlgorithm == null) {
+			deliveryService.signed = false;
+		} else {
+			deliveryService.signed = true;
+		}
+	};
+
+	$scope.encodeRegex = function(consistentHashRegex) {
+		if (consistentHashRegex != undefined) {
+			$scope.encodedRegex = encodeURIComponent(consistentHashRegex);
+		} else {
+			scope.encodedRegex = "";
+		}
+	};
+
+	$scope.addQueryParam = function() {
+		$scope.deliveryService.consistentHashQueryParams.push('');
+	};
+
+	$scope.removeQueryParam = function(index) {
+		if ($scope.deliveryService.consistentHashQueryParams.length > 1) {
+			$scope.deliveryService.consistentHashQueryParams.splice(index, 1);
+		} else {
+			// if only one query param is left, don't remove the item from the array. instead, just blank it out
+			// so the dynamic form widget will still be visible. empty strings get stripped out on save anyhow.
+			$scope.deliveryService.consistentHashQueryParams[index] = '';
+		}
+		$scope.deliveryServiceForm.$pristine = false; // this enables the 'update' button in the ds form
+	};
+
+	$scope.viewTargets = function() {
+		$location.path($location.path() + '/targets');
+	};
+
+	$scope.viewCapabilities = function() {
+		$location.path($location.path() + '/required-server-capabilities');
+	};
+
+	$scope.viewOrigins = function() {
+		$location.path($location.path() + '/origins');
+	};
+
+	$scope.viewServers = function() {
+		$location.path($location.path() + '/servers');
+	};
+
+	$scope.viewRegexes = function() {
+		$location.path($location.path() + '/regexes');
+	};
+
+	$scope.viewJobs = function() {
+		$location.path($location.path() + '/jobs');
+	};
+
+	$scope.manageSslKeys = function() {
+		$location.path($location.path() + '/ssl-keys');
+	};
+
+	$scope.manageUrlSigKeys = function() {
+		$location.path($location.path() + '/url-sig-keys');
+	};
+
+	$scope.manageUriSigningKeys = function() {
+		$location.path($location.path() + '/uri-signing-keys');
+	};
+
+	$scope.viewStaticDnsEntries = function() {
+		$location.path($location.path() + '/static-dns-entries');
+	};
+
+	$scope.viewCharts = function() {
+		$location.path($location.path() + '/charts');
+	};
+
+	$scope.navigateToPath = locationUtils.navigateToPath;
+
+	$scope.hasError = formUtils.hasError;
+
+	/**
+	 * Checks if a TLS Version has a specific error.
+	 *
+	 * @param {number} index The index of the TLS Version to check into the
+	 * form's Delivery Service's `tlsVersions` array.
+	 * @param {string} property The name of the error to check.
+	 * @returns {boolean} Whether or not the indicated TLS Version has the given
+	 * error.
+	 */
+	function tlsVersionHasPropertyError(index, property) {
+		if (!$scope.generalConfig) {
+			return false;
+		}
+		const propName = `tlsVersion${index+1}`;
+		if (!(propName in $scope.generalConfig)) {
+			return false;
+		}
+		return formUtils.hasPropertyError($scope.generalConfig[propName], property);
+	};
+	$scope.tlsVersionHasPropertyError = tlsVersionHasPropertyError;
+
+	/**
+	 * Checks if a TLS Version has any error.
+	 *
+	 * @param {number} index The index of the TLS Version to check into the
+	 * form's Delivery Service's `tlsVersions` array.
+	 * @returns {boolean} Whether or not the indicated TLS Version has an error.
+	 */
+	 function tlsVersionHasError(index) {
+		if (!$scope.generalConfig) {
+			return false;
+		}
+		const propName = `tlsVersion${index+1}`;
+		if (!(propName in $scope.generalConfig)) {
+			return false;
+		}
+		return formUtils.hasError($scope.generalConfig[propName]);
+	};
+	$scope.tlsVersionHasError = tlsVersionHasError;
+
+	$scope.hasPropertyError = formUtils.hasPropertyError;
+
+	$scope.rangeRequestSelected = function() {
+		if ($scope.deliveryService.rangeRequestHandling != 3) {
+			$scope.deliveryService.rangeSliceBlockSize = null;
+		}
+	};
+
+	var init = function () {
+		getCDNs();
+		getProfiles();
+		getTenants();
+		getServiceCategories();
+		getSteeringTargets();
+		if (!deliveryService.consistentHashQueryParams || deliveryService.consistentHashQueryParams.length < 1) {
+			// add an empty one so the dynamic form widget is visible. empty strings get stripped out on save anyhow.
+			$scope.deliveryService.consistentHashQueryParams = [ '' ];
+		}
+		if (deliveryService.lastUpdated) {
+			deliveryService.lastUpdated = new Date(deliveryService.lastUpdated.replace("+00", "Z"));
+		}
+	};
+	init();
 
 };
 

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -228,10 +228,10 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 	 * Gods have mercy.
 	 *
 	 * @param {import("../../../api/DeliveryServiceService").DeliveryService} ds
-	 * @returns {string} An absolutely unsafe direct HTML segment.
+	 * @returns {string | undefined} An absolutely unsafe direct HTML segment.
 	 */
 	$scope.edgeFQDNs = function(ds) {
-		return ds.exampleURLs.join("<br/>");
+		return ds.exampleURLs?.join("<br/>");
 	};
 
 	$scope.DRAFT = 0;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -172,7 +172,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 	 */
 	async function getCDNs() {
 		$scope.cdns = await cdnService.getCDNs();
-	};
+	}
 
 	/**
 	 * Updates the Profiles on the $scope.
@@ -182,7 +182,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		/** @type {{type: string}[]} */
 		const result = await profileService.getProfiles({ orderby: "name" });
 		$scope.profiles = result.filter(p => p.type === "DS_PROFILE");
-	};
+	}
 
 	/**
 	 * Updates the Tenants on the $scope.
@@ -194,7 +194,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		const tenant = tenants.find(t => t.id === userModel.user.tenantId);
 		$scope.tenants = tenantUtils.hierarchySort(tenantUtils.groupTenantsByParent(tenants), tenant?.parentId, []);
 		tenantUtils.addLevels($scope.tenants);
-	};
+	}
 
 	/**
 	 * Updates the Service Categories on the $scope.
@@ -202,7 +202,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 	 */
 	async function getServiceCategories() {
 		$scope.serviceCategories = await serviceCategoryService.getServiceCategories({dsId: deliveryService.id })
-	};
+	}
 
 	$scope.deliveryService = deliveryService;
 
@@ -416,7 +416,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 			return false;
 		}
 		return formUtils.hasPropertyError($scope.generalConfig[propName], property);
-	};
+	}
 	$scope.tlsVersionHasPropertyError = tlsVersionHasPropertyError;
 
 	/**
@@ -435,7 +435,7 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 			return false;
 		}
 		return formUtils.hasError($scope.generalConfig[propName]);
-	};
+	}
 	$scope.tlsVersionHasError = tlsVersionHasError;
 
 	$scope.hasPropertyError = formUtils.hasPropertyError;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -17,7 +17,29 @@
  * under the License.
  */
 
-var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin, topologies, type, types, $scope, $location, $uibModal, $window, formUtils, locationUtils, tenantUtils, deliveryServiceUtils, deliveryServiceService, cdnService, profileService, tenantService, propertiesModel, userModel, serviceCategoryService) {
+/**
+ * This is the parent controller for all kinds of Delivery Service forms - edit,
+ * creation, request, etc.
+ *
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService | undefined} dsCurrent
+ * @param {unknown} origin
+ * @param {unknown[]} topologies
+ * @param {string} type
+ * @param {{name: string}[]} types
+ * @param {import("angular").IScope & Record<PropertyKey, any>} $scope
+ * @param {import("../../../service/utils/FormUtils")} formUtils
+ * @param {import("../../../service/utils/TenantUtils")} tenantUtils
+ * @param {import("../../../service/utils/DeliveryServiceUtils")} deliveryServiceUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/CDNService")} cdnService
+ * @param {import("../../../api/ProfileService")} profileService
+ * @param {import("../../../api/TenantService")} tenantService
+ * @param {import("../../../models/PropertiesModel")} propertiesModel
+ * @param {import("../../../models/UserModel")} userModel
+ * @param {import("../../../api/ServiceCategoryService")} serviceCategoryService
+ */
+var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin, topologies, type, types, $scope, formUtils, tenantUtils, deliveryServiceUtils, deliveryServiceService, cdnService, profileService, tenantService, propertiesModel, userModel, serviceCategoryService) {
 
 	/**
 	 * This is used to cache TLS version settings when the checkbox is toggled.
@@ -394,5 +416,5 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 	}
 };
 
-FormDeliveryServiceController.$inject = ['deliveryService', 'dsCurrent', 'origin', 'topologies', 'type', 'types', '$scope', '$location', '$uibModal', '$window', 'formUtils', 'locationUtils', 'tenantUtils', 'deliveryServiceUtils', 'deliveryServiceService', 'cdnService', 'profileService', 'tenantService', 'propertiesModel', 'userModel', 'serviceCategoryService'];
+FormDeliveryServiceController.$inject = ["deliveryService", "dsCurrent", "origin", "topologies", "type", "types", "$scope", "formUtils", "tenantUtils", "deliveryServiceUtils", "deliveryServiceService", "cdnService", "profileService", "tenantService", "propertiesModel", "userModel", "serviceCategoryService"];
 module.exports = FormDeliveryServiceController;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -52,7 +52,7 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 	 * Creates a deletion DSR and the immediately fulfills it.
 	 *
 	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
-	 * @param {{}} dsRequest
+	 * @param {import("../../../../api/DeliveryServiceRequestService").DeliveryServiceRequest} dsRequest
 	 * @param {string} commentValue
 	 * @returns {Promise<void>}
 	 */

--- a/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/edit/FormEditDeliveryServiceController.js
@@ -17,145 +17,164 @@
  * under the License.
  */
 
+/**
+ * This is an extension of the general DS form that is meant to handle editing
+ * an existing DS - as apposed to creating a new one.
+ *
+ * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {unknown} origin
+ * @param {unknown[]} topologies
+ * @param {string} type
+ * @param {unknown[]} types
+ * @param {import("angular").IScope & Record<PropertyKey, any>} $scope
+ * @param {{reload: ()=>void}} $state
+ * @param {import("angular").IControllerService} $controller
+ * @param {{open: ({})=>{result: Promise<*>}}} $uibModal
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {import("../../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../../api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../../models/MessageModel")} messageModel
+ * @param {import("../../../../models/PropertiesModel")} propertiesModel
+ * @param {import("../../../../models/UserModel")} userModel
+ */
 var FormEditDeliveryServiceController = function(deliveryService, origin, topologies, type, types, $scope, $state, $controller, $uibModal, $anchorScroll, locationUtils, deliveryServiceService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
 
 	// extends the FormDeliveryServiceController to inherit common methods
-	angular.extend(this, $controller('FormDeliveryServiceController', { deliveryService: deliveryService, dsCurrent: deliveryService, origin: origin, topologies: topologies, type: type, types: types, $scope: $scope }));
+	angular.extend(this, $controller("FormDeliveryServiceController", { deliveryService: deliveryService, dsCurrent: deliveryService, origin: origin, topologies: topologies, type: type, types: types, $scope: $scope }));
 
 	this.$onInit = function() {
 		$scope.originalRoutingName = deliveryService.routingName;
 		$scope.originalCDN = deliveryService.cdnId;
 	};
 
-	var createDeliveryServiceDeleteRequest = function(deliveryService) {
-		var params = {
+	/**
+	 * Creates a deletion DSR and the immediately fulfills it.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+	 * @param {{}} dsRequest
+	 * @param {string} commentValue
+	 * @returns {Promise<void>}
+	 */
+	async function createAndCompleteDeletionRequest(deliveryService, dsRequest, commentValue) {
+		// first create the ds request
+		try {
+			const response = await deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest);
+
+			const comment = {
+				deliveryServiceRequestId: response.id,
+				value: commentValue
+			};
+
+			// then create the ds request comment
+			await deliveryServiceRequestService.createDeliveryServiceRequestComment(comment);
+
+			await Promise.all([
+				// assign the ds request
+				deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username),
+				// set the status to 'complete'
+				deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, "complete")
+			]);
+			// then, if all that works, delete the ds and navigate to the /delivery-services page
+			await deliveryServiceService.deleteDeliveryService(deliveryService);
+			messageModel.setMessages([ { level: "success", text: `Delivery service [ ${deliveryService.xmlId} ] deleted` } ], true);
+			locationUtils.navigateToPath("/delivery-services");
+		} catch (fault) {
+			$anchorScroll(); // scrolls window to top
+			messageModel.setMessages(fault.data.alerts, false);
+		}
+	}
+
+	/**
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+	 */
+	async function createDeliveryServiceDeleteRequest(deliveryService) {
+		const params = {
 			title: "Delivery Service Delete Request",
-			message: 'All delivery service deletions must be reviewed.'
+			message: "All delivery service deletions must be reviewed."
 		};
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html',
-			controller: 'DialogDeliveryServiceRequestController',
-			size: 'md',
+		const modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html",
+			controller: "DialogDeliveryServiceRequestController",
+			size: "md",
 			resolve: {
-				params: function () {
-					return params;
-				},
-				statuses: function() {
-					var statuses = [
-						{ id: $scope.DRAFT, name: 'Save Request as Draft' },
-						{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
+				params,
+				statuses: () => {
+					const statuses = [
+						{ id: $scope.DRAFT, name: "Save Request as Draft" },
+						{ id: $scope.SUBMITTED, name: "Submit Request for Review and Deployment" }
 					];
 					if (userModel.user.role == propertiesModel.properties.dsRequests.overrideRole) {
-						statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
+						statuses.push({ id: $scope.COMPLETE, name: "Fulfill Request Immediately" });
 					}
 					return statuses;
 				}
 			}
 		});
-		modalInstance.result.then(function(options) {
-			var status = 'draft';
-			if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
-				status = 'submitted';
-			};
+		/** @type {{comment: string; status: {id: number}}} */
+		let options;
+		try {
+			options = await modalInstance.result;
+		} catch {
+			// This means the user cancelled.
+			return;
+		}
+		let status = "draft";
+		if (options.status.id === $scope.SUBMITTED || options.status.id === $scope.COMPLETE) {
+			status = "submitted";
+		};
 
-			var dsRequest = {
-				changeType: 'delete',
-				status: status,
-				original: deliveryService
-			};
+		const dsRequest = {
+			changeType: "delete",
+			status: status,
+			original: deliveryService
+		};
 
-			// if the user chooses to complete/fulfill the delete request immediately, a delivery service request will be made and marked as complete,
-			// then if that is successful, the DS will be deleted
-			if (options.status.id === $scope.COMPLETE) {
-				// first create the ds request
-				deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest)
-					.then(function(response) {
-						var comment = {
-							deliveryServiceRequestId: response.id,
-							value: options.comment
-						};
-						// then create the ds request comment
-						deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
-							then(
-								function() {
-									var promises = [];
-									// assign the ds request
-									promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username));
-									// set the status to 'complete'
-									promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete'));
-								}
-							// then, if all that works, delete the ds and navigate to the /delivery-services page
-							).then(
-								function() {
-									deliveryServiceService.deleteDeliveryService(deliveryService).
-										then(
-											function() {
-												messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + deliveryService.xmlId + ' ] deleted' } ], true);
-												locationUtils.navigateToPath('/delivery-services');
-											}
-										);
-								}
-							);
-					}
-					// handle any failures just once
-					).catch(function(fault) {
-						$anchorScroll(); // scrolls window to top
-						messageModel.setMessages(fault.data.alerts, false);
-					}
-				);
-			} else {
-				deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
-					then(
-						function(response) {
-							var comment = {
-								deliveryServiceRequestId: response.id,
-								value: options.comment
-							};
-							deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
-								then(
-									function() {
-										const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original.xmlId;
-										messageModel.setMessages([ { level: 'success', text: 'Created request to ' + dsRequest.changeType + ' the ' + xmlId + ' delivery service' } ], true);
-										locationUtils.navigateToPath('/delivery-service-requests');
-									}
-								);
-						}
-					);
-			}
-		}, function () {
-			// do nothing
-		});
-	};
+		// if the user chooses to complete/fulfill the delete request immediately, a delivery service request will be made and marked as complete,
+		// then if that is successful, the DS will be deleted
+		if (options.status.id === $scope.COMPLETE) {
+			await createAndCompleteDeletionRequest(deliveryService, dsRequest, options.comment);
+			return
+		}
+		const response = await deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest);
+		const comment = {
+			deliveryServiceRequestId: response.id,
+			value: options.comment
+		};
+		await deliveryServiceRequestService.createDeliveryServiceRequestComment(comment);
+		const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original.xmlId;
+		messageModel.setMessages([ { level: "success", text: `Created request to ${dsRequest.changeType} the ${xmlId} delivery service` } ], true);
+		locationUtils.navigateToPath("/delivery-service-requests");
+	}
 
-	var createDeliveryServiceUpdateRequest = function(dsRequest, dsRequestComment, autoFulfilled) {
-		return deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
-			then(
-				function(response) {
-					var comment = {
-						deliveryServiceRequestId: response.id,
-						value: dsRequestComment
-					};
-					var promises = [];
-
-					deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
-						then(
-							function() {
-								if (!autoFulfilled) {
-									const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original.xmlId;
-									messageModel.setMessages([ { level: 'success', text: 'Created request to ' + dsRequest.changeType + ' the ' + xmlId + ' delivery service' } ], true);
-									locationUtils.navigateToPath('/delivery-service-requests');
-								}
-							}
-						);
-
-					if (autoFulfilled) {
-						// assign the ds request
-						promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username));
-						// set the status to 'complete'
-						promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete'));
-					}
-				}
-			);
+	/**
+	 * Creates a new DSR for updating a Delivery Service.
+	 *
+	 * @param {*} dsRequest
+	 * @param {string} dsRequestComment
+	 * @param {boolean} autoFulfilled
+	 * @returns {Promise<void>}
+	 */
+	async function createDeliveryServiceUpdateRequest(dsRequest, dsRequestComment, autoFulfilled) {
+		const response = await deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest);
+		const comment = {
+			deliveryServiceRequestId: response.id,
+			value: dsRequestComment
+		};
+		await deliveryServiceRequestService.createDeliveryServiceRequestComment(comment);
+		if (!autoFulfilled) {
+			const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original.xmlId;
+			messageModel.setMessages([ { level: "success", text: `Created request to ${dsRequest.changeType} the ${xmlId} delivery service` } ], true);
+			locationUtils.navigateToPath("/delivery-service-requests");
+			return;
+		}
+		await Promise.all([
+			// assign the ds request
+			deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username),
+			// set the status to 'complete'
+			deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete')
+		]);
 	};
 
 	$scope.deliveryServiceName = angular.copy(deliveryService.xmlId);
@@ -163,18 +182,100 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 	$scope.settings = {
 		isNew: false,
 		isRequest: false,
-		saveLabel: 'Update',
-		deleteLabel: 'Delete'
+		saveLabel: "Update",
+		deleteLabel: "Delete"
 	};
 
-	$scope.restrictTLS = deliveryService.tlsVersions instanceof Array && deliveryService.tlsVersions.length > 0;
+	$scope.restrictTLS = Array.isArray(deliveryService.tlsVersions) && deliveryService.tlsVersions.length > 0;
 
-	$scope.save = function(deliveryService) {
-		if (deliveryService.sslKeyVersion !== null && deliveryService.sslKeyVersion !== 0 &&
-			($scope.originalRoutingName !== deliveryService.routingName || $scope.originalCDN !== deliveryService.cdnId) &&
-			type.indexOf("HTTP") !== -1) {
+	/**
+	 * Saves the edit changes to the Delivery Service by creating a DSR to
+	 * effect the change.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService & {id: number}} deliveryService
+	 * @returns
+	 */
+	async function saveWithRequest(deliveryService) {
+		const params = {
+			title: "Delivery Service Update Request",
+			message: "All delivery service updates must be reviewed for completeness and accuracy before deployment."
+		};
+		const modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html",
+			controller: "DialogDeliveryServiceRequestController",
+			size: "md",
+			resolve: {
+				params,
+				statuses: () => {
+					const statuses = [
+						{ id: $scope.DRAFT, name: "Save Request as Draft" },
+						{ id: $scope.SUBMITTED, name: "Submit Request for Review and Deployment" }
+					];
+					if (userModel.user.role == propertiesModel.properties.dsRequests.overrideRole) {
+						statuses.push({ id: $scope.COMPLETE, name: "Fulfill Request Immediately" });
+					}
+					return statuses;
+				}
+			}
+		});
+		let options;
+		try {
+			options = await modalInstance.result;
+		} catch {
+			// this means they cancelled
+			return;
+		}
+		let status = "draft";
+		if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
+			status = "submitted";
+		};
+		const dsRequest = {
+			changeType: "update",
+			status: status,
+			requested: deliveryService
+		};
+		// if the user chooses to complete/fulfill the update request immediately, a delivery service request will be made and marked as complete,
+		// then if that is successful, the DS will be updated
+		if (options.status.id == $scope.COMPLETE) {
+			try {
+				await createDeliveryServiceUpdateRequest(dsRequest, options.comment, true);
+			} catch(fault) {
+				$anchorScroll(); // scrolls window to top
+				messageModel.setMessages(fault.data.alerts, false);
+				return;
+			}
+			try {
+				const response = await deliveryServiceService.updateDeliveryService(deliveryService);
+				$state.reload(); // reloads all the resolves for the view
+				messageModel.setMessages(response.alerts, false);
+			} catch(fault) {
+				// if the ds update fails, send to dsr view w/ error message
+				locationUtils.navigateToPath('/delivery-service-requests');
+				messageModel.setMessages(fault.data.alerts, true);
+			}
+		} else {
+			createDeliveryServiceUpdateRequest(dsRequest, options.comment, false);
+		}
+	}
 
-			let params = {
+	/**
+	 * Saves the edit changes to the Delivery Service.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService & {id: number}} deliveryService
+	 * @returns
+	 */
+	$scope.save = async function(deliveryService) {
+		if (
+			deliveryService.sslKeyVersion !== null &&
+			deliveryService.sslKeyVersion !== 0 &&
+			(
+				$scope.originalRoutingName !== deliveryService.routingName ||
+				$scope.originalCDN !== deliveryService.cdnId
+			) &&
+			type.includes("HTTP")
+		) {
+
+			const params = {
 				title: "Cannot update Delivery Service",
 				message: "Delivery Service has SSL Keys that cannot be updated"
 			};
@@ -184,12 +285,8 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 				controller: "DialogTextController",
 				size: "md",
 				resolve: {
-					params: function() {
-						return params;
-					},
-					text: function() {
-						return null;
-					}
+					params,
+					text: () => null
 				}
 			});
 			return;
@@ -201,119 +298,56 @@ var FormEditDeliveryServiceController = function(deliveryService, origin, topolo
 
 		// if ds requests are enabled in traffic_portal_properties.json, we'll create a ds request, else just update the ds
 		if ($scope.dsRequestsEnabled) {
-			var params = {
-				title: "Delivery Service Update Request",
-				message: 'All delivery service updates must be reviewed for completeness and accuracy before deployment.'
-			};
-			var modalInstance = $uibModal.open({
-				templateUrl: 'common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html',
-				controller: 'DialogDeliveryServiceRequestController',
-				size: 'md',
-				resolve: {
-					params: function () {
-						return params;
-					},
-					statuses: function() {
-						var statuses = [
-							{ id: $scope.DRAFT, name: 'Save Request as Draft' },
-							{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
-						];
-						if (userModel.user.role == propertiesModel.properties.dsRequests.overrideRole) {
-							statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
-						}
-						return statuses;
-					}
-				}
-			});
-			modalInstance.result.then(function(options) {
-				var status = 'draft';
-				if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
-					status = 'submitted';
-				};
-				var dsRequest = {
-					changeType: 'update',
-					status: status,
-					requested: deliveryService
-				};
-				// if the user chooses to complete/fulfill the update request immediately, a delivery service request will be made and marked as complete,
-				// then if that is successful, the DS will be updated
-				if (options.status.id == $scope.COMPLETE) {
-					createDeliveryServiceUpdateRequest(dsRequest, options.comment, true).then(
-						function() {
-							deliveryServiceService.updateDeliveryService(deliveryService).
-								then(
-									function(response) {
-										$state.reload(); // reloads all the resolves for the view
-										messageModel.setMessages(response.data.alerts, false);
-									}
-								).catch(function(fault) {
-									// if the ds update fails, send to dsr view w/ error message
-									locationUtils.navigateToPath('/delivery-service-requests');
-									messageModel.setMessages(fault.data.alerts, true);
-							});
-						}).catch(function(fault) {
-							$anchorScroll(); // scrolls window to top
-							messageModel.setMessages(fault.data.alerts, false);
-					});
-				} else {
-					createDeliveryServiceUpdateRequest(dsRequest, options.comment, false);
-				}
-
-			}, function () {
-				// do nothing
-			});
+			saveWithRequest(deliveryService);
 		} else {
-			deliveryServiceService.updateDeliveryService(deliveryService).
-				then(
-					function(response) {
-						$state.reload(); // reloads all the resolves for the view
-						messageModel.setMessages(response.data.alerts, false);
-					},
-					function(fault) {
-						$anchorScroll(); // scrolls window to top
-						messageModel.setMessages(fault.data.alerts, false);
-					}
-				);
+			try {
+				const response = await deliveryServiceService.updateDeliveryService(deliveryService);
+				$state.reload(); // reloads all the resolves for the view
+				messageModel.setMessages(response.alerts, false);
+			} catch(fault) {
+				$anchorScroll(); // scrolls window to top
+				messageModel.setMessages(fault.data.alerts, false);
+			}
 		}
 	};
 
-	$scope.confirmDelete = function(deliveryService) {
-		var params = {
-			title: 'Delete Delivery Service: ' + deliveryService.xmlId,
+	/**
+	 * Opens a dialog to confirm deletion of the current Delivery Service.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+	 */
+	$scope.confirmDelete = async function(deliveryService) {
+		const params = {
+			title: `Delete Delivery Service: ${deliveryService.xmlId}`,
 			key: deliveryService.xmlId
 		};
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
-			controller: 'DialogDeleteController',
-			size: 'md',
-			resolve: {
-				params: function () {
-					return params;
-				}
-			}
+		const modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/delete/dialog.delete.tpl.html",
+			controller: "DialogDeleteController",
+			size: "md",
+			resolve: { params }
 		});
-		modalInstance.result.then(function() {
-			if ($scope.dsRequestsEnabled) {
-				createDeliveryServiceDeleteRequest(deliveryService);
-			} else {
-				deliveryServiceService.deleteDeliveryService(deliveryService)
-					.then(
-						function(response) {
-							messageModel.setMessages(response.data.alerts, true);
-							locationUtils.navigateToPath('/delivery-services');
-						},
-						function(fault) {
-							$anchorScroll(); // scrolls window to top
-							messageModel.setMessages(fault.data.alerts, false);
-						}
-					);
-			}
-		}, function () {
-			// do nothing
-		});
+		try {
+			await modalInstance.result;
+		} catch {
+			// This means the user cancelled.
+			return;
+		}
+		if ($scope.dsRequestsEnabled) {
+			createDeliveryServiceDeleteRequest(deliveryService);
+			return;
+		}
+		try {
+			const response = await deliveryServiceService.deleteDeliveryService(deliveryService);
+			messageModel.setMessages(response.alerts, true);
+			locationUtils.navigateToPath("/delivery-services");
+		} catch(fault) {
+			$anchorScroll(); // scrolls window to top
+			messageModel.setMessages(fault.data.alerts, false);
+		}
 	};
 
 };
 
-FormEditDeliveryServiceController.$inject = ['deliveryService', 'origin', 'topologies', 'type', 'types', '$scope', '$state', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'deliveryServiceService', 'deliveryServiceRequestService', 'messageModel', 'propertiesModel', 'userModel'];
+FormEditDeliveryServiceController.$inject = ["deliveryService", "origin", "topologies", "type", "types", "$scope", "$state", "$controller", "$uibModal", "$anchorScroll", "locationUtils", "deliveryServiceService", "deliveryServiceRequestService", "messageModel", "propertiesModel", "userModel"];
 module.exports = FormEditDeliveryServiceController;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -115,11 +115,12 @@ under the License.
                     </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
-                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-							<br>
-							<br>
-							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
-					</div>
+                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.
+								<br>
+								<br>
+								<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+							</div>
+							</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -116,19 +116,23 @@ under the License.
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                             <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-                        </div>
+							<br>
+							<br>
+							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+					</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
-                                <option ng-value="true">Active</option>
-                                <option ng-value="false">Not Active</option>
+                                <option value="ACTIVE">Active</option>
+                                <option value="PRIMED">Primed</option>
+								<option value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active ? 'Active' : 'Not Active'}}</pre>
+                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -20,8 +20,8 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb pull-left">
-            <li ng-if="!settings.isRequest"><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
-            <li ng-if="settings.isRequest"><a ng-click="navigateToPath('/delivery-service-requests')">Delivery Service Requests</a></li>
+            <li ng-if="!settings.isRequest"><a href="/#!/delivery-services">Delivery Services</a></li>
+            <li ng-if="settings.isRequest"><a href="/#!/delivery-service-requests">Delivery Service Requests</a></li>
             <li ng-if="settings.isRequest" class="active">{{dsRequest.changeType}}</li>
             <li class="active">{{deliveryServiceName}}</li>
         </ol>
@@ -50,20 +50,20 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/ssl-keys">Manage SSL Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/url-sig-keys">Manage URL Sig Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/uri-signing-keys">Manage URI Signing Keys</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewJobs()">Manage Invalidation Requests</a></li>
-                    <li role="menuitem"><a ng-click="viewOrigins()">Manage Origins</a></li>
-                    <li role="menuitem"><a ng-click="viewRegexes()">Manage Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewCapabilities()">Manage Required Server Capabilities</a></li>
-                    <li name="manageServersMenuItem" role="menuitem"><button class="menu-item-button" type="button" ng-click="viewServers()">Manage Servers</button></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">Manage Static DNS Entries</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/jobs">Manage Invalidation Requests</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/origins">Manage Origins</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/regexes">Manage Regexes</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/required-server-capabilities">Manage Required Server Capabilities</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/servers">Manage Servers</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/static-dns-entries">Manage Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -20,8 +20,8 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb pull-left">
-            <li ng-if="!settings.isRequest"><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
-            <li ng-if="settings.isRequest"><a ng-click="navigateToPath('/delivery-service-requests')">Delivery Service Requests</a></li>
+            <li ng-if="!settings.isRequest"><a href="/#!/delivery-services">Delivery Services</a></li>
+            <li ng-if="settings.isRequest"><a href="/#!/delivery-service-requests">Delivery Service Requests</a></li>
             <li ng-if="settings.isRequest" class="active">{{dsRequest.changeType}}</li>
             <li class="active">{{deliveryServiceName}}</li>
         </ol>
@@ -50,20 +50,20 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
-                    <li role="menuitem"><a ng-click="manageUrlSigKeys()">Manage URL Sig Keys</a></li>
-                    <li role="menuitem"><a ng-click="manageUriSigningKeys()">Manage URI Signing Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/ssl-keys">Manage SSL Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/url-sig-keys">Manage URL Sig Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/uri-signing-keys">Manage URI Signing Keys</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewJobs()">Manage Invalidation Requests</a></li>
-                    <li role="menuitem"><a ng-click="viewOrigins()">Manage Origins</a></li>
-                    <li role="menuitem"><a ng-click="viewRegexes()">Manage Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewCapabilities()">Manage Required Server Capabilities</a></li>
-                    <li name="manageServersMenuItem" role="menuitem"><button class="menu-item-button" type="button" ng-click="viewServers()">Manage Servers</button></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">Manage Static DNS Entries</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/jobs">Manage Invalidation Requests</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/origins">Manage Origins</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/regexes">Manage Regexes</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/required-server-capabilities">Manage Required Server Capabilities</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/servers">Manage Servers</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/static-dns-entries">Manage Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -115,11 +115,12 @@ under the License.
                     </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
-                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-							<br>
-							<br>
-							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
-					</div>
+                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.
+								<br>
+								<br>
+								<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+							</div>
+							</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -50,7 +50,7 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-href="/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
                     <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -116,19 +116,23 @@ under the License.
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                             <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-                        </div>
+							<br>
+							<br>
+							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+					</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
-                                <option ng-value="true">Active</option>
-                                <option ng-value="false">Not Active</option>
+                                <option value="ACTIVE">Active</option>
+                                <option value="PRIMED">Primed</option>
+								<option value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active ? 'Active' : 'Not Active'}}</pre>
+                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -20,8 +20,8 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb pull-left">
-            <li ng-if="!settings.isRequest"><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
-            <li ng-if="settings.isRequest"><a ng-click="navigateToPath('/delivery-service-requests')">Delivery Service Requests</a></li>
+            <li ng-if="!settings.isRequest"><a href="/#!/delivery-services">Delivery Services</a></li>
+            <li ng-if="settings.isRequest"><a href="/#!/delivery-service-requests">Delivery Service Requests</a></li>
             <li ng-if="settings.isRequest" class="active">{{dsRequest.changeType}}</li>
             <li class="active">{{deliveryServiceName}}</li>
         </ol>
@@ -49,16 +49,16 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="manageSslKeys()">Manage SSL Keys</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/ssl-keys">Manage SSL Keys</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewJobs()">Manage Invalidation Requests</a></li>
-                    <li role="menuitem"><a ng-click="viewRegexes()">Manage Regexes</a></li>
-                    <li role="menuitem"><a ng-click="viewTargets()">Manage Targets</a></li>
-                    <li role="menuitem"><a ng-click="viewStaticDnsEntries()">Manage Static DNS Entries</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/jobs">Manage Invalidation Requests</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/regexes">Manage Regexes</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/targets">Manage Targets</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/static-dns-entries">Manage Static DNS Entries</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -111,19 +111,23 @@ under the License.
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
                             <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-                        </div>
+							<br>
+							<br>
+							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+					</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
-                                <option ng-value="true">Active</option>
-                                <option ng-value="false">Not Active</option>
+                                <option value="ACTIVE">Active</option>
+                                <option value="PRIMED">Primed</option>
+								<option value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active ? 'Active' : 'Not Active'}}</pre>
+                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -49,7 +49,7 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-href="/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
                     <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -110,11 +110,12 @@ under the License.
                     </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
-                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
-							<br>
-							<br>
-							<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
-					</div>
+                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.
+								<br>
+								<br>
+								<a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+								</div>
+							</div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -20,8 +20,8 @@ under the License.
 <div class="x_panel">
     <div class="x_title">
         <ol class="breadcrumb pull-left">
-            <li ng-if="!settings.isRequest"><a ng-click="navigateToPath('/delivery-services')">Delivery Services</a></li>
-            <li ng-if="settings.isRequest"><a ng-click="navigateToPath('/delivery-service-requests')">Delivery Service Requests</a></li>
+            <li ng-if="!settings.isRequest"><a href="/#!/delivery-services">Delivery Services</a></li>
+            <li ng-if="settings.isRequest"><a href="/#!/delivery-service-requests">Delivery Service Requests</a></li>
             <li ng-if="settings.isRequest" class="active">{{dsRequest.changeType}}</li>
             <li class="active">{{deliveryServiceName}}</li>
         </ol>
@@ -50,11 +50,11 @@ under the License.
                     <span class="caret"></span>
                 </button>
                 <ul class="dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem"><a ng-click="clone(deliveryService)">Clone Delivery Service</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/clone?dsType={{deliveryService.type}}">Clone Delivery Service</a></li>
                     <hr class="divider"/>
-                    <li role="menuitem"><a ng-click="viewCharts()">View Charts</a></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/charts">View Charts</a></li>
                     <hr class="divider"/>
-                    <li name="manageServersMenuItem" role="menuitem"><button class="menu-item-button" type="button" ng-click="viewServers()">Manage Servers</button></li>
+                    <li role="menuitem"><a ng-href="/#!/delivery-services/{{deliveryService.id}}/servers">Manage Servers</a></li>
                 </ul>
             </div>
         </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -101,19 +101,25 @@ under the License.
                     </div>
                     <div class="form-group" ng-class="{'has-error': hasError(generalConfig.active), 'has-feedback': hasError(generalConfig.active)}">
                         <label class="has-tooltip control-label col-md-2 col-sm-2 col-xs-12" for="active">Active *<div class="helptooltip">
-                            <div class="helptext">Whether or not this Delivery Service is active on the CDN and is capable of traffic.</div>
+                            <div class="helptext">
+								Whether or not this Delivery Service is active on the CDN and is capable of serving traffic.
+                                <br>
+                                <br>
+                                <a href="https://traffic-control-cdn.readthedocs.io/en/latest/overview/delivery_services.html#active" target="_blank">See Delivery Service Active States.</a>
+							</div>
                         </div>
                         </label>
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
-                                <option ng-value="true">Active</option> <!--- there is only one valid option as you cannot inactivate any map delivery services --->
+                                <option value="PRIMED">Active</option>
+								<option value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active ? 'Active' : 'Not Active'}}</pre>
+                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/new/FormNewDeliveryServiceController.js
@@ -17,133 +17,162 @@
  * under the License.
  */
 
+/**
+ * This is the controller for a form used to create a new Delivery Service.
+ *
+ * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {unknown} origin
+ * @param {unknown[]} topologies
+ * @param {string} type
+ * @param {unknown[]} types
+ * @param {*} $scope
+ * @param {import("angular").IControllerService} $controller
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {import("../../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../../api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../../models/MessageModel")} messageModel
+ * @param {import("../../../../models/PropertiesModel")} propertiesModel
+ * @param {import("../../../../models/UserModel")} userModel
+ */
 var FormNewDeliveryServiceController = function(deliveryService, origin, topologies, type, types, $scope, $controller, $uibModal, $anchorScroll, locationUtils, deliveryServiceService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
 
 	// extends the FormDeliveryServiceController to inherit common methods
-	angular.extend(this, $controller('FormDeliveryServiceController', { deliveryService: deliveryService,
+	angular.extend(this, $controller("FormDeliveryServiceController", { deliveryService: deliveryService,
 		dsCurrent: deliveryService, origin: origin, topologies: topologies, type: type, types: types, $scope: $scope }));
 
-	$scope.deliveryServiceName = 'New';
+	$scope.deliveryServiceName = "New";
 
 	$scope.settings = {
 		isNew: true,
 		isRequest: false,
-		saveLabel: 'Create'
+		saveLabel: "Create"
 	};
 
 	$scope.restrictTLS = false;
 
-	var createDeliveryServiceCreateRequest = function(dsRequest, dsRequestComment, autoFulfilled) {
-		deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest).
-			then(
-				function(response) {
-					var comment = {
-						deliveryServiceRequestId: response.id,
-						value: dsRequestComment
-					};
-					var promises = [];
+	/**
+	 * Creates a new request to create a Delivery Service.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceRequestService").DeliveryServiceRequest} dsRequest The creation DSR being created.
+	 * @param {string} dsRequestComment The initial comment to put on the DSR.
+	 * @param {boolean} autoFulfilled If `true`, the request is immediately marked as complete.
+	 * @returns {Promise<void>}
+	 */
+	async function createDeliveryServiceCreateRequest(dsRequest, dsRequestComment, autoFulfilled) {
+		const response = await deliveryServiceRequestService.createDeliveryServiceRequest(dsRequest);
+		const comment = {
+			deliveryServiceRequestId: response.id,
+			value: dsRequestComment
+		};
 
-					deliveryServiceRequestService.createDeliveryServiceRequestComment(comment).
-						then(
-							function() {
-								if (!autoFulfilled) {
-									const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original.xmlId;
-									messageModel.setMessages([ { level: 'success', text: 'Created request to ' + dsRequest.changeType + ' the ' + xmlId + ' delivery service' } ], true);
-									locationUtils.navigateToPath('/delivery-service-requests');
-								}
-							}
-						);
+		await deliveryServiceRequestService.createDeliveryServiceRequestComment(comment);
+		if (!autoFulfilled) {
+			const xmlId = (dsRequest.requested) ? dsRequest.requested.xmlId : dsRequest.original?.xmlId;
+			messageModel.setMessages([ { level: "success", text: `Created request to ${dsRequest.changeType} the ${xmlId} delivery service` } ], true);
+			locationUtils.navigateToPath("/delivery-service-requests");
+			return;
+		}
 
-					if (autoFulfilled) {
-						// assign the ds request
-						promises.push(deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username));
-						// set the status to 'complete'
-						promises.push(deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, 'complete'));
-					}
-				}
-			);
+		await Promise.all([
+			// assign the ds request
+			deliveryServiceRequestService.assignDeliveryServiceRequest(response.id, userModel.user.username),
+			// set the status to "complete"
+			deliveryServiceRequestService.updateDeliveryServiceRequestStatus(response.id, "complete")
+		]);
 	};
 
+	/**
+	 * Creates a new Delivery Service using the DSR system.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService The DS being created.
+	 * @returns {Promise<void>}
+	 */
+	async function createDSUsingRequest(deliveryService) {
+		const params = {
+			title: "Delivery Service Create Request",
+			message: "All new delivery services must be reviewed for completeness and accuracy before deployment."
+		};
+		const modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html",
+			controller: "DialogDeliveryServiceRequestController",
+			size: "md",
+			resolve: {
+				params,
+				statuses: () => {
+					const statuses = [
+						{ id: $scope.DRAFT, name: "Save Request as Draft" },
+						{ id: $scope.SUBMITTED, name: "Submit Request for Review and Deployment" }
+					];
+					if (userModel.user.role === propertiesModel.properties.dsRequests.overrideRole) {
+						statuses.push({ id: $scope.COMPLETE, name: "Fulfill Request Immediately" });
+					}
+					return statuses;
+				}
+			}
+		});
 
-	$scope.save = function(deliveryService) {
+		/** @type {{status: {id: number}; comment: string}} */
+		let options;
+		try {
+			options = await modalInstance.result;
+		} catch {
+			// This means the user cancelled
+			return;
+		}
+
+		let status = "draft";
+		if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
+			status = "submitted";
+		};
+		const dsRequest = {
+			changeType: "create",
+			status: status,
+			requested: deliveryService
+		};
+		// if the user chooses to complete/fulfill the create request immediately, the ds will be created and behind the
+		// scenes a delivery service request will be created and marked as complete
+		if (options.status.id === $scope.COMPLETE) {
+			try {
+				const result = await deliveryServiceService.createDeliveryService(deliveryService);
+				await createDeliveryServiceCreateRequest(dsRequest, options.comment, true);
+				messageModel.setMessages(result.alerts, true);
+				locationUtils.navigateToPath(`/delivery-services/${result.response.id}?dsType=${result.response.type}`);
+			} catch(fault) {
+				$anchorScroll(); // scrolls window to top
+				messageModel.setMessages(fault.data.alerts, false);
+			}
+			return;
+		}
+		return createDeliveryServiceCreateRequest(dsRequest, options.comment, false);
+	}
+
+	/**
+	 * Handles the user clicking the "Create" button.
+	 *
+	 * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+	 * @returns {Promise<void>}
+	 */
+	$scope.save = async function(deliveryService) {
 		if (!$scope.restrictTLS) {
 			deliveryService.tlsVersions = null;
 		}
 		// if ds requests are enabled in traffic_portal_properties.json, we'll create a ds request, else just create the ds
 		if ($scope.dsRequestsEnabled) {
-			var params = {
-				title: "Delivery Service Create Request",
-				message: 'All new delivery services must be reviewed for completeness and accuracy before deployment.'
-			};
-			var modalInstance = $uibModal.open({
-				templateUrl: 'common/modules/dialog/deliveryServiceRequest/dialog.deliveryServiceRequest.tpl.html',
-				controller: 'DialogDeliveryServiceRequestController',
-				size: 'md',
-				resolve: {
-					params: function () {
-						return params;
-					},
-					statuses: function() {
-						var statuses = [
-							{ id: $scope.DRAFT, name: 'Save Request as Draft' },
-							{ id: $scope.SUBMITTED, name: 'Submit Request for Review and Deployment' }
-						];
-						if (userModel.user.role == propertiesModel.properties.dsRequests.overrideRole) {
-							statuses.push({ id: $scope.COMPLETE, name: 'Fulfill Request Immediately' });
-						}
-						return statuses;
-					}
-				}
-			});
-			modalInstance.result.then(function(options) {
-				var status = 'draft';
-				if (options.status.id == $scope.SUBMITTED || options.status.id == $scope.COMPLETE) {
-					status = 'submitted';
-				};
-				var dsRequest = {
-					changeType: 'create',
-					status: status,
-					requested: deliveryService
-				};
-				// if the user chooses to complete/fulfill the create request immediately, the ds will be created and behind the
-				// scenes a delivery service request will be created and marked as complete
-				if (options.status.id == $scope.COMPLETE) {
-					deliveryServiceService.createDeliveryService(deliveryService).
-						then(
-							function(result) {
-								createDeliveryServiceCreateRequest(dsRequest, options.comment, true);
-								messageModel.setMessages(result.data.alerts, true);
-								locationUtils.navigateToPath('/delivery-services/' + result.data.response[0].id + '?dsType=' + result.data.response[0].type);
-							},
-							function(fault) {
-								$anchorScroll(); // scrolls window to top
-								messageModel.setMessages(fault.data.alerts, false);
-							}
-						);
-
-				} else {
-					createDeliveryServiceCreateRequest(dsRequest, options.comment, false);
-				}
-
-			}, function () {
-				// do nothing
-			});
-		} else {
-			deliveryServiceService.createDeliveryService(deliveryService).
-				then(
-					function(result) {
-						messageModel.setMessages(result.data.alerts, true);
-						locationUtils.navigateToPath('/delivery-services/' + result.data.response[0].id + '?dsType=' + result.data.response[0].type);
-					},
-					function(fault) {
-						$anchorScroll(); // scrolls window to top
-						messageModel.setMessages(fault.data.alerts, false);
-					}
-			);
+			await createDSUsingRequest(deliveryService);
+			return;
+		}
+		try {
+			const result = await deliveryServiceService.createDeliveryService(deliveryService);
+			messageModel.setMessages(result.alerts, true);
+			locationUtils.navigateToPath(`/delivery-services/${result.response.id}?dsType=${result.response.type}`);
+		} catch(fault) {
+			$anchorScroll(); // scrolls window to top
+			messageModel.setMessages(fault.data.alerts, false);
 		}
 	};
-
 };
 
-FormNewDeliveryServiceController.$inject = ['deliveryService', 'origin', 'topologies', 'type', 'types', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'deliveryServiceService', 'deliveryServiceRequestService', 'messageModel', 'propertiesModel', 'userModel'];
+FormNewDeliveryServiceController.$inject = ["deliveryService", "origin", "topologies", "type", "types", "$scope", "$controller", "$uibModal", "$anchorScroll", "locationUtils", "deliveryServiceService", "deliveryServiceRequestService", "messageModel", "propertiesModel", "userModel"];
 module.exports = FormNewDeliveryServiceController;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceConsistentHashRegex/FormDeliveryServiceConsistentHashRegexController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceConsistentHashRegex/FormDeliveryServiceConsistentHashRegexController.js
@@ -17,6 +17,17 @@
  * under the License.
  */
 
+/**
+ * This is the controller for the form used to test consistent hashing regular
+ * expressions for a DS against Traffic Router.
+ *
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {string|RegExp} consistentHashRegex
+ * @param {*} $scope
+ * @param {import("../../../service/utils/FormUtils")} formUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ */
 var FormDeliveryServiceConsistentHashRegexController = function (deliveryService, consistentHashRegex, $scope, formUtils, locationUtils, deliveryServiceService) {
 
     $scope.deliveryService = deliveryService;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/FormDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/FormDeliveryServiceTargetController.js
@@ -17,13 +17,26 @@
  * under the License.
  */
 
+/**
+ * This is the parent controller for the forms used to modify or create a Target
+ * of a Steering Delivery Service.
+ *
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {import("../../../api/DeliveryServiceService").SteeringTarget[]} currentTargets
+ * @param {import("../../../api/DeliveryServiceService").SteeringTarget} target
+ * @param {*} $scope
+ * @param {import("../../../service/utils/FormUtils")} formUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/TypeService")} typeService
+ */
 var FormDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, formUtils, locationUtils, deliveryServiceService, typeService) {
 
 	var getDeliveryServices = function() {
 		deliveryServiceService.getDeliveryServices({ cdn: deliveryService.cdnId })
 			.then(function(result) {
-				$scope.deliveryServices = _.filter(result, function(ds) {
-					return ds.type.startsWith('HTTP') && _.findWhere(currentTargets, {targetId: ds.id}) == undefined;
+				$scope.deliveryServices = result.filter(function(ds) {
+					return ds.type?.startsWith('HTTP') && currentTargets.find(t=>t.targetId === ds.id) === undefined;
 				});
 			});
 	};

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/edit/FormEditDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/edit/FormEditDeliveryServiceTargetController.js
@@ -17,7 +17,19 @@
  * under the License.
  */
 
-var FormEditDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, $controller, $uibModal, $anchorScroll, locationUtils, deliveryServiceService) {
+/**
+ * This is the controller for the form used to modify a Target of a Steering
+ * Delivery Service.
+ *
+ * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {import("../../../../api/DeliveryServiceService").SteeringTarget[]} currentTargets
+ * @param {import("../../../../api/DeliveryServiceService").SteeringTarget} target
+ * @param {*} $scope
+ * @param {import("angular").IControllerService} $controller
+ * @param {*} $uibModal
+ * @param {import("../../../../api/DeliveryServiceService")} deliveryServiceService
+ */
+var FormEditDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, $controller, $uibModal, deliveryServiceService) {
 
 	// extends the FormDeliveryServiceTargetController to inherit common methods
 	angular.extend(this, $controller('FormDeliveryServiceTargetController', { deliveryService: deliveryService, currentTargets: currentTargets, target: target, $scope: $scope }));
@@ -65,5 +77,5 @@ var FormEditDeliveryServiceTargetController = function(deliveryService, currentT
 
 };
 
-FormEditDeliveryServiceTargetController.$inject = ['deliveryService', 'currentTargets', 'target', '$scope', '$controller', '$uibModal', '$anchorScroll', 'locationUtils', 'deliveryServiceService'];
+FormEditDeliveryServiceTargetController.$inject = ['deliveryService', 'currentTargets', 'target', '$scope', '$controller', '$uibModal', 'deliveryServiceService'];
 module.exports = FormEditDeliveryServiceTargetController;

--- a/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/new/FormNewDeliveryServiceTargetController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryServiceTarget/new/FormNewDeliveryServiceTargetController.js
@@ -17,6 +17,17 @@
  * under the License.
  */
 
+/**
+ * This is the controller for the form used to add a new Target to a Steering
+ * Delivery Service.
+ *
+ * @param {import("../../../../api/DeliveryServiceService").DeliveryService} deliveryService
+ * @param {import("../../../../api/DeliveryServiceService").SteeringTarget[]} currentTargets
+ * @param {import("../../../../api/DeliveryServiceService").SteeringTarget} target
+ * @param {*} $scope
+ * @param {import("angular").IControllerService} $controller
+ * @param {import("../../../../api/DeliveryServiceService")} deliveryServiceService
+ */
 var FormNewDeliveryServiceTargetController = function(deliveryService, currentTargets, target, $scope, $controller, deliveryServiceService) {
 
 	// extends the FormDeliveryServiceTargetController to inherit common methods

--- a/traffic_portal/app/src/common/modules/form/job/FormJobController.js
+++ b/traffic_portal/app/src/common/modules/form/job/FormJobController.js
@@ -17,6 +17,16 @@
  * under the License.
  */
 
+/**
+ * This is the parent controller for forms used to modify or create Content
+ * Invalidation Jobs.
+ *
+ * @param {unknown} job
+ * @param {*} $scope
+ * @param {import("../../../service/utils/FormUtils")} formUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ */
 var FormJobController = function(job, $scope, formUtils, locationUtils, deliveryServiceService) {
 
 	var getDeliveryServices = function() {

--- a/traffic_portal/app/src/common/modules/form/origin/FormOriginController.js
+++ b/traffic_portal/app/src/common/modules/form/origin/FormOriginController.js
@@ -17,14 +17,28 @@
  * under the License.
  */
 
-var FormOriginController = function(origin, $scope, $window, $location, formUtils, locationUtils, tenantUtils, deliveryServiceService, profileService, tenantService, coordinateService, cacheGroupService, userModel) {
+/**
+ * This is the parent controller for all forms used to modify or create Origins.
+ *
+ * @param {unknown} origin
+ * @param {*} $scope
+ * @param {import("angular").IWindowService} $window
+ * @param {import("../../../service/utils/FormUtils")} formUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../service/utils/TenantUtils")} tenantUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/ProfileService")} profileService
+ * @param {import("../../../api/TenantService")} tenantService
+ * @param {import("../../../api/CoordinateService")} coordinateService
+ * @param {import("../../../api/CacheGroupService")} cacheGroupService
+ * @param {import("../../../models/UserModel")} userModel
+ */
+var FormOriginController = function(origin, $scope, $window, formUtils, locationUtils, tenantUtils, deliveryServiceService, profileService, tenantService, coordinateService, cacheGroupService, userModel) {
 
     var getProfiles = function() {
         profileService.getProfiles({ orderby: 'name' })
             .then(function(result) {
-                $scope.profiles = _.filter(result, function(profile) {
-                    return profile.type == 'ORG_PROFILE';
-                });
+                $scope.profiles = result.filter(profile => profile.type === 'ORG_PROFILE');
             });
     };
 
@@ -42,9 +56,7 @@ var FormOriginController = function(origin, $scope, $window, $location, formUtil
     var getCacheGroups = function() {
         cacheGroupService.getCacheGroups({ orderby: 'name' })
             .then(function(result) {
-                $scope.cacheGroups = _.filter(result, function(cachegroup) {
-                    return cachegroup.typeName == 'ORG_LOC';
-                });
+                $scope.cacheGroups = result.filter(cachegroup => cachegroup.typeName === 'ORG_LOC');
             });
     };
 
@@ -77,7 +89,7 @@ var FormOriginController = function(origin, $scope, $window, $location, formUtil
     $scope.navigateToPath = locationUtils.navigateToPath;
 
     $scope.editDeliveryService = function(deliveryServiceId) {
-        ds = _.findWhere($scope.deliveryServices, { id: deliveryServiceId });
+        const ds = $scope.deliveryServices.find(d => d.id === deliveryServiceId);
         $window.open('/#!/delivery-services/' + ds.id + '?dsType=' + ds.type, '_blank');
     };
 
@@ -96,5 +108,5 @@ var FormOriginController = function(origin, $scope, $window, $location, formUtil
 
 };
 
-FormOriginController.$inject = ['origin', '$scope', '$window', '$location', 'formUtils', 'locationUtils', 'tenantUtils', 'deliveryServiceService', 'profileService', 'tenantService', 'coordinateService', 'cacheGroupService', 'userModel'];
+FormOriginController.$inject = ['origin', '$scope', '$window', 'formUtils', 'locationUtils', 'tenantUtils', 'deliveryServiceService', 'profileService', 'tenantService', 'coordinateService', 'cacheGroupService', 'userModel'];
 module.exports = FormOriginController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceCapabilities/TableDeliveryServiceCapabilitiesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceCapabilities/TableDeliveryServiceCapabilitiesController.js
@@ -17,6 +17,19 @@
  * under the License.
  */
 
+/**
+ * The controller for the table that lists the server capabilities required by a
+ * Delivery Service.
+ *
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService & {id: number}} deliveryService
+ * @param {string[]} requiredCapabilities
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../models/MessageModel")} messageModel
+ */
 var TableDeliveryServiceCapabilitiesController = function(deliveryService, requiredCapabilities, $scope, $state, $uibModal, locationUtils, deliveryServiceService, messageModel) {
 
 	$scope.deliveryService = deliveryService;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceRequestComments/TableDeliveryServiceRequestCommentsController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceRequestComments/TableDeliveryServiceRequestCommentsController.js
@@ -17,7 +17,20 @@
  * under the License.
  */
 
-var TableDeliveryServicesRequestsController = function (request, $scope, $state, $stateParams, $uibModal, $anchorScroll, dateUtils, locationUtils, deliveryServiceRequestService, messageModel) {
+/**
+ * The controller for the table that lists the comments of a DSR.
+ *
+ * @param {import("../../../api/DeliveryServiceRequestService").DeliveryServiceRequest} request
+ * @param {*} $scope
+ * @param {*} $stateParams
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {import("../../../service/utils/DateUtils")} dateUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../models/MessageModel")} messageModel
+ */
+var TableDeliveryServicesRequestsController = function (request, $scope, $stateParams, $uibModal, $anchorScroll, dateUtils, locationUtils, deliveryServiceRequestService, messageModel) {
 
 	$scope.request = request[0];
 	$scope.type = $stateParams.dsType;
@@ -146,5 +159,5 @@ var TableDeliveryServicesRequestsController = function (request, $scope, $state,
 	$scope.getComments();
 };
 
-TableDeliveryServicesRequestsController.$inject = ['request', '$scope', '$state', '$stateParams', '$uibModal', '$anchorScroll', 'dateUtils', 'locationUtils', 'deliveryServiceRequestService', 'messageModel'];
+TableDeliveryServicesRequestsController.$inject = ['request', '$scope', '$stateParams', '$uibModal', '$anchorScroll', 'dateUtils', 'locationUtils', 'deliveryServiceRequestService', 'messageModel'];
 module.exports = TableDeliveryServicesRequestsController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
@@ -17,6 +17,24 @@
  * under the License.
  */
 
+/**
+ * The controller for the table that lists Delivery Service Requests.
+ *
+ * @param {string} tableName
+ * @param {import("../../../api/DeliveryServiceRequestService").DeliveryServiceRequest[]} dsRequests
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {import("angular").IDocumentService} $document
+ * @param {import("../../../service/utils/DateUtils")} dateUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/TypeService")} typeService
+ * @param {import("../../../api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../models/MessageModel")} messageModel
+ * @param {import("../../../models/PropertiesModel")} propertiesModel
+ * @param {import("../../../models/UserModel")} userModel
+ */
 var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $scope, $state, $uibModal, $anchorScroll, $document, dateUtils, locationUtils, typeService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
 
 	/**
@@ -124,6 +142,8 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 	/** All of the ds requests - createdAt and lastUpdated fields converted to actual Date */
 	$scope.dsRequests = dsRequests.map(
 		function(x) {
+			// The right way to do these is with an interceptor, but nobody wants
+			// to put in that kind of effort for a legacy product.
 			x.createdAt = x.createdAt ? new Date(x.createdAt.replace("+00", "Z")) : x.createdAt;
 			x.lastUpdated = x.lastUpdated ? new Date(x.lastUpdated.replace("+00", "Z")) : x.lastUpdated;
 		});
@@ -137,10 +157,10 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 	/** Options, configuration, data and callbacks for the ag-grid table. */
 	$scope.gridOptions = {
 		onCellMouseDown: function() {
-			$scope.mouseDownSelectionText = window.getSelection().toString();
+			$scope.mouseDownSelectionText = String(window.getSelection());
 		},
 		onRowClicked: function(params) {
-			const selection = window.getSelection().toString();
+			const selection = String(window.getSelection());
 			if(selection === "" || selection === $scope.mouseDownSelectionText) {
 				const typeId = (params.data.requested) ? params.data.requested.typeId : params.data.original.typeId;
 
@@ -200,7 +220,11 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 			$scope.menuStyle.bottom = "unset";
 			$scope.menuStyle.right = "unset";
 			$scope.$apply();
-			const boundingRect = document.getElementById("context-menu").getBoundingClientRect();
+			const ctxMenu = document.getElementById("context-menu");
+			if (!ctxMenu) {
+				throw new Error("context-menu ID not found in the DOM")
+			}
+			const boundingRect = ctxMenu.getBoundingClientRect();
 
 			if (boundingRect.bottom > window.innerHeight){
 				$scope.menuStyle.bottom = String(window.innerHeight - params.event.clientY) + "px";
@@ -269,9 +293,9 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 			}
 
 			try {
-				const ps = localStorage.getItem(tableName + "_page_size");
+				const ps = Number(localStorage.getItem(tableName + "_page_size"));
 				if (ps && ps > 0) {
-					$scope.pageSize = Number(ps);
+					$scope.pageSize = ps;
 					$scope.gridOptions.api.paginationSetPageSize($scope.pageSize);
 				}
 			} catch (e) {
@@ -372,13 +396,13 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 	$scope.assignRequest = function (request, assign, $event) {
 		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
 		var params = {
-			title: 'Assign Delivery Service Request',
-			message: (assign) ? 'Are you sure you want to assign this delivery service request to yourself?' : 'Are you sure you want to unassign this delivery service request?'
+			title: "Assign Delivery Service Request",
+			message: (assign) ? "Are you sure you want to assign this delivery service request to yourself?" : "Are you sure you want to unassign this delivery service request?"
 		};
 		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-			controller: 'DialogConfirmController',
-			size: 'md',
+			templateUrl: "common/modules/dialog/confirm/dialog.confirm.tpl.html",
+			controller: "DialogConfirmController",
+			size: "md",
 			resolve: {
 				params: function () {
 					return params;
@@ -390,9 +414,9 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 			deliveryServiceRequestService.assignDeliveryServiceRequest(request.id, assignee).then(function () {
 				$scope.refresh();
 				if (assign) {
-					messageModel.setMessages([ { level: 'success', text: 'Delivery service request was assigned' } ], false);
+					messageModel.setMessages([ { level: "success", text: "Delivery service request was assigned" } ], false);
 				} else {
-					messageModel.setMessages([ { level: 'success', text: 'Delivery service request was unassigned' } ], false);
+					messageModel.setMessages([ { level: "success", text: "Delivery service request was unassigned" } ], false);
 				}
 			});
 		}, function () {
@@ -400,37 +424,37 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 		});
 	};
 
-	$scope.editStatus = function (request, $event) {
+	/**
+	 * @param {import("../../../api/DeliveryServiceRequestService").DeliveryServiceRequest & {id: number}} request
+	 * @param {Event} $event
+	 */
+	$scope.editStatus = async function (request, $event) {
 		$event.stopPropagation(); // this kills the click event so it doesn't trigger anything else
-		var params = {
+		const params = {
 			title: "Edit Delivery Service Request Status",
-			message: 'Please select the appropriate status for this request.'
+			message: "Please select the appropriate status for this request."
 		};
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/select/dialog.select.tpl.html',
-			controller: 'DialogSelectController',
-			size: 'md',
+		const modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/select/dialog.select.tpl.html",
+			controller: "DialogSelectController",
+			size: "md",
 			resolve: {
-				params: function () {
-					return params;
-				},
-				collection: function () {
-					return [
-						{id: $scope.DRAFT, name: 'Save as Draft'},
-						{id: $scope.SUBMITTED, name: 'Submit for Review / Deployment'}
-					];
-				}
+				params,
+				collection: () => [
+					{id: $scope.DRAFT, name: "Save as Draft"},
+					{id: $scope.SUBMITTED, name: "Submit for Review / Deployment"}
+				]
 			}
 		});
-		modalInstance.result.then(function (action) {
-			var status = (action.id == $scope.DRAFT) ? 'draft' : 'submitted';
-			deliveryServiceRequestService.updateDeliveryServiceRequestStatus(request.id, status).then(function () {
-				$scope.refresh();
-				messageModel.setMessages([ { level: 'success', text: 'Delivery service request status was updated' } ], false);
-			});
-		}, function () {
+		try {
+			const action = await modalInstance.result;
+			const status = (action.id == $scope.DRAFT) ? "draft" : "submitted";
+			await deliveryServiceRequestService.updateDeliveryServiceRequestStatus(request.id, status);
+			$scope.refresh();
+			messageModel.setMessages([ { level: "success", text: "Delivery service request status was updated" } ], false);
+		} catch {
 			// do nothing
-		});
+		}
 	};
 
 	$scope.rejectRequest = function (request, $event) {

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceRequests/TableDeliveryServiceRequestsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $scope, $state, $uibModal, $anchorScroll, $q, $location, $document, dateUtils, locationUtils, typeService, deliveryServiceService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
+var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $scope, $state, $uibModal, $anchorScroll, $document, dateUtils, locationUtils, typeService, deliveryServiceRequestService, messageModel, propertiesModel, userModel) {
 
 	/**
 	 * Gets value to display a default tooltip.
@@ -567,5 +567,5 @@ var TableDeliveryServicesRequestsController = function (tableName, dsRequests, $
 
 };
 
-TableDeliveryServicesRequestsController.$inject = ['tableName', 'dsRequests', '$scope', '$state', '$uibModal', '$anchorScroll', '$q', '$location', '$document', 'dateUtils', 'locationUtils', 'typeService', 'deliveryServiceService', 'deliveryServiceRequestService', 'messageModel', 'propertiesModel', 'userModel'];
+TableDeliveryServicesRequestsController.$inject = ['tableName', 'dsRequests', '$scope', '$state', '$uibModal', '$anchorScroll', '$document', 'dateUtils', 'locationUtils', 'typeService', 'deliveryServiceRequestService', 'messageModel', 'propertiesModel', 'userModel'];
 module.exports = TableDeliveryServicesRequestsController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServiceTargets/TableDeliveryServiceTargetsController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServiceTargets/TableDeliveryServiceTargetsController.js
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-var TableDeliveryServiceTargetsController = function(deliveryService, targets, $scope, $state, locationUtils, deliveryServiceService) {
+var TableDeliveryServiceTargetsController = function(deliveryService, targets, $scope, $state, locationUtils) {
 
 	$scope.deliveryService = deliveryService;
 
@@ -47,5 +47,5 @@ var TableDeliveryServiceTargetsController = function(deliveryService, targets, $
 
 };
 
-TableDeliveryServiceTargetsController.$inject = ['deliveryService', 'targets', '$scope', '$state', 'locationUtils', 'deliveryServiceService'];
+TableDeliveryServiceTargetsController.$inject = ['deliveryService', 'targets', '$scope', '$state', 'locationUtils'];
 module.exports = TableDeliveryServiceTargetsController;

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -17,6 +17,25 @@
  * under the License.
  */
 
+/**
+ * This is the controller for (almost) all tables of Delivery Services.
+ *
+ * @param {string} tableName
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService[]} deliveryServices
+ * @param {unknown[]} steeringTargets
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {import("angular").ILocationService} $location
+ * @param {{open: ({})=>{result: Promise<*>}}} $uibModal
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../service/utils/DeliveryServiceUtils")} deliveryServiceUtils
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../models/MessageModel")} messageModel
+ * @param {import("../../../models/PropertiesModel")} propertiesModel
+ * @param {import("../../../models/UserModel")} userModel
+ */
 function TableDeliveryServicesController(tableName, deliveryServices, steeringTargets, $anchorScroll, $scope, $state, $location, $uibModal, deliveryServiceService, deliveryServiceRequestService, deliveryServiceUtils, locationUtils, messageModel, propertiesModel, userModel) {
 	$scope.tableName = tableName;
 
@@ -410,7 +429,7 @@ function TableDeliveryServicesController(tableName, deliveryServices, steeringTa
 	 * Opens a dialog asking the user for confirmation before deleting the given
 	 * Delivery Service.
 	 *
-	 * @param {{readonly xmlId: string;}} ds
+	 * @param {import("../../../api/DeliveryServiceService").DeliveryService} ds
 	 */
 	async function confirmDelete(ds) {
 		const params = {
@@ -443,7 +462,7 @@ function TableDeliveryServicesController(tableName, deliveryServices, steeringTa
 	/**
 	 * Creates a new DSR to delete the given Delivery Service.
 	 *
-	 * @param {{readonly xmlId: string}} ds
+	 * @param {import("../../../api/DeliveryServiceService").DeliveryService} ds
 	 */
 	async function createDeliveryServiceDeleteRequest(ds) {
 		const params = {

--- a/traffic_portal/app/src/common/modules/table/parameterProfiles/TableParameterProfilesController.js
+++ b/traffic_portal/app/src/common/modules/table/parameterProfiles/TableParameterProfilesController.js
@@ -17,7 +17,24 @@
  * under the License.
  */
 
-const TableParameterProfilesController = function (parameter, profiles, $scope, $state, $uibModal, $window, locationUtils, deliveryServiceService, profileParameterService, serverService, profileService, messageModel, fileUtils) {
+/**
+ *
+ * @param {{id: number; name: string}} parameter
+ * @param {unknown[]} profiles
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("angular").IWindowService} $window
+ * @param {import("angular").ILocationService} $location
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/ProfileParameterService")} profileParameterService
+ * @param {import("../../../api/ServerService")} serverService
+ * @param {import("../../../api/ProfileService")} profileService
+ * @param {import("../../../models/MessageModel")} messageModel
+ * @param {import("../../../service/utils/FileUtils")} fileUtils
+ */
+const TableParameterProfilesController = function (parameter, profiles, $scope, $state, $uibModal, $window, $location, locationUtils, deliveryServiceService, profileParameterService, serverService, profileService, messageModel, fileUtils) {
 	const deleteProfile = function (profile) {
 		profileService.deleteProfile(profile.id)
 			.then(function (result) {
@@ -331,8 +348,7 @@ const TableParameterProfilesController = function (parameter, profiles, $scope, 
 			}
 		});
 	});
-
 };
 
-TableParameterProfilesController.$inject = ['parameter', 'profiles', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService', 'profileService', 'messageModel', 'fileUtils'];
+TableParameterProfilesController.$inject = ["parameter", "profiles", "$scope", "$state", "$uibModal", "$window", "$location", "locationUtils", "deliveryServiceService", "profileParameterService", "serverService", "profileService", "messageModel", "fileUtils"];
 module.exports = TableParameterProfilesController;

--- a/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
+++ b/traffic_portal/app/src/common/modules/table/profileParameters/TableProfileParametersController.js
@@ -17,7 +17,22 @@
  * under the License.
  */
 
-var TableProfileParametersController = function(profile, parameters, $controller, $scope, $state, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService, messageModel) {
+/**
+ * This is the controller for the table that lists the Parameters used by a
+ * Profile.
+ *
+ * @param {{id: number; name: string; type: string}} profile
+ * @param {unknown[]} parameters
+ * @param {import("angular").IControllerService} $controller
+ * @param {*} $scope
+ * @param {{open: ({})=>{result: Promise<*>}}} $uibModal
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/ProfileParameterService")} profileParameterService
+ * @param {import("../../../api/ServerService")} serverService
+ * @param {import("../../../models/MessageModel")} messageModel
+ */
+var TableProfileParametersController = function(profile, parameters, $controller, $scope, $uibModal, locationUtils, deliveryServiceService, profileParameterService, serverService, messageModel) {
 
 	// extends the TableParametersController to inherit common methods
 	angular.extend(this, $controller('TableParametersController', { parameters: parameters, $scope: $scope }));
@@ -161,5 +176,5 @@ var TableProfileParametersController = function(profile, parameters, $controller
 
 };
 
-TableProfileParametersController.$inject = ['profile', 'parameters', '$controller', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService', 'messageModel'];
+TableProfileParametersController.$inject = ['profile', 'parameters', '$controller', '$scope', '$uibModal', 'locationUtils', 'deliveryServiceService', 'profileParameterService', 'serverService', 'messageModel'];
 module.exports = TableProfileParametersController;

--- a/traffic_portal/app/src/common/modules/table/profilesParamsCompare/TableProfilesParamsCompareController.js
+++ b/traffic_portal/app/src/common/modules/table/profilesParamsCompare/TableProfilesParamsCompareController.js
@@ -17,6 +17,24 @@
  * under the License.
  */
 
+/**
+ * This is a controller for the table used to compare the Parameters of two
+ * Profiles.
+ *
+ * @param {{name: string; params: {id: number}[]}} profile1
+ * @param {{name: string; params: {id: number}[]}} profile2
+ * @param {{id: number}[]} profilesParams
+ * @param {boolean} showAll
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {import("angular").IQService} $q
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("../../../models/MessageModel")} messageModel
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/ProfileParameterService")} profileParameterService
+ * @param {import("../../../api/ServerService")} serverService
+ */
 var TableProfilesParamsCompareController = function(profile1, profile2, profilesParams, showAll, $scope, $state, $q, $uibModal, messageModel, locationUtils, deliveryServiceService, profileParameterService, serverService) {
 
 	let updateProfile1 = false,
@@ -127,8 +145,8 @@ var TableProfilesParamsCompareController = function(profile1, profile2, profiles
 	};
 
 	$scope.selectedParams = profilesParams.map(function(param) {
-		let isAssignedToProfile1 = profile1.params ? profile1.params.some(function(pp){return pp.id === param.id}) : false,
-			isAssignedToProfile2 = profile2.params ? profile2.params.some(function(pp){return pp.id === param.id}) : false;
+		let isAssignedToProfile1 = profile1.params ? profile1.params.some(pp => pp.id === param.id) : false,
+			isAssignedToProfile2 = profile2.params ? profile2.params.some(pp => pp.id === param.id) : false;
 
 		if (isAssignedToProfile1) {
 			param['origSelected1'] = true;

--- a/traffic_portal/app/src/common/modules/table/serverCapabilityDeliveryServices/TableServerCapabilityDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/serverCapabilityDeliveryServices/TableServerCapabilityDeliveryServicesController.js
@@ -17,7 +17,20 @@
  * under the License.
  */
 
-var TableServerCapabilityDeliveryServicesController = function(serverCapability, deliveryServices, $scope, $state, $uibModal, $window, locationUtils, deliveryServiceService, messageModel) {
+/**
+ * The controller for the table that lists the Delivery Services that require a
+ * particular Server Capability.
+ *
+ * @param {{name: string}} serverCapability
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService[]} deliveryServices
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../models/MessageModel")} messageModel
+ */
+var TableServerCapabilityDeliveryServicesController = function(serverCapability, deliveryServices, $scope, $state, $uibModal, locationUtils, deliveryServiceService, messageModel) {
 
 	var removeCapability = function(dsId) {
 		deliveryServiceService.removeServerCapability(dsId, serverCapability.name)
@@ -103,5 +116,5 @@ var TableServerCapabilityDeliveryServicesController = function(serverCapability,
 
 };
 
-TableServerCapabilityDeliveryServicesController.$inject = ['serverCapability', 'deliveryServices', '$scope', '$state', '$uibModal', '$window', 'locationUtils', 'deliveryServiceService', 'messageModel'];
+TableServerCapabilityDeliveryServicesController.$inject = ['serverCapability', 'deliveryServices', '$scope', '$state', '$uibModal', 'locationUtils', 'deliveryServiceService', 'messageModel'];
 module.exports = TableServerCapabilityDeliveryServicesController;

--- a/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/serverDeliveryServices/TableServerDeliveryServicesController.js
@@ -17,6 +17,20 @@
  * under the License.
  */
 
+/**
+ *
+ * @param {{cdnId: number; id: number; hostName: string; type: string}} server
+ * @param {import("../../../api/DeliveryServiceService").DeliveryService[]} deliveryServices
+ * @param {unknown[]} steeringTargets
+ * @param {unknown} filter
+ * @param {import("angular").IControllerService} $controller
+ * @param {*} $scope
+ * @param {{open: ({})=>{result: Promise<*>}}} $uibModal
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../service/utils/ServerUtils")} serverUtils
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/ServerService")} serverService
+ */
 function TableServerDeliveryServicesController(server, deliveryServices, steeringTargets, filter, $controller, $scope, $uibModal, locationUtils, serverUtils, deliveryServiceService, serverService) {
 
 	// extends the TableDeliveryServicesController to inherit common methods
@@ -141,7 +155,7 @@ function TableServerDeliveryServicesController(server, deliveryServices, steerin
 			size: "lg",
 			resolve: {
 				server: () => server,
-				deliveryServices: deliveryServiceService => deliveryServiceService.getDeliveryServices({ cdn: server.cdnId }),
+				deliveryServices: () => deliveryServiceService.getDeliveryServices({ cdn: server.cdnId }),
 				assignedDeliveryServices: () => deliveryServices
 			}
 		});

--- a/traffic_portal/app/src/common/modules/widget/deliveryServices/WidgetDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/widget/deliveryServices/WidgetDeliveryServicesController.js
@@ -17,7 +17,19 @@
  * under the License.
  */
 
-var WidgetDeliveryServicesController = function ($scope, $timeout, $filter, $q, $interval, deliveryServiceService, deliveryServiceStatsService, locationUtils, dateUtils, numberUtils, propertiesModel) {
+/**
+ * @param {*} $scope
+ * @param {import("angular").ITimeoutService} $timeout
+ * @param {import("angular").IQService} $q
+ * @param {import("angular").IIntervalService} $interval
+ * @param {import("../../../api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../api/DeliveryServiceStatsService")} deliveryServiceStatsService
+ * @param {import("../../../service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../service/utils/DateUtils")} dateUtils
+ * @param {import("../../../service/utils/NumberUtils")} numberUtils
+ * @param {import("../../../models/PropertiesModel")} propertiesModel
+ */
+var WidgetDeliveryServicesController = function ($scope, $timeout, $q, $interval, deliveryServiceService, deliveryServiceStatsService, locationUtils, dateUtils, numberUtils, propertiesModel) {
 
 	var interval,
 		autoRefresh = propertiesModel.properties.dashboard.autoRefresh;
@@ -92,7 +104,7 @@ var WidgetDeliveryServicesController = function ($scope, $timeout, $filter, $q, 
 	$scope.buildBandwidthChartData = function (series, start) {
 		var normalizedChartData = [];
 		if (angular.isDefined(series)) {
-			_.each(series.values, function (seriesItem) {
+			series.values.foreach((seriesItem) => {
 				if (moment(seriesItem[0]).isSame(start) || moment(seriesItem[0]).isAfter(start)) {
 					normalizedChartData.push([moment(seriesItem[0]).valueOf(), numberUtils.convertTo(seriesItem[1], $scope.unitSize)]); // converts data to appropriate unit
 				}
@@ -251,5 +263,5 @@ var WidgetDeliveryServicesController = function ($scope, $timeout, $filter, $q, 
 	init();
 };
 
-WidgetDeliveryServicesController.$inject = ['$scope', '$timeout', '$filter', '$q', '$interval', 'deliveryServiceService', 'deliveryServiceStatsService', 'locationUtils', 'dateUtils', 'numberUtils', 'propertiesModel'];
+WidgetDeliveryServicesController.$inject = ['$scope', '$timeout', '$q', '$interval', 'deliveryServiceService', 'deliveryServiceStatsService', 'locationUtils', 'dateUtils', 'numberUtils', 'propertiesModel'];
 module.exports = WidgetDeliveryServicesController;

--- a/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
@@ -17,6 +17,30 @@
  * under the License.
  */
 
+/**
+ * This is the controller for the form used to edit Delivery Service Requests -
+ * **NOT** the form used to edit Delivery Services *using* requests.
+ *
+ * @param {import("../../../../common/api/DeliveryServiceRequestService").DeliveryServiceRequest} deliveryServiceRequest
+ * @param {import("../../../../common/api/DeliveryServiceService").DeliveryService} dsCurrent
+ * @param {unknown} origin
+ * @param {unknown[]} topologies
+ * @param {string} type
+ * @param {unknown[]} types
+ * @param {*} $scope
+ * @param {*} $state
+ * @param {*} $stateParams
+ * @param {import("angular").IControllerService} $controller
+ * @param {{open: ({}) => {result: Promise<*>}}} $uibModal
+ * @param {import("angular").IAnchorScrollService} $anchorScroll
+ * @param {import("angular").IQService} $q
+ * @param {import("angular").ILocationService} $location
+ * @param {import("../../../../common/service/utils/LocationUtils")} locationUtils
+ * @param {import("../../../../common/api/DeliveryServiceService")} deliveryServiceService
+ * @param {import("../../../../common/api/DeliveryServiceRequestService")} deliveryServiceRequestService
+ * @param {import("../../../../common/models/MessageModel")} messageModel
+ * @param {import("../../../../common/models/UserModel")} userModel
+ */
 var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, dsCurrent, origin, topologies, type, types, $scope, $state, $stateParams, $controller, $uibModal, $anchorScroll, $q, $location, locationUtils, deliveryServiceService, deliveryServiceRequestService, messageModel, userModel) {
 
 	$scope.dsRequest = deliveryServiceRequest[0];
@@ -58,7 +82,7 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 	};
 
 	$scope.magicNumberLabel = function(collection, magicNumber) {
-		var item = _.findWhere(collection, { value: magicNumber });
+		const item = collection.find(i => i.value === magicNumber);
 		return item.label;
 	};
 
@@ -103,101 +127,78 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 		return promises;
 	};
 
-	$scope.fulfillRequest = function(ds) {
-		var params = {
-			title: 'Delivery Service ' + $scope.changeType + ': ' + ds.xmlId,
-			message: 'Are you sure you want to fulfill this delivery service request and ' + $scope.changeType + ' the ' + ds.xmlId + ' delivery service'
+	/**
+	 * @param {import("../../../../common/api/DeliveryServiceService").DeliveryService} ds
+	 */
+	$scope.fulfillRequest = async function(ds) {
+		/** @type {{title: string; message?: string; key?: string}} */
+		let params = {
+			title: `Delivery Service ${$scope.changeType}: ${ds.xmlId}`,
+			message: `Are you sure you want to fulfill this delivery service request and ${$scope.changeType} the ${ds.xmlId} delivery service`
 		};
-		params['message'] += ($scope.changeType == 'create' || $scope.changeType == 'update') ? ' with these configuration settings?' : '?';
-		var modalInstance = $uibModal.open({
-			templateUrl: 'common/modules/dialog/confirm/dialog.confirm.tpl.html',
-			controller: 'DialogConfirmController',
-			size: 'md',
+		params.message += ($scope.changeType === "create" || $scope.changeType === "update") ? " with these configuration settings?" : "?";
+		let modalInstance = $uibModal.open({
+			templateUrl: "common/modules/dialog/confirm/dialog.confirm.tpl.html",
+			controller: "DialogConfirmController",
+			size: "md",
 			resolve: {
-				params: function () {
-					return params;
-				}
+				params
 			}
 		});
-		modalInstance.result.then(function() {
+
+		try {
+			await modalInstance.result;
+		} catch {
+			// this means the user cancelled
+			return;
+		}
+
+		try {
 			// create, update or delete the ds per the ds request
-			if ($scope.changeType == 'create') {
-				deliveryServiceService.createDeliveryService(ds).
-					then(
-						function(result) {
-							updateDeliveryServiceRequest('pending'); // after a successful create, update the ds request, assignee and status
-							messageModel.setMessages([ { level: 'success', text: 'Delivery Service [ ' + ds.xmlId + ' ] created' } ], true);
-							locationUtils.navigateToPath('/delivery-services/' + result.data.response[0].id + '?dsType=' + result.data.response[0].type);
-						},
-						function(fault) {
-							$anchorScroll(); // scrolls window to top
-							messageModel.setMessages(fault.data.alerts, false);
-						}
-					);
-			} else if ($scope.changeType == 'update') {
-				deliveryServiceRequestService.updateDeliveryServiceRequestStatus($scope.dsRequest.id, 'pending').
-					then(
-						function(result) {
-							deliveryServiceService.updateDeliveryService(ds).then(
-								function (result) {
-									updateDeliveryServiceRequest(); // after a successful ds update, update the assignee
-									messageModel.setMessages([{
-										level: 'success',
-										text: 'Delivery Service [ ' + ds.xmlId + ' ] updated'
-									}], true);
-									locationUtils.navigateToPath('/delivery-services/' + result.data.response[0].id + '?dsType=' + result.data.response[0].type);
-								},
-								function (fault) {
-									$anchorScroll(); // scrolls window to top
-									messageModel.setMessages(fault.data.alerts, false);
-								}
-							)
-						},
-						function (fault) {
-							$anchorScroll(); // scrolls window to top
-							messageModel.setMessages(fault.data.alerts, false);
-						}
-				);
-			} else if ($scope.changeType == 'delete') {
-				// and we're going to ask even again if they really want to delete but this time they need to enter the ds name to confirm the delete
+			if ($scope.changeType === "create") {
+					const result = await deliveryServiceService.createDeliveryService(ds);
+					await updateDeliveryServiceRequest("pending"); // after a successful create, update the ds request, assignee and status
+					messageModel.setMessages([ { level: "success", text: `Delivery Service [ ${ds.xmlId} ] created` } ], true);
+					locationUtils.navigateToPath(`/delivery-services/${result.response.id}?dsType=${result.response.type}`);
+			} else if ($scope.changeType === "update") {
+				await deliveryServiceRequestService.updateDeliveryServiceRequestStatus($scope.dsRequest.id, "pending");
+				// If the change type is "update", we assume the DS has an ID.
+				const result = await deliveryServiceService.updateDeliveryService(ds);
+				await updateDeliveryServiceRequest(); // after a successful ds update, update the assignee
+				messageModel.setMessages([{
+					level: "success",
+					text: `Delivery Service [ ${ds.xmlId} ] updated`
+				}], true);
+				locationUtils.navigateToPath(`/delivery-services/${result.response.id}?dsType=${result.response.type}`);
+			} else if ($scope.changeType === "delete") {
+				// and we"re going to ask even again if they really want to delete but this time they need to enter the ds name to confirm the delete
 				params = {
-					title: 'Delete Delivery Service: ' + ds.xmlId,
+					title: `Delete Delivery Service: ${ds.xmlId}`,
 					key: ds.xmlId
 				};
 				modalInstance = $uibModal.open({
-					templateUrl: 'common/modules/dialog/delete/dialog.delete.tpl.html',
-					controller: 'DialogDeleteController',
-					size: 'md',
+					templateUrl: "common/modules/dialog/delete/dialog.delete.tpl.html",
+					controller: "DialogDeleteController",
+					size: "md",
 					resolve: {
-						params: function () {
-							return params;
-						}
+						params
 					}
 				});
-				modalInstance.result.then(function() {
-					deliveryServiceService.deleteDeliveryService(ds).
-						then(
-							function() {
-								const promises = updateDeliveryServiceRequest('pending'); // after a successful delete, update the ds request, assignee and status and navigate to ds requests page
-								$q.all(promises)
-									.then(
-										function() {
-											messageModel.setMessages([ { level: 'success', text: 'Delivery service [ ' + ds.xmlId + ' ] deleted' } ], true);
-											locationUtils.navigateToPath('/delivery-service-requests');
-										});
-							},
-							function(fault) {
-								$anchorScroll(); // scrolls window to top
-								messageModel.setMessages(fault.data.alerts, false);
-							}
-						);
-				}, function () {
-					// do nothing
-				});
+				try {
+					await modalInstance.result;
+				} catch {
+					// this means the user cancelled.
+					return;
+				}
+				await deliveryServiceService.deleteDeliveryService(ds);
+				await Promise.all(updateDeliveryServiceRequest("pending")); // after a successful delete, update the ds request, assignee and status and navigate to ds requests page
+				messageModel.setMessages([ { level: "success", text: `Delivery service [ ${ds.xmlId} ] deleted` } ], true);
+				locationUtils.navigateToPath("/delivery-service-requests");
 			}
-		}, function () {
-			// do nothing
-		});
+		} catch (fault) {
+			$anchorScroll(); // scrolls window to top
+			messageModel.setMessages(fault.data.alerts, false);
+		}
 	};
 
 	$scope.save = function(deliveryService) {

--- a/traffic_portal/app/src/modules/private/deliveryServices/urlSigKeys/DeliveryServiceUrlSigKeysController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServices/urlSigKeys/DeliveryServiceUrlSigKeysController.js
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-var DeliveryServiceUrlSigKeysController = function(deliveryService, urlSigKeys, $scope, $state, locationUtils, deliveryServiceService, deliveryServiceUrlSigKeysService, $uibModal) {
+var DeliveryServiceUrlSigKeysController = function(deliveryService, urlSigKeys, $scope, $state, locationUtils, deliveryServiceUrlSigKeysService, $uibModal) {
 	$scope.deliveryService = deliveryService;
-    //Here we take the unordered map of keys returned from riak: 
+    //Here we take the unordered map of keys returned from riak:
     //"response": {
     //   "key9":"ZvVQNYpPVQWQV8tjQnUl6osm4y7xK4zD",
     //   "key6":"JhGdpw5X9o8TqHfgezCm0bqb9SQPASWL",
@@ -119,5 +119,5 @@ var DeliveryServiceUrlSigKeysController = function(deliveryService, urlSigKeys, 
 	});
 };
 
-DeliveryServiceUrlSigKeysController.$inject = ['deliveryService', 'urlSigKeys', '$scope', '$state', 'locationUtils', 'deliveryServiceService', 'deliveryServiceUrlSigKeysService', '$uibModal'];
+DeliveryServiceUrlSigKeysController.$inject = ['deliveryService', 'urlSigKeys', '$scope', '$state', 'locationUtils', 'deliveryServiceUrlSigKeysService', '$uibModal'];
 module.exports = DeliveryServiceUrlSigKeysController;

--- a/traffic_portal/app/src/scripts/config.js
+++ b/traffic_portal/app/src/scripts/config.js
@@ -17,10 +17,13 @@
  * under the License.
  */
 
-// this is the config the TO UI uses
+/**
+ * @file
+ * Configuration for the environment within which TP runs.
+ */
 
 "use strict";
 
 angular.module('config', [])
 
-.constant('ENV', { api: { unstable:'/api/4.1/', stable: "/api/4.0/" } });
+.constant('ENV', { api: { next: "/api/5.0/", unstable:'/api/4.1/', stable: "/api/4.0/" } });

--- a/traffic_portal/package-lock.json
+++ b/traffic_portal/package-lock.json
@@ -28,6 +28,7 @@
         "json3": "3.3.3"
       },
       "devDependencies": {
+        "@types/angular": "^1.8.4",
         "angular-mocks": "1.8.3",
         "browserify": "16.5.1",
         "connect-livereload": "0.6.1",
@@ -367,30 +368,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -564,6 +541,12 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "node_modules/@types/angular": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.4.tgz",
+      "integrity": "sha512-wPS/ncJWhyxJsndsW1B6Ta8D4mi97x1yItSu+rkLDytU3oRIh2CFAjMuJceYwFAh9+DIohndWM0QBA9OU2Hv0g==",
+      "dev": true
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -597,9 +580,9 @@
       }
     },
     "node_modules/abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "node_modules/accepts": {
@@ -999,15 +982,6 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "node_modules/body-parser/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/body-parser/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -1032,15 +1006,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/body-parser/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -1585,21 +1550,18 @@
       }
     },
     "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
+        "color-name": "1.1.3"
       }
     },
     "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "node_modules/colors": {
@@ -1712,6 +1674,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/connect/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/console-browserify": {
@@ -1955,42 +1926,32 @@
       }
     },
     "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+    "node_modules/defined": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
       "dev": true,
-      "dependencies": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
-      "dev": true
-    },
     "node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/deps-sort": {
@@ -2094,15 +2055,6 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
-      }
-    },
-    "node_modules/dom-serialize/node_modules/void-elements": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/domain-browser": {
@@ -2264,60 +2216,6 @@
         "string-template": "~0.2.1"
       }
     },
-    "node_modules/es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "dependencies": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/es5-shim": {
       "version": "4.6.7",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.7.tgz",
@@ -2348,6 +2246,19 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/etag": {
@@ -2453,15 +2364,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/express/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -2486,15 +2388,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2631,15 +2524,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/finalhandler/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -2840,33 +2724,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "node_modules/function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
@@ -2904,30 +2761,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3069,6 +2910,18 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -3235,16 +3088,15 @@
       }
     },
     "node_modules/grunt-browserify/node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -3382,30 +3234,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/grunt-dart-sass/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/grunt-dart-sass/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/grunt-dart-sass/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/grunt-dart-sass/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -3519,6 +3347,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/grunt-legacy-log-utils/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/grunt-legacy-log-utils/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/grunt-legacy-log-utils/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3610,6 +3465,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/grunt-string-replace/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/grunt-string-replace/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/grunt-string-replace/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/grunt-string-replace/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -3678,34 +3560,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -3874,6 +3735,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/http-errors/node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -3885,6 +3755,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
@@ -4009,20 +3888,6 @@
         "lodash.toarray": "^3.0.0"
       }
     },
-    "node_modules/internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -4067,18 +3932,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
-      "dependencies": {
-        "has-bigints": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -4091,22 +3944,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -4114,9 +3951,9 @@
       "dev": true
     },
     "node_modules/is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -4126,27 +3963,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4220,18 +4042,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4239,21 +4049,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
-      }
-    },
-    "node_modules/is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-plain-object": {
@@ -4280,6 +4075,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -4303,58 +4099,16 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "dependencies": {
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
-      "dependencies": {
-        "has-symbols": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       },
       "engines": {
@@ -4374,18 +4128,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-windows": {
@@ -4465,6 +4207,15 @@
         "make-dir": "^3.0.0",
         "supports-color": "^7.1.0"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4612,32 +4363,6 @@
         "esprima": "^4.0.1"
       }
     },
-    "node_modules/js-yaml-js-types/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/js-yaml/node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4686,12 +4411,12 @@
       }
     },
     "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "dev": true,
-      "engines": {
-        "node": "*"
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonparse": {
@@ -4858,18 +4583,6 @@
         "jasmine-core": "^4.0.0",
         "karma": "^6.0.0",
         "karma-jasmine": "^5.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/karma/node_modules/mkdirp": {
@@ -5252,15 +4965,15 @@
       "dev": true
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5388,15 +5101,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/morgan/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -5487,33 +5191,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6001,6 +5678,16 @@
         "with": "^7.0.0"
       }
     },
+    "node_modules/pug-code-gen/node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pug-error": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.0.0.tgz",
@@ -6183,15 +5870,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/raw-body/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/raw-body/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6204,15 +5882,6 @@
         "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6278,23 +5947,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/relateurl": {
@@ -6525,15 +6177,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/send/node_modules/depd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/send/node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -6550,6 +6193,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6564,15 +6219,6 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -6631,10 +6277,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -6786,12 +6435,12 @@
       }
     },
     "node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/stream-browserify": {
@@ -6935,34 +6584,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/strip-ansi": {
@@ -7213,9 +6834,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
-      "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -7231,21 +6852,6 @@
       "dev": true,
       "bin": {
         "umd": "bin/cli.js"
-      }
-    },
-    "node_modules/unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/unc-path-regex": {
@@ -7416,11 +7022,10 @@
       "dev": true
     },
     "node_modules/void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7590,16 +7195,15 @@
       }
     },
     "node_modules/watchify/node_modules/util": {
-      "version": "0.12.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-      "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
         "is-generator-function": "^1.0.7",
         "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
         "which-typed-array": "^1.1.2"
       }
     },
@@ -7641,34 +7245,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
-      "dependencies": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7733,6 +7321,24 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -8054,27 +7660,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -8211,6 +7796,12 @@
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
       "dev": true
     },
+    "@types/angular": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/angular/-/angular-1.8.4.tgz",
+      "integrity": "sha512-wPS/ncJWhyxJsndsW1B6Ta8D4mi97x1yItSu+rkLDytU3oRIh2CFAjMuJceYwFAh9+DIohndWM0QBA9OU2Hv0g==",
+      "dev": true
+    },
     "@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
@@ -8244,9 +7835,9 @@
       }
     },
     "abbrev": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha512-LEyx4aLEC3x6T0UguF6YILf+ntvmOaWsVfENmIW0E9H09vKlLDGelMjjSm0jkDHALj8A8quZ/HapKNigzwge+Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -8594,12 +8185,6 @@
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        },
         "http-errors": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -8621,12 +8206,6 @@
           "requires": {
             "ee-first": "1.1.1"
           }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
         }
       }
     },
@@ -9057,18 +8636,18 @@
       "dev": true
     },
     "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
-        "color-name": "~1.1.4"
+        "color-name": "1.1.3"
       }
     },
     "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
     },
     "colors": {
@@ -9137,6 +8716,12 @@
             "statuses": "~1.5.0",
             "unpipe": "~1.0.0"
           }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+          "dev": true
         }
       }
     },
@@ -9373,33 +8958,23 @@
       }
     },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha512-s82itHOnYrN0Ib8r+z7laQz3sdE+4FP3d9Q7VLO7U+KRT+CR0GsWuyHxzdAY82I7cXv0G/twrqomTJLOssO5HA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "requires": {
         "clone": "^1.0.2"
       }
     },
-    "define-properties": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
-      "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
-      "dev": true,
-      "requires": {
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      }
-    },
     "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha512-Y2caI5+ZwS5c3RiNDJ6u53VhQHv+hHKwhkI1iHvceKUHw9Df6EK2zRLfjejRgMuCuxK7PfSWIMwWecceVvThjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
+      "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
       "dev": true
     },
     "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
     "deps-sort": {
@@ -9489,14 +9064,6 @@
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
-      },
-      "dependencies": {
-        "void-elements": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-          "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
-          "dev": true
-        }
       }
     },
     "domain-browser": {
@@ -9632,48 +9199,6 @@
         "string-template": "~0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
-      "integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "function.prototype.name": "^1.1.5",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.12.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.4.3",
-        "string.prototype.trimend": "^1.0.5",
-        "string.prototype.trimstart": "^1.0.5",
-        "unbox-primitive": "^1.0.2"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "es5-shim": {
       "version": "4.6.7",
       "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.7.tgz",
@@ -9695,6 +9220,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "etag": {
@@ -9785,12 +9316,6 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        },
         "http-errors": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -9812,12 +9337,6 @@
           "requires": {
             "ee-first": "1.1.1"
           }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
         }
       }
     },
@@ -9931,12 +9450,6 @@
           "requires": {
             "ee-first": "1.1.1"
           }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
         }
       }
     },
@@ -10084,24 +9597,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "function.prototype.name": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
-      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.0",
-        "functions-have-names": "^1.2.2"
-      }
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
-    },
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
@@ -10130,24 +9625,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
-      "integrity": "sha512-Jfm3OyCxHh9DJyc28qGk+JmfkpO41A4XkneDSujN9MDXrm4oDKdHvndhZ2dN94+ERNfkYJWDclW6k2L/ZGHjXA==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.3"
-      }
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
       }
     },
     "getobject": {
@@ -10254,6 +9739,15 @@
             "brace-expansion": "^1.1.7"
           }
         }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -10426,16 +9920,15 @@
           }
         },
         "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "is-arguments": "^1.0.4",
             "is-generator-function": "^1.0.7",
             "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
             "which-typed-array": "^1.1.2"
           }
         }
@@ -10546,27 +10039,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -10645,6 +10117,27 @@
             "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10714,6 +10207,27 @@
             "supports-color": "^7.1.0"
           }
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10743,26 +10257,11 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true
-    },
     "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.1"
-      }
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -10890,6 +10389,12 @@
         "statuses": ">= 1.4.0 < 2"
       },
       "dependencies": {
+        "depd": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+          "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+          "dev": true
+        },
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -10900,6 +10405,12 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+          "dev": true
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
           "dev": true
         }
       }
@@ -11004,17 +10515,6 @@
         "lodash.toarray": "^3.0.0"
       }
     },
-    "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
-      }
-    },
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
@@ -11047,15 +10547,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
-      "requires": {
-        "has-bigints": "^1.0.1"
-      }
-    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -11065,16 +10556,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -11082,27 +10563,18 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true
     },
     "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
       }
     },
     "is-expression": {
@@ -11152,26 +10624,11 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -11194,6 +10651,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -11208,43 +10666,16 @@
         "is-unc-path": "^1.0.0"
       }
     },
-    "is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
     "is-typed-array": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.9.tgz",
-      "integrity": "sha512-kfrlnTTn8pZkfpJMUgYD7YZ3qzeJgWUn8XfVYBARc4wnmNOmLbmuuaAs3q5fvB0UJOn6yHAKaGTPM7d6ezoD/A==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0"
       }
     },
@@ -11255,15 +10686,6 @@
       "dev": true,
       "requires": {
         "unc-path-regex": "^0.1.2"
-      }
-    },
-    "is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
       }
     },
     "is-windows": {
@@ -11326,6 +10748,12 @@
         "supports-color": "^7.1.0"
       },
       "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -11431,14 +10859,6 @@
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "js-yaml-js-types": {
@@ -11448,14 +10868,6 @@
       "dev": true,
       "requires": {
         "esprima": "^4.0.1"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-          "dev": true
-        }
       }
     },
     "jsesc": {
@@ -11494,9 +10906,9 @@
       }
     },
     "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha512-trvBk1ki43VZptdBI5rIlG4YOzyeH/WefQt5rj1grasPn4iiZWKet8nkgc4GlsAylaztn0qZfUYOiTsASJFdNA==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
       "dev": true
     },
     "jsonparse": {
@@ -11558,12 +10970,6 @@
         "yargs": "^16.1.1"
       },
       "dependencies": {
-        "mime": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-          "dev": true
-        },
         "mkdirp": {
           "version": "0.5.6",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -11955,9 +11361,9 @@
       }
     },
     "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true
     },
     "mime-db": {
@@ -12058,14 +11464,6 @@
         "depd": "~2.0.0",
         "on-finished": "~2.3.0",
         "on-headers": "~1.0.2"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        }
       }
     },
     "ms": {
@@ -12140,24 +11538,6 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
       "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
-        "object-keys": "^1.1.1"
-      }
     },
     "object.defaults": {
       "version": "1.1.0",
@@ -12555,6 +11935,15 @@
         "pug-runtime": "^3.0.0",
         "void-elements": "^3.1.0",
         "with": "^7.0.0"
+      },
+      "dependencies": {
+        "void-elements": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+          "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "pug-error": {
@@ -12717,12 +12106,6 @@
         "unpipe": "1.0.0"
       },
       "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        },
         "http-errors": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -12735,12 +12118,6 @@
             "statuses": "2.0.1",
             "toidentifier": "1.0.1"
           }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
         }
       }
     },
@@ -12801,17 +12178,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
       }
     },
     "relateurl": {
@@ -12970,12 +12336,6 @@
         "statuses": "2.0.1"
       },
       "dependencies": {
-        "depd": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-          "dev": true
-        },
         "http-errors": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -12988,6 +12348,12 @@
             "statuses": "2.0.1",
             "toidentifier": "1.0.1"
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.3",
@@ -13003,12 +12369,6 @@
           "requires": {
             "ee-first": "1.1.1"
           }
-        },
-        "statuses": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-          "dev": true
         }
       }
     },
@@ -13060,9 +12420,9 @@
       }
     },
     "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
     },
     "side-channel": {
@@ -13174,9 +12534,9 @@
       }
     },
     "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
     "stream-browserify": {
@@ -13303,28 +12663,6 @@
             "ansi-regex": "^5.0.1"
           }
         }
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
       }
     },
     "strip-ansi": {
@@ -13521,9 +12859,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.0.tgz",
-      "integrity": "sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==",
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "dev": true
     },
     "umd": {
@@ -13531,18 +12869,6 @@
       "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
       "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
-    },
-    "unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      }
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -13678,11 +13004,10 @@
       "dev": true
     },
     "void-elements": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
-      "dev": true,
-      "optional": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
+      "dev": true
     },
     "watchify": {
       "version": "4.0.0",
@@ -13834,16 +13159,15 @@
           }
         },
         "util": {
-          "version": "0.12.4",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
-          "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+          "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "is-arguments": "^1.0.4",
             "is-generator-function": "^1.0.7",
             "is-typed-array": "^1.1.3",
-            "safe-buffer": "^5.1.2",
             "which-typed-array": "^1.1.2"
           }
         }
@@ -13875,31 +13199,18 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      }
-    },
     "which-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.8.tgz",
-      "integrity": "sha512-Jn4e5PItbcAHyLoRDwvPj1ypu27DJbtdYXUa5zsinrUx77Uvfb0cXwwnGMTn7cjUfhhqgVQnVJCwF+7cgU7tpw==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
       "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
-        "es-abstract": "^1.20.0",
         "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
         "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.9"
+        "is-typed-array": "^1.1.10"
       }
     },
     "with": {
@@ -13940,6 +13251,21 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.1",

--- a/traffic_portal/package.json
+++ b/traffic_portal/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "angular-mocks": "1.8.3",
+    "@types/angular": "^1.8.4",
     "browserify": "16.5.1",
     "connect-livereload": "0.6.1",
     "connect-modrewrite": "0.10.2",

--- a/traffic_portal/test/integration/PageObjects/DeliveryServicePage.po.ts
+++ b/traffic_portal/test/integration/PageObjects/DeliveryServicePage.po.ts
@@ -159,7 +159,7 @@ export class DeliveryServicePage extends BasePage {
 	 */
 	public async AssignServerToDeliveryService(serverName: string): Promise<string>{
 		await this.btnMore.click();
-		await element(by.buttonText("Manage Servers")).click();
+		await element(by.linkText("Manage Servers")).click();
 		await this.btnMore.click();
 		await element(by.partialButtonText("Assign")).click();
 		const serverCell = element(by.cssContainingText(".ag-cell-value", serverName));


### PR DESCRIPTION
Primarily the motivation of this PR was to support the change of the "Active" property of Delivery Services from a boolean to an enumerated constant. More generally, though, that means using APIv5 for requests that include DS representations in either the request or response body(ies). The structure of responses changed in APIv5 for certain requests - not just because of "active".  POST requests, for example, used to return a `response` that was an array where the length was always one and the only element was the created DS; instead they now just return the DS without wrapping it in an array.

Also, the service was returning the entire HTTP response, so I had to go track down all the places it was used. To make it easier for both me and anyone else who ever has to do anything similar, I added typings to the Delivery Service and Delivery Service Request API services. I also eliminated like half the lines of code by just using `async`/`await` instead of `.then` chains and callbacks.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure existing tests still pass, filter Delivery Services on the basis of their "Active" property, create, update, and delete DSes and DSRs

## PR submission checklist
- [x] This PR uses existing tests
- [x] This PR doesn't need documentation 
- [x] This PR doesn't need a CHANGELOG.md entry since the change to the DS structure is already in the changelog
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**