### PR TITLE
Fix a syntax error in a table on the DS overview page

### DIFF
--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -1091,8 +1091,8 @@ Each :term:`Parameter` directly corresponds to a field in a line of the :abbr:`A
 	| parent_retry                            | `parent_retry`_                                            | Sets whether the :term:`cache servers` will use "simple retries",                   |
 	|                                         |                                                            | "unavailable server retries", or both. (deprecated)                                 |
 	+-----------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+
-	| simple_server_retry_responses           | `simple_server_retry_responses`_                           | Defines HTTP response codes for an :term:`origin server                             |
-	|                                         |                                                            | that necessitate a "simple retry".                                                  |
+	| simple_server_retry_responses           | `simple_server_retry_responses`_                           | Defines HTTP response codes for an :term:`origin server` that necessitate a "simple |
+	|                                         |                                                            | retry".                                                                             |
 	+-----------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+
 	| max_simple_retries                      | `max_simple_retries`_                                      | Sets a strict limit on the number of "simple retries" allowed before giving up      |
 	+-----------------------------------------+------------------------------------------------------------+-------------------------------------------------------------------------------------+


### PR DESCRIPTION
There's a syntax error on the DS overview page that's breaking rendering in a table cell. For whatever reason, Sphinx decides to classify this as a warning instead, so you can see a warning if you look at the action logs for PRs that run the docs action, but it won't fail pretty much no matter what.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build without warnings

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR is documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**