### PR TITLE
Traffic Portal Configurable DS Active Flags visibility (continued)

### DIFF
--- a/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
+++ b/traffic_portal/app/src/common/modules/form/deliveryService/FormDeliveryServiceController.js
@@ -215,7 +215,11 @@ var FormDeliveryServiceController = function(deliveryService, dsCurrent, origin,
 		if (!dsCurrent) {
 			return "";
 		}
-		return dsCurrent.active.split(" ").map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(" ");
+		let {active} = dsCurrent;
+		if (!propertiesModel.properties.deliveryServices?.exposeInactive && active !== "ACTIVE") {
+			active = "INACTIVE";
+		}
+		return active.split(" ").map(w => w[0].toUpperCase() + w.substring(1).toLowerCase()).join(" ");
 	}
 
 	$scope.formatCurrentActive = formatCurrentActive;

--- a/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
+++ b/traffic_portal/app/src/common/modules/table/deliveryServices/TableDeliveryServicesController.js
@@ -40,7 +40,13 @@ function TableDeliveryServicesController(tableName, deliveryServices, steeringTa
 		{
 			headerName: "Active",
 			field: "active",
-			hide: false
+			hide: false,
+			valueGetter: ({data}) => {
+				if (propertiesModel.properties.deliveryServices?.exposeInactive || data.active === "ACTIVE") {
+					return data.active;
+				}
+				return "INACTIVE";
+			}
 		},
 		{
 			headerName: "Anonymous Blocking",
@@ -378,9 +384,9 @@ function TableDeliveryServicesController(tableName, deliveryServices, steeringTa
 		}
 	];
 
-	let dsRequestsEnabled = propertiesModel.properties.dsRequests.enabled;
+	let dsRequestsEnabled = propertiesModel.properties?.dsRequests?.enabled;
 
-	let showCustomCharts = propertiesModel.properties.deliveryServices.charts.customLink.show;
+	let showCustomCharts = propertiesModel.properties.deliveryServices?.charts.customLink.show;
 
 	/**
 	 * @param {string} typeName
@@ -476,7 +482,7 @@ function TableDeliveryServicesController(tableName, deliveryServices, steeringTa
 						{ id: $scope.DRAFT, name: "Save Request as Draft" },
 						{ id: $scope.SUBMITTED, name: "Submit Request for Review and Deployment" }
 					];
-					if (userModel.user.role == propertiesModel.properties.dsRequests.overrideRole) {
+					if (userModel.user.role === propertiesModel.properties?.dsRequests?.overrideRole) {
 						statuses.push({ id: $scope.COMPLETE, name: "Fulfill Request Immediately" });
 					}
 					return statuses;


### PR DESCRIPTION
This PR hides the true value of a DS's `Active` property _everywhere_ across the Traffic Portal UI, whereas #7296 only did so for drop-down active selections in DS forms. Specifically, this missed two places where the true value was still visible:

- Tables
- DSR "Current/Previous Value" boxes

... and this PR hides it in both places (when `exposeInactive` isn't `true`).

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make a DS and a DSR where `Active` is PRIMED, then check in Traffic Portal and verify that in tables and the DSR comparison/comments view it displays as "INACTIVE" (or "Inactive", as appropriate). Then set `exposeInactive` to `true` in the Traffic Portal properties and observe that the actual value of PRIMED is used.

Also, make sure I didn't miss anywhere that the flag is displayed.

## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**