### PR TITLE
Update API v4 cdn_locks documentation to include currently missing response structure

### DIFF
--- a/docs/source/api/v4/cdn_locks.rst
+++ b/docs/source/api/v4/cdn_locks.rst
@@ -214,3 +214,13 @@ Response Structure
 		],
 		"lastUpdated": "2021-05-26T10:59:10-06"
 	}}
+	
+Response Structure
+-----------------
+:HTTPstatuscode: This would typically be a 204 No Content for a successful deletion, or a 4xx status code (such as 400 Bad Request, 401 Unauthorized, or 403 Forbidden) if the deletion was not successful.   	
+:Message:   This would provide additional information about the outcome of the request. For example, it may include an error message if the request failed, or a success message if the lock was deleted. 
+:Additionaldata: Depending on the specific implementation of the API, the response object may include additional data such as the ID of the deleted lock, the timestamp of when the lock was deleted, or other information relevant to the request.
+
+
+
+


### PR DESCRIPTION

the following pull request provides some context for the deletion request of the API v4  

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
