### PR TITLE
renaming tm.sameipservers.control to tm.sameipservers.enabled

### DIFF
--- a/docs/source/admin/traffic_monitor.rst
+++ b/docs/source/admin/traffic_monitor.rst
@@ -79,7 +79,7 @@ traffic_monitor.cfg
 - ``health.polling.interval``
 - ``peers.polling.interval``
 - ``heartbeat.polling.interval``
-- ``tm.sameipservers.control`` - When set to true, performs an AND operation on the availability statuses of servers with same ip. Any unavailable server(s) with same ip as other server(s) will cause the other server(s) to be set to unavailable.
+- ``tm.sameipservers.enabled`` - When set to true, performs an AND operation on the availability statuses of servers with same ip. Any unavailable server(s) with same ip as other server(s) will cause the other server(s) to be set to unavailable.
 
 Upon receiving this configuration, Traffic Monitor begins polling :term:`cache server` s. Once every :term:`cache server` has been polled, :ref:`health-proto` state is available via RESTful JSON endpoints and a web browser UI.
 

--- a/traffic_monitor/datareq/crstate.go
+++ b/traffic_monitor/datareq/crstate.go
@@ -83,7 +83,7 @@ func filterDirectlyPolledCaches(crstates tc.CRStates) tc.CRStates {
 }
 
 func srvTRStateData(localStates peer.CRStatesThreadsafe, directlyPolledOnly bool, toData todata.TODataThreadsafe, monitorConfig threadsafe.TrafficMonitorConfigMap) ([]byte, error) {
-	if val, ok := monitorConfig.Get().Config["tm.sameipservers.control"]; ok && val.(string) == "true" {
+	if val, ok := monitorConfig.Get().Config["tm.sameipservers.enabled"]; ok && val.(string) == "true" {
 		localStatesC := updateStatusSameIpServers(localStates, toData)
 		if !directlyPolledOnly {
 			return tc.CRStatesMarshall(localStatesC)

--- a/traffic_monitor/todata/todata.go
+++ b/traffic_monitor/todata/todata.go
@@ -187,7 +187,7 @@ func (d TODataThreadsafe) Update(to towrap.TrafficOpsSessionThreadsafe, cdn stri
 		return fmt.Errorf("getting server types from monitoring config: %v", err)
 	}
 
-	if val, ok := mc.Config["tm.sameipservers.control"]; ok && val.(string) == "true" {
+	if val, ok := mc.Config["tm.sameipservers.enabled"]; ok && val.(string) == "true" {
 		newTOData.SameIpServers = getSameIPServers(mc)
 	} else {
 		newTOData.SameIpServers = make(map[tc.CacheName]map[tc.CacheName]bool)


### PR DESCRIPTION
Related: #7302

Renaming tm.sameipservers.control to tm.sameipservers.enabled for clarity

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
use  tm.sameipservers.enabled instead of tm.sameipservers.control to verify functionality in #7302

## PR submission checklist
- [0] This PR has tests - verify simple and small code change
- [x] This PR has documentation - documentation updated
- [0] This PR has a CHANGELOG.md entry - this pr is a follow up for #7302
