### PR TITLE
t3c parentdotconfig: ensure ocgmap is ordered by prim, sec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7352](https://github.com/apache/trafficcontrol/pull/7352) *Traffic Control Cache Config (t3c)* Fixed issue with application locking which would allow multiple instances of `t3c apply` to run concurrently.
 - [#6775](https://github.com/apache/trafficcontrol/issues/6775) *Traffic Ops* Invalid "orgServerFqdn" in Delivery Service creation/update causes Internal Server Error
 - [#6695](https://github.com/apache/trafficcontrol/issues/6695) *Traffic Control Cache Config (t3c)* Directory creation was erroneously reporting an error when actually succeeding.
+- [#7411](https://github.com/apache/trafficcontrol/pull/7411) *Traffic Control Cache Config (t3c)* Fixed issue with wrong parent ordering with MSO non-topology delivery services.
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -165,13 +165,14 @@ func MakeParentDotConfig(
 	}, nil
 }
 
-type PrimarySecondary struct {
+// primarySecondary contains the names of the primary and secondary parent cache groups.
+type primarySecondary struct {
 	Primary   string
 	Secondary string
 }
 
 // createTopology creates an on the fly topology for this server and non topology delivery service.
-func createTopology(server *Server, ds DeliveryService, nameTopologies map[TopologyName]tc.Topology, ocgmap map[OriginHost]PrimarySecondary) (string, tc.Topology, []string) {
+func createTopology(server *Server, ds DeliveryService, nameTopologies map[TopologyName]tc.Topology, ocgmap map[OriginHost]primarySecondary) (string, tc.Topology, []string) {
 
 	topoName := ""
 	topo := tc.Topology{}
@@ -445,7 +446,7 @@ func makeParentDotConfigData(
 	warnings = append(warnings, dsOriginWarns...)
 
 	// Note map cache group lists are ordered, prim first, sec second
-	ocgmap := map[OriginHost]PrimarySecondary{}
+	ocgmap := map[OriginHost]primarySecondary{}
 
 	for _, ds := range dses {
 
@@ -482,7 +483,7 @@ func makeParentDotConfigData(
 			if len(ocgmap) == 0 {
 				ocgmap = makeOCGMap(parentInfos)
 				if len(ocgmap) == 0 {
-					ocgmap[""] = PrimarySecondary{}
+					ocgmap[""] = primarySecondary{}
 				}
 			}
 
@@ -629,8 +630,8 @@ func (p parentInfo) ToAbstract() *ParentAbstractionServiceParent {
 type parentInfos map[OriginHost]parentInfo
 
 // Returns a map of parent cache groups names per origin host.
-func makeOCGMap(opis map[OriginHost][]parentInfo) map[OriginHost]PrimarySecondary {
-	ocgnames := map[OriginHost]PrimarySecondary{}
+func makeOCGMap(opis map[OriginHost][]parentInfo) map[OriginHost]primarySecondary {
+	ocgnames := map[OriginHost]primarySecondary{}
 
 	for host, pis := range opis {
 		cgnames := make(map[string]bool)
@@ -638,7 +639,7 @@ func makeOCGMap(opis map[OriginHost][]parentInfo) map[OriginHost]PrimarySecondar
 			cgnames[string(pi.Cachegroup)] = pi.PrimaryParent
 		}
 
-		ps := PrimarySecondary{}
+		ps := primarySecondary{}
 		for cg, isPrim := range cgnames {
 			if isPrim {
 				ps.Primary = cg

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -3754,13 +3754,13 @@ func TestMakeParentDotConfigTopologiesServerMultipleProfileParams(t *testing.T) 
 		tc.Parameter{
 			Name:       ParentConfigCacheParamWeight,
 			ConfigFile: "parent.config",
-			Value:      "200",
+			Value:      "100",
 			Profiles:   []byte(`["serverprofile0"]`),
 		},
 		tc.Parameter{
 			Name:       ParentConfigCacheParamWeight,
 			ConfigFile: "parent.config",
-			Value:      "100",
+			Value:      "200",
 			Profiles:   []byte(`["serverprofile1"]`),
 		},
 	}
@@ -3899,18 +3899,6 @@ func TestMakeParentDotConfigFirstLastNoTopo(t *testing.T) {
 			Value:      "myQstringParam",
 			Profiles:   []byte(`["serverprofile"]`),
 		},
-		tc.Parameter{
-			Name:       ParentConfigCacheParamRank,
-			ConfigFile: "parent.config",
-			Value:      "2",
-			Profiles:   []byte(`["serverprofile0"]`),
-		},
-		tc.Parameter{
-			Name:       ParentConfigCacheParamRank,
-			ConfigFile: "parent.config",
-			Value:      "1",
-			Profiles:   []byte(`["serverprofile1"]`),
-		},
 	}
 
 	// Create set of DS params
@@ -4003,7 +3991,6 @@ func TestMakeParentDotConfigFirstLastNoTopo(t *testing.T) {
 	setIP(org0, "192.168.2.4")
 	org0.Type = tc.OriginTypeName
 	org0.TypeID = util.IntPtr(991)
-	org0.ProfileNames = []string{"serverprofile0"}
 
 	org1 := makeTestParentServer()
 	org1.Cachegroup = util.StrPtr("orgCG1")
@@ -4013,7 +4000,6 @@ func TestMakeParentDotConfigFirstLastNoTopo(t *testing.T) {
 	setIP(org1, "192.168.2.5")
 	org1.Type = tc.OriginTypeName
 	org1.TypeID = util.IntPtr(991)
-	org1.ProfileNames = []string{"serverprofile1"}
 
 	servers := []Server{*edge, *mid0, *mid1, *org0, *org1}
 
@@ -4184,6 +4170,7 @@ func TestMakeParentDotConfigFirstLastNoTopo(t *testing.T) {
 			}
 		}
 
+		// Check parent ordering (based on cache group prim/sec parents)
 		if !strings.Contains(txt, `parent="myorg0`) {
 			t.Errorf("Incorrect parent ordering, got %v", txt)
 		}
@@ -4196,6 +4183,7 @@ func TestMakeParentDotConfigFirstLastNoTopo(t *testing.T) {
 		}
 		txt := cfg.Text
 
+		// Check parent ordering (based on cache group prim/sec parents)
 		if !strings.Contains(txt, `parent="myorg1`) {
 			t.Errorf("Incorrect parent ordering, got %v", txt)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

A bug in t3c was found when a topology for a MID is simulated for a non topology MSO delivery service with 2 origins in the primary and secondary groups and round_robin=false.  The primary and secondary origin parent cache groups assignments weren't properly being transferred over to the created topology resulting in inconsistent origin ordering in parent.config 

This bug fixes that by explicitly assigning primary and secondary parent cache groups to the intermediate struct.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Tested by creating a DS with:
- Not consistent hash (round_robin=false)
- Mid cache group with primary and secondary parent
- Origin assigned from one of each of the above cache groups.

Run t3c multiple times and ensure the parent.config is consistently created.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 7.1.0

## PR submission checklist
- [x] This PR has tests
- [ ] ~~This PR has documentation~~ -- bug fix
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
