### PR TITLE
Fix issues with TPv2 CiaB Environment

### DIFF
--- a/experimental/traffic-portal/nightwatch/config.json
+++ b/experimental/traffic-portal/nightwatch/config.json
@@ -1,6 +1,7 @@
 {
 	"adminPass": "twelve12",
 	"adminUser": "admin",
+	"disableColors": false,
 	"retryAssertionTimeoutMS": 5000,
 	"to_url": "https://localhost:6443",
 	"tp_url": "http://localhost:4200",

--- a/experimental/traffic-portal/nightwatch/nightwatch.conf.js
+++ b/experimental/traffic-portal/nightwatch/nightwatch.conf.js
@@ -19,7 +19,10 @@ try {
 	config = JSON.parse(fs.readFileSync("./dist/nightwatch/config.json", "utf8"));
 } catch(e) {
 	console.warn("Cannot read config.json");
-	config.tp_url = "http://localhost:4200";
+	config = {
+		disableColors: false,
+		tp_url: "http://localhost:4200"
+	};
 }
 
 // Refer to the online docs for more details: https://nightwatchjs.org/gettingstarted/configuration/
@@ -96,6 +99,7 @@ module.exports = {
 					]
 				}
 			},
+			disable_colors: config.disableColors,
 			disable_error_log: false,
 			enable_fail_fast: true,
 			launch_url: config.tp_url,

--- a/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/Dockerfile
@@ -43,8 +43,12 @@ RUN if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
         net-tools \
         $utils_package && \
     set -o pipefail && \
-    dnf -y install chromium jq && \
+    dnf -y install jq && \
     dnf -y clean all
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
+    dnf install -y ./google-chrome-stable_current_x86_64.rpm && \
+    rm google-chrome-stable_current_x86_64.rpm
 
 FROM os-dependencies AS node-dependencies
 # Download and install node

--- a/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/Dockerfile
@@ -39,7 +39,6 @@ RUN if [[ "${RHEL_VERSION%%.*}" -eq 7 ]]; then \
         wget \
         GConf2 \
         git \
-        jq \
         java-1.8.0-openjdk \
         net-tools \
         $utils_package && \
@@ -60,8 +59,6 @@ RUN dnf -y install nodejs || ( \
         dnf -y install nodejs \
     )
 
-# Install chromium
-RUN dnf -y install chromium
 
 FROM node-dependencies
 

--- a/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/run.sh
@@ -44,7 +44,7 @@ TMOUT
 
 cd /lang/traffic-portal
 
-jq --arg TPURL $TP_URL --arg TOURL https://$TO_FQDN:$TO_PORT '.tp_url = $TPURL | .to_url = $TOURL | .disableColors = true' \
+jq --arg TPURL $TP_URL --arg TOURL https://$TO_FQDN:$TO_PORT '.tp_url = $TPURL | .to_url = $TOURL | .disableColors = true | .retryAssertionTimeoutMS = 10000 | .waitForConditionTimeoutMS = 10000' \
 	nightwatch/config.json > config.tmp.json && mv config.tmp.json nightwatch/config.json
 
 npm run e2e:ci

--- a/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/run.sh
@@ -44,7 +44,7 @@ TMOUT
 
 cd /lang/traffic-portal
 
-jq --arg TP_URL $TP_URL --arg TO_URL https://$TO_FQDN:$TO_PORT '.tp_url = $TP_URL | .to_url = $TO_URL' \
+jq --arg TPURL $TP_URL --arg TOURL https://$TO_FQDN:$TO_PORT '.tp_url = $TPURL | .to_url = $TOURL | .disableColors = true' \
 	nightwatch/config.json > config.tmp.json && mv config.tmp.json nightwatch/config.json
 
 npm run e2e:ci


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR adds the ability to disabled colorful output from nightwatch, making console output more readable in a non "rich" environment. Also removed some duplicate installs in the TPv2 e2e CiaB docker file.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Portal v2
- CDN in a Box

## What is the best way to verify this PR?
Ensure the TPv2 CiaB E2E tests container works. Verify that you can disable color output when running the E2E tests in general.
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
