### PR TITLE
adding sslkey_expirations methods in clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7322](https://github.com/apache/trafficcontrol/issues/7322) *t3c Adds support for anycast on http routed edges.
 - [#7367](https://github.com/apache/trafficcontrol/pull/7367) *Traffic Ops* Adds ACME:CREATE, ACME:DELETE, ACME:DELETE, and ACME:READ permissions to operations role.
 - [#7380](https://github.com/apache/trafficcontrol/pull/7380) *Traffic Portal* Adds strikethrough (expired), red (7 days until expiration) and yellow (30 days until expiration) visuals to delivery service cert expiration grid rows.
+- [#7388](https://github.com/apache/trafficcontrol/pull/7388) *TC go Client* Adds sslkey_expiration methodology in v4 and v5 clients
 
 ### Changed
 - [#7369](https://github.com/apache/trafficcontrol/pull/7369) *Traffic Portal* Adds better labels to routing methods widget on the TP dashboard.

--- a/lib/go-tc/sslkey_expirations.go
+++ b/lib/go-tc/sslkey_expirations.go
@@ -1,0 +1,25 @@
+package tc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+type SSLKeyExpirationGetResponse struct {
+	Response []SSLKeyExpirationInformation `json:"response"`
+	Alerts
+}

--- a/lib/go-tc/sslkey_expirations.go
+++ b/lib/go-tc/sslkey_expirations.go
@@ -19,6 +19,7 @@ package tc
  * under the License.
  */
 
+// SSLKeyExpirationGetResponse is the format of a response to a GET request for API /sslkey_expirations endpoint.
 type SSLKeyExpirationGetResponse struct {
 	Response []SSLKeyExpirationInformation `json:"response"`
 	Alerts

--- a/traffic_ops/testing/api/v4/sslkey_expirations_test.go
+++ b/traffic_ops/testing/api/v4/sslkey_expirations_test.go
@@ -1,0 +1,66 @@
+package v4
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/testing/api/utils"
+	client "github.com/apache/trafficcontrol/traffic_ops/v4-client"
+)
+
+func TestSSLExpirations(t *testing.T) {
+
+	if !includeSystemTests {
+		t.Skip()
+	}
+
+	methodTests := utils.TestCase[client.Session, client.RequestOptions, struct{}]{
+		"GET": {
+			"OK when VALID request": {
+				ClientSession: TOSession,
+				Expectations:  utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
+			},
+			"OK when VALID DAYS PARAMETER": {
+				ClientSession: TOSession,
+				RequestOpts:   client.RequestOptions{QueryParameters: url.Values{"days": {"30"}}},
+				Expectations:  utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
+			},
+			"UNAUTHORIZED when NOT LOGGED IN": {
+				ClientSession: NoAuthTOSession,
+				Expectations:  utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusUnauthorized)),
+			},
+		},
+	}
+
+	for method, testCases := range methodTests {
+		t.Run(method, func(t *testing.T) {
+			for name, testCase := range testCases {
+				switch method {
+				case "GET":
+					t.Run(name, func(t *testing.T) {
+						resp, reqInf, err := testCase.ClientSession.GetExpiringCerts(testCase.RequestOpts)
+						for _, check := range testCase.Expectations {
+							check(t, reqInf, resp, tc.Alerts{}, err)
+						}
+					})
+				}
+			}
+		})
+	}
+}

--- a/traffic_ops/testing/api/v5/sslkey_expirations_test.go
+++ b/traffic_ops/testing/api/v5/sslkey_expirations_test.go
@@ -1,0 +1,66 @@
+package v5
+
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/testing/api/utils"
+	client "github.com/apache/trafficcontrol/traffic_ops/v5-client"
+)
+
+func TestSSLExpirations(t *testing.T) {
+
+	if !includeSystemTests {
+		t.Skip()
+	}
+
+	methodTests := utils.TestCase[client.Session, client.RequestOptions, struct{}]{
+		"GET": {
+			"OK when VALID request": {
+				ClientSession: TOSession,
+				Expectations:  utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
+			},
+			"OK when VALID DAYS PARAMETER": {
+				ClientSession: TOSession,
+				RequestOpts:   client.RequestOptions{QueryParameters: url.Values{"days": {"30"}}},
+				Expectations:  utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK)),
+			},
+			"UNAUTHORIZED when NOT LOGGED IN": {
+				ClientSession: NoAuthTOSession,
+				Expectations:  utils.CkRequest(utils.HasError(), utils.HasStatus(http.StatusUnauthorized)),
+			},
+		},
+	}
+
+	for method, testCases := range methodTests {
+		t.Run(method, func(t *testing.T) {
+			for name, testCase := range testCases {
+				switch method {
+				case "GET":
+					t.Run(name, func(t *testing.T) {
+						resp, reqInf, err := testCase.ClientSession.GetExpiringCerts(testCase.RequestOpts)
+						for _, check := range testCase.Expectations {
+							check(t, reqInf, resp, tc.Alerts{}, err)
+						}
+					})
+				}
+			}
+		})
+	}
+}

--- a/traffic_ops/v4-client/sslkey_expirations.go
+++ b/traffic_ops/v4-client/sslkey_expirations.go
@@ -1,0 +1,31 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package client provides Go bindings to the Traffic Ops RPC API.
+package client
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
+func (to *Session) GetExpiringCerts(opts RequestOptions) (tc.SSLKeyExpirationGetResponse, toclientlib.ReqInf, error) {
+	const sslKeyExpirations = "/sslkey_expirations"
+
+	var data tc.SSLKeyExpirationGetResponse
+
+	reqInf, err := to.get(sslKeyExpirations, opts, &data)
+	return data, reqInf, err
+}

--- a/traffic_ops/v4-client/sslkey_expirations.go
+++ b/traffic_ops/v4-client/sslkey_expirations.go
@@ -21,6 +21,8 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
+// GetExpiringCerts gets the exiring certs within the days if 'days' param is passed
+// or the full list of all Delivery services and there expirations
 func (to *Session) GetExpiringCerts(opts RequestOptions) (tc.SSLKeyExpirationGetResponse, toclientlib.ReqInf, error) {
 	const sslKeyExpirations = "/sslkey_expirations"
 

--- a/traffic_ops/v5-client/sslkey_expirations.go
+++ b/traffic_ops/v5-client/sslkey_expirations.go
@@ -1,0 +1,31 @@
+/*
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package client provides Go bindings to the Traffic Ops RPC API.
+package client
+
+import (
+	"github.com/apache/trafficcontrol/lib/go-tc"
+	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
+)
+
+func (to *Session) GetExpiringCerts(opts RequestOptions) (tc.SSLKeyExpirationGetResponse, toclientlib.ReqInf, error) {
+	const sslKeyExpirations = "/sslkey_expirations"
+
+	var data tc.SSLKeyExpirationGetResponse
+
+	reqInf, err := to.get(sslKeyExpirations, opts, &data)
+	return data, reqInf, err
+}

--- a/traffic_ops/v5-client/sslkey_expirations.go
+++ b/traffic_ops/v5-client/sslkey_expirations.go
@@ -21,6 +21,8 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/toclientlib"
 )
 
+// GetExpiringCerts gets the exiring certs within the days if 'days' param is passed
+// or the full list of all Delivery services and there expirations
 func (to *Session) GetExpiringCerts(opts RequestOptions) (tc.SSLKeyExpirationGetResponse, toclientlib.ReqInf, error) {
 	const sslKeyExpirations = "/sslkey_expirations"
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR adds sslkey_expirations methodology to v4 and v5 clients
Closes: #7387 
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Control Client (go) <!-- Please specify which (Python, Go, or Java) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
to verify this PR, call GetExipiringCerts using TC client


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
