### PR TITLE
TimeConstant format changed to include minute hand(:00) for zone offset[Outside US].

### DIFF
--- a/lib/go-tc/time.go
+++ b/lib/go-tc/time.go
@@ -37,7 +37,7 @@ type Time struct {
 //
 // Deprecated: New code should use RFC3339 (with optional nanosecond
 // precision).
-const TimeLayout = "2006-01-02 15:04:05-07"
+const TimeLayout = "2006-01-02 15:04:05-07:00"
 
 // Do not ever use this. It only exists for compatibility with Perl.
 const legacyLayout = "2006-01-02 15:04:05"


### PR DESCRIPTION
Fixes: #ISSUE
### **Issue:** 

- Current time format used in the code from tafficcontrol/lib/go-tc/time.go

`const TimeLayout = "2006-01-02 15:04:05-07"
`

- Because the timezone offset is cut to only hour hand “07" and minute hand is left out ":00",  it creates issues to countries which have UTC offset in minutes. For eg, India its +05:30. And it is rounded of to +05, as there is no minute format definition.

- So any API response which returns time, is returning incorrect time from India. This applies to any countries that have offset with minutes. 

- Since none of the US time zones have UTC offset in minutes, this issue will not be observed from US. 

Example, 
**API Call:**
`$ curl -k -X POST -H "Content-Type: application/json" --cookie $mojolicious_id --data @test_data.json "https://localhost:8443/api/4.1/service_categories"    `   

**API Response:**
```
{
  "alerts": [
    {
      "text": "serviceCategory was created.",
      "level": "success"
    }
  ],
  "response": {
    "lastUpdated": "2023-03-13 13:52:02+05",
    "name": "apps"
  }
}
```

- This time layout inadvertently contributes to the failure of the testcases if run out of US as well. 

- Example: The following test case from "TestStatsSummary" fails with error, 

```
=== RUN   TestStatsSummary/GET/OK_when_VALID_LASTSUMMARYDATE_parameter
    stats_summary_test.go:146: Not equal. Expected: 2023-03-13 13:56:35 +0530 IST Actual: 2023-03-13 14:26:35 +0500 +0500 Messages: Expected SummaryTime to be 2023-03-13 13:56:35 +0530 IST, but got 2023-03-13 14:26:35 +0500 +0500

--- FAIL: TestStatsSummary (0.01s)
    --- FAIL: TestStatsSummary/GET (0.00s)
        --- FAIL: TestStatsSummary/GET/OK_when_VALID_LASTSUMMARYDATE_parameter (0.00s)
```


### **Fix:**  

- Changed TimeLayout to include minute hand in timezone offset. 

**Previous Version:** `const TimeLayout = "2006-01-02 15:04:05-07"`
**New Version:**  `const TimeLayout = "2006-01-02 15:04:05-07:00"`
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
- Documentation?????????????????????
- Traffic Ops

## What is the best way to verify this PR?

- Changes can be tested when your local time does have an UTC timezone offset with minutes hand. 

- For Example, Can be verified if your offset is UTC +5:30. Can't be verified if your offset is UTC +5:00 

### Test 1: 

- Any API which returns a time, can be used for the testing. 

- Eg. **POST** call to **service_categories**, returns "**lastUpdated**" time. Hence this API can be used for testing. 

#### API Call:

`$ curl -k -X POST -H "Content-Type: application/json" --cookie $mojolicious_id --data @test_data.json "https://localhost:8443/api/4.1/service_categories"`

#### API Response for previous version of TimeLayout:

```
{
  "alerts": [
    {
      "text": "serviceCategory was created.",
      "level": "success"
    }
  ],
  "response": {
    "lastUpdated": "2023-03-13 13:52:02+05",
    "name": "apps"
  }
}
```


#### API Response for updated version of TimeLayout:
```
{
  "alerts": [
    {
      "text": "serviceCategory was created.",
      "level": "success"
    }
  ],
  "response": {
    "lastUpdated": "2023-03-13 14:01:49+05:30",
    "name": "apps"
  }
}
```

### Test 2:

-  Verify if previously failed test case "TestStatsSummary" passes with new TimeLayout. 

- **Previous failure message:** : RUN   TestStatsSummary/GET/OK_when_VALID_LASTSUMMARYDATE_parameter

```
stats_summary_test.go:146: Not equal. 
Expected: 2023-03-13 13:56:35 +0530 IST 
Actual: 2023-03-13 14:26:35 +0500 +0500 
```

- Latest testcase should pass after the code change. 

## If this is a bugfix, which Traffic Control versions contained the bug?
7.0.1


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
