### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.36.2",
         "@typescript-eslint/parser": "^5.36.2",
         "axios": "^0.27.2",
-        "chromedriver": "^110.0.0",
+        "chromedriver": "^112.0.0",
         "codelyzer": "^6.0.0",
         "eslint": "^8.23.0",
         "eslint-plugin-import": "^2.25.3",
@@ -6078,9 +6078,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-110.0.0.tgz",
-      "integrity": "sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==",
+      "version": "112.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
+      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -22869,9 +22869,9 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "110.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-110.0.0.tgz",
-      "integrity": "sha512-Le6q8xrA/3fAt+g8qiN0YjsYxINIhQMC6wj9X3W5L77uN4NspEzklDrqYNwBcEVn7PcAEJ73nLlS7mTyZRspHA==",
+      "version": "112.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
+      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
     "axios": "^0.27.2",
-    "chromedriver": "^110.0.0",
+    "chromedriver": "^112.0.0",
     "codelyzer": "^6.0.0",
     "eslint": "^8.23.0",
     "eslint-plugin-import": "^2.25.3",

--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -29,7 +29,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^111.0.0",
+        "chromedriver": "^112.0.0",
         "jasmine": "^3.5.0",
         "typescript": "^3.6.4"
       },
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "112.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
+      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2639,9 +2639,9 @@
       }
     },
     "chromedriver": {
-      "version": "111.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-111.0.0.tgz",
-      "integrity": "sha512-XavNYNBBfKIrT8Oi/ywJ0DoOOU+jHF5bQWTkqStFsAXvfCV9VzYN3J+TGAvZdrpXeoixqPRGUxQ2yZhD2iowdQ==",
+      "version": "112.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-112.0.0.tgz",
+      "integrity": "sha512-fEw1tI05dmK1KK8MGh99LAppP7zCOPEXUxxbYX5wpIBCCmKasyrwZhk/qsdnxJYKd/h0TfiHvGEj7ReDQXW1AA==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -24,7 +24,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^111.0.0",
+    "chromedriver": "^112.0.0",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.4"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 111.0.0 -> 112.0.0
experimental/traffic-portal: 110.0.0 -> 112.0.0


## Which Traffic Control components are affected by this PR?
* Traffic Portal
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
