### PR TITLE
Fix reserved consistentHashQueryParams entries causing internal server error instead of client error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6695](https://github.com/apache/trafficcontrol/issues/6695) *Traffic Control Cache Config (t3c)* Directory creation was erroneously reporting an error when actually succeeding.
 - [#7411](https://github.com/apache/trafficcontrol/pull/7411) *Traffic Control Cache Config (t3c)* Fixed issue with wrong parent ordering with MSO non-topology delivery services.
 - [#7425](https://github.com/apache/trafficcontrol/pull/7425) *Traffic Control Cache Config (t3c)* Fixed issue with layered profile iteration being done in the wrong order.
+- [#6385](https://github.com/apache/trafficcontrol/issues/6385) *Traffic Ops* Reserved consistentHashQueryParameters cause internal server error
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -49,6 +49,14 @@ const MaxRangeSliceBlockSize = 33554432
 // values of a Delivery Service's 'Active' property (v3.0+).
 type DeliveryServiceActiveState string
 
+// These names of URL query string parameters are not allowed to be in a
+// Delivery Service's "ConsistentHashQueryParams" set, because they collide with
+// query string parameters reserved for use by Traffic Router.
+const (
+	ReservedConsistentHashingQueryParameterFormat = "format"
+	ReservedConsistentHashingQueryParameterTRRED  = "trred"
+)
+
 // A DeliveryServiceActiveState describes the availability of Delivery Service
 // content from the perspective of caching servers and Traffic Routers.
 const (

--- a/lib/go-tc/deliveryservices.go
+++ b/lib/go-tc/deliveryservices.go
@@ -53,8 +53,9 @@ type DeliveryServiceActiveState string
 // Delivery Service's "ConsistentHashQueryParams" set, because they collide with
 // query string parameters reserved for use by Traffic Router.
 const (
-	ReservedConsistentHashingQueryParameterFormat = "format"
-	ReservedConsistentHashingQueryParameterTRRED  = "trred"
+	ReservedConsistentHashingQueryParameterFormat              = "format"
+	ReservedConsistentHashingQueryParameterTRRED               = "trred"
+	ReservedConsistentHashingQueryParameterFakeClientIPAddress = "fakeClientIpAddress"
 )
 
 // A DeliveryServiceActiveState describes the availability of Delivery Service

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1722,7 +1722,7 @@ func validateTypeFields(tx *sql.Tx, ds *tc.DeliveryServiceV5) error {
 				}
 
 				for _, param := range ds.ConsistentHashQueryParams {
-					if param == tc.ReservedConsistentHashingQueryParameterFormat || param == tc.ReservedConsistentHashingQueryParameterTRRED {
+					if param == tc.ReservedConsistentHashingQueryParameterFormat || param == tc.ReservedConsistentHashingQueryParameterTRRED || param == tc.ReservedConsistentHashingQueryParameterFakeClientIPAddress {
 						return fmt.Errorf("'%s' cannot be used in consistent hashing, because it is reserved for use by Traffic Router", param)
 					}
 				}

--- a/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/deliveryservices.go
@@ -1714,10 +1714,20 @@ func validateTypeFields(tx *sql.Tx, ds *tc.DeliveryServiceV5) error {
 		"consistentHashQueryParams": validation.Validate(ds,
 			validation.By(func(dsi interface{}) error {
 				ds := dsi.(*tc.DeliveryServiceV5)
-				if len(ds.ConsistentHashQueryParams) == 0 || tc.DSType(typeName).IsHTTP() {
+				if len(ds.ConsistentHashQueryParams) == 0 {
 					return nil
 				}
-				return fmt.Errorf("consistentHashQueryParams not allowed for '%s' deliveryservice type", typeName)
+				if !tc.DSType(typeName).IsHTTP() {
+					return fmt.Errorf("consistentHashQueryParams not allowed for '%s' deliveryservice type", typeName)
+				}
+
+				for _, param := range ds.ConsistentHashQueryParams {
+					if param == tc.ReservedConsistentHashingQueryParameterFormat || param == tc.ReservedConsistentHashingQueryParameterTRRED {
+						return fmt.Errorf("'%s' cannot be used in consistent hashing, because it is reserved for use by Traffic Router", param)
+					}
+				}
+
+				return nil
 			})),
 		"initialDispersion": validation.Validate(ds.InitialDispersion,
 			validation.By(requiredIfMatchesTypeName([]string{httpTypeRegexp}, typeName)),


### PR DESCRIPTION
This PR fixes #6385 by causing Traffic Ops to return the correct error code (400 Bad Request) and an alert describing what went wrong when a client attempts to create or modify a Delivery Service such that it would an entry in its Consistent Hashing Query string Parameters that is reserved for use by Traffic Router.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
```bash
topost -kp deliveryservices '{       
        "active": false,
        "cdnId": 2,
        "consistentHashQueryParams": ["format"],
        "displayName": "test",
        "dnsBypassCname": "test",
        "dscp": 1,
        "geoLimit": 1,
        "geoLimitCountries": "US,CA",
        "geoProvider": -7,
        "initialDispersion": 1,
        "ipv6RoutingEnabled": true,
        "logsEnabled": true,
        "missLat": 0,
        "missLong": 0,
        "multiSiteOrigin": false,
        "orgServerFqdn": "test.quest",
        "protocol": 7,
        "qstringIgnore": 5,
        "rangeRequestHandling": 0,
        "regionalGeoBlocking": false,
        "tenantId": 1,
        "typeId": 1,
        "xmlId": "test"
}'
```

## If this is a bugfix, which Traffic Control versions contained the bug
- not sure


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**