### PR TITLE
TP: adds strikethru for expired certs and red for less than 7 days until expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7332](https://github.com/apache/trafficcontrol/pull/7332) *Traffic Ops* Creates new role needed for TR to watch TO resources.
 - [#7322](https://github.com/apache/trafficcontrol/issues/7322) *t3c Adds support for anycast on http routed edges.
 - [#7367](https://github.com/apache/trafficcontrol/pull/7367) *Traffic Ops* Adds ACME:CREATE, ACME:DELETE, ACME:DELETE, and ACME:READ permissions to operations role.
+- [#7380](https://github.com/apache/trafficcontrol/pull/7380) *Traffic Portal* Adds strikethrough (expired), red (7 days until expiration) and yellow (30 days until expiration) visuals to delivery service cert expiration grid rows.
 
 ### Changed
 - [#7369](https://github.com/apache/trafficcontrol/pull/7369) *Traffic Portal* Adds better labels to routing methods widget on the TP dashboard.

--- a/traffic_portal/app/src/common/modules/table/_table.scss
+++ b/traffic_portal/app/src/common/modules/table/_table.scss
@@ -221,9 +221,15 @@ div.dropdown button.menu-item-button {
     }
   }
   .ag-row.expired-cert {
+    background-color: #fcfcfc;
+    .ag-cell {
+      text-decoration: line-through;
+    }
+  }
+  .ag-row.seven-days-until-expired {
     background-color: #f8d7da;
   }
-  .ag-row.soon-expired-cert {
+  .ag-row.thirty-days-until-expired {
     background-color: #fff3cd;
   }
 }

--- a/traffic_portal/app/src/common/modules/table/certExpirations/TableCertExpirationsController.js
+++ b/traffic_portal/app/src/common/modules/table/certExpirations/TableCertExpirationsController.js
@@ -96,7 +96,12 @@ var TableCertExpirationsController = function(certExpirations, $scope, locationU
 				const now = new Date();
 				return params.data.expiration < now;
 			},
-			'soon-expired-cert': function(params) {
+			'seven-days-until-expired': function(params) {
+				const sevenDays = new Date();
+				sevenDays.setDate(sevenDays.getDate()+7);
+				return params.data.expiration >= new Date() && params.data.expiration <= sevenDays;
+			},
+			'thirty-days-until-expired': function(params) {
 				const thirtyDays = new Date();
 				thirtyDays.setDate(thirtyDays.getDate()+30);
 				return params.data.expiration >= new Date() && params.data.expiration <= thirtyDays;


### PR DESCRIPTION
Added some color coding to the rows of the cert expiration table:

expired = strikethru
7 days until expiration = red
30 days until expiration = yellow
30+ days until expiration = none/default

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Navigate to tp.domain.tld//#!/cert-expirations and view the different formats based on cert expiration dates.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
