### PR TITLE
Fixed t3c for layered profile order issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#6775](https://github.com/apache/trafficcontrol/issues/6775) *Traffic Ops* Invalid "orgServerFqdn" in Delivery Service creation/update causes Internal Server Error
 - [#6695](https://github.com/apache/trafficcontrol/issues/6695) *Traffic Control Cache Config (t3c)* Directory creation was erroneously reporting an error when actually succeeding.
 - [#7411](https://github.com/apache/trafficcontrol/pull/7411) *Traffic Control Cache Config (t3c)* Fixed issue with wrong parent ordering with MSO non-topology delivery services.
+- [#7425](https://github.com/apache/trafficcontrol/pull/7425) *Traffic Control Cache Config (t3c)* Fixed issue with layered profile iteration being done in the wrong order.
 
 ## [7.0.0] - 2022-07-19
 ### Added

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -849,7 +849,7 @@ func layerProfilesFromMap(profileNames []string, params []parameterWithProfilesM
 
 	layeredParamMap := map[ParamKey]tc.Parameter{}
 	// profileNames is ordered, we need to iterate through this backwards
-	// because we need subsequent params on other profiles to override previous ones, 
+	// because we need subsequent params on other profiles to override previous ones,
 	// this will provide the proper "layering" that we want.
 	for i := len(profileNames) - 1; i >= 0; i-- {
 		profileParams := allProfileParams[profileNames[i]]

--- a/lib/go-atscfg/atscfg.go
+++ b/lib/go-atscfg/atscfg.go
@@ -848,13 +848,13 @@ func layerProfilesFromMap(profileNames []string, params []parameterWithProfilesM
 	}
 
 	layeredParamMap := map[ParamKey]tc.Parameter{}
-
-	for _, profileName := range profileNames {
-		profileParams := allProfileParams[profileName]
+	// profileNames is ordered, we need to iterate through this backwards
+	// because we need subsequent params on other profiles to override previous ones, 
+	// this will provide the proper "layering" that we want.
+	for i := len(profileNames) - 1; i >= 0; i-- {
+		profileParams := allProfileParams[profileNames[i]]
 		for _, param := range profileParams {
 			paramkey := getParamKey(param)
-			// because profileNames is ordered, this will cause subsequent params
-			// on other profiles to override previous ones, "layering" like we want.
 			layeredParamMap[paramkey] = param
 		}
 	}

--- a/lib/go-atscfg/atscfg_test.go
+++ b/lib/go-atscfg/atscfg_test.go
@@ -185,18 +185,21 @@ func TestLayerProfiles(t *testing.T) {
 	}
 
 	// per the params, on the layered profiles "FOO,BAR,BAZ" (in that order):
-	// (1) beta in BAR should override alpha FOO,
-	//    because they share the ConfigFile+Name key and BAR is later in the layering
-	// (2) gamma should be added, but not override
+	// we iterate through params in reverse order because FOO will have the highest priority
+	// then BAR then BAZ, any duplicate params that exist with the same ConfigFile+Name
+	// in subsequent profiles can be overwritten by the next higher profile 
+	// (1) alpha in FOO, should override beta in BAR
+	//    because they share the ConfigFile+Name key and FOO is later in the layering
+	// (2) gamma should be added, but not overridden
 	//    because the key is ConfigFile+Name, which isn't on any previous profile
-	// (3) epsilon in BAZ should override delta in BAR
-	//    because they share the ConfigFile+Name key and BAZ is later in the layering
+	// (3) delta in BAR should override epsilon in BAZ
+	//    because they share the ConfigFile+Name key and BAR is later in the layering
 	//    - this tests the parameters being in a different order than (1)
 	// (4) zeta should be added, but not override
 	//    because the key is ConfigFile+Name, which isn't on any previous profile
 	//    - this tests the name matching but not config file, reverse of (2).
-	// (5) theta in BAZ should override eta and iota in FOO and BAR
-	//    because they share the ConfigFile+Name key and BAZ is last in the layering
+	// (5) iota in FOO should override theta in BAZ and eta and BAR
+	//    because they share the ConfigFile+Name key and FOO is last in the layering
 	//    - this tests multiple overrides
 
 	layeredParams, err := LayerProfiles(profileNames, allParams)
@@ -209,32 +212,32 @@ func TestLayerProfiles(t *testing.T) {
 		vals[param.Value] = struct{}{}
 	}
 
-	if _, ok := vals["alpha"]; ok {
-		t.Errorf("expected: param 'beta' to override 'alpha', actual: alpha in layered parameters")
+	if _, ok := vals["beta"]; ok {
+		t.Errorf("expected: param 'alpha' to override 'beta', actual: beta in layered parameters")
 	}
-	if _, ok := vals["beta"]; !ok {
-		t.Errorf("expected: param 'beta' to override 'alpha', actual: beta not in layered parameters")
+	if _, ok := vals["alpha"]; !ok {
+		t.Errorf("expected: param 'alpha' to override 'beta', actual: alpha not in layered parameters")
 	}
 	if _, ok := vals["gamma"]; !ok {
 		t.Errorf("expected: param 'gamma' with no ConfigFile+Name in another profile to be in layered parameters, actual: gamma not in layered parameters")
 	}
-	if _, ok := vals["delta"]; ok {
-		t.Errorf("expected: param 'epsilon' to override 'delta' in prior profile, actual: delta in layered parameters")
+	if _, ok := vals["epsilon"]; ok {
+		t.Errorf("expected: param 'delta' to override 'epsilon' in prior profile, actual: epsilon in layered parameters")
 	}
-	if _, ok := vals["epsilon"]; !ok {
-		t.Errorf("expected: param 'epsilon' to override 'delta' in prior profile, actual: epsilon not in layered parameters")
+	if _, ok := vals["delta"]; !ok {
+		t.Errorf("expected: param 'delta' to override 'epsilon' in prior profile, actual: delta not in layered parameters")
 	}
 	if _, ok := vals["zeta"]; !ok {
 		t.Errorf("expected: param 'zeta' with no ConfigFile+Name in another profile to be in layered parameters, actual: zeta not in layered parameters")
 	}
-	if _, ok := vals["theta"]; !ok {
-		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: theta not in layered parameters")
+	if _, ok := vals["iota"]; !ok {
+		t.Errorf("expected: param 'iota' to override 'eta' and 'theta' in prior profile, actual: iota not in layered parameters")
 	}
 	if _, ok := vals["eta"]; ok {
-		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: eta in layered parameters")
+		t.Errorf("expected: param 'iota' to override 'eta' and 'theta' in prior profile, actual: eta in layered parameters")
 	}
-	if _, ok := vals["iota"]; ok {
-		t.Errorf("expected: param 'theta' to override 'eta' and 'iota' in prior profile, actual: iota in layered parameters")
+	if _, ok := vals["theta"]; ok {
+		t.Errorf("expected: param 'iota' to override 'eta' and 'theta' in prior profile, actual: theta in layered parameters")
 	}
 }
 

--- a/lib/go-atscfg/atscfg_test.go
+++ b/lib/go-atscfg/atscfg_test.go
@@ -187,7 +187,7 @@ func TestLayerProfiles(t *testing.T) {
 	// per the params, on the layered profiles "FOO,BAR,BAZ" (in that order):
 	// we iterate through params in reverse order because FOO will have the highest priority
 	// then BAR then BAZ, any duplicate params that exist with the same ConfigFile+Name
-	// in subsequent profiles can be overwritten by the next higher profile 
+	// in subsequent profiles can be overwritten by the next higher profile
 	// (1) alpha in FOO, should override beta in BAR
 	//    because they share the ConfigFile+Name key and FOO is later in the layering
 	// (2) gamma should be added, but not overridden

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -3734,13 +3734,13 @@ func TestMakeParentDotConfigTopologiesServerMultipleProfileParams(t *testing.T) 
 			Name:       ParentConfigCacheParamWeight,
 			ConfigFile: "parent.config",
 			Value:      "100",
-			Profiles:   []byte(`["serverprofile0"]`),
+			Profiles:   []byte(`["serverprofile1"]`),
 		},
 		tc.Parameter{
 			Name:       ParentConfigCacheParamWeight,
 			ConfigFile: "parent.config",
 			Value:      "200",
-			Profiles:   []byte(`["serverprofile1"]`),
+			Profiles:   []byte(`["serverprofile0"]`),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
when layered profiles are used, t3c was not iterating through the profiles in the proper order,
which was causing duplicate parameters to be incorrectly overridden

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
run the unit test for layered profiles, otherwise build and install t3c setup layered profiles on a cache and 
have 2 or more parameters with the same config file and name but different values. run t3c and verify 
duplicate parameters have been overridden by the profile with the highest priority.  

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- trafficcontrol-cache-config-7.1.0-12303.79ed7a01

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
