### PR TITLE
Fix APIv4 and under DSRs not having Original set on Update DSRs

### DIFF
--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -1031,7 +1031,8 @@ func (dsr DeliveryServiceRequestV4) Upgrade() DeliveryServiceRequestV5 {
 	if dsr.Requested != nil {
 		downgraded.Requested = new(DeliveryServiceV5)
 		*downgraded.Requested = dsr.Requested.Upgrade()
-	} else if dsr.Original != nil {
+	}
+	if dsr.Original != nil {
 		downgraded.Original = new(DeliveryServiceV5)
 		*downgraded.Original = dsr.Original.Upgrade()
 	}

--- a/lib/go-tc/deliveryservice_requests.go
+++ b/lib/go-tc/deliveryservice_requests.go
@@ -996,7 +996,8 @@ func (dsr DeliveryServiceRequestV5) Downgrade() DeliveryServiceRequestV4 {
 	if dsr.Requested != nil {
 		downgraded.Requested = new(DeliveryServiceV4)
 		*downgraded.Requested = dsr.Requested.Downgrade()
-	} else if dsr.Original != nil {
+	}
+	if dsr.Original != nil {
 		downgraded.Original = new(DeliveryServiceV4)
 		*downgraded.Original = dsr.Original.Downgrade()
 	}

--- a/lib/go-tc/deliveryservice_requests_test.go
+++ b/lib/go-tc/deliveryservice_requests_test.go
@@ -257,13 +257,14 @@ func TestDeliveryServiceRequestV4UpgradeAndV5Downgrade(t *testing.T) {
 		AssigneeID:     util.IntPtr(1),
 		Author:         "author",
 		AuthorID:       util.IntPtr(2),
-		ChangeType:     DSRChangeTypeCreate,
+		ChangeType:     DSRChangeTypeUpdate,
 		CreatedAt:      time.Time{},
 		ID:             util.IntPtr(3),
 		LastEditedBy:   "last edited by",
 		LastEditedByID: util.IntPtr(4),
 		LastUpdated:    time.Now(),
 		Requested:      &ds,
+		Original:       &ds,
 		Status:         RequestStatusComplete,
 	}
 	cpy := dsr.Upgrade().Downgrade()

--- a/traffic_portal/app/src/common/api/DeliveryServiceService.js
+++ b/traffic_portal/app/src/common/api/DeliveryServiceService.js
@@ -20,6 +20,7 @@
 /**
  * This is a minimal type definition for Delivery Services. Expand as necessary.
  * @typedef DeliveryService
+ * @property {"ACTIVE" | "INACTIVE" | "PRIMED"} active
  * @property {number} cdnId
  * @property {string[]} consistentHashQueryParams
  * @property {string[]} [exampleURLs]

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -204,6 +204,21 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		$scope.serviceCategories = await serviceCategoryService.getServiceCategories({dsId: deliveryService.id })
 	}
 
+	/**
+	 * Formats the 'dsCurrent' active flag into a human-readable string. Returns
+	 * an empty string if dsCurrent isn't defined.
+	 *
+	 * @returns {string}
+	 */
+	function formatCurrentActive() {
+		if (!dsCurrent) {
+			return "";
+		}
+		return dsCurrent.active.split(" ").map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(" ");
+	}
+
+	$scope.formatCurrentActive = formatCurrentActive;
+
 	$scope.deliveryService = deliveryService;
 
 	$scope.showGeneralConfig = true;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -133,7 +133,7 @@ under the License.
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
+                                <pre>{{::formatCurrentActive()}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -133,7 +133,7 @@ under the License.
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
+                                <pre>{{::formatCurrentActive()}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -128,7 +128,7 @@ under the License.
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
+                                <pre>{{::formatCurrentActive()}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -119,7 +119,7 @@ under the License.
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">
                                 <h3 ng-if="open()">Current Value</h3>
                                 <h3 ng-if="!open()">Previous Value</h3>
-                                <pre>{{::dsCurrent.active.split(' ').map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(' ')}}</pre>
+                                <pre>{{::formatCurrentActive()}}</pre>
                             </aside>
                         </div>
                     </div>

--- a/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
+++ b/traffic_portal/app/src/modules/private/deliveryServiceRequests/edit/FormEditDeliveryServiceRequestController.js
@@ -83,6 +83,10 @@ var FormEditDeliveryServiceRequestController = function(deliveryServiceRequest, 
 
 	$scope.magicNumberLabel = function(collection, magicNumber) {
 		const item = collection.find(i => i.value === magicNumber);
+		if (!item) {
+			console.error("unable to find a label for", magicNumber, "in collection:", collection);
+			return "";
+		}
 		return item.label;
 	};
 


### PR DESCRIPTION
DSRs in versions earlier than 5.0 should have their requested _and_ original DS's set, but because of a bug in the downgrade process, the original was being discarded. This PR fixes that bug.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
I added unit test coverage for the case where neither original nor requested should be nil, so it should suffice that the tests pass. But the way this bug was found was because the DSR edit page was busted, so you may want to check that out to make sure it works.   

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**