### PR TITLE
Various improvements to the API contract tests

### DIFF
--- a/traffic_control/clients/python/pylint.rc
+++ b/traffic_control/clients/python/pylint.rc
@@ -360,13 +360,6 @@ max-line-length=100
 # Maximum number of lines in a module.
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-			   dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -165,9 +165,9 @@ def parse_to_url(raw: str) -> tuple[APIVersion, int]:
 	if parsed.scheme and parsed.scheme.lower() != "https":
 		raise ValueError("invalid scheme; must use HTTPS")
 
-	port_str = parsed.netloc.split(":")[-1]
 	port = 443
-	if port_str:
+	if ":" in parsed.netloc:
+		port_str = parsed.netloc.split(":")[-1]
 		try:
 			port = int(port_str)
 		except ValueError as e:

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -12,8 +12,11 @@
 # limitations under the License.
 #
 
-"""This module is used to create a Traffic Ops session
-and to store prerequisite data for endpoints."""
+"""
+This module is used to create a Traffic Ops session and to store prerequisite
+data for endpoints.
+"""
+
 import json
 import logging
 import sys
@@ -21,8 +24,10 @@ import os
 from random import randint
 from typing import NamedTuple, Optional
 from urllib.parse import urlparse
+
 import pytest
 import requests
+
 from trafficops.tosession import TOSession
 from trafficops.restapi import OperationError
 
@@ -30,27 +35,24 @@ from trafficops.restapi import OperationError
 # Create and configure logger
 logger = logging.getLogger()
 
-
 class ArgsType(NamedTuple):
-	"""Represents the arguments needed to create Traffic Ops session.
-
-	Attributes:
-		user (str): The username used for authentication.
-		password (str): The password used for authentication.
-		url (str): The URL of the environment.
-		port (int): The port number to use for session.
-		api_version (float): The version number of the API to use.
-	"""
+	"""Represents the arguments needed to create Traffic Ops session."""
 	user: str
 	password: str
 	url: str
 	port: int
 	api_version: float
 
+ArgsType.user.__doc__ = """The username used for authentication."""
+ArgsType.password.__doc__ = """The password used for authentication."""
+ArgsType.url.__doc__ = """The URL of the environment."""
+ArgsType.port.__doc__ = """The port number to use for session."""
+ArgsType.api_version.__doc__ = """The version number of the API to use."""
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-	"""Passing in Traffic Ops arguments [Username, Password, Url and Hostname] from command line.
-	:param parser: Parser to parse command line arguments
+	"""
+	Parses the Traffic Ops arguments from command line.
+	:param parser: Parser to parse command line arguments.
 	"""
 	parser.addoption(
 		"--to-user", action="store", help="User name for Traffic Ops Session."
@@ -65,9 +67,11 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 @pytest.fixture(name="to_args")
 def to_data(pytestconfig: pytest.Config) -> ArgsType:
-	"""PyTest fixture to store Traffic ops arguments passed from command line.
-	:param pytestconfig: Session-scoped fixture that returns the session's pytest.Config object
-	:returns args: Return Traffic Ops arguments
+	"""
+	PyTest fixture to store Traffic ops arguments passed from command line.
+	:param pytestconfig: Session-scoped fixture that returns the session's
+		pytest.Config object.
+	:returns: Configuration for connecting to Traffic Ops.
 	"""
 	with open(os.path.join(os.path.dirname(__file__), "to_data.json"),
 			encoding="utf-8", mode="r") as session_file:
@@ -75,19 +79,25 @@ def to_data(pytestconfig: pytest.Config) -> ArgsType:
 	to_user = pytestconfig.getoption("--to-user")
 	to_password = pytestconfig.getoption("--to-password")
 	to_url = pytestconfig.getoption("--to-url")
-	api_version = urlparse(
-		session_data.get("url")).path.strip("/").split("/")[1]
+	api_version = urlparse(session_data.get("url")).path.strip("/").split("/")[1]
 
 	if not all([to_user, to_password, to_url]):
-		logger.info(
-			"Traffic Ops session data were not passed from Command line Args.")
-		args = ArgsType(user=session_data.get("user"), password=session_data.get(
-			"password"), url=session_data.get("url"), port=session_data.get("port"),
-			api_version=api_version)
-
+		logger.info("Traffic Ops session data were not passed from Command line Args.")
+		args = ArgsType(
+			user = session_data.get("user"),
+			password = session_data.get("password"),
+			url = session_data.get("url"),
+			port = session_data.get("port"),
+			api_version = api_version
+		)
 	else:
-		args = ArgsType(user=to_user, password=to_password, url=to_url,
-						port=session_data.get("port"), api_version=api_version)
+		args = ArgsType(
+			user=to_user,
+			password=to_password,
+			url=to_url,
+			port=session_data.get("port"),
+			api_version=api_version
+		)
 		logger.info("Parsed Traffic ops session data from args %s", args)
 	return args
 
@@ -103,13 +113,17 @@ def to_login(to_args: ArgsType) -> TOSession:
 	to_url = urlparse(to_args.url)
 	to_host = to_url.hostname
 	try:
-		to_session = TOSession(host_ip=to_host, host_port=to_args.port,
-							   api_version=to_args.api_version, ssl=True, verify_cert=False)
+		to_session = TOSession(
+			host_ip=to_host,
+			host_port=to_args.port,
+			api_version=to_args.api_version,
+			ssl=True,
+			verify_cert=False
+		)
 		logger.info("Established Traffic Ops Session.")
 	except OperationError as error:
 		logger.debug("%s", error, exc_info=True, stack_info=True)
-		logger.error(
-			"Failure in Traffic Ops session creation. Reason: %s", error)
+		logger.error("Failure in Traffic Ops session creation. Reason: %s", error)
 		sys.exit(-1)
 
 	# Login To TO_API
@@ -119,12 +133,12 @@ def to_login(to_args: ArgsType) -> TOSession:
 
 
 @pytest.fixture()
-def cdn_post_data(to_session: TOSession, cdn_prereq_data:
-				  object) -> Optional[list[dict[str, str] | requests.Response]]:
-	"""PyTest Fixture to create POST data for cdns endpoint.
-	:param to_session: Fixture to get Traffic ops session
-	:param get_cdn_data: Fixture to get cdn data from a prereq file
-	:returns prerequisite_data: Returns sample Post data and actual api response
+def cdn_post_data(to_session: TOSession, cdn_prereq_data: object) -> Optional[list[dict[str, str] | requests.Response]]:
+	"""
+	PyTest Fixture to create POST data for cdns endpoint.
+	:param to_session: Fixture to get Traffic Ops session.
+	:param get_cdn_data: Fixture to get CDN data from a prerequisites file.
+	:returns: Returns sample Post data and actual api response.
 	"""
 
 	# Return new post data and post response from cdns POST request

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -213,7 +213,10 @@ def to_data(pytestconfig: pytest.Config) -> ArgsType:
 	if not to_url:
 		raise ValueError("Traffic Ops URL is not configured - use '--to-url', the config file, or an environment variable to do so")
 
-	api_version, port = parse_to_url(to_url)
+	try:
+		api_version, port = parse_to_url(to_url)
+	except ValueError as e:
+		raise ValueError("invalid Traffic Ops URL") from e
 
 	return ArgsType(
 		to_user,

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -180,7 +180,7 @@ def parse_to_url(raw: str) -> tuple[APIVersion, int]:
 			raise ValueError(f"invalid API path: {parsed.path} (should be e.g. '/api/4.0')")
 		api_version = APIVersion.from_string(ver_str)
 	else:
-		logging.warn("using default API version: %s", api_version)
+		logging.warning("using default API version: %s", api_version)
 
 	return (api_version, port)
 

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -122,6 +122,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 	parser.addoption(
 		"--config", help="Path to configuration file.", default=os.path.join(os.path.dirname(__file__), "to_data.json")
 	)
+	parser.addoption(
+		"--prerequisites", help="Path to prerequisites file.", default=os.path.join(os.path.dirname(__file__), "prerequisite_data.json")
+	)
 
 def coalesce_config(arg: object | None, file_key: str, file_contents: dict[str, object | None] | None, env_key: str) -> Optional[str]:
 	"""

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-"""This module is used to create a Traffic Ops session 
+"""This module is used to create a Traffic Ops session
 and to store prerequisite data for endpoints."""
 import json
 import logging
@@ -32,112 +32,112 @@ logger = logging.getLogger()
 
 
 class ArgsType(NamedTuple):
-    """Represents the arguments needed to create Traffic Ops session.
+	"""Represents the arguments needed to create Traffic Ops session.
 
-    Attributes:
-        user (str): The username used for authentication.
-        password (str): The password used for authentication.
-        url (str): The URL of the environment.
-        port (int): The port number to use for session.
-        api_version (float): The version number of the API to use.
-    """
-    user: str
-    password: str
-    url: str
-    port: int
-    api_version: float
+	Attributes:
+		user (str): The username used for authentication.
+		password (str): The password used for authentication.
+		url (str): The URL of the environment.
+		port (int): The port number to use for session.
+		api_version (float): The version number of the API to use.
+	"""
+	user: str
+	password: str
+	url: str
+	port: int
+	api_version: float
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
-    """Passing in Traffic Ops arguments [Username, Password, Url and Hostname] from command line.
-    :param parser: Parser to parse command line arguments
-    """
-    parser.addoption(
-        "--to-user", action="store", help="User name for Traffic Ops Session."
-    )
-    parser.addoption(
-        "--to-password", action="store", help="Password for Traffic Ops Session."
-    )
-    parser.addoption(
-        "--to-url", action="store", help="Traffic Ops URL."
-    )
+	"""Passing in Traffic Ops arguments [Username, Password, Url and Hostname] from command line.
+	:param parser: Parser to parse command line arguments
+	"""
+	parser.addoption(
+		"--to-user", action="store", help="User name for Traffic Ops Session."
+	)
+	parser.addoption(
+		"--to-password", action="store", help="Password for Traffic Ops Session."
+	)
+	parser.addoption(
+		"--to-url", action="store", help="Traffic Ops URL."
+	)
 
 
 @pytest.fixture(name="to_args")
 def to_data(pytestconfig: pytest.Config) -> ArgsType:
-    """PyTest fixture to store Traffic ops arguments passed from command line.
-    :param pytestconfig: Session-scoped fixture that returns the session's pytest.Config object
-    :returns args: Return Traffic Ops arguments
-    """
-    with open(os.path.join(os.path.dirname(__file__), "to_data.json"),
-            encoding="utf-8", mode="r") as session_file:
-        session_data = json.load(session_file)
-    to_user = pytestconfig.getoption("--to-user")
-    to_password = pytestconfig.getoption("--to-password")
-    to_url = pytestconfig.getoption("--to-url")
-    api_version = urlparse(
-        session_data.get("url")).path.strip("/").split("/")[1]
+	"""PyTest fixture to store Traffic ops arguments passed from command line.
+	:param pytestconfig: Session-scoped fixture that returns the session's pytest.Config object
+	:returns args: Return Traffic Ops arguments
+	"""
+	with open(os.path.join(os.path.dirname(__file__), "to_data.json"),
+			encoding="utf-8", mode="r") as session_file:
+		session_data = json.load(session_file)
+	to_user = pytestconfig.getoption("--to-user")
+	to_password = pytestconfig.getoption("--to-password")
+	to_url = pytestconfig.getoption("--to-url")
+	api_version = urlparse(
+		session_data.get("url")).path.strip("/").split("/")[1]
 
-    if not all([to_user, to_password, to_url]):
-        logger.info(
-            "Traffic Ops session data were not passed from Command line Args.")
-        args = ArgsType(user=session_data.get("user"), password=session_data.get(
-            "password"), url=session_data.get("url"), port=session_data.get("port"),
-            api_version=api_version)
+	if not all([to_user, to_password, to_url]):
+		logger.info(
+			"Traffic Ops session data were not passed from Command line Args.")
+		args = ArgsType(user=session_data.get("user"), password=session_data.get(
+			"password"), url=session_data.get("url"), port=session_data.get("port"),
+			api_version=api_version)
 
-    else:
-        args = ArgsType(user=to_user, password=to_password, url=to_url,
-                        port=session_data.get("port"), api_version=api_version)
-        logger.info("Parsed Traffic ops session data from args %s", args)
-    return args
+	else:
+		args = ArgsType(user=to_user, password=to_password, url=to_url,
+						port=session_data.get("port"), api_version=api_version)
+		logger.info("Parsed Traffic ops session data from args %s", args)
+	return args
 
 
 @pytest.fixture(name="to_session")
 def to_login(to_args: ArgsType) -> TOSession:
-    """PyTest Fixture to create a Traffic Ops session from Traffic Ops Arguments
-    passed as command line arguments in to_args fixture in conftest.
-    :param to_args: Fixture to get Traffic ops session arguments
-    :returns to_session: Return Traffic ops session
-    """
-    # Create a Traffic Ops V4 session and login
-    to_url = urlparse(to_args.url)
-    to_host = to_url.hostname
-    try:
-        to_session = TOSession(host_ip=to_host, host_port=to_args.port,
-                               api_version=to_args.api_version, ssl=True, verify_cert=False)
-        logger.info("Established Traffic Ops Session.")
-    except OperationError as error:
-        logger.debug("%s", error, exc_info=True, stack_info=True)
-        logger.error(
-            "Failure in Traffic Ops session creation. Reason: %s", error)
-        sys.exit(-1)
+	"""PyTest Fixture to create a Traffic Ops session from Traffic Ops Arguments
+	passed as command line arguments in to_args fixture in conftest.
+	:param to_args: Fixture to get Traffic ops session arguments
+	:returns to_session: Return Traffic ops session
+	"""
+	# Create a Traffic Ops V4 session and login
+	to_url = urlparse(to_args.url)
+	to_host = to_url.hostname
+	try:
+		to_session = TOSession(host_ip=to_host, host_port=to_args.port,
+							   api_version=to_args.api_version, ssl=True, verify_cert=False)
+		logger.info("Established Traffic Ops Session.")
+	except OperationError as error:
+		logger.debug("%s", error, exc_info=True, stack_info=True)
+		logger.error(
+			"Failure in Traffic Ops session creation. Reason: %s", error)
+		sys.exit(-1)
 
-    # Login To TO_API
-    to_session.login(to_args.user, to_args.password)
-    logger.info("Successfully logged into Traffic Ops.")
-    return to_session
+	# Login To TO_API
+	to_session.login(to_args.user, to_args.password)
+	logger.info("Successfully logged into Traffic Ops.")
+	return to_session
 
 
 @pytest.fixture()
 def cdn_post_data(to_session: TOSession, cdn_prereq_data:
-                  object) -> Optional[list[dict[str, str] | requests.Response]]:
-    """PyTest Fixture to create POST data for cdns endpoint.
-    :param to_session: Fixture to get Traffic ops session 
-    :param get_cdn_data: Fixture to get cdn data from a prereq file
-    :returns prerequisite_data: Returns sample Post data and actual api response
-    """
+				  object) -> Optional[list[dict[str, str] | requests.Response]]:
+	"""PyTest Fixture to create POST data for cdns endpoint.
+	:param to_session: Fixture to get Traffic ops session
+	:param get_cdn_data: Fixture to get cdn data from a prereq file
+	:returns prerequisite_data: Returns sample Post data and actual api response
+	"""
 
-    # Return new post data and post response from cdns POST request
-    cdn_prereq_data["name"] = cdn_prereq_data["name"][:4]+str(randint(0, 1000))
-    cdn_prereq_data["domainName"] = cdn_prereq_data["domainName"][:5] + \
-        str(randint(0, 1000))
-    logger.info("New cdn data to hit POST method %s", cdn_prereq_data)
-    # Hitting cdns POST methed
-    response = to_session.create_cdn(data=cdn_prereq_data)
-    prerequisite_data = None
-    try:
-        cdn_response = response[0]
-        prerequisite_data = [cdn_prereq_data, cdn_response]
-    except IndexError:
-        logger.error("No CDN response data from cdns POST request.")
-    return prerequisite_data
+	# Return new post data and post response from cdns POST request
+	cdn_prereq_data["name"] = cdn_prereq_data["name"][:4]+str(randint(0, 1000))
+	cdn_prereq_data["domainName"] = cdn_prereq_data["domainName"][:5] + \
+		str(randint(0, 1000))
+	logger.info("New cdn data to hit POST method %s", cdn_prereq_data)
+	# Hitting cdns POST methed
+	response = to_session.create_cdn(data=cdn_prereq_data)
+	prerequisite_data = None
+	try:
+		cdn_response = response[0]
+		prerequisite_data = [cdn_prereq_data, cdn_response]
+	except IndexError:
+		logger.error("No CDN response data from cdns POST request.")
+	return prerequisite_data

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -120,7 +120,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 		"--to-url", action="store", help="Traffic Ops URL."
 	)
 	parser.addoption(
-		"-c", "--config", help="Path to configuration file.", default=os.path.join(os.path.dirname(__file__), "to_data.json")
+		"--config", help="Path to configuration file.", default=os.path.join(os.path.dirname(__file__), "to_data.json")
 	)
 
 def coalesce_config(arg: object | None, file_key: str, file_contents: dict[str, object | None] | None, env_key: str) -> Optional[str]:

--- a/traffic_ops/testing/api_contract/v4/conftest.py
+++ b/traffic_ops/testing/api_contract/v4/conftest.py
@@ -22,7 +22,7 @@ import logging
 import sys
 import os
 from random import randint
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Union, Optional, TypeAlias
 from urllib.parse import urlparse
 
 import pytest
@@ -31,22 +31,78 @@ import requests
 from trafficops.tosession import TOSession
 from trafficops.restapi import OperationError
 
-
 # Create and configure logger
 logger = logging.getLogger()
 
+JSONData: TypeAlias = Union[dict[str, object], list[object], bool, int, float, str | None]
+JSONData.__doc__ = """An alias for the kinds of data that JSON can encode."""
+
+class APIVersion(NamedTuple):
+	"""Represents an API version."""
+	major: int
+	minor: int
+
+	@staticmethod
+	def from_string(ver_str: str) -> "APIVersion":
+		"""
+		Instantiates a new version from a string.
+
+		>>> APIVersion.from_string("4.0")
+		APIVersion(major=4, minor=0)
+		>>> try:
+		... 	APIVersion("not a version string")
+		... except ValueError:
+		... 	print("whoops")
+		...
+		whoops
+		>>>
+		>>> try:
+		... 	APIVersion("4.Q")
+		... except ValueError:
+		... 	print("whoops")
+		...
+		whoops
+		"""
+		parts = ver_str.split(".", 1)
+		if len(parts) != 2:
+			raise ValueError("invalid version; must be of the form '{{major}}.{{minor}}'")
+		return APIVersion(int(parts[0]), int(parts[1]))
+
+	def __str__(self) -> str:
+		"""
+		Coalesces the version to a string.
+
+		>>> print(APIVersion(4, 1))
+		4.1
+		"""
+		return f"{self.major}.{self.minor}"
+
+APIVersion.major.__doc__ = """The API's major version number."""
+APIVersion.major.__doc__ = """The API's minor version number."""
+
 class ArgsType(NamedTuple):
-	"""Represents the arguments needed to create Traffic Ops session."""
+	"""Represents the configuration needed to create Traffic Ops session."""
 	user: str
 	password: str
 	url: str
 	port: int
-	api_version: float
+	api_version: APIVersion
+
+	def __str__(self) -> str:
+		"""
+		Formats the configuration as a string. Omits password and extraneous
+		properties.
+
+		>>> print(ArgsType("user", "password", "url", 420, APIVersion(4, 0)))
+		User: 'user', URL: 'url'
+		"""
+		return f"User: '{self.user}', URL: '{self.url}'"
+
 
 ArgsType.user.__doc__ = """The username used for authentication."""
 ArgsType.password.__doc__ = """The password used for authentication."""
 ArgsType.url.__doc__ = """The URL of the environment."""
-ArgsType.port.__doc__ = """The port number to use for session."""
+ArgsType.port.__doc__ = """The port number on which to connect to Traffic Ops."""
 ArgsType.api_version.__doc__ = """The version number of the API to use."""
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -63,51 +119,118 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 	parser.addoption(
 		"--to-url", action="store", help="Traffic Ops URL."
 	)
+	parser.addoption(
+		"-c", "--config", help="Path to configuration file.", default=os.path.join(os.path.dirname(__file__), "to_data.json")
+	)
 
+def coalesce_config(arg: object | None, file_key: str, file_contents: dict[str, object | None] | None, env_key: str) -> Optional[str]:
+	"""
+	Coalesces configuration retrieved from different sources into a single
+	string.
+
+	This will raise a ValueError if the type of the configuration value in the
+	parsed configuration file is not a string.
+
+	:param arg: The command-line argument value.
+	:param file_key: The key under which to look in the parsed JSON configuration file data.
+	:param file_contents: The parsed JSON configuration file (if one was used).
+	:param env_key: The environment variable name to look for a value if one wasn't provided elsewhere.
+	:returns: In order of descending precedence: the command-line argument value, the configuration file value, or the environment variable value. Or, None if a value wasn't found anywhere.
+	"""
+	if isinstance(arg, str):
+		return arg
+
+	if file_contents:
+		file_value = file_contents.get(file_key)
+		if isinstance(file_value, str):
+			return file_value
+		if file_value is not None:
+			raise ValueError(f"incorrect value; want: 'str', got: '{type(file_value)}'")
+
+	return os.environ.get(env_key)
+
+def parse_to_url(raw: str) -> tuple[APIVersion, int]:
+	"""
+	Parses the API version and port number from a raw URL string.
+
+	>>> parse_to_url("https://trafficops.example.test:420/api/5.270)
+	(APIVersion(major=5, minor=270), 420)
+	>>> parse_to_url("trafficops.example.test")
+	(APIVersion(major=4, minor=0), 443)
+	"""
+	parsed = urlparse(raw)
+	if not parsed.netloc:
+		raise ValueError("missing network location (hostname & optional port)")
+
+	if parsed.scheme and parsed.scheme.lower() != "https":
+		raise ValueError("invalid scheme; must use HTTPS")
+
+	port_str = parsed.netloc.split(":")[-1]
+	port = 443
+	if port_str:
+		try:
+			port = int(port_str)
+		except ValueError as e:
+			raise ValueError(f"invalid port number: {port_str}") from e
+
+	api_version = APIVersion(4, 0)
+	if parsed.path and parsed.path != "/":
+		ver_str = parsed.path.lstrip("/api/").split("/", 1)[0]
+		if not ver_str:
+			raise ValueError(f"invalid API path: {parsed.path} (should be e.g. '/api/4.0')")
+		api_version = APIVersion.from_string(ver_str)
+	else:
+		logging.warn("using default API version: %s", api_version)
+
+	return (api_version, port)
 
 @pytest.fixture(name="to_args")
 def to_data(pytestconfig: pytest.Config) -> ArgsType:
 	"""
 	PyTest fixture to store Traffic ops arguments passed from command line.
-	:param pytestconfig: Session-scoped fixture that returns the session's
-		pytest.Config object.
+	:param pytestconfig: Session-scoped fixture that returns the session's pytest.Config object.
 	:returns: Configuration for connecting to Traffic Ops.
 	"""
-	with open(os.path.join(os.path.dirname(__file__), "to_data.json"),
-			encoding="utf-8", mode="r") as session_file:
-		session_data = json.load(session_file)
-	to_user = pytestconfig.getoption("--to-user")
-	to_password = pytestconfig.getoption("--to-password")
-	to_url = pytestconfig.getoption("--to-url")
-	api_version = urlparse(session_data.get("url")).path.strip("/").split("/")[1]
+	session_data: JSONData = None
+	cfg_path = pytestconfig.getoption("--config")
+	if isinstance(cfg_path, str):
+		try:
+			with open(cfg_path, encoding="utf-8", mode="r") as session_file:
+				session_data = json.load(session_file)
+		except (FileNotFoundError, PermissionError) as read_err:
+			raise ValueError(f"could not read configuration file at '{cfg_path}'") from read_err
 
-	if not all([to_user, to_password, to_url]):
-		logger.info("Traffic Ops session data were not passed from Command line Args.")
-		args = ArgsType(
-			user = session_data.get("user"),
-			password = session_data.get("password"),
-			url = session_data.get("url"),
-			port = session_data.get("port"),
-			api_version = api_version
-		)
-	else:
-		args = ArgsType(
-			user=to_user,
-			password=to_password,
-			url=to_url,
-			port=session_data.get("port"),
-			api_version=api_version
-		)
-		logger.info("Parsed Traffic ops session data from args %s", args)
-	return args
+	if session_data is not None and not isinstance(session_data, dict):
+		raise ValueError(f"invalid configuration file; expected top-level object, got: {type(session_data)}")
 
+	to_user = coalesce_config(pytestconfig.getoption("--to-user"), "user", session_data, "TO_USER")
+	if not to_user:
+		raise ValueError("Traffic Ops password is not configured - use '--to-password', the config file, or an environment variable to do so")
+	to_password = coalesce_config(pytestconfig.getoption("--to-password"), "password", session_data, "TO_PASSWORD")
+	if not to_password:
+		raise ValueError("Traffic Ops password is not configured - use '--to-password', the config file, or an environment variable to do so")
+	to_url = coalesce_config(pytestconfig.getoption("--to-url"), "url", session_data, "TO_USER")
+	if not to_url:
+		raise ValueError("Traffic Ops URL is not configured - use '--to-url', the config file, or an environment variable to do so")
+
+	api_version, port = parse_to_url(to_url)
+
+	return ArgsType(
+		to_user,
+		to_password,
+		to_url,
+		port,
+		api_version
+	)
 
 @pytest.fixture(name="to_session")
 def to_login(to_args: ArgsType) -> TOSession:
-	"""PyTest Fixture to create a Traffic Ops session from Traffic Ops Arguments
+	"""
+	PyTest Fixture to create a Traffic Ops session from Traffic Ops Arguments
 	passed as command line arguments in to_args fixture in conftest.
-	:param to_args: Fixture to get Traffic ops session arguments
-	:returns to_session: Return Traffic ops session
+
+	:param to_args: Fixture to get Traffic ops session arguments.
+	:returns: An authenticated Traffic Ops session.
 	"""
 	# Create a Traffic Ops V4 session and login
 	to_url = urlparse(to_args.url)
@@ -116,7 +239,7 @@ def to_login(to_args: ArgsType) -> TOSession:
 		to_session = TOSession(
 			host_ip=to_host,
 			host_port=to_args.port,
-			api_version=to_args.api_version,
+			api_version=str(to_args.api_version),
 			ssl=True,
 			verify_cert=False
 		)
@@ -136,10 +259,14 @@ def to_login(to_args: ArgsType) -> TOSession:
 def cdn_post_data(to_session: TOSession, cdn_prereq_data: object) -> Optional[list[dict[str, str] | requests.Response]]:
 	"""
 	PyTest Fixture to create POST data for cdns endpoint.
+
 	:param to_session: Fixture to get Traffic Ops session.
 	:param get_cdn_data: Fixture to get CDN data from a prerequisites file.
-	:returns: Returns sample Post data and actual api response.
+	:returns: Sample POST data and the actual API response.
 	"""
+
+	if not isinstance(cdn_prereq_data, dict):
+		raise TypeError(f"prerequisite data must be 'dict', not '{type(cdn_prereq_data)}'")
 
 	# Return new post data and post response from cdns POST request
 	cdn_prereq_data["name"] = cdn_prereq_data["name"][:4]+str(randint(0, 1000))
@@ -147,8 +274,8 @@ def cdn_post_data(to_session: TOSession, cdn_prereq_data: object) -> Optional[li
 		str(randint(0, 1000))
 	logger.info("New cdn data to hit POST method %s", cdn_prereq_data)
 	# Hitting cdns POST methed
-	response = to_session.create_cdn(data=cdn_prereq_data)
-	prerequisite_data = None
+	response: tuple[requests.Response, object] = to_session.create_cdn(data=cdn_prereq_data)
+	prerequisite_data: Optional[list[dict[str, str] | requests.Response]] = None
 	try:
 		cdn_response = response[0]
 		prerequisite_data = [cdn_prereq_data, cdn_response]

--- a/traffic_ops/testing/api_contract/v4/prerequisite_data.json
+++ b/traffic_ops/testing/api_contract/v4/prerequisite_data.json
@@ -1,9 +1,9 @@
 {
-    "cdns": {
-        "name": "test",
-        "domainName": "quest",
-        "dnssecEnabled": false,
-        "id": null,
-        "lastUpdated": null
-    }
+	"cdns": [{
+		"name": "test",
+		"domainName": "quest",
+		"dnssecEnabled": false,
+		"id": null,
+		"lastUpdated": null
+	}]
 }

--- a/traffic_ops/testing/api_contract/v4/test_cdns.py
+++ b/traffic_ops/testing/api_contract/v4/test_cdns.py
@@ -23,16 +23,26 @@ from trafficops.tosession import TOSession
 # Create and configure logger
 logger = logging.getLogger()
 
+primitive = bool | int | float | str | None
 
 @pytest.fixture(name="cdn_prereq_data")
-def get_cdn_prereq_data() -> object:
+def get_cdn_prereq_data(pytestconfig: pytest.Config) -> list[dict[str, object] | list[object] | primitive]:
 	"""
-	PyTest Fixture to store prerequisite data for cdns endpoint.
+	PyTest Fixture to store POST request body data for cdns endpoint.
+
 	:returns: Prerequisite data for cdns endpoint.
 	"""
+	prereq_path = pytestconfig.getoption("prerequisites")
+	if not isinstance(prereq_path, str):
+		# unlike the configuration file, this must be present
+		raise ValueError("prereqisites path not configured")
+
 	# Response keys for cdns endpoint
-	with open(os.path.join(os.path.dirname(__file__), "prerequisite_data.json"), encoding="utf-8", mode="r") as prereq_file:
+	data: dict[str, list[dict[str, object] | list[object] | primitive] | dict[str, object] | primitive] | list[object] | primitive = None
+	with open(prereq_path, encoding="utf-8", mode="r") as prereq_file:
 		data = json.load(prereq_file)
+	if not isinstance(data, dict):
+		raise TypeError(f"prerequisite data must be an object, not '{type(data)}'")
 	cdn_data = data["cdns"]
 	return cdn_data
 

--- a/traffic_ops/testing/api_contract/v4/test_cdns.py
+++ b/traffic_ops/testing/api_contract/v4/test_cdns.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-"""Api Contract Test Case for cdns endpoint."""
+"""API Contract Test Case for cdns endpoint."""
 import json
 import logging
 import os
@@ -26,23 +26,24 @@ logger = logging.getLogger()
 
 @pytest.fixture(name="cdn_prereq_data")
 def get_cdn_prereq_data() -> object:
-	"""PyTest Fixture to store prereq data for cdns endpoint.
-	:returns cdn_data: Returns prerequisite data for cdns endpoint
+	"""
+	PyTest Fixture to store prerequisite data for cdns endpoint.
+	:returns: Prerequisite data for cdns endpoint.
 	"""
 	# Response keys for cdns endpoint
-	with open(os.path.join(os.path.dirname(__file__), "prerequisite_data.json"),
-			  encoding="utf-8", mode="r") as prereq_file:
+	with open(os.path.join(os.path.dirname(__file__), "prerequisite_data.json"), encoding="utf-8", mode="r") as prereq_file:
 		data = json.load(prereq_file)
 	cdn_data = data["cdns"]
 	return cdn_data
 
 
-def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object,
-					  cdn_post_data: list[dict[str, str] | requests.Response]) -> None:
-	"""Test step to validate keys, values and data types from cdns endpoint response.
-	:param to_session: Fixture to get Traffic ops session
-	:param get_cdn_data: Fixture to get cdn data from a prereq file
-	:param cdn_prereq: Fixture to get sample cdn data and actual cdn response
+def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object, cdn_post_data: list[dict[str, str] | requests.Response]) -> None:
+	"""
+	Test step to validate keys, values and data types from cdns endpoint
+	response.
+	:param to_session: Fixture to get Traffic Ops session.
+	:param get_cdn_data: Fixture to get CDN data from a prerequisites file.
+	:param cdn_prereq: Fixture to get sample CDN data and actual CDN response.
 	"""
 	# validate CDN keys from cdns get response
 	logger.info("Accessing Cdn endpoint through Traffic ops session.")
@@ -52,13 +53,10 @@ def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object,
 	try:
 		cdn_data = cdn_get_response[0]
 		cdn_keys = list(cdn_data[0].keys())
-		logger.info(
-			"CDN Keys from cdns endpoint response %s", cdn_keys)
+		logger.info("CDN Keys from cdns endpoint response %s", cdn_keys)
 		# validate cdn values from prereq data in cdns get response.
-		prereq_values = [cdn_post_data[0]["name"], cdn_post_data[0]
-						 ["domainName"], cdn_post_data[0]["dnssecEnabled"]]
-		get_values = [cdn_data[0]["name"], cdn_data[0]
-					  ["domainName"], cdn_data[0]["dnssecEnabled"]]
+		prereq_values = [cdn_post_data[0]["name"], cdn_post_data[0]["domainName"], cdn_post_data[0]["dnssecEnabled"]]
+		get_values = [cdn_data[0]["name"], cdn_data[0]["domainName"], cdn_data[0]["dnssecEnabled"]]
 		# validate data types for values from cdn get json response.
 		for (prereq_value, get_value) in zip(prereq_values, get_values):
 			assert isinstance(prereq_value, type(get_value))
@@ -75,5 +73,4 @@ def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object,
 			to_session.delete_cdn_by_id(cdn_id=cdn_id)
 		except IndexError:
 			logger.error("CDN wasn't created")
-			pytest.fail(
-				"Response from delete request is empty, Failing test_get_cdn")
+			pytest.fail("Response from delete request is empty, Failing test_get_cdn")

--- a/traffic_ops/testing/api_contract/v4/test_cdns.py
+++ b/traffic_ops/testing/api_contract/v4/test_cdns.py
@@ -52,7 +52,7 @@ def get_cdn_prereq_data(pytestconfig: pytest.Config) -> list[dict[str, object] |
 	return cdn_data
 
 
-def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object, cdn_post_data: list[dict[str, str] | requests.Response]) -> None:
+def test_cdn_contract(to_session: TOSession, cdn_prereq_data: list[dict[str, object] | list[object] | primitive], cdn_post_data: dict[str, object]) -> None:
 	"""
 	Test step to validate keys, values and data types from cdns endpoint
 	response.
@@ -61,31 +61,44 @@ def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object, cdn_post_d
 	:param cdn_prereq: Fixture to get sample CDN data and actual CDN response.
 	"""
 	# validate CDN keys from cdns get response
-	logger.info("Accessing Cdn endpoint through Traffic ops session.")
-	cdn_name = cdn_post_data[0]["name"]
-	cdn_get_response = to_session.get_cdns(
-		query_params={"name": cdn_name})
+	logger.info("Accessing /cdns endpoint through Traffic ops session.")
+
+	cdn = cdn_prereq_data[0]
+	if not isinstance(cdn, dict):
+		raise TypeError("malformed cdn in prerequisite data; not an object")
+
+	cdn_name = cdn.get("name")
+	if not isinstance(cdn_name, str):
+		raise TypeError("malformed cdn in prerequisite data; 'name' not a string")
+
+	cdn_get_response: tuple[dict[str, object] | list[dict[str, object] | list[object] | primitive] | primitive, requests.Response] = to_session.get_cdns(query_params={"name": cdn_name})
 	try:
 		cdn_data = cdn_get_response[0]
-		cdn_keys = list(cdn_data[0].keys())
+		if not isinstance(cdn_data, list):
+			raise TypeError("malformed API response; 'response' property not an array")
+
+		first_cdn = cdn_data[0]
+		if not isinstance(first_cdn, dict):
+			raise TypeError("malformed API response; first CDN in response is not an object")
+		cdn_keys = set(first_cdn.keys())
+
 		logger.info("CDN Keys from cdns endpoint response %s", cdn_keys)
 		# validate cdn values from prereq data in cdns get response.
-		prereq_values = [cdn_post_data[0]["name"], cdn_post_data[0]["domainName"], cdn_post_data[0]["dnssecEnabled"]]
-		get_values = [cdn_data[0]["name"], cdn_data[0]["domainName"], cdn_data[0]["dnssecEnabled"]]
+		prereq_values = [cdn_post_data["name"], cdn_post_data["domainName"], cdn_post_data["dnssecEnabled"]]
+		get_values = [first_cdn["name"], first_cdn["domainName"], first_cdn["dnssecEnabled"]]
 		# validate data types for values from cdn get json response.
 		for (prereq_value, get_value) in zip(prereq_values, get_values):
 			assert isinstance(prereq_value, type(get_value))
-		assert cdn_keys.sort() == list(cdn_prereq_data.keys()).sort()
+		assert cdn_keys == {k for k in cdn_post_data.keys()}
 		assert get_values == prereq_values
 	except IndexError:
-		logger.error("No CDN data from cdns get request")
-		pytest.fail("Response from get request is empty, Failing test_get_cdn")
+		logger.error("Either prerequisite data or API response was malformed")
+		pytest.fail("Either prerequisite data or API response was malformed")
 	finally:
 		# Delete CDN after test execution to avoid redundancy.
 		try:
-			cdn_response = cdn_post_data[1]
-			cdn_id = cdn_response["id"]
+			cdn_id = cdn_post_data["id"]
 			to_session.delete_cdn_by_id(cdn_id=cdn_id)
 		except IndexError:
-			logger.error("CDN wasn't created")
+			logger.error("CDN returned by Traffic Ops is missing an 'id' property")
 			pytest.fail("Response from delete request is empty, Failing test_get_cdn")

--- a/traffic_ops/testing/api_contract/v4/test_cdns.py
+++ b/traffic_ops/testing/api_contract/v4/test_cdns.py
@@ -15,9 +15,10 @@
 """API Contract Test Case for cdns endpoint."""
 import json
 import logging
-import os
+
 import pytest
 import requests
+
 from trafficops.tosession import TOSession
 
 # Create and configure logger
@@ -43,7 +44,11 @@ def get_cdn_prereq_data(pytestconfig: pytest.Config) -> list[dict[str, object] |
 		data = json.load(prereq_file)
 	if not isinstance(data, dict):
 		raise TypeError(f"prerequisite data must be an object, not '{type(data)}'")
+
 	cdn_data = data["cdns"]
+	if not isinstance(cdn_data, list):
+		raise TypeError(f"cdns data must be a list, not '{type(cdn_data)}'")
+
 	return cdn_data
 
 

--- a/traffic_ops/testing/api_contract/v4/test_cdns.py
+++ b/traffic_ops/testing/api_contract/v4/test_cdns.py
@@ -26,54 +26,54 @@ logger = logging.getLogger()
 
 @pytest.fixture(name="cdn_prereq_data")
 def get_cdn_prereq_data() -> object:
-    """PyTest Fixture to store prereq data for cdns endpoint.
-    :returns cdn_data: Returns prerequisite data for cdns endpoint
-    """
-    # Response keys for cdns endpoint
-    with open(os.path.join(os.path.dirname(__file__), "prerequisite_data.json"),
-              encoding="utf-8", mode="r") as prereq_file:
-        data = json.load(prereq_file)
-    cdn_data = data["cdns"]
-    return cdn_data
+	"""PyTest Fixture to store prereq data for cdns endpoint.
+	:returns cdn_data: Returns prerequisite data for cdns endpoint
+	"""
+	# Response keys for cdns endpoint
+	with open(os.path.join(os.path.dirname(__file__), "prerequisite_data.json"),
+			  encoding="utf-8", mode="r") as prereq_file:
+		data = json.load(prereq_file)
+	cdn_data = data["cdns"]
+	return cdn_data
 
 
 def test_cdn_contract(to_session: TOSession, cdn_prereq_data: object,
-                      cdn_post_data: list[dict[str, str] | requests.Response]) -> None:
-    """Test step to validate keys, values and data types from cdns endpoint response.
-    :param to_session: Fixture to get Traffic ops session 
-    :param get_cdn_data: Fixture to get cdn data from a prereq file
-    :param cdn_prereq: Fixture to get sample cdn data and actual cdn response
-    """
-    # validate CDN keys from cdns get response
-    logger.info("Accessing Cdn endpoint through Traffic ops session.")
-    cdn_name = cdn_post_data[0]["name"]
-    cdn_get_response = to_session.get_cdns(
-        query_params={"name": cdn_name})
-    try:
-        cdn_data = cdn_get_response[0]
-        cdn_keys = list(cdn_data[0].keys())
-        logger.info(
-            "CDN Keys from cdns endpoint response %s", cdn_keys)
-        # validate cdn values from prereq data in cdns get response.
-        prereq_values = [cdn_post_data[0]["name"], cdn_post_data[0]
-                         ["domainName"], cdn_post_data[0]["dnssecEnabled"]]
-        get_values = [cdn_data[0]["name"], cdn_data[0]
-                      ["domainName"], cdn_data[0]["dnssecEnabled"]]
-        # validate data types for values from cdn get json response.
-        for (prereq_value, get_value) in zip(prereq_values, get_values):
-            assert isinstance(prereq_value, type(get_value))
-        assert cdn_keys.sort() == list(cdn_prereq_data.keys()).sort()
-        assert get_values == prereq_values
-    except IndexError:
-        logger.error("No CDN data from cdns get request")
-        pytest.fail("Response from get request is empty, Failing test_get_cdn")
-    finally:
-        # Delete CDN after test execution to avoid redundancy.
-        try:
-            cdn_response = cdn_post_data[1]
-            cdn_id = cdn_response["id"]
-            to_session.delete_cdn_by_id(cdn_id=cdn_id)
-        except IndexError:
-            logger.error("CDN wasn't created")
-            pytest.fail(
-                "Response from delete request is empty, Failing test_get_cdn")
+					  cdn_post_data: list[dict[str, str] | requests.Response]) -> None:
+	"""Test step to validate keys, values and data types from cdns endpoint response.
+	:param to_session: Fixture to get Traffic ops session
+	:param get_cdn_data: Fixture to get cdn data from a prereq file
+	:param cdn_prereq: Fixture to get sample cdn data and actual cdn response
+	"""
+	# validate CDN keys from cdns get response
+	logger.info("Accessing Cdn endpoint through Traffic ops session.")
+	cdn_name = cdn_post_data[0]["name"]
+	cdn_get_response = to_session.get_cdns(
+		query_params={"name": cdn_name})
+	try:
+		cdn_data = cdn_get_response[0]
+		cdn_keys = list(cdn_data[0].keys())
+		logger.info(
+			"CDN Keys from cdns endpoint response %s", cdn_keys)
+		# validate cdn values from prereq data in cdns get response.
+		prereq_values = [cdn_post_data[0]["name"], cdn_post_data[0]
+						 ["domainName"], cdn_post_data[0]["dnssecEnabled"]]
+		get_values = [cdn_data[0]["name"], cdn_data[0]
+					  ["domainName"], cdn_data[0]["dnssecEnabled"]]
+		# validate data types for values from cdn get json response.
+		for (prereq_value, get_value) in zip(prereq_values, get_values):
+			assert isinstance(prereq_value, type(get_value))
+		assert cdn_keys.sort() == list(cdn_prereq_data.keys()).sort()
+		assert get_values == prereq_values
+	except IndexError:
+		logger.error("No CDN data from cdns get request")
+		pytest.fail("Response from get request is empty, Failing test_get_cdn")
+	finally:
+		# Delete CDN after test execution to avoid redundancy.
+		try:
+			cdn_response = cdn_post_data[1]
+			cdn_id = cdn_response["id"]
+			to_session.delete_cdn_by_id(cdn_id=cdn_id)
+		except IndexError:
+			logger.error("CDN wasn't created")
+			pytest.fail(
+				"Response from delete request is empty, Failing test_get_cdn")


### PR DESCRIPTION
This PR makes a bunch of changes to the newly added API contract tests. The changes fit into three categories:

- typing errors - typing errors were reduced from 13 to 0
- linting errors - linting score was improved from 1.86/10 to 10/10 with respect to the linting configuration file at `traffic_control/clients/python/pylint.rc`
- configurability - I added the ability to specify locations for prerequisite files and configuration files using command-line option-arguments. I also added the use of the environment variables `TO_USER`, `TO_PASSWORD`, and `TO_URL`. Also, the API version and optional non-standard port are now parsed from the URL instead of double-specified.

Those were the only things I wanted to accomplish with this PR, but I did run into two bugs that I fixed

- if you use `--to-url`, it will use that URL to connect to Traffic Ops, but it'll use the API version parsed from whatever was in the config file.
- API version is stored in a `float`; so version 4.10 will be indistinguishable from version 4.1 to the testing script

and in the prerequisite data, `"cdns"` was just a single object defining a CDN, instead of an array of such objects as implied by the plural name. I assume that the original intention was to be akin to our tc-fixtures files for the TO Go client tests, so I made that an array containing the CDN instead. That should be a very unobtrusive change, but it could bear mentioning.

<hr/>

## Which Traffic Control components are affected by this PR?
- Other: API "contract" tests

## What is the best way to verify this PR?
To verify no typing issues, use a static type checker. I suggest [Pyright](https://pypi.org/project/pyright/)  (I checked using `pyright` version 1.1.300). It should report 0 errors and 0 warnings.

To verify no linting issues, use Pylint with our Pylint configuration file located at `traffic_ops/clients/python/pylint.rc` e.g.
`pylint --rcfile=../../../../traffic_control/clients/python/pylint.rc ./conftest.py ./test_cdns.py`. It should report a perfect 10/10 score (I checked using Pylint 2.16.2 (asteroid 2.14.2)).

To verify configurability, move/copy/rename the prerequisites file and the configuration file and then pass them into pytest using the `--prerequisites` and `--config` long options, respectively. The tests should pass as normal. You should also be able to get them to run and pass as normal by removing the configuration file entirely and just using the aforementioned environment variables (as is customary with some of our other tools e.g. `toget`).

I also added a few docstring testable examples, but getting those to run is surprisingly annoying, so I wouldn't bother.

## PR submission checklist
- [x] This PR has tests
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**