### PR TITLE
t3c remove stale git lock file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7204](https://github.com/apache/trafficcontrol/pull/7204) *Traffic Control Cache Config (t3c)* strategies.yaml hash_key only for consistent_hash
 - [#7277](https://github.com/apache/trafficcontrol/pull/7277) *Traffic Control Cache Config (t3c)* remapdotconfig: remove skip check at mids for nocache/live
 - [#7282](https://github.com/apache/trafficcontrol/pull/7282) *Traffic Ops* Fixed issue with user getting correctly logged when using an access or bearer token authentication.
+- [#7346](https://github.com/apache/trafficcontrol/pull/7346) *Traffic Control Cache Config (t3c)* Fixed issue with stale lock file when using git to track changes.
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -151,7 +151,7 @@ func Main() int {
 		const gitMaxLockAgeMinutes = 5
 		const gitLock = ".git/index.lock"
 		gitLockFile := filepath.Join(cfg.TsConfigDir, gitLock)
-		oldLock, err := util.IsGitLockFileOld(gitLockFile, time.Now(), gitMaxLockAgeMinutes * time.Minute)
+		oldLock, err := util.IsGitLockFileOld(gitLockFile, time.Now(), gitMaxLockAgeMinutes*time.Minute)
 		if err != nil {
 			log.Errorln("checking for git lock file: " + err.Error())
 		}

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -146,6 +146,19 @@ func Main() int {
 	}
 
 	if cfg.UseGit == config.UseGitYes || cfg.UseGit == config.UseGitAuto {
+		//need to see if there is an old lock file laying around.
+		const gitMaxLockAge = 5
+		oldLock, err := util.IsGitLockFileOld(cfg, time.Now(), gitMaxLockAge)
+		if err != nil {
+			log.Errorln("checking for git lock file: " + err.Error())
+		}
+		if oldLock {
+			log.Errorf("removing git lock file older than %dm", gitMaxLockAge)
+			err := util.RemoveGitLock(cfg)
+			if err != nil {
+				log.Errorf("couldn't remove git lock file: %v", err.Error())
+			}
+		}
 		// commit anything someone else changed when we weren't looking,
 		// with a keyword indicating it wasn't our change
 		if err := util.MakeGitCommitAll(cfg, util.GitChangeNotSelf, true); err != nil {

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -147,13 +147,14 @@ func Main() int {
 
 	if cfg.UseGit == config.UseGitYes || cfg.UseGit == config.UseGitAuto {
 		//need to see if there is an old lock file laying around.
-		const gitMaxLockAge = 5
-		oldLock, err := util.IsGitLockFileOld(cfg, time.Now(), gitMaxLockAge)
+		//older than 5 minutes
+		const gitMaxLockAgeMinutes = 5
+		oldLock, err := util.IsGitLockFileOld(cfg, time.Now(), gitMaxLockAgeMinutes)
 		if err != nil {
 			log.Errorln("checking for git lock file: " + err.Error())
 		}
 		if oldLock {
-			log.Errorf("removing git lock file older than %dm", gitMaxLockAge)
+			log.Errorf("removing git lock file older than %dm", gitMaxLockAgeMinutes)
 			err := util.RemoveGitLock(cfg)
 			if err != nil {
 				log.Errorf("couldn't remove git lock file: %v", err.Error())

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -149,13 +149,15 @@ func Main() int {
 		//need to see if there is an old lock file laying around.
 		//older than 5 minutes
 		const gitMaxLockAgeMinutes = 5
-		oldLock, err := util.IsGitLockFileOld(cfg, time.Now(), gitMaxLockAgeMinutes)
+		const gitLock = ".git/index.lock"
+		gitLockFile := filepath.Join(cfg.TsConfigDir, gitLock)
+		oldLock, err := util.IsGitLockFileOld(gitLockFile, time.Now(), gitMaxLockAgeMinutes * time.Minute)
 		if err != nil {
 			log.Errorln("checking for git lock file: " + err.Error())
 		}
 		if oldLock {
 			log.Errorf("removing git lock file older than %dm", gitMaxLockAgeMinutes)
-			err := util.RemoveGitLock(cfg)
+			err := util.RemoveGitLock(gitLockFile)
 			if err != nil {
 				log.Errorf("couldn't remove git lock file: %v", err.Error())
 			}

--- a/cache-config/t3c-apply/util/gitutil.go
+++ b/cache-config/t3c-apply/util/gitutil.go
@@ -26,7 +26,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -204,24 +203,18 @@ func makeGitCommitMsg(cfg config.Cfg, now time.Time, self bool, success bool) st
 	return strings.Join([]string{appStr, selfStr, modeStr, successStr, timeStr}, sep)
 }
 
-const gitLock = ".git/index.lock"
-
-func IsGitLockFileOld(cfg config.Cfg, now time.Time, maxAge time.Duration) (bool, error) {
-
-	lockFile := filepath.Join(cfg.TsConfigDir, gitLock)
-	oldLock := maxAge * time.Minute
+func IsGitLockFileOld(lockFile string, now time.Time, maxAge time.Duration) (bool, error) {
 	lockFileInfo, err := os.Stat(lockFile)
 	if err != nil {
 		return false, fmt.Errorf("stat returned error: %v on file %v", err, lockFile)
 	}
-	if diff := now.Sub(lockFileInfo.ModTime()); diff > oldLock {
+	if diff := now.Sub(lockFileInfo.ModTime()); diff > maxAge {
 		return true, nil
 	}
 	return false, nil
 }
 
-func RemoveGitLock(cfg config.Cfg) error {
-	lockFile := filepath.Join(cfg.TsConfigDir, gitLock)
+func RemoveGitLock(lockFile string) error {
 	err := os.Remove(lockFile)
 	if err != nil {
 		return fmt.Errorf("error removing file: %v, %v", lockFile, err.Error())

--- a/cache-config/t3c-apply/util/gitutil.go
+++ b/cache-config/t3c-apply/util/gitutil.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -200,4 +201,29 @@ func makeGitCommitMsg(cfg config.Cfg, now time.Time, self bool, success bool) st
 	}
 	const sep = " "
 	return strings.Join([]string{appStr, selfStr, modeStr, successStr, timeStr}, sep)
+}
+
+const gitLock = "/.git/index.lock"
+
+func IsGitLockFileOld(cfg config.Cfg, now time.Time, maxAge time.Duration) (bool, error) {
+
+	lockFile := cfg.TsConfigDir + gitLock
+	oldLock := maxAge * time.Minute
+	lockFileInfo, err := os.Stat(lockFile)
+	if err != nil {
+		return false, fmt.Errorf("stat returned error: %v on file %v", err, lockFile)
+	}
+	if diff := now.Sub(lockFileInfo.ModTime()); diff > oldLock {
+		return true, nil
+	}
+	return false, nil
+}
+
+func RemoveGitLock(cfg config.Cfg) error {
+	lockFile := cfg.TsConfigDir + gitLock
+	err := os.Remove(lockFile)
+	if err != nil {
+		return fmt.Errorf("error removing file: %v, %v", lockFile, err.Error())
+	}
+	return nil
 }

--- a/cache-config/t3c-apply/util/gitutil.go
+++ b/cache-config/t3c-apply/util/gitutil.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -203,11 +204,11 @@ func makeGitCommitMsg(cfg config.Cfg, now time.Time, self bool, success bool) st
 	return strings.Join([]string{appStr, selfStr, modeStr, successStr, timeStr}, sep)
 }
 
-const gitLock = "/.git/index.lock"
+const gitLock = ".git/index.lock"
 
 func IsGitLockFileOld(cfg config.Cfg, now time.Time, maxAge time.Duration) (bool, error) {
 
-	lockFile := cfg.TsConfigDir + gitLock
+	lockFile := filepath.Join(cfg.TsConfigDir, gitLock)
 	oldLock := maxAge * time.Minute
 	lockFileInfo, err := os.Stat(lockFile)
 	if err != nil {
@@ -220,7 +221,7 @@ func IsGitLockFileOld(cfg config.Cfg, now time.Time, maxAge time.Duration) (bool
 }
 
 func RemoveGitLock(cfg config.Cfg) error {
-	lockFile := cfg.TsConfigDir + gitLock
+	lockFile := filepath.Join(cfg.TsConfigDir, gitLock)
 	err := os.Remove(lockFile)
 	if err != nil {
 		return fmt.Errorf("error removing file: %v, %v", lockFile, err.Error())


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
When using git to track changes in etc/trafficserver sometimes the lock file isn't cleared and git will stop updating. This PR will cause t3c-apply to look for a lock file that is more than 5 min old and remove if it exists.   

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Control Cache Config (`t3c`, formerly ORT)


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
The best way to verify and to create an `index.lock` file in `/opt/trafficserver/etc/trafficserver/.git/` and tail `reval.log` and `syncds.log` when the file is 5 minutes old it will be cleared. 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
