### PR TITLE
T3c apply metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7242](https://github.com/apache/trafficcontrol/pull/7276) *Traffic Portal* Now depends on NodeJS version 16 or later.
 - [#7120](https://github.com/apache/trafficcontrol/pull/7120) *Docs* Update t3c documentation regarding parent.config parent_retry.
 - [#7044](https://github.com/apache/trafficcontrol/issues/7044) *CDN in a Box* [CDN in a Box, the t3c integration tests, and the tc health client integration tests now use Apache Traffic Server 9.1.
-- [] () *t3c* Removed timestamp from metadata file since it's changing every minute and causing excessive commits to git repo.
+- [#7366](https://github.com/apache/trafficcontrol/pull/7366) *t3c* Removed timestamp from metadata file since it's changing every minute and causing excessive commits to git repo.
 
 ### Fixed
 - [#7340](https://github.com/apache/trafficcontrol/pull/7340) *Traffic Router* Fixed TR logging for the `cqhv` field when absent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7242](https://github.com/apache/trafficcontrol/pull/7276) *Traffic Portal* Now depends on NodeJS version 16 or later.
 - [#7120](https://github.com/apache/trafficcontrol/pull/7120) *Docs* Update t3c documentation regarding parent.config parent_retry.
 - [#7044](https://github.com/apache/trafficcontrol/issues/7044) *CDN in a Box* [CDN in a Box, the t3c integration tests, and the tc health client integration tests now use Apache Traffic Server 9.1.
+- [] () *t3c* Removed timestamp from metadata file since it's changing every minute and causing excessive commits to git repo.
 
 ### Fixed
 - [#7340](https://github.com/apache/trafficcontrol/pull/7340) *Traffic Router* Fixed TR logging for the `cqhv` field when absent.

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -423,7 +423,6 @@ const MetaDataFileMode = 0600
 //
 // On error, an error is written to the log, but no error is returned.
 func WriteMetaData(cfg config.Cfg, metaData *t3cutil.ApplyMetaData) {
-	metaData.SetTime(time.Now())
 	bts, err := metaData.Format()
 	if err != nil {
 		log.Errorln("formatting metadata file: " + err.Error())

--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -34,7 +34,6 @@ import (
 	"sort"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
 )
@@ -281,12 +280,6 @@ type ApplyMetaData struct {
 	// metadata files from different servers.
 	ServerHostName string `json:"server-hostname"`
 
-	// Time is an RFC3339Nano timestamp of the time t3c-apply ran for this metadata.
-	// This should be treated as approximate, as it could be the start time, end time, or
-	// any inexact time in-between.
-	// However, times of different metadata files should always be monotonically increasing.
-	Time string `json:"time"`
-
 	// ReloadedATS is whether this run restarted ATS.
 	// Note this is whether ATS was actually restarted, not whether it would have been,
 	// e.g. because of --report-only or --service-action.
@@ -371,12 +364,6 @@ func (md *ApplyMetaData) Format() ([]byte, error) {
 	return bts, nil
 }
 
-// SetTime sets the Time field in the prescribed format, based on the given time.
-// To set to the current time, call SetTime(time.Now()).
-// The format is UTC RFC3339Nano. See ApplyMetaData.
-func (md *ApplyMetaData) SetTime(tm time.Time) {
-	md.Time = tm.UTC().Format(time.RFC3339Nano)
-}
 
 // CombineOwnedFilePaths combines the owned file paths of two metadata objects.
 //

--- a/cache-config/t3cutil/t3cutil.go
+++ b/cache-config/t3cutil/t3cutil.go
@@ -364,7 +364,6 @@ func (md *ApplyMetaData) Format() ([]byte, error) {
 	return bts, nil
 }
 
-
 // CombineOwnedFilePaths combines the owned file paths of two metadata objects.
 //
 // This is primarily useful when a config run, such as revalidate, adds owned files, but not


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Right now the t3c-metadata.json file is updated every time t3c runs. Each run updates the timestamp field witch causes git to commit the change to the repo. Since t3c is running every minute in revalidate mode this is causing excessive commits to the repo and actual changes are being lost in the noise. This PR will remove the timestamp field, which reduces the amount of commits to the repo. The file itself still has the filesystem timestamp and we can also see the last change to the metadata file in git when it does change. 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Control Cache Config (`t3c`, formerly ORT)



## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run t3c with no updates queued and verify that timestamp file has been removed. force a config file change, queue updates, run t3c in syncds mode, verify changes to t3c-metadata.json and config files have been committed. run t3c again without updates queued and verify no changes to metadata file. 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
Not a bug fix

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
