### PR TITLE
Update traffic_router.logrotate as well as Ansible block to copy file. 

### DIFF
--- a/.github/workflows/codeql.java.yml
+++ b/.github/workflows/codeql.java.yml
@@ -38,7 +38,7 @@ jobs:
       STARTUP_SCRIPT_DIR: /startup-dir
       STARTUP_SCRIPT_LOC: ../core/src/main/lib/systemd/system
       LOGROTATE_SCRIPT_DIR: /etc/logrotate.d
-      LOGROTATE_SCRIPT_LOC: ./core/src/main/lib/logrotate
+      LOGROTATE_SCRIPT_LOC: ../core/src/main/lib/logrotate
       TOMCAT_RELEASE: tomcat_release
       TOMCAT_VERSION: tomcat_version
 

--- a/.github/workflows/codeql.java.yml
+++ b/.github/workflows/codeql.java.yml
@@ -37,6 +37,8 @@ jobs:
       RHEL_VERSION: rhel_version
       STARTUP_SCRIPT_DIR: /startup-dir
       STARTUP_SCRIPT_LOC: ../core/src/main/lib/systemd/system
+      LOGROTATE_SCRIPT_DIR: /etc/logrotate.d
+      LOGROTATE_SCRIPT_LOC: ./core/src/main/lib/logrotate
       TOMCAT_RELEASE: tomcat_release
       TOMCAT_VERSION: tomcat_version
 

--- a/.github/workflows/tr.tests.yaml
+++ b/.github/workflows/tr.tests.yaml
@@ -25,7 +25,7 @@ env:
   STARTUP_SCRIPT_DIR: /startup-dir
   STARTUP_SCRIPT_LOC: ../core/src/main/lib/systemd/system
   LOGROTATE_SCRIPT_DIR: /etc/logrotate.d
-  LOGROTATE_SCRIPT_LOC: ./core/src/main/lib/logrotate
+  LOGROTATE_SCRIPT_LOC: ../core/src/main/lib/logrotate
   TOMCAT_RELEASE: tomcat_release
   TOMCAT_VERSION: tomcat_version
 

--- a/.github/workflows/tr.tests.yaml
+++ b/.github/workflows/tr.tests.yaml
@@ -24,6 +24,8 @@ env:
   RHEL_VERSION: rhel_version
   STARTUP_SCRIPT_DIR: /startup-dir
   STARTUP_SCRIPT_LOC: ../core/src/main/lib/systemd/system
+  LOGROTATE_SCRIPT_DIR: /etc/logrotate.d
+  LOGROTATE_SCRIPT_LOC: ./core/src/main/lib/logrotate
   TOMCAT_RELEASE: tomcat_release
   TOMCAT_VERSION: tomcat_version
 

--- a/infrastructure/ansible/roles/traffic-router/files/traffic_router.logrotate
+++ b/infrastructure/ansible/roles/traffic-router/files/traffic_router.logrotate
@@ -1,3 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
 /opt/traffic_router/var/log/access.log {
     daily
     size 100m

--- a/infrastructure/ansible/roles/traffic-router/tasks/traffic_router.yml
+++ b/infrastructure/ansible/roles/traffic-router/tasks/traffic_router.yml
@@ -95,7 +95,7 @@
   register: tr_systemd
 
 - name: Copy traffic router logrotate file
-  file:
+  copy:
     src: traffic_router.logrotate
     dest: /etc/logrotate.d/traffic_router
     mode: 0644

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -42,6 +42,8 @@ buildRpmTrafficRouter () {
 	export LOGROTATE_SCRIPT_DIR="/etc/logrotate.d"
 	export LOGROTATE_SCRIPT_LOC="../core/src/main/lib/logrotate"
 
+	mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
+
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; return 1; }
 	mvn -P rpm-build -Dmaven.test.skip=true -DminimumTPS=1 clean package ||  \
 		{ echo "RPM BUILD FAILED: $?"; return 1; }

--- a/traffic_router/build/build_rpm.sh
+++ b/traffic_router/build/build_rpm.sh
@@ -42,8 +42,6 @@ buildRpmTrafficRouter () {
 	export LOGROTATE_SCRIPT_DIR="/etc/logrotate.d"
 	export LOGROTATE_SCRIPT_LOC="../core/src/main/lib/logrotate"
 
-	mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
-
 	cd "$TR_DIR" || { echo "Could not cd to $TR_DIR: $?"; return 1; }
 	mvn -P rpm-build -Dmaven.test.skip=true -DminimumTPS=1 clean package ||  \
 		{ echo "RPM BUILD FAILED: $?"; return 1; }

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -94,6 +94,8 @@
 									<variableName>RPM_TARGET_OS</variableName>
 									<variableName>STARTUP_SCRIPT_DIR</variableName>
 									<variableName>STARTUP_SCRIPT_LOC</variableName>
+									<variableName>LOGROTATE_SCRIPT_DIR</variableName>
+									<variableName>LOGROTATE_SCRIPT_LOC</variableName>
 								</requireEnvironmentVariable>
 							</rules>
 							<fail>true</fail>

--- a/traffic_router/core/src/main/lib/logrotate/traffic_router
+++ b/traffic_router/core/src/main/lib/logrotate/traffic_router
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 /opt/traffic_router/var/log/access.log {
     daily
     size 1k


### PR DESCRIPTION
Related: #6533

This PR Is related to 6533, logrotate file for traffic router did not have an Apache license attached. 

## Which Traffic Control components are affected by this PR?

- Traffic Router

## What is the best way to verify this PR?
License added to /etc/logrotate.d/traffic_router

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
