### PR TITLE
[Docs] Change Role to Api Name  

### DIFF
--- a/docs/source/api/v4/users_register.rst
+++ b/docs/source/api/v4/users_register.rst
@@ -31,7 +31,7 @@ Register a user and send registration email.
 Request Structure
 -----------------
 :email:    Email address of the new user The given email is validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that it can't actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
-:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
+:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with only Permissions the requesting user has.
 :tenantId: A field containing the integral, unique identifier of the :term:`Tenant` to which the new user will belong. It restricts the allowed values to identifiers for :term:`Tenants` within the requesting user's :term:`Tenant`'s permissions.
 
 .. code-block:: http

--- a/docs/source/api/v4/users_register.rst
+++ b/docs/source/api/v4/users_register.rst
@@ -31,7 +31,7 @@ Register a user and send registration email.
 Request Structure
 -----------------
 :email:    Email address of the new user The given email is validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that it can't actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
-:role:     The integral, unique identifier of the highest permissions :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
+:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
 :tenantId: A field containing the integral, unique identifier of the :term:`Tenant` to which the new user will belong. It restricts the allowed values to identifiers for :term:`Tenants` within the requesting user's :term:`Tenant`'s permissions.
 
 .. code-block:: http

--- a/docs/source/api/v4/users_register.rst
+++ b/docs/source/api/v4/users_register.rst
@@ -47,7 +47,7 @@ Request Structure
 
 	{
 		"email": "test@example.com",
-		"role": 3,
+		"role": "admin",
 		"tenantId": 1
 	}
 

--- a/docs/source/api/v5/users_register.rst
+++ b/docs/source/api/v5/users_register.rst
@@ -31,7 +31,7 @@ Register a user and send registration email.
 Request Structure
 -----------------
 :email:    Email address of the new user The given email is validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that it can't actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
-:role:     The integral, unique identifier of the highest permissions :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
+:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
 :tenantId: A field containing the integral, unique identifier of the :term:`Tenant` to which the new user will belong. It restricts the allowed values to identifiers for :term:`Tenants` within the requesting user's :term:`Tenant`'s permissions.
 
 .. code-block:: http

--- a/docs/source/api/v5/users_register.rst
+++ b/docs/source/api/v5/users_register.rst
@@ -47,7 +47,7 @@ Request Structure
 
 	{
 		"email": "test@example.com",
-		"role": 3,
+		"role": "admin",
 		"tenantId": 1
 	}
 

--- a/docs/source/api/v5/users_register.rst
+++ b/docs/source/api/v5/users_register.rst
@@ -31,7 +31,7 @@ Register a user and send registration email.
 Request Structure
 -----------------
 :email:    Email address of the new user The given email is validated (circuitously) by `GitHub user asaskevich's regular expression <https://github.com/asaskevich/govalidator/blob/9a090521c4893a35ca9a228628abf8ba93f63108/patterns.go#L7>`_ . Note that it can't actually distinguish a valid, deliverable, email address but merely ensure the email is in a commonly-found format.
-:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at most the same permissions level as the requesting user.
+:role:     The name of the :term:`Role` which will be afforded to the new user. It restricts the allowed values to identifiers for :term:`Roles` with at only Permissions the requesting user has.
 :tenantId: A field containing the integral, unique identifier of the :term:`Tenant` to which the new user will belong. It restricts the allowed values to identifiers for :term:`Tenants` within the requesting user's :term:`Tenant`'s permissions.
 
 .. code-block:: http


### PR DESCRIPTION

Closes: #7326 

Documentation changes for user registration endpoint `role` property. In APIv4 and later, Roles don't have IDs and use names as their primary identifiers. The /users/register endpoint was updated accordingly, and the role property should actually be a Role's name, not its ID.


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation

## What is the best way to verify this PR?
- Build Docs

## PR submission checklist
- [x] This PR has documentation changes 
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
