### PR TITLE
TPv2 fix login redirect

### DIFF
--- a/experimental/traffic-portal/src/app/login/login.component.spec.ts
+++ b/experimental/traffic-portal/src/app/login/login.component.spec.ts
@@ -18,7 +18,7 @@ import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatDialog, MatDialogModule } from "@angular/material/dialog";
 import { Router } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import {ReplaySubject} from "rxjs";
+import { ReplaySubject } from "rxjs";
 
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
 import { NavigationService } from "src/app/shared/navigation/navigation.service";

--- a/experimental/traffic-portal/src/app/login/login.component.ts
+++ b/experimental/traffic-portal/src/app/login/login.component.ts
@@ -66,11 +66,15 @@ export class LoginComponent implements OnInit {
 		this.returnURL = params.get("returnUrl") ?? "core";
 		const token = params.get("token");
 		if (token) {
-			const response = await this.auth.login(token);
-			if (response) {
-				this.navSvc.headerHidden.next(false);
-				this.navSvc.sidebarHidden.next(false);
-				this.router.navigate(["/core/me"], {queryParams: {edit: true, updatePassword: true}});
+			try {
+				const response = await this.auth.login(token);
+				if (response) {
+					this.navSvc.headerHidden.next(false);
+					this.navSvc.sidebarHidden.next(false);
+					this.router.navigate(["/core/me"], {queryParams: {edit: true, updatePassword: true}});
+				}
+			} catch (e) {
+				console.error("token login failed:", e);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #7317: Login redirect is broken because it can't handle query string parameters. This PR fixes it so unauthenticated users are directed back where they were trying to go after logging in.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Assuming you have Traffic Ops running locally on port `6443`, run `ng serve` in the TPv2 directory, then open the URL http://localhost:4200/core/servers?search=test in a new private browsing context (or just any context where you aren't already authenticated). It should send you back to the login page, then after logging in that should take you to the servers table with the search field set to the string "text".

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR uses existing tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**