### PR TITLE
Have TPv2 reuse TPv1 builder

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -45,7 +45,6 @@ else
 	done
 fi
 
-
 badproj=''
 goodproj=''
 for p in ${projects}; do
@@ -59,6 +58,9 @@ for p in ${projects}; do
 			echo "---- Skipping tarball creation"
 		fi
 		continue
+	fi
+	if [ "$p" = traffic_portal_v2 ]; then
+		ln -s experimental/traffic-portal/ traffic_portal_v2
 	fi
 	if [ "$p" = docs ]; then
 		if isInGitTree; then

--- a/infrastructure/docker/build/Dockerfile-traffic_portal
+++ b/infrastructure/docker/build/Dockerfile-traffic_portal
@@ -39,13 +39,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-* && \
 RUN	curl -sL https://rpm.nodesource.com/setup_16.x | bash - && \
 	yum -y install nodejs
 
-FROM common-dependencies as traffic_portal_v1
 RUN npm -g install make grunt-cli sass
 CMD /trafficcontrol/build/clean_build.sh traffic_portal
-
-FROM common-dependencies as traffic_portal_v2
-RUN mkdir -p /trafficcontrol/experimental/traffic-portal
-RUN ln -s /trafficcontrol/experimental/traffic-portal/ /trafficcontrol/traffic_portal_v2
-CMD /trafficcontrol/build/clean_build.sh traffic_portal_v2
 
 # vi:syntax=Dockerfile

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -133,7 +133,7 @@ services:
     volumes:
       - ../../..:/trafficcontrol:z
       - ../../../.npm:/root/.npm:z
-    command: [ "/bin/bash", "-c", "mkdir -p /trafficcontrol/experimental/traffic-portal && ln -s /trafficcontrol/experimental/traffic-portal/ /trafficcontrol/traffic_portal_v2 && /trafficcontrol/build/clean_build.sh traffic_portal_v2", ]
+    command: [ "/bin/bash", "-c", "/trafficcontrol/build/clean_build.sh traffic_portal_v2" ]
 
   traffic_router_build:
     image: apache/traffic_router_builder:master

--- a/infrastructure/docker/build/docker-compose.yml
+++ b/infrastructure/docker/build/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     image: licenseweasel/weasel:v0.4
     volumes:
       - ../../..:/trafficcontrol:z
-    command: ['-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol']
+    command: [ '-f', '/trafficcontrol/dist/weasel.txt', '/trafficcontrol' ]
 
   source:
     image: apache/traffic_source_tarballer:master
@@ -104,7 +104,6 @@ services:
     image: apache/traffic_portal_builder:master
     build:
       dockerfile: infrastructure/docker/build/Dockerfile-traffic_portal
-      target: traffic_portal_v1
       context: ../../..
       args:
         # Change BASE_IMAGE to centos when RHEL_VERSION=7
@@ -119,11 +118,9 @@ services:
       - ../../../.npm:/root/.npm:z
 
   traffic_portal_v2_build:
-    container_name: traffic_portal_v2
-    image: apache/traffic_portal_v2_builder:master
+    image: apache/traffic_portal_builder:master
     build:
       dockerfile: infrastructure/docker/build/Dockerfile-traffic_portal
-      target: traffic_portal_v2
       context: ../../..
       args:
         # Change BASE_IMAGE to centos when RHEL_VERSION=7
@@ -136,6 +133,7 @@ services:
     volumes:
       - ../../..:/trafficcontrol:z
       - ../../../.npm:/root/.npm:z
+    command: [ "/bin/bash", "-c", "mkdir -p /trafficcontrol/experimental/traffic-portal && ln -s /trafficcontrol/experimental/traffic-portal/ /trafficcontrol/traffic_portal_v2 && /trafficcontrol/build/clean_build.sh traffic_portal_v2", ]
 
   traffic_router_build:
     image: apache/traffic_router_builder:master


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR removes the tpv2 builder image to use the tpv1 image, as well as update the tpv2 build so it runs the correct command. 

This fixes an issue with the current `traffic_portal_builder` image where building it won't succeed because it's trying to build tpv2.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Portal
- Traffic Portal v2

## What is the best way to verify this PR?
Ensure that tp and tpv2 both build using `./pkg` and that they _only_ build themselves
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- master
- 5.1.2
- 5.1.3 (RC1)
 -->
- master


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
