### PR TITLE
Traffic Portal configuration option for Delivery Service active flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7176](https://github.com/apache/trafficcontrol/pull/7176) *ATC Build system* Support building ATC for the `aarch64` CPU architecture
 - [#7113](https://github.com/apache/trafficcontrol/pull/7113) *Traffic Portal* Minimize the Server Server Capability part of the *Traffic Servers* section of the Snapshot Diff
 - [#7273](https://github.com/apache/trafficcontrol/pull/7273) *Traffic Ops* Adds SSL-KEY-EXPIRATION:READ permission to operations, portal, read-only, federation and steering roles
+- [#7296](https://github.com/apache/trafficcontrol/pull/7296) *Traffic Portal* New configuration option in `traffic_portal_properties.json` at `deliveryServices.exposeInactive` controls exposing APIv5 DS Active State options in the TP UI.
 
 ### Changed
 - [#7224](https://github.com/apache/trafficcontrol/pull/7224) *Traffic Ops* Required Capabilities are now a part of the `DeliveryService` structure.

--- a/traffic_portal/app/src/common/models/PropertiesModel.js
+++ b/traffic_portal/app/src/common/models/PropertiesModel.js
@@ -15,12 +15,24 @@
 
 */
 
-var PropertiesModel = function() {
+/**
+ * PropertiesModel models the "properties" (i.e. configuration) of Traffic
+ * Portal.
+ */
+class PropertiesModel {
 
-	this.properties = {};
-	this.loaded = false;
+	/**
+	 * @type {Partial<typeof import("../../traffic_portal_properties.json").properties>}
+	 */
+	properties = {};
+	loaded = false;
 
-	this.setProperties = function(properties) {
+	/**
+	 * Loads in properties if not already done.
+	 *
+	 * @param {Partial<typeof import("../../traffic_portal_properties.json").properties>} properties
+	 */
+	setProperties(properties) {
 		if (this.loaded) return;
 		this.properties = properties;
 		this.loaded = true;

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -478,6 +478,10 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		// ... the right way to do this is with an interceptor, but nobody
 		// wants to put in that kinda work on a legacy product.
 	}
+
+	if (!$scope.exposeInactive && deliveryService.active === "INACTIVE") {
+		deliveryService.active = "PRIMED";
+	}
 };
 
 FormDeliveryServiceController.$inject = ["deliveryService", "dsCurrent", "origin", "topologies", "type", "types", "$scope", "formUtils", "tenantUtils", "deliveryServiceUtils", "deliveryServiceService", "cdnService", "profileService", "tenantService", "propertiesModel", "userModel", "serviceCategoryService"];

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -47,6 +47,8 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 	 */
 	let cachedTLSVersions = null;
 
+	$scope.exposeInactive = !!(propertiesModel.properties.deliveryServices?.exposeInactive);
+
 	$scope.showSensitive = false;
 
 	const knownVersions = new Set(["1.0", "1.1", "1.2", "1.3"]);

--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -232,11 +232,11 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 
 	$scope.topologies = topologies;
 
-	$scope.showChartsButton = propertiesModel.properties.deliveryServices.charts.customLink.show;
+	$scope.showChartsButton = !!(propertiesModel.properties.deliveryServices?.charts?.customLink?.show);
 
 	$scope.openCharts = ds => deliveryServiceUtils.openCharts(ds);
 
-	$scope.dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
+	$scope.dsRequestsEnabled = !!(propertiesModel.properties.dsRequests?.enabled);
 
 	/**
 	 * Gods have mercy.

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.DNS.tpl.html
@@ -126,8 +126,8 @@ under the License.
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
                                 <option value="ACTIVE">Active</option>
-                                <option value="PRIMED">Primed</option>
-								<option value="INACTIVE">Inactive</option>
+                                <option value="PRIMED">{{exposeInactive ? 'Primed' : 'Inactive'}}</option>
+								<option ng-if="exposeInactive" value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.HTTP.tpl.html
@@ -126,8 +126,8 @@ under the License.
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
                                 <option value="ACTIVE">Active</option>
-                                <option value="PRIMED">Primed</option>
-								<option value="INACTIVE">Inactive</option>
+                                <option value="PRIMED">{{exposeInactive ? 'Primed' : 'Inactive'}}</option>
+								<option ng-if="exposeInactive" value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.Steering.tpl.html
@@ -121,8 +121,8 @@ under the License.
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
                                 <option value="ACTIVE">Active</option>
-                                <option value="PRIMED">Primed</option>
-								<option value="INACTIVE">Inactive</option>
+                                <option value="PRIMED">{{exposeInactive ? 'Primed' : 'Inactive'}}</option>
+								<option ng-if="exposeInactive" value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">

--- a/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/form.deliveryService.anyMap.tpl.html
@@ -112,8 +112,9 @@ under the License.
                         <div class="col-md-10 col-sm-10 col-xs-12">
                             <select id="active" name="active" class="form-control" ng-model="deliveryService.active" required>
                                 <option disabled hidden value="">Select...</option>
-                                <option value="PRIMED">Active</option>
-								<option value="INACTIVE">Inactive</option>
+                                <option value="ACTIVE">Active</option>
+                                <option value="PRIMED">{{exposeInactive ? 'Primed' : 'Inactive'}}</option>
+								<option ng-if="exposeInactive" value="INACTIVE">Inactive</option>
                             </select>
                             <small class="input-error" ng-show="hasPropertyError(generalConfig.active, 'required')">Required</small>
                             <aside class="current-value" ng-if="settings.isRequest" ng-show="deliveryService.active != dsCurrent.active">

--- a/traffic_portal/app/src/traffic_portal_properties.json
+++ b/traffic_portal/app/src/traffic_portal_properties.json
@@ -190,7 +190,8 @@
           "show": false,
           "baseUrl": "https://trafficstats.domain.com/dashboard/script/traffic_ops_deliveryservice.js?which="
         }
-      }
+      },
+	  "exposeInactive": false
     },
     "dsRequests": {
       "_comments": "Should all delivery service changes go through the delivery service request/review process? You can also provide a override role name (i.e. admin) that will allow users with the given role to circumvent the delivery service request process.",


### PR DESCRIPTION
This PR adds a new configuration option for Traffic Portal that allows exposing the new DS Active flag states. Disabled by default.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Set `exposeInactive` in the Traffic Portal Properties file to `false` and `true` and make sure each respective behavior works as expected.

## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR doesn't have documentation because TP configuration options are not documented
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**