### PR TITLE
TPv2 Query String Parameter filtering

### DIFF
--- a/dev/traffic_ops/seed.psql
+++ b/dev/traffic_ops/seed.psql
@@ -260,6 +260,10 @@ INSERT INTO interface (
 	TRUE,
 	'eth0',
 	(SELECT id FROM "server" WHERE host_name = 'edge' LIMIT 1)
+), (
+	FALSE,
+	'eth0',
+	(SELECT id FROM "server" WHERE host_name = 'trafficrouter' LIMIT 1)
 )
 ON CONFLICT DO NOTHING;
 
@@ -277,6 +281,11 @@ INSERT INTO ip_address (
 	'129.0.0.2'::inet,
 	'eth0',
 	(SELECT id FROM "server" WHERE host_name = 'edge' LIMIT 1),
+	TRUE
+), (
+	'129.0.0.2'::inet,
+	'eth0',
+	(SELECT id FROM "server" WHERE host_name = 'trafficrouter' LIMIT 1),
 	TRUE
 )
 ON CONFLICT DO NOTHING;

--- a/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.html
+++ b/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.html
@@ -26,4 +26,4 @@ limitations under the License.
 	</tp-generic-table>
 </mat-card>
 
-<button class="page-fab" mat-fab title="Create a new Division" *ngIf="auth.hasPermission('DIVISION:CREATE')" routerLink="new"><mat-icon>add</mat-icon></button>
+<a class="page-fab" mat-fab title="Create a new Division" *ngIf="auth.hasPermission('DIVISION:CREATE')" routerLink="new"><mat-icon>add</mat-icon></a>

--- a/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.spec.ts
@@ -13,11 +13,21 @@
 */
 
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { MatDialogModule } from "@angular/material/dialog";
+import { MatDialog, MatDialogModule, type MatDialogRef } from "@angular/material/dialog";
+import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import { of } from "rxjs";
 
+import { CacheGroupService } from "src/app/api";
 import { APITestingModule } from "src/app/api/testing";
 import { DivisionsTableComponent } from "src/app/core/cache-groups/divisions/table/divisions-table.component";
+import { isAction } from "src/app/shared/generic-table/generic-table.component";
+
+const testDivision = {
+	id: 1,
+	lastUpdated: new Date(),
+	name: "TestQuest",
+};
 
 describe("DivisionsTableComponent", () => {
 	let component: DivisionsTableComponent;
@@ -26,9 +36,12 @@ describe("DivisionsTableComponent", () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [ DivisionsTableComponent ],
-			imports: [ APITestingModule, RouterTestingModule, MatDialogModule ]
-		})
-			.compileComponents();
+			imports: [
+				APITestingModule,
+				RouterTestingModule,
+				MatDialogModule
+			]
+		}).compileComponents();
 
 		fixture = TestBed.createComponent(DivisionsTableComponent);
 		component = fixture.componentInstance;
@@ -38,6 +51,22 @@ describe("DivisionsTableComponent", () => {
 	it("should create", () => {
 		expect(component).toBeTruthy();
 	});
+
+	it("sets the fuzzy search subject based on the search query param", fakeAsync(() => {
+		const router = TestBed.inject(ActivatedRoute);
+		const searchString = "testquest";
+		spyOnProperty(router, "queryParamMap").and.returnValue(of(new Map([["search", searchString]])));
+
+		let searchValue = "not the right string";
+		component.fuzzySubject.subscribe(
+			s => searchValue = s
+		);
+
+		component.ngOnInit();
+		tick();
+
+		expect(searchValue).toBe(searchString);
+	}));
 
 	it("updates the fuzzy search output", fakeAsync(() => {
 		let called = false;
@@ -59,10 +88,102 @@ describe("DivisionsTableComponent", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 	}));
 
-	it("handles contextmenu events", () => {
+	it("handles unrecognized contextmenu events", () => {
 		expect(async () => component.handleContextMenu({
 			action: component.contextMenuItems[0].name,
 			data: {id: 1, lastUpdated: new Date(), name: "Div"}
 		})).not.toThrow();
+	});
+
+	it("handles the 'delete' context menu item", fakeAsync(async () => {
+		const item = component.contextMenuItems.find(c => c.name === "Delete");
+		if (!item) {
+			return fail("missing 'Delete' context menu item");
+		}
+		if (!isAction(item)) {
+			return fail("expected an action, not a link");
+		}
+		expect(item.multiRow).toBeFalsy();
+		expect(item.disabled).toBeUndefined();
+
+		const api = TestBed.inject(CacheGroupService);
+		const spy = spyOn(api, "deleteDivision").and.callThrough();
+		expect(spy).not.toHaveBeenCalled();
+
+		const dialogService = TestBed.inject(MatDialog);
+		const openSpy = spyOn(dialogService, "open").and.returnValue({
+			afterClosed: () => of(true)
+		} as MatDialogRef<unknown>);
+
+		const div = await api.createDivision({name: "test"});
+		expect(openSpy).not.toHaveBeenCalled();
+		const asyncExpectation = expectAsync(component.handleContextMenu({action: "delete", data: div})).toBeResolvedTo(undefined);
+		tick();
+
+		expect(openSpy).toHaveBeenCalled();
+		tick();
+
+		expect(spy).toHaveBeenCalled();
+
+		await asyncExpectation;
+	}));
+
+	it("generates 'Edit' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "Edit");
+		if (!item) {
+			return fail("missing 'Edit' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (typeof(item.href) !== "function") {
+			return fail(`'Edit' context menu item should use a function to determine href, instead uses: ${item.href}`);
+		}
+		expect(item.href(testDivision)).toBe(String(testDivision.id));
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeFalsy();
+	});
+
+	it("generates 'Open in New Tab' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "Open in New Tab");
+		if (!item) {
+			return fail("missing 'Open in New Tab' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (typeof(item.href) !== "function") {
+			return fail(`'Open in New Tab' context menu item should use a function to determine href, instead uses: ${item.href}`);
+		}
+		expect(item.href(testDivision)).toBe(String(testDivision.id));
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeTrue();
+	});
+
+	it("generates 'View Regions' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "View Regions");
+		if (!item) {
+			return fail("missing 'View Regions' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (!item.href) {
+			return fail("missing 'href' property");
+		}
+		if (typeof(item.href) !== "string") {
+			return fail("'View Regions' context menu item should use a static string to determine href, instead uses a function");
+		}
+		expect(item.href).toBe("/core/regions");
+		if (typeof(item.queryParams) !== "function") {
+			return fail(
+				`'View Regions' context menu item should use a function to determine query params, instead uses: ${item.queryParams}`
+			);
+		}
+		expect(item.queryParams(testDivision)).toEqual({divisionName: testDivision.name});
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeFalsy();
 	});
 });

--- a/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.ts
+++ b/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.ts
@@ -37,29 +37,6 @@ export class DivisionsTableComponent implements OnInit {
 	/** List of divisions */
 	public divisions: Promise<Array<ResponseDivision>>;
 
-	constructor(private readonly route: ActivatedRoute, private readonly navSvc: NavigationService,
-		private readonly api: CacheGroupService, private readonly dialog: MatDialog, public readonly auth: CurrentUserService) {
-		this.fuzzySubject = new BehaviorSubject<string>("");
-		this.divisions = this.api.getDivisions();
-		this.navSvc.headerTitle.next("Divisions");
-	}
-
-	/** Initializes table data, loading it from Traffic Ops. */
-	public ngOnInit(): void {
-		this.route.queryParamMap.subscribe(
-			m => {
-				const search = m.get("search");
-				if (search) {
-					this.fuzzControl.setValue(decodeURIComponent(search));
-					this.updateURL();
-				}
-			},
-			e => {
-				console.error("Failed to get query parameters:", e);
-			}
-		);
-	}
-
 	/** Definitions of the table's columns according to the ag-grid API */
 	public columnDefs = [
 		{
@@ -104,11 +81,31 @@ export class DivisionsTableComponent implements OnInit {
 	public fuzzySubject: BehaviorSubject<string>;
 
 	/** Form controller for the user search input. */
-	public fuzzControl = new FormControl<string>("");
+	public fuzzControl = new FormControl<string>("", {nonNullable: true});
+
+	constructor(private readonly route: ActivatedRoute, private readonly navSvc: NavigationService,
+		private readonly api: CacheGroupService, private readonly dialog: MatDialog, public readonly auth: CurrentUserService) {
+		this.fuzzySubject = new BehaviorSubject<string>("");
+		this.divisions = this.api.getDivisions();
+		this.navSvc.headerTitle.next("Divisions");
+	}
+
+	/** Initializes table data, loading it from Traffic Ops. */
+	public ngOnInit(): void {
+		this.route.queryParamMap.subscribe(
+			m => {
+				const search = m.get("search");
+				if (search) {
+					this.fuzzControl.setValue(decodeURIComponent(search));
+					this.updateURL();
+				}
+			}
+		);
+	}
 
 	/** Update the URL's 'search' query parameter for the user's search input. */
 	public updateURL(): void {
-		this.fuzzySubject.next(this.fuzzControl.value ?? "");
+		this.fuzzySubject.next(this.fuzzControl.value);
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.ts
+++ b/experimental/traffic-portal/src/app/core/cache-groups/divisions/table/divisions-table.component.ts
@@ -12,17 +12,17 @@
 * limitations under the License.
 */
 
-import { Component, OnInit } from "@angular/core";
+import { Component, type OnInit } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, type Params } from "@angular/router";
 import { BehaviorSubject } from "rxjs";
 import { ResponseDivision } from "trafficops-types";
 
 import { CacheGroupService } from "src/app/api";
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
 import { DecisionDialogComponent } from "src/app/shared/dialogs/decision-dialog/decision-dialog.component";
-import { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
+import type { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
 import { NavigationService } from "src/app/shared/navigation/navigation.service";
 
 /**
@@ -80,8 +80,13 @@ export class DivisionsTableComponent implements OnInit {
 	/** Definitions for the context menu items (which act on augmented division data). */
 	public contextMenuItems: Array<ContextMenuItem<ResponseDivision>> = [
 		{
-			href: (div: ResponseDivision): string => `core/divisions/${div.id}`,
+			href: (div: ResponseDivision): string => `${div.id}`,
 			name: "Edit"
+		},
+		{
+			href: (div: ResponseDivision): string => `${div.id}`,
+			name: "Open in New Tab",
+			newTab: true
 		},
 		{
 			action: "delete",
@@ -89,8 +94,9 @@ export class DivisionsTableComponent implements OnInit {
 			name: "Delete"
 		},
 		{
-			href: (div: ResponseDivision): string => `core/regions?search=${div.name}`,
-			name: "View Regions"
+			href: "/core/regions",
+			name: "View Regions",
+			queryParams: (div: ResponseDivision): Params => ({divisionName: div.name})
 		}
 	];
 

--- a/experimental/traffic-portal/src/app/core/cache-groups/regions/table/regions-table.component.html
+++ b/experimental/traffic-portal/src/app/core/cache-groups/regions/table/regions-table.component.html
@@ -27,4 +27,4 @@ limitations under the License.
 </mat-card>
 
 
-<button class="page-fab" mat-fab title="Create a new Region" *ngIf="auth.hasPermission('REGION:CREATE')" routerLink="new"><mat-icon>add</mat-icon></button>
+<a class="page-fab" mat-fab title="Create a new Region" *ngIf="auth.hasPermission('REGION:CREATE')" routerLink="new"><mat-icon>add</mat-icon></a>

--- a/experimental/traffic-portal/src/app/core/cache-groups/regions/table/regions-table.component.ts
+++ b/experimental/traffic-portal/src/app/core/cache-groups/regions/table/regions-table.component.ts
@@ -12,17 +12,17 @@
 * limitations under the License.
 */
 
-import { Component, OnInit } from "@angular/core";
+import { Component, type OnInit } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, type Params } from "@angular/router";
 import { BehaviorSubject } from "rxjs";
-import { Region, ResponseRegion } from "trafficops-types";
+import type { Region, ResponseRegion } from "trafficops-types";
 
 import { CacheGroupService } from "src/app/api";
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
 import { DecisionDialogComponent } from "src/app/shared/dialogs/decision-dialog/decision-dialog.component";
-import { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
+import type { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
 import { NavigationService } from "src/app/shared/navigation/navigation.service";
 
 /**
@@ -68,7 +68,8 @@ export class RegionsTableComponent implements OnInit {
 		},
 		{
 			field: "divisionName",
-			headerName: "Division"
+			headerName: "Division",
+			valueGetter: ({data}: {data: ResponseRegion}): string => `${data.divisionName} (#${data.division})`
 		},
 		{
 			field: "id",
@@ -84,8 +85,13 @@ export class RegionsTableComponent implements OnInit {
 	/** Definitions for the context menu items (which act on augmented region data). */
 	public contextMenuItems: Array<ContextMenuItem<ResponseRegion>> = [
 		{
-			href: (selectedRow: ResponseRegion): string => `/core/regions/${selectedRow.id}`,
+			href: (selectedRow: ResponseRegion): string => `${selectedRow.id}`,
 			name: "Edit"
+		},
+		{
+			href: (selectedRow: ResponseRegion): string => `${selectedRow.id}`,
+			name: "Open in New Tab",
+			newTab: true
 		},
 		{
 			action: "delete",
@@ -97,8 +103,9 @@ export class RegionsTableComponent implements OnInit {
 			name: "View Division"
 		},
 		{
-			href: (selectedRow: Region): string => `/core/phys-locs?search=${selectedRow.name}`,
-			name: "View Physical Locations"
+			href: "/core/phys-locs",
+			name: "View Physical Locations",
+			queryParams: (selectedRow: ResponseRegion): Params => ({region: selectedRow.name})
 		}
 	];
 

--- a/experimental/traffic-portal/src/app/core/change-logs/change-logs.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/change-logs/change-logs.component.spec.ts
@@ -11,33 +11,32 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { TestbedHarnessEnvironment } from "@angular/cdk/testing/testbed";
 import { HttpClientModule } from "@angular/common/http";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { MatDialog } from "@angular/material/dialog";
+import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { MatDialogHarness } from "@angular/material/dialog/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
-import { Observable, of, ReplaySubject } from "rxjs";
+import { of, ReplaySubject } from "rxjs";
 
 import { APITestingModule } from "src/app/api/testing";
 import { NavigationService } from "src/app/shared/navigation/navigation.service";
 
 import { ChangeLogsComponent } from "./change-logs.component";
 
-/**
- * Define the MockDialog
- */
-class MockDialog {
+const testCLEntry = {
+	id: 1,
+	lastUpdated: new Date(),
+	level: "APICHANGE" as const,
+	longTime: "",
+	message: "testquest",
+	relativeTime: "3 seconds ago",
+	ticketNum: null,
+	user: "admin"
+};
 
-	/**
-	 * Fake opens the dialog
-	 *
-	 * @returns unknown
-	 */
-	public open(): unknown {
-		return {
-			afterClosed: (): Observable<number> => of(3)
-		};
-	}
-}
 describe("ChangeLogsComponent", () => {
 	let component: ChangeLogsComponent;
 	let fixture: ComponentFixture<ChangeLogsComponent>;
@@ -49,17 +48,15 @@ describe("ChangeLogsComponent", () => {
 			imports: [
 				APITestingModule,
 				HttpClientModule,
-				RouterTestingModule
+				RouterTestingModule,
+				NoopAnimationsModule,
+				MatDialogModule
 			],
 			providers: [
-				{ provide: MatDialog, useClass: MockDialog },
 				{ provide: NavigationService, useValue: navSvc },
 			]
-		})
-			.compileComponents();
-	});
+		}).compileComponents();
 
-	beforeEach(() => {
 		fixture = TestBed.createComponent(ChangeLogsComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
@@ -68,4 +65,100 @@ describe("ChangeLogsComponent", () => {
 	it("should create", () => {
 		expect(component).toBeTruthy();
 	});
+
+	it("handles unknown actions", async () => {
+		await expectAsync(component.handleContextMenu({action: "something unknown", data: []})).toBeResolvedTo(undefined);
+		await expectAsync(component.handleTitleButton("something unknown")).toBeResolvedTo(undefined);
+	});
+
+	it("updates the fuzzy search output", fakeAsync(() => {
+		let called = false;
+		const text = "testquest";
+		const spy = jasmine.createSpy("subscriber", (txt: string): void =>{
+			if (!called) {
+				expect(txt).toBe("");
+				called = true;
+			} else {
+				expect(txt).toBe(text);
+			}
+		});
+		component.fuzzySubj.subscribe(spy);
+		tick();
+		expect(spy).toHaveBeenCalled();
+		component.searchText = text;
+		component.updateURL();
+		tick();
+		expect(spy).toHaveBeenCalledTimes(2);
+	}));
+
+	it("sets the fuzzy search subject based on the search query param", fakeAsync(() => {
+		const router = TestBed.inject(ActivatedRoute);
+		const searchString = "testquest";
+		spyOnProperty(router, "queryParamMap").and.returnValue(of(new Map([["search", searchString]])));
+
+		let searchValue = "not the right string";
+		component.fuzzySubj.subscribe(
+			s => searchValue = s
+		);
+
+		component.ngOnInit();
+		tick();
+
+		expect(searchValue).toBe(searchString);
+	}));
+
+	it("opens a dialog to view changelog item details (array data)", fakeAsync(async () => {
+		const asyncExpectation = expectAsync(
+			component.handleContextMenu({action: "viewChangeLog", data: [testCLEntry]})
+		).toBeResolvedTo(undefined);
+
+		tick();
+
+		const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+		const dialogs = await loader.getAllHarnesses(MatDialogHarness);
+		if (dialogs.length !== 1) {
+			return fail(`expected exactly one dialog to be opened; got: ${dialogs.length}`);
+		}
+
+		await dialogs[0].close();
+
+		await asyncExpectation;
+	}));
+
+	it("opens a dialog to view changelog item details (single object data)", fakeAsync(async () => {
+		const asyncExpectation = expectAsync(
+			component.handleContextMenu({action: "viewChangeLog", data: testCLEntry})
+		).toBeResolvedTo(undefined);
+
+		tick();
+
+		const loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
+
+		const dialogs = await loader.getAllHarnesses(MatDialogHarness);
+		if (dialogs.length !== 1) {
+			return fail(`expected exactly one dialog to be opened; got: ${dialogs.length}`);
+		}
+
+		await dialogs[0].close();
+
+		await asyncExpectation;
+	}));
+
+	it("opens a dialog to set the number of days to which to filter the changelogs", fakeAsync(async () => {
+		const numDays = 5;
+		component.lastDays = numDays + 1;
+
+		const dialogService = TestBed.inject(MatDialog);
+		const openSpy = spyOn(dialogService, "open").and.returnValue({
+			afterClosed: () => of(numDays)
+		} as MatDialogRef<unknown>);
+		expect(openSpy).not.toHaveBeenCalled();
+
+		const asyncExpectation = expectAsync(component.handleTitleButton("lastDays")).toBeResolvedTo(undefined);
+		tick();
+		await asyncExpectation;
+		expect(openSpy).toHaveBeenCalled();
+		expect(component.lastDays).toBe(numDays);
+	}));
 });

--- a/experimental/traffic-portal/src/app/core/servers/phys-loc/table/phys-loc-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/servers/phys-loc/table/phys-loc-table.component.spec.ts
@@ -12,11 +12,33 @@
  * limitations under the License.
  */
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
-import { MatDialogModule } from "@angular/material/dialog";
+import { MatDialog, MatDialogModule, MatDialogRef } from "@angular/material/dialog";
+import { ActivatedRoute } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
+import type { ValueFormatterParams } from "ag-grid-community";
+import { of } from "rxjs";
 
+import { PhysicalLocationService } from "src/app/api";
 import { APITestingModule } from "src/app/api/testing";
 import { PhysLocTableComponent } from "src/app/core/servers/phys-loc/table/phys-loc-table.component";
+import { isAction } from "src/app/shared/generic-table/generic-table.component";
+
+const testPhysLoc = {
+	address: "address",
+	city: "city",
+	comments: null,
+	email: null,
+	id: 9001,
+	lastUpdated: new Date(),
+	name: "test",
+	phone: null,
+	poc: null,
+	region: "region",
+	regionId: 1,
+	shortName: "test",
+	state: "state",
+	zip: "zip"
+};
 
 describe("PhysLocTableComponent", () => {
 	let component: PhysLocTableComponent;
@@ -38,6 +60,22 @@ describe("PhysLocTableComponent", () => {
 		expect(component).toBeTruthy();
 	});
 
+	it("sets the fuzzy search subject based on the search query param", fakeAsync(() => {
+		const router = TestBed.inject(ActivatedRoute);
+		const searchString = "testquest";
+		spyOnProperty(router, "queryParamMap").and.returnValue(of(new Map([["search", searchString]])));
+
+		let searchValue = "not the right string";
+		component.fuzzySubject.subscribe(
+			s => searchValue = s
+		);
+
+		component.ngOnInit();
+		tick();
+
+		expect(searchValue).toBe(searchString);
+	}));
+
 	it("updates the fuzzy search output", fakeAsync(() => {
 		let called = false;
 		const text = "testquest";
@@ -58,10 +96,133 @@ describe("PhysLocTableComponent", () => {
 		expect(spy).toHaveBeenCalledTimes(2);
 	}));
 
-	it("handles contextmenu events", async (): Promise<void> => {
+	it("handles unrecognized contextmenu events", async (): Promise<void> => {
 		expect(async () => component.handleContextMenu({
 			action: component.contextMenuItems[0].name,
 			data: (await component.physLocations)[0]
 		})).not.toThrow();
+	});
+
+	it("handles the 'delete' context menu item", fakeAsync(async () => {
+		const item = component.contextMenuItems.find(c => c.name === "Delete");
+		if (!item) {
+			return fail("missing 'Delete' context menu item");
+		}
+		if (!isAction(item)) {
+			return fail("expected an action, not a link");
+		}
+		expect(item.multiRow).toBeFalsy();
+		expect(item.disabled).toBeUndefined();
+
+		const api = TestBed.inject(PhysicalLocationService);
+		const spy = spyOn(api, "deletePhysicalLocation").and.callThrough();
+		expect(spy).not.toHaveBeenCalled();
+
+		const dialogService = TestBed.inject(MatDialog);
+		const openSpy = spyOn(dialogService, "open").and.returnValue({
+			afterClosed: () => of(true)
+		} as MatDialogRef<unknown>);
+
+		const physLoc = await api.createPhysicalLocation(testPhysLoc);
+		expect(openSpy).not.toHaveBeenCalled();
+		const asyncExpectation = expectAsync(component.handleContextMenu({action: "delete", data: physLoc})).toBeResolvedTo(undefined);
+		tick();
+
+		expect(openSpy).toHaveBeenCalled();
+		tick();
+
+		expect(spy).toHaveBeenCalled();
+
+		await asyncExpectation;
+	}));
+
+	it("generates 'Edit' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "Edit");
+		if (!item) {
+			return fail("missing 'Edit' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (typeof(item.href) !== "function") {
+			return fail(`'Edit' context menu item should use a function to determine href, instead uses: ${item.href}`);
+		}
+		expect(item.href(testPhysLoc)).toBe(String(testPhysLoc.id));
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeFalsy();
+	});
+
+	it("generates 'Open in New Tab' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "Open in New Tab");
+		if (!item) {
+			return fail("missing 'Open in New Tab' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (typeof(item.href) !== "function") {
+			return fail(`'Open in New Tab' context menu item should use a function to determine href, instead uses: ${item.href}`);
+		}
+		expect(item.href(testPhysLoc)).toBe(String(testPhysLoc.id));
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeTrue();
+	});
+
+	it("generates 'View Servers' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "View Servers");
+		if (!item) {
+			return fail("missing 'View Servers' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (!item.href) {
+			return fail("missing 'href' property");
+		}
+		if (typeof(item.href) !== "string") {
+			return fail("'View Servers' context menu item should use a static string to determine href, instead uses a function");
+		}
+		expect(item.href).toBe("/core/servers");
+		if (typeof(item.queryParams) !== "function") {
+			return fail(
+				`'View Servers' context menu item should use a function to determine query params, instead uses: ${item.queryParams}`
+			);
+		}
+		expect(item.queryParams(testPhysLoc)).toEqual({physLocation: testPhysLoc.name});
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeFalsy();
+	});
+
+	it("generates 'View Region' context menu item href", () => {
+		const item = component.contextMenuItems.find(i => i.name === "View Region");
+		if (!item) {
+			return fail("missing 'View Region' context menu item");
+		}
+		if (isAction(item)) {
+			return fail("expected a link, not an action");
+		}
+		if (!item.href) {
+			return fail("missing 'href' property");
+		}
+		if (typeof(item.href) !== "function") {
+			return fail(`'View Region' context menu item should use a function to determine href, instead uses: ${item.href}`);
+		}
+		expect(item.href(testPhysLoc)).toBe(`/core/regions/${testPhysLoc.regionId}`);
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
+		expect(item.newTab).toBeFalsy();
+	});
+
+	it("formats region cell data", () => {
+		const item = component.columnDefs.find(i => i.field === "region");
+		if (!item) {
+			return fail("missing 'region' column");
+		}
+		if (!item.valueFormatter) {
+			return fail("'region' column should have a valueFormatter");
+		}
+		expect(item.valueFormatter({data: testPhysLoc} as ValueFormatterParams)).toBe(`${testPhysLoc.region} (#${testPhysLoc.regionId})`);
 	});
 });

--- a/experimental/traffic-portal/src/app/core/servers/phys-loc/table/phys-loc-table.component.ts
+++ b/experimental/traffic-portal/src/app/core/servers/phys-loc/table/phys-loc-table.component.ts
@@ -11,17 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Component, OnInit } from "@angular/core";
+import { Component, type OnInit } from "@angular/core";
 import { FormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, type Params } from "@angular/router";
 import { BehaviorSubject } from "rxjs";
 import { ResponsePhysicalLocation } from "trafficops-types";
 
 import { CacheGroupService, PhysicalLocationService } from "src/app/api";
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
 import { DecisionDialogComponent } from "src/app/shared/dialogs/decision-dialog/decision-dialog.component";
-import { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
+import type { ContextMenuActionEvent, ContextMenuItem } from "src/app/shared/generic-table/generic-table.component";
 import { NavigationService } from "src/app/shared/navigation/navigation.service";
 
 /**
@@ -58,7 +58,8 @@ export class PhysLocTableComponent implements OnInit {
 		headerName: "State"
 	}, {
 		field: "region",
-		headerName: "Region"
+		headerName: "Region",
+		valueFormatter: ({data}: {data: ResponsePhysicalLocation}): string => `${data.region} (#${data.regionId})`
 	}, {
 		field: "lastUpdated",
 		headerName: "Last Updated"
@@ -67,8 +68,13 @@ export class PhysLocTableComponent implements OnInit {
 	/** Definitions for the context menu items (which act on augmented cache-group data). */
 	public contextMenuItems: Array<ContextMenuItem<ResponsePhysicalLocation>> = [
 		{
-			href: (physLoc: ResponsePhysicalLocation): string => `/core/phys-locs/${physLoc.id}`,
+			href: (physLoc: ResponsePhysicalLocation): string => `${physLoc.id}`,
 			name: "Edit"
+		},
+		{
+			href: (physLoc: ResponsePhysicalLocation): string => `${physLoc.id}`,
+			name: "Open in New Tab",
+			newTab: true
 		},
 		{
 			action: "delete",
@@ -78,6 +84,11 @@ export class PhysLocTableComponent implements OnInit {
 		{
 			href: (physLoc: ResponsePhysicalLocation): string => `/core/regions/${physLoc.regionId}`,
 			name: "View Region"
+		},
+		{
+			href: "/core/servers",
+			name: "View Servers",
+			queryParams: (physLoc: ResponsePhysicalLocation): Params => ({physLocation: physLoc.name})
 		}
 	];
 	/** A subject that child components can subscribe to for access to the fuzzy search query text */

--- a/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.spec.ts
@@ -262,14 +262,12 @@ describe("ServersTableComponent", () => {
 		expect((await component.servers).length).toBeGreaterThan(0);
 	});
 
-	it("handles its context menu actions", fakeAsync(() => {
+	it("handles its context menu actions", fakeAsync(async () => {
 		const augmentFields = {ipv4Address: "192.0.2.0", ipv6Address: "2001::1"};
 		const server = {...defaultServer, id: 9001, type: "EDGE", ...augmentFields};
 
-		component.handleContextMenu({action: "viewDetails", data: server});
-		tick();
-		expect(router.url).toBe("/core/server/9001");
-		expectAsync(component.handleContextMenu({action: "viewDetails", data: [server]})).toBeRejected();
+		await expectAsync(component.handleContextMenu({action: "viewDetails", data: [server]})).toBeRejected();
+		await expectAsync(component.handleContextMenu({action: "viewDetails", data: server})).toBeRejected();
 
 		component.handleContextMenu({action: "updateStatus", data: server});
 

--- a/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.ts
+++ b/experimental/traffic-portal/src/app/core/servers/servers-table/servers-table.component.ts
@@ -15,7 +15,7 @@
 import { Component , type OnInit} from "@angular/core";
 import { UntypedFormControl } from "@angular/forms";
 import { MatDialog } from "@angular/material/dialog";
-import { ActivatedRoute , Router} from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 import type { ITooltipParams } from "ag-grid-community";
 import { BehaviorSubject } from "rxjs";
 import { type ResponseServer, serviceAddresses } from "trafficops-types";
@@ -218,7 +218,8 @@ export class ServersTableComponent implements OnInit {
 		{
 			field: "physLocation",
 			headerName: "Phys Location",
-			hide: true
+			hide: true,
+			valueFormatter: ({data}: {data: AugmentedServer}): string => `${data.physLocation} (#${data.physLocationId})`
 		},
 		{
 			field: "profile",
@@ -280,8 +281,21 @@ export class ServersTableComponent implements OnInit {
 	/** Definitions for the context menu items (which act on augmented server data). */
 	public contextMenuItems: Array<ContextMenuItem<AugmentedServer>> = [
 		{
-			action: "viewDetails",
+			href: (row: AugmentedServer): string => `${row.id}`,
 			name: "View Server Details"
+		},
+		{
+			href: (row: AugmentedServer): string => `${row.id}`,
+			name: "Open in New Tab",
+			newTab: true
+		},
+		{
+			href: (row: AugmentedServer): string => `/core/cache-groups/${row.cachegroupId}`,
+			name: "View Cache Group"
+		},
+		{
+			href: (row: AugmentedServer): string => `/core/phys-locs/${row.physLocationId}`,
+			name: "View Physical Location"
 		},
 		{
 			action: "updateStatus",
@@ -319,7 +333,6 @@ export class ServersTableComponent implements OnInit {
 	 */
 	constructor(private readonly api: ServerService,
 		private readonly route: ActivatedRoute,
-		private readonly router: Router,
 		private readonly navSvc: NavigationService,
 		private readonly dialog: MatDialog) {
 		this.fuzzySubject = new BehaviorSubject<string>("");
@@ -354,12 +367,6 @@ export class ServersTableComponent implements OnInit {
 	 */
 	public async handleContextMenu(action: ContextMenuActionEvent<AugmentedServer>): Promise<void> {
 		switch (action.action) {
-			case "viewDetails":
-				if (action.data instanceof Array) {
-					throw new Error("'viewDetails' is a single-row action, but was called with multiple rows");
-				}
-				await this.router.navigate(["/core/server", action.data.id]);
-				break;
 			case "updateStatus":
 				const dialogRef = this.dialog.open(UpdateStatusComponent, {
 					data: action.data instanceof Array ? action.data : [action.data]

--- a/experimental/traffic-portal/src/app/core/users/tenants/tenants.component.html
+++ b/experimental/traffic-portal/src/app/core/users/tenants/tenants.component.html
@@ -27,4 +27,4 @@ limitations under the License.
 	<div id="loading" *ngIf="loading"><tp-loading></tp-loading></div>
 </mat-card>
 
-<button class="page-fab" mat-fab title="Create a new Tenant" *ngIf="auth.hasPermission('TENANT:CREATE')" routerLink="new"><mat-icon>add</mat-icon></button>
+<a class="page-fab" mat-fab title="Create a new Tenant" *ngIf="auth.hasPermission('TENANT:CREATE')" routerLink="new"><mat-icon>add</mat-icon></a>

--- a/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
@@ -142,6 +142,8 @@ describe("UsersComponent", () => {
 			return fail(`should use a function to generate an href, but uses static string: '${item.href}'`);
 		}
 		expect(item.href(testUser)).toBe(`${testUser.id}`, "generated incorrect href");
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
 	});
 
 	it("has a proper 'Open in New Tab' context menu item", () => {
@@ -163,6 +165,8 @@ describe("UsersComponent", () => {
 			return fail(`should use a function to generate an href, but uses static string: '${item.href}'`);
 		}
 		expect(item.href(testUser)).toBe(`${testUser.id}`, "generated incorrect href");
+		expect(item.queryParams).toBeUndefined();
+		expect(item.fragment).toBeUndefined();
 	});
 
 	it("has a proper 'View User Changelogs' context menu item", () => {

--- a/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.spec.ts
@@ -16,7 +16,7 @@ import { waitForAsync, ComponentFixture, TestBed, fakeAsync, tick } from "@angul
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { MatDialogModule } from "@angular/material/dialog";
 import { RouterTestingModule } from "@angular/router/testing";
-import type { ValueGetterParams } from "ag-grid-community";
+import type { ValueFormatterParams } from "ag-grid-community";
 
 import { APITestingModule } from "src/app/api/testing";
 import { CurrentUserService } from "src/app/shared/currentUser/current-user.service";
@@ -118,10 +118,10 @@ describe("UsersComponent", () => {
 		if (!tenantColDef) {
 			return fail("table missing column definition for the 'tenant' property");
 		}
-		if (!tenantColDef.valueGetter) {
+		if (!tenantColDef.valueFormatter) {
 			return fail("column definition for 'tenant' property missing 'valueGetter' property");
 		}
-		expect(tenantColDef.valueGetter({data: testUser} as ValueGetterParams)).toBe(`${testUser.tenant} (#${testUser.tenantId})`);
+		expect(tenantColDef.valueFormatter({data: testUser} as ValueFormatterParams)).toBe(`${testUser.tenant} (#${testUser.tenantId})`);
 	});
 
 	it("has a proper 'View User Details' context menu item", () => {
@@ -141,7 +141,7 @@ describe("UsersComponent", () => {
 		if (typeof(item.href) === "string") {
 			return fail(`should use a function to generate an href, but uses static string: '${item.href}'`);
 		}
-		expect(item.href(testUser)).toBe(`/core/users/${testUser.id}`, "generated incorrect href");
+		expect(item.href(testUser)).toBe(`${testUser.id}`, "generated incorrect href");
 	});
 
 	it("has a proper 'Open in New Tab' context menu item", () => {
@@ -162,16 +162,13 @@ describe("UsersComponent", () => {
 		if (typeof(item.href) === "string") {
 			return fail(`should use a function to generate an href, but uses static string: '${item.href}'`);
 		}
-		expect(item.href(testUser)).toBe(`/core/users/${testUser.id}`, "generated incorrect href");
+		expect(item.href(testUser)).toBe(`${testUser.id}`, "generated incorrect href");
 	});
 
 	it("has a proper 'View User Changelogs' context menu item", () => {
-		const item = component.contextMenuItems[2];
+		const item = component.contextMenuItems.find(i => i.name === "View User Changelogs");
 		if (!item) {
-			return fail("table is missing 'contextMenuItems' property");
-		}
-		if (item.name !== "View User Changelogs") {
-			return fail(`The third context menu item should've been 'View User Changelogs', but it was '${item.name}'`);
+			return fail("table is missing 'view user changelogs' context menu item");
 		}
 		if (isAction(item)) {
 			return fail("the third context menu item should've been a link but it was an action");
@@ -179,9 +176,14 @@ describe("UsersComponent", () => {
 		if (!item.href) {
 			return fail("missing 'href' property");
 		}
-		if (typeof(item.href) === "string") {
-			return fail(`should use a function to generate an href, but uses static string: '${item.href}'`);
+		if (typeof(item.href) !== "string") {
+			return fail("should use a static string: for href, but instead uses a function");
 		}
-		expect(item.href(testUser)).toBe(`/core/change-logs?search=${testUser.username}`, "generated incorrect href");
+		expect(item.href).toBe("/core/change-logs");
+		if (typeof(item.queryParams) !== "function") {
+			return fail(`should use a function to determine query string parameters, instead uses: ${item.queryParams}`);
+		}
+		expect(item.queryParams(testUser)).toEqual({user: testUser.username});
+		expect(item.fragment).toBeUndefined();
 	});
 });

--- a/experimental/traffic-portal/src/app/core/users/users.component.ts
+++ b/experimental/traffic-portal/src/app/core/users/users.component.ts
@@ -14,7 +14,8 @@
 import { animate, style, transition, trigger } from "@angular/animations";
 import { Component, type OnInit } from "@angular/core";
 import { MatDialog } from "@angular/material/dialog";
-import type { ValueGetterParams } from "ag-grid-community";
+import { Params } from "@angular/router";
+import type { ValueFormatterParams } from "ag-grid-community";
 import { BehaviorSubject } from "rxjs";
 import { ResponseUser } from "trafficops-types";
 
@@ -202,7 +203,7 @@ export class UsersComponent implements OnInit {
 			field: "tenant",
 			headerName: "Tenant",
 			hide: false,
-			valueGetter: (params: ValueGetterParams): string => `${params.data.tenant} (#${params.data.tenantId})`
+			valueFormatter: (params: ValueFormatterParams): string => `${params.data.tenant} (#${params.data.tenantId})`
 		},
 		{
 			field: "uid",
@@ -220,17 +221,22 @@ export class UsersComponent implements OnInit {
 	/** Definitions for the context menu items (which act on user data). */
 	public contextMenuItems: Array<ContextMenuItem<ResponseUser>> = [
 		{
-			href: (u: ResponseUser): string => `/core/users/${u.id}`,
+			href: (u: ResponseUser): string => `${u.id}`,
 			name: "View User Details"
 		},
 		{
-			href: (u: ResponseUser): string => `/core/users/${u.id}`,
+			href: (u: ResponseUser): string => `${u.id}`,
 			name: "Open in New Tab",
 			newTab: true
 		},
 		{
-			href: (u: ResponseUser): string => `/core/change-logs?search=${u.username}`,
-			name: "View User Changelogs"
+			href: (u: ResponseUser): string => `/core/tenants/${u.tenantId}`,
+			name: "View Tenant"
+		},
+		{
+			href: "/core/change-logs",
+			name: "View User Changelogs",
+			queryParams: (u: ResponseUser): Params => ({user: u.username})
 		}
 	];
 

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
@@ -51,7 +51,7 @@ limitations under the License.
 	<ul>
 		<li *ngFor="let item of contextMenuItems" role="menuitem">
 			<ng-container *ngIf="!isAction(item)">
-				<a *ngIf="!isDisabled(item)" [routerLink]="href(item)" [target]="item.newTab ? '_blank' : '_self'">{{item.name}}</a>
+				<a *ngIf="!isDisabled(item)" [routerLink]="href(item)" [queryParams]="queryParameters(item)" [fragment]="fragment(item)" [target]="item.newTab ? '_blank' : '_self'">{{item.name}}</a>
 				<button type="button" *ngIf="isDisabled(item)" disabled>{{item.name}}</button>
 			</ng-container>
 			<button name="{{itemName(item)}}" *ngIf="isAction(item)" type="button" (click)="emitContextMenuAction(item.action, item.multiRow, $event)" [disabled]="isDisabled(item)">{{item.name}}</button>

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
@@ -38,7 +38,7 @@ limitations under the License.
 	[components]="components"
 	[gridOptions]="gridOptions"
 	(gridReady)="setAPI($event)"
-	(filterChanged)="storeFilter()"
+	(filterChanged)="storeFilter($event)"
 	(sortChanged)="storeColumns()"
 	(columnMoved)="storeColumns()"
 	(columnVisible)="storeColumns(true)"

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.html
@@ -12,13 +12,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <div class="extra-actions">
-	<button mat-flat-button color="accent" type="button" title="select all rows" (click)="selectAll()">Select All</button>
-	<button mat-flat-button color="accent" type="button" title="de-select all rows" (click)="selectAll(true)">De-Select All</button>
-	<button mat-flat-button color="accent" type="button"*ngFor="let btn of tableTitleButtons" (click)="emitTitleButtonAction(btn.action)">{{btn.text}}</button>
-	<button mat-flat-button color="accent" type="button" (click)="download()" title="save as CSV"><fa-icon [icon]="downloadIcon"></fa-icon></button>
-	<button mat-flat-button color="accent" type="button" (click)="gridAPI.sizeColumnsToFit()">Resize</button>
+	<button mat-flat-button type="button" title="select all rows" (click)="selectAll()">Select All</button>
+	<button mat-flat-button type="button" title="de-select all rows" (click)="selectAll(true)">De-Select All</button>
+	<button mat-flat-button type="button" title="clear all active filters" (click)="clearFilters()"><mat-icon>filter_list</mat-icon> Clear</button>
+	<button mat-flat-button type="button"*ngFor="let btn of tableTitleButtons" (click)="emitTitleButtonAction(btn.action)">{{btn.text}}</button>
+	<button mat-flat-button type="button" (click)="download()" title="save as CSV"><fa-icon [icon]="downloadIcon"></fa-icon></button>
+	<button mat-flat-button type="button" (click)="gridAPI.sizeColumnsToFit()">Resize</button>
 	<div class="toggle-columns" role="group" title="Select Table Columns">
-		<button mat-flat-button color="accent" [matMenuTriggerFor]="menu">
+		<button mat-flat-button [matMenuTriggerFor]="menu">
 			<fa-icon [icon]="columnsIcon"></fa-icon>&nbsp;
 			<fa-icon [icon]="caretIcon" class="caret" [ngClass]="{'rotate': showMenu}"></fa-icon>
 		</button>

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.spec.ts
@@ -14,12 +14,13 @@
 
 import { type ComponentFixture, TestBed } from "@angular/core/testing";
 import { MatMenuModule } from "@angular/material/menu";
+import { Params } from "@angular/router";
 import { RouterTestingModule } from "@angular/router/testing";
 import { AgGridModule } from "ag-grid-angular";
 import type { CellContextMenuEvent, ColDef, GridApi, RowNode, ValueGetterParams } from "ag-grid-community";
 import { BehaviorSubject } from "rxjs";
 
-import { type ContextMenuAction, GenericTableComponent } from "./generic-table.component";
+import { type ContextMenuAction, GenericTableComponent, getColType, ContextMenuItem } from "./generic-table.component";
 
 /**
  * TestData is the type of a row of data for the generic table component tests.
@@ -358,5 +359,64 @@ describe("GenericTableComponent", () => {
 
 		action.disabled = (): boolean => true;
 		expect(component.isDisabled(action)).toBeTrue();
+	});
+
+	it("calculates an href for a context menu link item", () => {
+		const hrefValue = "href value";
+		const menuLinkItem: ContextMenuItem<unknown> = {
+			href: hrefValue,
+			name: "test",
+		};
+		component.selected = {};
+		expect(component.href(menuLinkItem)).toBe(hrefValue);
+		menuLinkItem.href = (): string => hrefValue;
+		expect(component.href(menuLinkItem)).toBe(hrefValue);
+		component.selected = null;
+		expect(component.href(menuLinkItem)).toBe("");
+	});
+
+	it("calculates a fragment for a context menu link item", () => {
+		const fragmentValue = "fragment value";
+		const menuLinkItem: ContextMenuItem<unknown> = {
+			href: "inconsequential",
+			name: "test",
+		};
+		component.selected = {};
+		expect(component.fragment(menuLinkItem)).toBeNull();
+		menuLinkItem.fragment = fragmentValue;
+		expect(component.fragment(menuLinkItem)).toBe(fragmentValue);
+		menuLinkItem.fragment = (): string => fragmentValue;
+		expect(component.fragment(menuLinkItem)).toBe(fragmentValue);
+		component.selected = null;
+		expect(component.fragment(menuLinkItem)).toBeNull();
+	});
+
+	it("calculates query parameters for a context menu link item", () => {
+		const qParamsValue = {query: "params"};
+		const menuLinkItem: ContextMenuItem<unknown> = {
+			href: "inconsequential",
+			name: "test",
+		};
+		component.selected = {};
+		expect(component.queryParameters(menuLinkItem)).toBeNull();
+		menuLinkItem.queryParams = qParamsValue;
+		expect(component.queryParameters(menuLinkItem)).toEqual(qParamsValue);
+		menuLinkItem.queryParams = (): Params => qParamsValue;
+		expect(component.queryParameters(menuLinkItem)).toEqual(qParamsValue);
+		component.selected = null;
+		expect(component.queryParameters(menuLinkItem)).toBeNull();
+	});
+});
+
+describe("generic table utility functions", () => {
+	it("gets the correct column type from a definition", () => {
+		expect(getColType({})).toBe("string");
+		expect(getColType({filter: true})).toBe("string");
+		expect(getColType({filter: "textFilter"})).toBe("string");
+		expect(getColType({filter: "agTextColumnFilter"})).toBe("string");
+		expect(getColType({filter: "agNumberColumnFilter"})).toBe("number");
+		expect(getColType({filter: "agDateColumnFilter"})).toBe("date");
+		expect(getColType({filter: "unrecognized filter name"})).toBeNull();
+		expect(getColType({filter: {}})).toBeNull();
 	});
 });

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.spec.ts
@@ -243,7 +243,7 @@ describe("GenericTableComponent", () => {
 		expect(
 			component.columns.map(c=>c.getDefinition())
 		).toEqual(
-			component.cols.map(c=>({... component.gridOptions.defaultColDef, ...c}))
+			component.cols.map(c=>({... component.gridOptions.defaultColDef, ...c})).reverse()
 		);
 	});
 

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
@@ -389,7 +389,7 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 		if (!this.columnAPI) {
 			return [];
 		}
-		return (this.columnAPI.getColumns() ?? []).sort().reverse();
+		return (this.columnAPI.getColumns() ?? []).reverse();
 	}
 
 	constructor(private readonly router: Router, private readonly route: ActivatedRoute) {

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
@@ -484,6 +484,9 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 	 */
 	public clearFilters(): void {
 		this.gridAPI.setFilterModel(null);
+		const queryParams = Object.fromEntries(this.cols.filter((c: ColDef) => c.field).map((c: ColDef) => [c.field, null]));
+		queryParams.search = null;
+		this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route, replaceUrl: true});
 	}
 
 	/**
@@ -515,7 +518,7 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 		if (!model) {
 			queryParams = {...this.route.snapshot.queryParams};
 			queryParams[col.field] = null;
-			this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route});
+			this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route, replaceUrl: true});
 			return;
 		}
 		let value = null;
@@ -547,7 +550,7 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 			return;
 		}
 		queryParams[col.field] = value;
-		this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route});
+		this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route, replaceUrl: true});
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
@@ -428,7 +428,8 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 					if (this.gridAPI) {
 						this.gridAPI.onFilterChanged();
 					}
-					this.router.navigate([], {queryParams: {search: query}, queryParamsHandling: "merge", relativeTo: this.route});
+					const queryParams = {search: query ? query : null};
+					this.router.navigate([], {queryParams, queryParamsHandling: "merge", relativeTo: this.route, replaceUrl: true});
 				}
 			);
 		}

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
@@ -385,7 +385,7 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 		if (!this.columnAPI) {
 			return [];
 		}
-		return this.columnAPI.getColumns() ?? [];
+		return (this.columnAPI.getColumns() ?? []).sort().reverse();
 	}
 
 	constructor(private readonly router: Router, private readonly route: ActivatedRoute) {
@@ -472,6 +472,13 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 			console.error(`Failure to retrieve required column info from localStorage (key=${this.context}_table_columns):`, e);
 		}
 
+	}
+
+	/**
+	 * Triggered by a table button, clears all the filters on the table.
+	 */
+	public clearFilters(): void {
+		this.gridAPI.setFilterModel(null);
 	}
 
 	/**

--- a/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
+++ b/experimental/traffic-portal/src/app/shared/generic-table/generic-table.component.ts
@@ -351,7 +351,7 @@ export class GenericTableComponent<T> implements OnInit, OnDestroy {
 	public readonly downloadIcon = faDownload;
 
 	/** Used to handle the case that Angular loads faster than AG-Grid (as it usually does) */
-	private initialize = false;
+	private initialize = true;
 
 	/** Tracks whether the menu button has been clicked. */
 	private menuClicked = false;

--- a/experimental/traffic-portal/src/app/shared/table-components/boolean-filter/boolean-filter.component.ts
+++ b/experimental/traffic-portal/src/app/shared/table-components/boolean-filter/boolean-filter.component.ts
@@ -111,7 +111,13 @@ export class BooleanFilterComponent implements AgFilterComponent {
 	 *
 	 * @param model A full representation of a filter state.
 	 */
-	public setModel(model: BooleanFilterModel): void {
+	public setModel(model: BooleanFilterModel | null): void {
+		if (!model) {
+			model = {
+				should: false,
+				value: false
+			};
+		}
 		this.shouldFilter = model.should;
 		this.value = model.value;
 	}


### PR DESCRIPTION
This PR adds a feature to TPv2, specifically it ties table filters to URL-encoded parameters in the URL's query string. Now, for example, when you navigate to `/core/servers?domainName=test` the table will automatically apply a filter that shows only those servers with the `domainName` `test`. Multiple columns can be specified without restriction. Also, unlike in TPv1, the reverse binding is also upheld; when the user navigates to `/core/servers` and *then* filters to show only servers with a `domainName` of exactly `test`, the URL will update to reflect that i.e. `/core/servers?domainName=test`.

This PR also fixes the `search` query string parameter being ever-present in the URL of table views by removing it whenever it would be blank.

It also also fixes the search box adding to the users history, so that clicking a "back" button in the browser actually takes you to a different view instead of the same view with a different filter.

Finally, many links were updated to make use of this by setting filters directly rather than relying on search matching.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the provided tests pass.

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**