### PR TITLE
Fix unable to create DSRs for updating existing DSs

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1884,7 +1884,7 @@ func GetDeliveryServices(query string, queryValues map[string]interface{}, tx *s
 	// ensure json generated from this slice won't come out as `null` if empty
 	dsQueryParams := []string{}
 
-	geoLimitCountries := util.StrPtr("")
+	geoLimitCountries := new(string)
 	for rows.Next() {
 		var ds tc.DeliveryServiceV5
 		var longDesc1 *string

--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/requests.go
@@ -498,31 +498,23 @@ func createV4(w http.ResponseWriter, r *http.Request, inf *api.APIInfo) (result 
 		return
 	}
 
-	dsr.SetXMLID()
-	if ok, err = dbhelpers.DSRExistsWithXMLID(dsr.XMLID, tx); err != nil {
-		err = fmt.Errorf("checking for existence of DSR with xmlid '%s'", dsr.XMLID)
+	upgraded.SetXMLID()
+	if ok, err = dbhelpers.DSRExistsWithXMLID(upgraded.XMLID, tx); err != nil {
+		err = fmt.Errorf("checking for existence of DSR with xmlid '%s'", upgraded.XMLID)
 		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, err)
 		return
 	} else if ok {
-		userErr := fmt.Errorf("an open Delivery Service Request for XMLID '%s' already exists", dsr.XMLID)
+		userErr := fmt.Errorf("an open Delivery Service Request for XMLID '%s' already exists", upgraded.XMLID)
 		api.HandleErr(w, r, tx, http.StatusBadRequest, userErr, nil)
 		return
 	}
-	if dsr.Original != nil {
-		if dsr.Original.LongDesc1 != nil || dsr.Original.LongDesc2 != nil {
-			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("the longDesc1 and longDesc2 fields are no longer supported in API 4.0 onwards"), nil)
-			return
-		}
-		if len(dsr.Original.TLSVersions) < 1 {
+	if upgraded.Original != nil {
+		if len(upgraded.Original.TLSVersions) < 1 {
 			upgraded.Original.TLSVersions = nil
 		}
 	}
-	if dsr.Requested != nil {
-		if dsr.Requested.LongDesc1 != nil || dsr.Requested.LongDesc2 != nil {
-			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("the longDesc1 and longDesc2 fields are no longer supported in API 4.0 onwards"), nil)
-			return
-		}
-		if len(dsr.Requested.TLSVersions) < 1 {
+	if upgraded.Requested != nil {
+		if len(upgraded.Requested.TLSVersions) < 1 {
 			upgraded.Requested.TLSVersions = nil
 		}
 	}


### PR DESCRIPTION
Fixes #7212

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Make sure the tests pass. To test manually, just make a DSR for updating an existing DS in APIv4

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [x] This PR needs no documentation
- [x] This PR needs no CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**