### PR TITLE
return correct error on duplicate email while updating user

### DIFF
--- a/traffic_ops/traffic_ops_golang/user/current.go
+++ b/traffic_ops/traffic_ops_golang/user/current.go
@@ -479,9 +479,9 @@ func ReplaceCurrent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err = updateLegacyUser(&user, tx, changePasswd, changeConfirmPasswd); err != nil {
-		errCode = http.StatusInternalServerError
+		userErr, sysErr, statusCode := api.ParseDBError(err)
 		sysErr = fmt.Errorf("updating legacy user: %w", err)
-		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		api.HandleErr(w, r, tx, statusCode, userErr, sysErr)
 		return
 	}
 
@@ -600,9 +600,9 @@ func ReplaceCurrentV4(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := updateUser(&user, tx, changePasswd); err != nil {
-		errCode = http.StatusInternalServerError
+		userErr, sysErr, statusCode := api.ParseDBError(err)
 		sysErr = fmt.Errorf("updating user: %w", err)
-		api.HandleErr(w, r, tx, errCode, nil, sysErr)
+		api.HandleErr(w, r, tx, statusCode, userErr, sysErr)
 		return
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #7249 

Currently, a user updating their email to one that's already in use returns an `500 Internal Server Error`. This PR updates the implementation to ensure that a `400 Bad Request` error with a description is returned instead.


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

- Create a user (using the `POST /users` endpoint)
- Attempt to modify the user (using the `PUT /user/current` endpoint)
- Verify that you're receiving an error with HTTP status code 400 with a message mentioning that the email already exists


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
 
Wasn't able to track down the exact release where this bug originated. This bug is present in `master` branch & https://github.com/apache/trafficcontrol/pull/3996 is the PR where the endpoint was first written for API V3.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation
	PR doesn't need any separate documentation since only the error handling behaviour has been changed. API docs only document the request & response structure.
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
