### PR TITLE
Fix APIv5 attempting to validate Delete-type DSRs as v4 structures

### DIFF
--- a/traffic_ops/traffic_ops_golang/deliveryservice/request/validate.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/request/validate.go
@@ -84,7 +84,7 @@ func validateV4(dsr tc.DeliveryServiceRequestV4, tx *sql.Tx) (error, error) {
 	return validateV5(dsr.Upgrade(), tx)
 }
 
-// validateV4 validates a DSR, returning - in order - a user-facing error that
+// validateV5 validates a DSR, returning - in order - a user-facing error that
 // should be shown to the client, and a system error.
 func validateV5(dsr tc.DeliveryServiceRequestV5, tx *sql.Tx) (error, error) {
 	var userErr, sysErr error
@@ -143,7 +143,7 @@ func validateV5(dsr tc.DeliveryServiceRequestV5, tx *sql.Tx) (error, error) {
 				if o == nil {
 					return fmt.Errorf("required for changeType='%s'", dsr.ChangeType)
 				}
-				ds, ok := o.(*tc.DeliveryServiceV4)
+				ds, ok := o.(*tc.DeliveryServiceV5)
 				if !ok {
 					return fmt.Errorf("expected a Delivery Service, got %T", o)
 				}


### PR DESCRIPTION
The APIv5 handler for creating Delivery Service Requests to delete a Delivery Service currently attempts to cast the structure to a v4 DSR struct, which results in a false validation failure. This PR fixes that.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
1. Make a DS
2. Create a DSR to delete that DS and make sure that succeeds.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [ ] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**