### PR TITLE
TPv2 Date Revival

### DIFF
--- a/experimental/traffic-portal/src/app/api/cache-group.service.ts
+++ b/experimental/traffic-portal/src/app/api/cache-group.service.ts
@@ -84,12 +84,9 @@ export class CacheGroupService extends APIService {
 			if (resp.length !== 1) {
 				throw new Error(`Traffic Ops returned wrong number of results for Cache Group identifier: ${params}`);
 			}
-			const cg = resp[0];
-			//  lastUpdated comes in as a string
-			return {...cg, lastUpdated: new Date((cg.lastUpdated as unknown as string).replace("+00", "Z"))};
+			return resp[0];
 		}
-		const r = await this.get<Array<ResponseCacheGroup>>(path).toPromise();
-		return r.map(cg => ({...cg, lastUpdated: new Date((cg.lastUpdated as unknown as string).replace("+00", "Z"))}));
+		return this.get<Array<ResponseCacheGroup>>(path).toPromise();
 	}
 
 	/**
@@ -249,14 +246,10 @@ export class CacheGroupService extends APIService {
 				case "number":
 					params = {id: String(nameOrID)};
 			}
-			const r = await this.get<[ResponseDivision]>(path, undefined, params).toPromise();
-			return {...r[0], lastUpdated: new Date((r[0].lastUpdated as unknown as string).replace("+00", "Z"))};
+			return this.get<[ResponseDivision]>(path, undefined, params).toPromise();
 
 		}
-		const divisions = await this.get<Array<ResponseDivision>>(path).toPromise();
-		return divisions.map(
-			d => ({...d, lastUpdated: new Date((d.lastUpdated as unknown as string).replace("+00", "Z"))})
-		);
+		return this.get<Array<ResponseDivision>>(path).toPromise();
 	}
 
 	/**
@@ -267,11 +260,7 @@ export class CacheGroupService extends APIService {
 	 */
 	public async updateDivision(division: ResponseDivision): Promise<ResponseDivision> {
 		const path = `divisions/${division.id}`;
-		const response = await this.put<ResponseDivision>(path, division).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.put<ResponseDivision>(path, division).toPromise();
 	}
 
 	/**
@@ -281,11 +270,7 @@ export class CacheGroupService extends APIService {
 	 * @returns The created division.
 	 */
 	public async createDivision(division: RequestDivision): Promise<ResponseDivision> {
-		const response = await this.post<ResponseDivision>("divisions", division).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.post<ResponseDivision>("divisions", division).toPromise();
 	}
 
 	/**
@@ -321,13 +306,10 @@ export class CacheGroupService extends APIService {
 					params = {id: String(nameOrID)};
 			}
 			const r = await this.get<[ResponseRegion]>(path, undefined, params).toPromise();
-			return {...r[0], lastUpdated: new Date((r[0].lastUpdated as unknown as string).replace("+00", "Z"))};
+			return r[0];
 
 		}
-		const regions = await this.get<Array<ResponseRegion>>(path).toPromise();
-		return regions.map(
-			d => ({...d, lastUpdated: new Date((d.lastUpdated as unknown as string).replace("+00", "Z"))})
-		);
+		return this.get<Array<ResponseRegion>>(path).toPromise();
 	}
 
 	/**
@@ -338,11 +320,7 @@ export class CacheGroupService extends APIService {
 	 */
 	public async updateRegion(region: ResponseRegion): Promise<ResponseRegion> {
 		const path = `regions/${region.id}`;
-		const response = await this.put<ResponseRegion>(path, region).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.put<ResponseRegion>(path, region).toPromise();
 	}
 
 	/**
@@ -352,11 +330,7 @@ export class CacheGroupService extends APIService {
 	 * @returns The created region.
 	 */
 	public async createRegion(region: RequestRegion): Promise<ResponseRegion> {
-		const response = await this.post<ResponseRegion>("regions", region).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.post<ResponseRegion>("regions", region).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/api/cache-group.service.ts
+++ b/experimental/traffic-portal/src/app/api/cache-group.service.ts
@@ -246,7 +246,8 @@ export class CacheGroupService extends APIService {
 				case "number":
 					params = {id: String(nameOrID)};
 			}
-			return this.get<[ResponseDivision]>(path, undefined, params).toPromise();
+			const div = await this.get<[ResponseDivision]>(path, undefined, params).toPromise();
+			return div[0];
 
 		}
 		return this.get<Array<ResponseDivision>>(path).toPromise();

--- a/experimental/traffic-portal/src/app/api/delivery-service.service.ts
+++ b/experimental/traffic-portal/src/app/api/delivery-service.service.ts
@@ -193,19 +193,9 @@ export class DeliveryServiceService extends APIService {
 					params = {id: String(id)};
 			}
 			const r = await this.get<[ResponseDeliveryService]>(path, undefined, params).toPromise();
-			const ds = r[0];
-			return {
-				...ds,
-				lastUpdated: new Date((ds.lastUpdated as unknown as string).replace("+00", "Z"))
-			};
+			return r[0];
 		}
-		const resp = await this.get<Array<ResponseDeliveryService>>(path).toPromise();
-		return resp.map(
-			ds => ({
-				...ds,
-				lastUpdated: new Date((ds.lastUpdated as unknown as string).replace("+00", "Z"))
-			})
-		);
+		return this.get<Array<ResponseDeliveryService>>(path).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/api/invalidation-job.service.ts
+++ b/experimental/traffic-portal/src/app/api/invalidation-job.service.ts
@@ -70,14 +70,7 @@ export class InvalidationJobService extends APIService {
 				params.userId = String(opts.user.id);
 			}
 		}
-		const js = await this.get<Array<ResponseInvalidationJob>>(path, undefined, params).toPromise();
-		const jobs = new Array<ResponseInvalidationJob>();
-		for (const j of js) {
-			const tmp = String(j.startTime).replace(" ", "T").replace("+00", "Z");
-			j.startTime = new Date(tmp);
-			jobs.push(j);
-		}
-		return jobs;
+		return this.get<Array<ResponseInvalidationJob>>(path, undefined, params).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/api/physical-location.service.ts
+++ b/experimental/traffic-portal/src/app/api/physical-location.service.ts
@@ -45,13 +45,10 @@ export class PhysicalLocationService extends APIService {
 					params = {id: String(nameOrID)};
 			}
 			const r = await this.get<[ResponsePhysicalLocation]>(path, undefined, params).toPromise();
-			return {...r[0], lastUpdated: new Date((r[0].lastUpdated as unknown as string).replace("+00", "Z"))};
+			return r[0];
 
 		}
-		const physicalLocations = await this.get<Array<ResponsePhysicalLocation>>(path).toPromise();
-		return physicalLocations.map(
-			d => ({...d, lastUpdated: new Date((d.lastUpdated as unknown as string).replace("+00", "Z"))})
-		);
+		return this.get<Array<ResponsePhysicalLocation>>(path).toPromise();
 	}
 
 	/**
@@ -62,11 +59,7 @@ export class PhysicalLocationService extends APIService {
 	 */
 	public async updatePhysicalLocation(physicalLocation: ResponsePhysicalLocation): Promise<ResponsePhysicalLocation> {
 		const path = `phys_locations/${physicalLocation.id}`;
-		const response = await this.put<ResponsePhysicalLocation>(path, physicalLocation).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.put<ResponsePhysicalLocation>(path, physicalLocation).toPromise();
 	}
 
 	/**
@@ -76,11 +69,7 @@ export class PhysicalLocationService extends APIService {
 	 * @returns The created Physical Location.
 	 */
 	public async createPhysicalLocation(physicalLocation: RequestPhysicalLocation): Promise<ResponsePhysicalLocation> {
-		const response = await this.post<ResponsePhysicalLocation>("physicalLocations", physicalLocation).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.post<ResponsePhysicalLocation>("physicalLocations", physicalLocation).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/api/profile.service.ts
+++ b/experimental/traffic-portal/src/app/api/profile.service.ts
@@ -19,21 +19,6 @@ import { ResponseProfile } from "trafficops-types";
 import { APIService } from "./base-api.service";
 
 /**
- * Shared mapping function for converting Profile 'lastUpdated' fields to
- * actual dates, as well as the `lastUpdated` property of any and all
- * constituent Parameters thereof.
- *
- * @param p The Profile being converted.
- * @returns the converted Profile.
- */
-function profileMap(p: ResponseProfile): ResponseProfile {
-	return {
-		...p,
-		lastUpdated: new Date((p.lastUpdated as unknown as string).replace("+00", "Z"))
-	};
-}
-
-/**
  * ProfileService exposes API functionality related to Profiles.
  */
 @Injectable()
@@ -58,7 +43,6 @@ export class ProfileService extends APIService {
 	 */
 	public async getProfiles(idOrName?: number | string): Promise<Array<ResponseProfile> | ResponseProfile> {
 		const path = "profiles";
-		let prom;
 		if (idOrName !== undefined) {
 			let params;
 			switch (typeof idOrName) {
@@ -68,10 +52,9 @@ export class ProfileService extends APIService {
 				case "string":
 					params = {name: idOrName};
 			}
-			prom = this.get<[ResponseProfile]>(path, undefined, params).toPromise().then(r=>r[0]).then(profileMap);
-		} else {
-			prom = this.get<Array<ResponseProfile>>(path).toPromise().then(r=>r.map(profileMap));
+			const r = await this.get<[ResponseProfile]>(path, undefined, params).toPromise();
+			return r[0];
 		}
-		return prom;
+		return this.get<Array<ResponseProfile>>(path).toPromise();
 	}
 }

--- a/experimental/traffic-portal/src/app/api/type.service.ts
+++ b/experimental/traffic-portal/src/app/api/type.service.ts
@@ -67,12 +67,7 @@ export class TypeService extends APIService {
 	 * @returns The requested Types.
 	 */
 	public async getTypesInTable(useInTable: UseInTable): Promise<Array<TypeFromResponse>> {
-		return this.get<Array<TypeFromResponse>>("types", undefined, {useInTable}).toPromise().catch(
-			(e) => {
-				console.error("Failed to get Types:", e);
-				return [];
-			}
-		);
+		return this.get<Array<TypeFromResponse>>("types", undefined, {useInTable}).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/api/user.service.ts
+++ b/experimental/traffic-portal/src/app/api/user.service.ts
@@ -12,18 +12,18 @@
 * limitations under the License.
 */
 
-import { HttpClient, HttpResponse } from "@angular/common/http";
+import { HttpClient, type HttpResponse } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import {
-	Capability,
-	ResponseUser,
-	PostRequestUser,
-	RequestTenant,
-	ResponseCurrentUser,
-	ResponseRole,
-	ResponseTenant,
-	PutRequestUser,
-	RegistrationRequest,
+	type Capability,
+	type ResponseUser,
+	type PostRequestUser,
+	type RequestTenant,
+	type ResponseCurrentUser,
+	type ResponseRole,
+	type ResponseTenant,
+	type PutRequestUser,
+	type RegistrationRequest,
 	userEmailIsValid
 } from "trafficops-types";
 
@@ -50,20 +50,10 @@ export class UserService extends APIService {
 	public async login(uOrT: string, p?: string): Promise<HttpResponse<object> | null> {
 		let path = `/api/${this.apiVersion}/user/login`;
 		if (p !== undefined) {
-			return this.http.post(path, {p, u: uOrT}, this.defaultOptions).toPromise().catch(
-				e => {
-					console.error("Failed to login:", e);
-					return null;
-				}
-			);
+			return this.http.post(path, {p, u: uOrT}, this.defaultOptions).toPromise();
 		}
 		path += "/token";
-		return this.http.post(path, {t: uOrT}, this.defaultOptions).toPromise().catch(
-			e => {
-				console.error("Failed to login with token:", e);
-				return null;
-			}
-		);
+		return this.http.post(path, {t: uOrT}, this.defaultOptions).toPromise();
 	}
 
 	/**
@@ -74,12 +64,7 @@ export class UserService extends APIService {
 	 */
 	public async logout(): Promise<HttpResponse<object> | null> {
 		const path = `/api/${this.apiVersion}/user/logout`;
-		return this.http.post(path, undefined, this.defaultOptions).toPromise().catch(
-			e => {
-				console.error("Failed to logout:", e);
-				return null;
-			}
-		);
+		return this.http.post(path, undefined, this.defaultOptions).toPromise();
 	}
 
 	/**
@@ -89,11 +74,7 @@ export class UserService extends APIService {
 	 */
 	public async getCurrentUser(): Promise<ResponseCurrentUser> {
 		const path = "user/current";
-		const r = await this.get<ResponseCurrentUser>(path).toPromise();
-		return {
-			...r,
-			lastUpdated: new Date((r.lastUpdated as unknown as string).replace("+00", "Z"))
-		};
+		return this.get<ResponseCurrentUser>(path).toPromise();
 	}
 
 	/**
@@ -149,22 +130,9 @@ export class UserService extends APIService {
 					params = {id: String(nameOrID)};
 			}
 			const r = await this.get<[ResponseUser]>(path, undefined, params).toPromise();
-			return {
-				...r[0],
-				lastAuthenticated: r[0].lastAuthenticated ? new Date((r[0].lastAuthenticated as unknown as string)) : null,
-				lastUpdated: new Date((r[0].lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z")),
-				registrationSent: r[0].registrationSent ? new Date((r[0].registrationSent as unknown as string)) : null
-			};
+			return r[0];
 		}
-		const users = await this.get<Array<ResponseUser>>(path).toPromise();
-		return users.map(
-			u => ({
-				...u,
-				lastAuthenticated: u.lastAuthenticated ? new Date((u.lastAuthenticated as unknown as string)) : null,
-				lastUpdated: new Date((u.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z")),
-				registrationSent: u.registrationSent ? new Date((u.registrationSent as unknown as string)) : null
-			})
-		);
+		return this.get<Array<ResponseUser>>(path).toPromise();
 	}
 
 	/**
@@ -204,13 +172,7 @@ export class UserService extends APIService {
 			id = user.id;
 		}
 		const path = `users/${id}`;
-		const response = await this.put<ResponseUser>(path, body).toPromise();
-		return {
-			...response,
-			lastAuthenticated: response.lastAuthenticated ? new Date((response.lastAuthenticated as unknown as string)) : null,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z")),
-			registrationSent: response.registrationSent ? new Date((response.registrationSent as unknown as string)) : null
-		};
+		return this.put<ResponseUser>(path, body).toPromise();
 	}
 
 	/**
@@ -220,13 +182,7 @@ export class UserService extends APIService {
 	 * @returns The created user.
 	 */
 	public async createUser(user: PostRequestUser): Promise<ResponseUser> {
-		const response = await  this.post<ResponseUser>("users", user).toPromise();
-		return {
-			...response,
-			lastAuthenticated: response.lastAuthenticated ? new Date((response.lastAuthenticated as unknown as string)) : null,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z")),
-			registrationSent: response.registrationSent ? new Date((response.registrationSent as unknown as string)) : null
-		};
+		return this.post<ResponseUser>("users", user).toPromise();
 	}
 
 	/**
@@ -354,11 +310,7 @@ export class UserService extends APIService {
 	 * @returns The created tenant.
 	 */
 	public async createTenant(tenant: RequestTenant): Promise<ResponseTenant> {
-		const response = await this.post<ResponseTenant>("tenants", tenant).toPromise();
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.post<ResponseTenant>("tenants", tenant).toPromise();
 	}
 
 	/**
@@ -368,12 +320,7 @@ export class UserService extends APIService {
 	 * @returns The updated tenant.
 	 */
 	public async updateTenant(tenant: ResponseTenant): Promise<ResponseTenant> {
-		const response = await this.put<ResponseTenant>(`tenants/${tenant.id}`, tenant).toPromise();
-
-		return {
-			...response,
-			lastUpdated: new Date((response.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))
-		};
+		return this.put<ResponseTenant>(`tenants/${tenant.id}`, tenant).toPromise();
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
+++ b/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
@@ -12,7 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <mat-card>
-	<mat-card-content>
+	<tp-loading *ngIf="!server"></tp-loading>
+	<mat-card-content *ngIf="server">
 		<div class="actions-container" *ngIf="!isNew">
 			<button [disabled]="!isCache()" mat-button type="button">Manage Capabilities</button>
 			<button [disabled]="!isCache()" mat-button type="button">Manage Delivery Services</button>

--- a/experimental/traffic-portal/src/app/shared/interceptor/date-reviver.interceptor.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/interceptor/date-reviver.interceptor.spec.ts
@@ -1,0 +1,123 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { HttpClient, HTTP_INTERCEPTORS } from "@angular/common/http";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+
+import { DateReviverInterceptor } from "./date-reviver.interceptor";
+
+/**
+ * Holds some Date instance data fields for testing Date revival.
+ */
+interface TestResponse {
+	lastAuthenticated: Date;
+	lastUpdated: Date;
+	statusLastUpdated: Date;
+}
+
+describe("DateReviverInterceptor", () => {
+	let httpClient: HttpClient;
+	let httpTestingController: HttpTestingController;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [
+				HttpClientTestingModule
+			],
+			providers: [
+				DateReviverInterceptor,
+				{ multi: true, provide: HTTP_INTERCEPTORS, useClass: DateReviverInterceptor}
+			]
+		});
+		// Inject the http service and test controller for each test
+		httpClient = TestBed.inject(HttpClient);
+		httpTestingController = TestBed.inject(HttpTestingController);
+	});
+
+	it("should be created", () => {
+		const interceptor: DateReviverInterceptor = TestBed.inject(DateReviverInterceptor);
+		expect(interceptor).toBeTruthy();
+	});
+
+	it("revives dates sent in responses", () => {
+		const testData = {
+			lastAuthenticated: "2022-03-31T08:01:02.000+00",
+			lastUpdated: "2022-03-31 08:01:02+00",
+			statusLastUpdated: "2022-03-31T08:01:02Z"
+		};
+
+		httpClient.get<TestResponse>("/api/data").subscribe(
+			data => {
+				expect(typeof data).toBe("object");
+
+				const dataProperties = Object.keys(data);
+				expect(dataProperties.length).toBe(3);
+				expect(dataProperties).toContain("lastAuthenticated");
+				expect(data.lastAuthenticated).toBeInstanceOf(Date);
+				expect(dataProperties).toContain("lastUpdated");
+				expect(data.lastUpdated).toBeInstanceOf(Date);
+				expect(dataProperties).toContain("statusLastUpdated");
+				expect(data.statusLastUpdated).toBeInstanceOf(Date);
+
+				const expectedDate = new Date(Date.UTC(2022, 2, 31, 8, 1, 2, 0));
+
+				expect(data.lastAuthenticated).toEqual(expectedDate);
+				expect(data.lastUpdated).toEqual(expectedDate);
+				expect(data.statusLastUpdated).toEqual(expectedDate);
+			}
+		);
+
+		httpTestingController.expectOne("/api/data").flush(testData);
+	});
+
+	it("doesn't modify non-date properties of responses", () => {
+		const testData = {
+			arr: [],
+			bool: true,
+			num: 1,
+			obj: {},
+			str: "some string that doesn't look like a date",
+			strNum: "12345"
+		};
+
+		httpClient.get<typeof testData>("/api/data").subscribe(
+			data => {
+				expect(data).toEqual(testData);
+			}
+		);
+
+		httpTestingController.expectOne("/api/data").flush(testData);
+	});
+
+	it("doesn't modify responses where JSON parsing wasn't requested", ()=>{
+		const testData = JSON.stringify({
+			lastAuthenticated: "2022-03-31T08:01:02.000+00",
+			lastUpdated: "2022-03-31 08:01:02+00",
+			statusLastUpdated: "2022-03-31T08:01:02Z"
+		});
+
+		httpClient.get("/api/data", {responseType: "text"}).subscribe(
+			data => {
+				expect(data).toEqual(testData);
+			}
+		);
+
+		httpTestingController.expectOne("/api/data").flush(testData);
+	});
+
+	afterEach(() => {
+		httpTestingController.verify();
+	});
+});

--- a/experimental/traffic-portal/src/app/shared/interceptor/date-reviver.interceptor.ts
+++ b/experimental/traffic-portal/src/app/shared/interceptor/date-reviver.interceptor.ts
@@ -1,0 +1,72 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import {
+	type HttpRequest,
+	type HttpHandler,
+	type HttpEvent,
+	type HttpInterceptor,
+	HttpResponse
+} from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import type { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+
+import { dateReviver } from "src/app/utils/date";
+
+/**
+ * The DateReviverInterceptor adds custom JSON parsing to all HTTP requests that
+ * converts date strings to Date instances.
+ */
+@Injectable()
+export class DateReviverInterceptor implements HttpInterceptor {
+
+	/**
+	 * Parses the eventually received response (if indeed one is received) as a
+	 * JSON payload, reviving string values that look like dates into Date
+	 * instances.
+	 *
+	 * @param request The outgoing request.
+	 * @param next The next step in the request process.
+	 * @returns The response events. Non-response events or those without
+	 * response bodies are untouched.
+	 */
+	private parseResponseJSON(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+		request = request.clone({responseType: "text"});
+		return next.handle(request).pipe(map(
+			event => {
+				if (event instanceof HttpResponse && typeof event.body === "string") {
+					return event.clone({body: JSON.parse(event.body, dateReviver)});
+				}
+				return event;
+			}));
+	}
+
+	/**
+	 * Intercepts requests with the "json" response type to add a custom parser
+	 * for date strings.
+	 *
+	 * @param request The outgoing request, before being sent.
+	 * @param next The next step in the HTTP handler stack.
+	 * @returns The response events. Non-response events or those without
+	 * response bodies are untouched.
+	 */
+	public intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+		if (request.responseType === "json") {
+			// If the expected response type is JSON then handle it here.
+			return this.parseResponseJSON(request, next);
+		}
+		return next.handle(request);
+	}
+}

--- a/experimental/traffic-portal/src/app/shared/shared.module.ts
+++ b/experimental/traffic-portal/src/app/shared/shared.module.ts
@@ -28,6 +28,7 @@ import { DecisionDialogComponent } from "./dialogs/decision-dialog/decision-dial
 import { TextDialogComponent } from "./dialogs/text-dialog/text-dialog.component";
 import { GenericTableComponent } from "./generic-table/generic-table.component";
 import { AlertInterceptor } from "./interceptor/alerts.interceptor";
+import { DateReviverInterceptor } from "./interceptor/date-reviver.interceptor";
 import { ErrorInterceptor } from "./interceptor/error.interceptor";
 import { LoadingComponent } from "./loading/loading.component";
 import { ObscuredTextInputComponent } from "./obscured-text-input/obscured-text-input.component";
@@ -83,7 +84,8 @@ import { CustomvalidityDirective } from "./validation/customvalidity.directive";
 	],
 	providers: [
 		{ multi: true, provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor },
-		{ multi: true, provide: HTTP_INTERCEPTORS, useClass: AlertInterceptor }
+		{ multi: true, provide: HTTP_INTERCEPTORS, useClass: AlertInterceptor },
+		{ multi: true, provide: HTTP_INTERCEPTORS, useClass: DateReviverInterceptor}
 	]
 })
 export class SharedModule { }

--- a/experimental/traffic-portal/src/app/utils/date.spec.ts
+++ b/experimental/traffic-portal/src/app/utils/date.spec.ts
@@ -82,6 +82,15 @@ describe("date utilities", () => {
 		expect(parsedDate.getUTCMilliseconds()).toBe(678);
 	});
 
+	it("leaves unparsable dates alone", () => {
+		const data = {
+			lastAuthenticated: "not a valid date",
+			lastUpdated: "9999-99-99T99:99:99.99Z"
+		};
+		const parsed = JSON.parse(JSON.stringify(data), dateReviver);
+		expect(parsed).toEqual(data);
+	});
+
 	it("parses HTTP header dates", () => {
 		let date = "Sun, 02 Jan 2022 03:04:05 GMT";
 		let parsed = parseHTTPDate(date);

--- a/experimental/traffic-portal/src/app/utils/date.spec.ts
+++ b/experimental/traffic-portal/src/app/utils/date.spec.ts
@@ -1,0 +1,211 @@
+/*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { dateReviver, parseHTTPDate } from "./date";
+
+describe("date utilities", () => {
+	it("revives legacy, custom TO timestamps into dates", ()=>{
+		const data = '{"notADate": "testquest", "myDate": "2022-01-02 03:04:05+00"}';
+		const parsed = JSON.parse(data, dateReviver);
+		const keys = Object.keys(parsed);
+		expect(keys.length).toBe(2);
+		expect(keys).toContain("notADate");
+		expect(keys).toContain("myDate");
+		expect(typeof(parsed.notADate)).toBe("string");
+
+		const parsedDate = parsed.myDate;
+		if (!(parsedDate instanceof Date)) {
+			return fail(`expected "${parsedDate}" to be a Date`);
+		}
+		expect(parsedDate.getUTCFullYear()).toBe(2022);
+		expect(parsedDate.getUTCMonth()).toBe(0);
+		expect(parsedDate.getUTCDate()).toBe(2);
+		expect(parsedDate.getUTCHours()).toBe(3);
+		expect(parsedDate.getUTCMinutes()).toBe(4);
+		expect(parsedDate.getUTCSeconds()).toBe(5);
+		expect(parsedDate.getUTCMilliseconds()).toBe(0);
+	});
+
+	it("revives RFC3339 timestamps into dates", () => {
+		const data = '{"notADate": "testquest", "myDate": "2022-01-02T03:04:05Z"}';
+		const parsed = JSON.parse(data, dateReviver);
+		const keys = Object.keys(parsed);
+		expect(keys.length).toBe(2);
+		expect(keys).toContain("notADate");
+		expect(keys).toContain("myDate");
+		expect(typeof(parsed.notADate)).toBe("string");
+
+		const parsedDate = parsed.myDate;
+		if (!(parsedDate instanceof Date)) {
+			return fail(`expected "${parsedDate}" to be a Date`);
+		}
+		expect(parsedDate.getUTCFullYear()).toBe(2022);
+		expect(parsedDate.getUTCMonth()).toBe(0);
+		expect(parsedDate.getUTCDate()).toBe(2);
+		expect(parsedDate.getUTCHours()).toBe(3);
+		expect(parsedDate.getUTCMinutes()).toBe(4);
+		expect(parsedDate.getUTCSeconds()).toBe(5);
+		expect(parsedDate.getUTCMilliseconds()).toBe(0);
+	});
+
+	it("revives RFC3339 timestamps with sub-second precision into dates", () => {
+		const data = '{"notADate": "testquest", "myDate": "2022-01-02T03:04:05.6789Z"}';
+		const parsed = JSON.parse(data, dateReviver);
+		const keys = Object.keys(parsed);
+		expect(keys.length).toBe(2);
+		expect(keys).toContain("notADate");
+		expect(keys).toContain("myDate");
+		expect(typeof(parsed.notADate)).toBe("string");
+
+		const parsedDate = parsed.myDate;
+		if (!(parsedDate instanceof Date)) {
+			return fail(`expected "${parsedDate}" to be a Date`);
+		}
+		expect(parsedDate.getUTCFullYear()).toBe(2022);
+		expect(parsedDate.getUTCMonth()).toBe(0);
+		expect(parsedDate.getUTCDate()).toBe(2);
+		expect(parsedDate.getUTCHours()).toBe(3);
+		expect(parsedDate.getUTCMinutes()).toBe(4);
+		expect(parsedDate.getUTCSeconds()).toBe(5);
+		expect(parsedDate.getUTCMilliseconds()).toBe(678);
+	});
+
+	it("parses HTTP header dates", () => {
+		let date = "Sun, 02 Jan 2022 03:04:05 GMT";
+		let parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(0);
+		expect(parsed.getUTCDate()).toBe(2);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Mon, 07 Feb 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(1);
+		expect(parsed.getUTCDate()).toBe(7);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Tue, 01 Mar 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(2);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Wed, 06 Apr 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(3);
+		expect(parsed.getUTCDate()).toBe(6);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Thu, 05 May 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(4);
+		expect(parsed.getUTCDate()).toBe(5);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Fri, 03 Jun 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(5);
+		expect(parsed.getUTCDate()).toBe(3);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Sat, 02 Jul 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(6);
+		expect(parsed.getUTCDate()).toBe(2);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Mon, 01 Aug 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(7);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Thu, 01 Sep 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(8);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Sat, 01 Oct 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(9);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Tue, 01 Nov 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(10);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+
+		date = "Thu, 01 Dec 2022 03:04:05 GMT";
+		parsed = parseHTTPDate(date);
+		expect(parsed.getUTCFullYear()).toBe(2022);
+		expect(parsed.getUTCMonth()).toBe(11);
+		expect(parsed.getUTCDate()).toBe(1);
+		expect(parsed.getUTCHours()).toBe(3);
+		expect(parsed.getUTCMinutes()).toBe(4);
+		expect(parsed.getUTCSeconds()).toBe(5);
+		expect(parsed.getUTCMilliseconds()).toBe(0);
+	});
+
+	it("fails to parse invalid dates", ()=>{
+		expect(()=>parseHTTPDate("not a date")).toThrow();
+		expect(()=>parseHTTPDate("Thu, 01 NaN 2022 03:04:05 GMT")).toThrow();
+	});
+});

--- a/experimental/traffic-portal/src/app/utils/date.ts
+++ b/experimental/traffic-portal/src/app/utils/date.ts
@@ -1,0 +1,165 @@
+/*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * MalformedDateError is an Error that provides the raw date that caused it as a
+ * readable property. Other than that, it's just like an Error.
+ */
+export class MalformedDateError extends Error {
+
+	public readonly date: string;
+
+	constructor(date: string) {
+		super();
+		this.message = `malformed date: ${date}`;
+		this.date = date;
+	}
+}
+
+/** Matches both the legacy, custom TO timestamp strings and RFC3339 with optional sub-second precision.  */
+const datePattern = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2}(?:\.\d+)?)(?:[\+-]00|Z)$/;
+
+/**
+ * dateReviver is meant to be passed into a JSON.parse call as a "reviver"
+ * callback. It causes strings that look like dates to be converted to Date
+ * objects.
+ *
+ * This only supports UTC timestamps (which is all Traffic Ops is capable of
+ * producing).
+ *
+ * If a timestamp has sub-milisecond precision, the trailing digits beyond the
+ * thousandths place are truncated before parsing.
+ *
+ * Note that this will do this for **all** strings that look like dates! If, for
+ * example, a Delivery Service's LongDescription contains only an RFC3339
+ * datestamp, it will be improperly converted!
+ *
+ * @todo Find a way to specify object keys that should be left alone.
+ *
+ * @example
+ *
+ * const data = `{"notADate": "testquest", "myDate": "2022-01-01T00:00:00Z"}`;
+ * const parsed = JSON.parse(data, dateReviver);
+ * console.log(typeof parsed.notADate); // prints "string"
+ * console.log(parsed.myDate instanceof Date); // prints true
+ *
+ * @param _ The name of the property being parsed - unused here.
+ * @param v The value of the property being parsed.
+ * @returns Either the parsed date, or just whatever the value is if it's not a
+ * string that looks like a date.
+ */
+export function dateReviver(_: PropertyKey, v: unknown): Date | unknown {
+	if (typeof v !== "string") {
+		return v;
+	}
+	const matches = datePattern.exec(v.trim());
+	if (!matches) {
+		return v;
+	}
+	const [year, month, day, hour, minute] = matches.slice(1, 6).map(Number);
+	let seconds;
+	let ms = 0;
+
+	if (matches[6].includes(".")) {
+		const [secondsStr, msStr] = matches[6].split(".", 2);
+		seconds = Number(secondsStr);
+		ms = Number(msStr.slice(0, 3));
+	} else {
+		seconds = Number(matches[6]);
+	}
+
+	const date = new Date(0);
+	date.setUTCFullYear(year, month-1, day);
+	date.setUTCHours(hour, minute, seconds, ms);
+	return date;
+}
+
+/** A MonthName is the abbreviated name of a month as it appears in HTTP header dates. */
+type MonthName = "Jan"|"Feb"|"Mar"|"Apr"|"May"|"Jun"|"Jul"|"Aug"|"Sep"|"Oct"|"Nov"|"Dec";
+
+/**
+ * Checks if a string is a valid abbreviated month name.
+ *
+ * @param s The string to check.
+ * @returns `true` if `s` is a valid abbreviated month name, `false` otherwise.
+ */
+function isMonthName(s: string): s is MonthName {
+	switch(s) {
+		case "Jan":
+		case "Feb":
+		case "Mar":
+		case "Apr":
+		case "May":
+		case "Jun":
+		case "Jul":
+		case "Aug":
+		case "Sep":
+		case "Oct":
+		case "Nov":
+		case "Dec":
+			return true;
+	}
+	return false;
+}
+
+/** Index with an abbreviated month name to obtain its number. */
+const monthNumbers: Readonly<Record<MonthName, number>> = {
+	// Month names are decided by RFC specs, can't be changed to match our conventions.
+	// They should also be in the actual order of months in a year, not lexical order.
+	/* eslint-disable @typescript-eslint/naming-convention */
+	/* eslint-disable sort-keys */
+	Jan: 0,
+	Feb: 1,
+	Mar: 2,
+	Apr: 3,
+	May: 4,
+	Jun: 5,
+	Jul: 6,
+	Aug: 7,
+	Sep: 8,
+	Oct: 9,
+	Nov: 10,
+	Dec: 11
+	/* eslint-enable @typescript-eslint/naming-convention */
+	/* eslint-enable sort-keys */
+};
+
+/** Matches dates as formatted in HTTP headers e.g. "Date", "Last-Modified" etc. */
+const httpDatePattern = /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),\s*(\d{2})\s+([A-Za-z]{3})\s+(\d{4})\s+(\d{2}):(\d{2}):(\d{2})\s+GMT$/;
+
+/**
+ * Parses a date as formatted in HTTP headers to a Javascript Date.
+ *
+ * @param raw The raw value of the header (or part of a header) being parsed.
+ * @returns The Date represented by `raw`.
+ * @throws {MalformedDateError} if `raw` fails to parse.
+ */
+export function parseHTTPDate(raw: string): Date {
+	const matches = httpDatePattern.exec(raw.trim().replace(/\s\s+/g, " "));
+	if (!matches || matches.length !== 7 || matches.some(x=>x===undefined)) {
+		throw new MalformedDateError(raw);
+	}
+	const [, d, M, y, h, m, s] = matches;
+	const [day, year, hour, minute, second] = [d, y, h, m, s].map(Number);
+	if (!isMonthName(M)) {
+		throw new MalformedDateError(raw);
+	}
+	const month = monthNumbers[M];
+
+	const date = new Date(0);
+	date.setUTCFullYear(year, month, day);
+	date.setUTCHours(hour, minute, second);
+	return date;
+}

--- a/experimental/traffic-portal/src/environments/environment.prod.ts
+++ b/experimental/traffic-portal/src/environments/environment.prod.ts
@@ -13,10 +13,12 @@
 * limitations under the License.
 */
 
+import type { Environment } from "./environment.type";
+
 /**
  * environment contains information about the running environment.
  */
-export const environment = {
+export const environment: Environment = {
 	apiVersion: "4.0",
 	customModule: false,
 	production: true

--- a/experimental/traffic-portal/src/environments/environment.ts
+++ b/experimental/traffic-portal/src/environments/environment.ts
@@ -13,6 +13,8 @@
 * limitations under the License.
 */
 
+import { Environment } from "./environment.type";
+
 // This file can be replaced during build by using the `fileReplacements` array.
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
@@ -20,7 +22,7 @@
 /**
  * environment contains information about the running environment.
  */
-export const environment = {
+export const environment: Environment = {
 	apiVersion: "4.0",
 	customModule: false,
 	production: false,

--- a/experimental/traffic-portal/src/environments/environment.ts
+++ b/experimental/traffic-portal/src/environments/environment.ts
@@ -24,4 +24,5 @@ export const environment = {
 	apiVersion: "4.0",
 	customModule: false,
 	production: false,
+	useExhaustiveDates: true
 };

--- a/experimental/traffic-portal/src/environments/environment.type.d.ts
+++ b/experimental/traffic-portal/src/environments/environment.type.d.ts
@@ -1,0 +1,34 @@
+/*
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/**
+ * Environment is the type of an Angular deployment environment.
+ */
+export interface Environment {
+	/** The version of the Traffic Ops API to be used */
+	apiVersion: `${number}.${number}`;
+	/** Whether the "Custom" module should be loaded. */
+	customModule?: boolean;
+	/**
+	 * Whether the environment should be treated as a "production" environment.
+	 */
+	production?: boolean;
+	/**
+	 * If defined and `true`, the date-reviving HTTP interceptor will attempt to
+	 * convert anything that looks like a date into a `Date`. Otherwise, it uses
+	 * a specific list of property names known to contain Date information.
+	 */
+	useExhaustiveDates?: boolean;
+}


### PR DESCRIPTION
This PR adds an HTTP interceptor to TPv2 that parses JSON responses with a special "reviver" function that converts strings-representing-dates into actual `Date` instances. This eliminates the need to do so by hand e.g.

```typescript
const resp = await this.get<MyType>("my/type");
return resp.map(
    m => ({...m, lastUpdated: new Date((m.lastUpdated as unknown as string).replace(" ", "T").replace("+00", "Z"))})
);
```

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the provided tests pass.

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**