### PR TITLE
add missing lastUpdated prop to PUT /roles

### DIFF
--- a/docs/source/api/v4/roles.rst
+++ b/docs/source/api/v4/roles.rst
@@ -67,6 +67,7 @@ Response Structure
 :permissions:  An array of the names of the Permissions given to this :term:`Role`
 :description:  A description of the :term:`Role`
 :name:         The name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -171,6 +172,7 @@ Response Structure
 
 :description: A description of the :term:`Role`
 :name:        The name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -194,7 +196,8 @@ Response Structure
 	"response": {
 		"name": "test",
 		"description": "quest",
-		"permissions": null
+		"permissions": null,
+		"lastUpdated": "2021-05-03T14:50:18.93513-06:00"
 	}}
 
 ``PUT``
@@ -249,6 +252,7 @@ Response Structure
 
 :description: A description of the :term:`Role`
 :name:        The name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -275,7 +279,8 @@ Response Structure
 		"response": {
 			"name": "test",
 			"description": "quest_updated",
-			"permissions": null
+			"permissions": null,
+			"lastUpdated": "2021-05-03T14:50:18.93513-06:00"
 		}
 	}
 

--- a/docs/source/api/v5/roles.rst
+++ b/docs/source/api/v5/roles.rst
@@ -67,6 +67,7 @@ Response Structure
 :permissions:  An array of the names of the Permissions given to this :term:`Role`
 :description:  A description of the :term:`Role`
 :name:         The name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -171,6 +172,7 @@ Response Structure
 
 :description: A description of the :term:`Role`
 :name:        The name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Response Example
@@ -194,7 +196,8 @@ Response Structure
 	"response": {
 		"name": "test",
 		"description": "quest",
-		"permissions": null
+		"permissions": null,
+		"lastUpdated": "2021-05-03T14:50:18.93513-06:00"
 	}}
 
 ``PUT``
@@ -222,6 +225,7 @@ Request Structure
 
 :description: A helpful description of the :term:`Role`'s purpose.
 :name:        The new name of the :term:`Role`
+:lastUpdated: The date and time at which this :term:`Role` was last updated, in :rfc:`3339` format
 
 .. code-block:: http
 	:caption: Request Example
@@ -275,7 +279,8 @@ Response Structure
 		"response": {
 			"name": "test",
 			"description": "quest_updated",
-			"permissions": null
+			"permissions": null,
+			"lastUpdated": "2021-05-03T14:50:18.93513-06:00"
 		}
 	}
 

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -397,7 +397,7 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 	err = tx.QueryRow(updateRoleQuery(), roleV4.Name, roleV4.Description, currentRoleName).Scan(&roleV4.LastUpdated)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			api.HandleErr(w, r, tx, http.StatusNotFound, errors.New("no such role"), nil)
 			return
 		}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes: #7248 

`PUT /roles` was missing the `lastUpdated` property from its response which made it inconsistent with the response for `POST /roles` & `GET /roles`. This PR adds the `lastUpdated` property to the response of `PUT /roles`.

Note: API v3 wasn't updated because it's already deprecated & `GET`, `POST` endpoints for API v3 don't return the `lastUpdated` property so there's no inconsistency there.


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

- Create a new role (using `POST /roles` endpoint)
- Update the role (using `PUT /roles` endpoint)
- Verify that the `lastUpdated` property exists in the response


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
 
The updated function was added in PR: https://github.com/apache/trafficcontrol/pull/6124 which appeared first in `RELEASE-6.1.0-RC0`


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
