### PR TITLE
TM: update CDN name in shared config when overriding it

### DIFF
--- a/traffic_monitor/manager/opsconfig.go
+++ b/traffic_monitor/manager/opsconfig.go
@@ -190,7 +190,6 @@ func StartOpsConfigManager(
 				break
 			}
 		}
-		opsConfig.Set(newOpsConfig)
 
 		if cdn, err := toSession.MonitorCDN(staticAppData.Hostname); err != nil {
 			handleErr(fmt.Errorf("getting CDN name from Traffic Ops, using config CDN '%s': %s\n", newOpsConfig.CdnName, err))
@@ -200,6 +199,7 @@ func StartOpsConfigManager(
 			}
 			newOpsConfig.CdnName = cdn
 		}
+		opsConfig.Set(newOpsConfig)
 
 		// These must be in a goroutine, because the monitorConfigPoller tick sends to a channel this select listens for. Thus, if we block on sends to the monitorConfigPoller, we have a livelock race condition.
 		// More generically, we're using goroutines as an infinite chan buffer, to avoid potential livelocks


### PR DESCRIPTION
If there's a mismatch between the CDN name found in Traffic Ops and the one defined in traffic_ops.cfg, make sure the CDN name from Traffic Ops also overrides the shared "opsConfig" (which is what the API handlers use, e.g. /publish/CrConfig).

This fixes an issue where a misconfigured `cdnName` in traffic_ops.cfg causes the `/publish/CrConfig` handler to get stuck serving an old CRConfig file indefinitely.

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Start up TM with an invalid `cdnName` in traffic_ops.cfg compared to what's in Traffic Ops for the TM's hostname. Once it has successfully retrieved a CRConfig/TMConfig from TO, request `http://tm-host.example.com/publish/CrConfig` to confirm it's serving the current snapshot (may need to wait a bit for it to finish polling the caches upon startup). Snapshot the CDN, wait for TM to request the new snapshot from TO, then request `http://tm-host.example.com/publish/CrConfig` to verify that TM is now serving the new snapshot.

_Without_ this fix, TM would continue to serve the old snapshot indefinitely.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
6.x, 7.x

## PR submission checklist
- [x] No new tests for this one but it has been verified manually <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] Bug fix, no docs necessary <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] Minor bug fix, no changelog necessary <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
