### PR TITLE
Run TP/TPv2 tests when TO DB files have changed

### DIFF
--- a/.github/workflows/tp.integration.tests.yml
+++ b/.github/workflows/tp.integration.tests.yml
@@ -31,6 +31,8 @@ on:
       - .github/workflows/tp.integration.tests.yml
       - GO_VERSION
       - infrastructure/cdn-in-a-box/optional/traffic_vault/**
+      - lib/go-tc/**
+      - traffic_ops/app/db/**
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_portal/**
   create:
@@ -42,6 +44,8 @@ on:
       - .github/workflows/tp.integration.tests.yml
       - GO_VERSION
       - infrastructure/cdn-in-a-box/optional/traffic_vault/**
+      - lib/go-tc/**
+      - traffic_ops/app/db/**
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_portal/**
     types: [ opened, reopened, ready_for_review, synchronize ]

--- a/.github/workflows/tpv2.yml
+++ b/.github/workflows/tpv2.yml
@@ -26,12 +26,18 @@ on:
       - experimental/traffic-portal/**
       - .github/workflows/tpv2.yml
       - .github/actions/tpv2-integration-tests
+      - lib/go-tc/**
+      - traffic_ops/app/db/**
+      - traffic_ops/traffic_ops_golang/**.go
   create:
   pull_request:
     paths:
       - experimental/traffic-portal/**
       - .github/workflows/tpv2.yml
       - .github/actions/tpv2-integration-tests
+      - lib/go-tc/**
+      - traffic_ops/app/db/**
+      - traffic_ops/traffic_ops_golang/**.go
     types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR makes the Traffic Portal and Traffic Portal v2 tests run when the Traffic Ops database-related files were changed.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - TP tests<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->
- Automation - TPv2 tests<!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
