### PR TITLE
Add server attribute copy to TPv2 ISO generation form

### DIFF
--- a/experimental/traffic-portal/src/app/api/server.service.spec.ts
+++ b/experimental/traffic-portal/src/app/api/server.service.spec.ts
@@ -419,7 +419,7 @@ describe("ServerService", () => {
 					name: "eth0"
 				}],
 				physLocationId: -1,
-				profileId: -1,
+				profileNames: [],
 				statusId: -1,
 				typeId: -1,
 			})).toThrow();

--- a/experimental/traffic-portal/src/app/api/server.service.spec.ts
+++ b/experimental/traffic-portal/src/app/api/server.service.spec.ts
@@ -338,6 +338,105 @@ describe("ServerService", () => {
 		});
 	});
 
+	describe("static methods", () => {
+		it("finds a service address", () => {
+			const infs = [
+				{
+					ipAddresses: [
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						}
+					],
+					maxBandwidth: null,
+					monitor: false,
+					mtu: null,
+					name: "eth0"
+				},
+				{
+					ipAddresses: [
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						},
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						}
+					],
+					maxBandwidth: null,
+					monitor: false,
+					mtu: null,
+					name: "eth1"
+				},
+				{
+					ipAddresses: [
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						},
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: true
+						},
+					],
+					maxBandwidth: null,
+					monitor: false,
+					mtu: null,
+					name: "eth2"
+				}
+			];
+			const serviceInf = ServerService.getServiceInterface(infs);
+			expect(serviceInf).toBe(infs[2]);
+		});
+		it("throws an error when a server has no service addresses", () => {
+			expect(()=>ServerService.getServiceInterface({
+				cachegroupId: -1,
+				cdnId: -1,
+				domainName: "",
+				hostName: "",
+				interfaces: [{
+					ipAddresses: [
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						},
+						{
+							address: "",
+							gateway: "",
+							serviceAddress: false
+						}
+					],
+					maxBandwidth: null,
+					monitor: false,
+					mtu: null,
+					name: "eth0"
+				}],
+				physLocationId: -1,
+				profileId: -1,
+				statusId: -1,
+				typeId: -1,
+			})).toThrow();
+		});
+		it("extracts netmasks", () => {
+			const [addr, netmask] = ServerService.extractNetmask("192.168.0.1/16");
+			expect(addr).toBe("192.168.0.1");
+			expect(netmask).toBe("255.255.0.0");
+		});
+		it("doesn't break when a plain address (no CIDR suffix) is passed", () => {
+			const raw = "192.168.0.1";
+			const [addr, netmask] = ServerService.extractNetmask(raw);
+			expect(addr).toBe(raw);
+			expect(netmask).toBeUndefined();
+		});
+	});
+
 	afterEach(() => {
 		httpTestingController.verify();
 	});

--- a/experimental/traffic-portal/src/app/api/server.service.ts
+++ b/experimental/traffic-portal/src/app/api/server.service.ts
@@ -350,7 +350,7 @@ export class ServerService extends APIService {
 	 * @returns The network interface that contains the service addresses.
 	 * @throws {Error} If no service addresses are found on any interface.
 	 */
-	public getServiceInterface(server: Server | Interface[]): Interface {
+	public static getServiceInterface(server: Server | Interface[]): Interface {
 		const infs = Array.isArray(server) ? server : server.interfaces;
 		for (const inf of infs) {
 			for (const addr of inf.ipAddresses) {
@@ -371,7 +371,7 @@ export class ServerService extends APIService {
 	 * @returns The address without a netmask and the netmask itself (if one
 	 * could be found; otherwise it'll be `undefined`).
 	 */
-	public extractNetmask(addr: IPAddress | string): [string, string | undefined] {
+	public static extractNetmask(addr: IPAddress | string): [string, string | undefined] {
 		let addrStr = typeof(addr) === "string" ? addr : addr.address;
 		let maskStr;
 		if (addrStr.includes("/")) {

--- a/experimental/traffic-portal/src/app/api/testing/server.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/server.service.ts
@@ -14,17 +14,21 @@
 
 import { Injectable } from "@angular/core";
 import type {
+	Interface,
+	IPAddress,
 	RequestServer,
 	RequestServerCapability,
 	RequestStatus,
 	ResponseServer,
 	ResponseServerCapability,
 	ResponseStatus,
+	Server,
 	ServerCapability,
-	Servercheck
+	Servercheck,
 } from "trafficops-types";
 
 import { CDNService, PhysicalLocationService, ProfileService, TypeService } from "..";
+import { ServerService as ConcreteService } from "../server.service";
 
 /**
  * Generates a `Servercheck` for a given `server`.
@@ -503,5 +507,31 @@ export class ServerService {
 		const ret = this.servers[index];
 		this.servers.splice(index, 1);
 		return ret;
+	}
+
+	/**
+	 * Gets the "service" interface for a server; that is, the interface that
+	 * contains service addresses.
+	 *
+	 * @param server Either the server for which to find the "service"
+	 * interface, or just the interfaces thereof.
+	 * @returns The network interface that contains the service addresses.
+	 * @throws {Error} If no service addresses are found on any interface.
+	 */
+	public static getServiceInterface(server: Server | Interface[]): Interface {
+		return ConcreteService.getServiceInterface(server);
+	}
+
+	/**
+	 * Pulls apart an IP address with a CIDR-notation suffix into a plain
+	 * address (with no suffix) and a netmask that represents the same subnet
+	 * as the CIDR-notation suffix.
+	 *
+	 * @param addr The address from which to extract the netmask.
+	 * @returns The address without a netmask and the netmask itself (if one
+	 * could be found; otherwise it'll be `undefined`).
+	 */
+	public static extractNetmask(addr: IPAddress | string): [string, string | undefined] {
+		return ConcreteService.extractNetmask(addr);
 	}
 }

--- a/experimental/traffic-portal/src/app/api/testing/type.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/type.service.ts
@@ -135,6 +135,13 @@ export class TypeService {
 			lastUpdated: new Date(),
 			name: "STEERING",
 			useInTable: "deliveryservice"
+		},
+		{
+			description: "Edge Cache",
+			id: 15,
+			lastUpdated: new Date(),
+			name: "EDGE",
+			useInTable: "server"
 		}
 	];
 

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.html
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.html
@@ -13,9 +13,10 @@ limitations under the License.
 -->
 <mat-card appearance="outlined">
 	<form [formGroup]="form" (ngSubmit)="submit($event)">
-		<mat-card-header>
+		<mat-card-actions align="start">
+			<button mat-raised-button type="button" (click)="openCopyDialog()">Copy Info From Server</button>
 			<mat-slide-toggle name="useDHCP" formControlName="useDHCP">Use DHCP?</mat-slide-toggle>
-		</mat-card-header>
+		</mat-card-actions>
 		<mat-card-content>
 			<mat-form-field>
 				<mat-label>Operating System</mat-label>

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.html
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.html
@@ -13,10 +13,10 @@ limitations under the License.
 -->
 <mat-card appearance="outlined">
 	<form [formGroup]="form" (ngSubmit)="submit($event)">
-		<mat-card-actions align="start">
-			<button mat-raised-button type="button" (click)="openCopyDialog()">Copy Info From Server</button>
+		<div class="form-header">
 			<mat-slide-toggle name="useDHCP" formControlName="useDHCP">Use DHCP?</mat-slide-toggle>
-		</mat-card-actions>
+			<button mat-raised-button type="button" (click)="openCopyDialog()">Copy Info From Server</button>
+		</div>
 		<mat-card-content>
 			<mat-form-field>
 				<mat-label>Operating System</mat-label>

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.scss
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.scss
@@ -22,3 +22,7 @@
 		row-gap: 2em;
 	}
 }
+
+mat-card-actions mat-slide-toggle {
+	margin-left: 16px;
+}

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.scss
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.scss
@@ -23,6 +23,11 @@
 	}
 }
 
-mat-card-actions mat-slide-toggle {
-	margin-left: 16px;
+div.form-header {
+	display: flex;
+	margin: 16px;
+	justify-content: space-between;
+	mat-slide-toggle {
+		margin-left: 16px;
+	}
 }

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.spec.ts
@@ -124,7 +124,7 @@ describe("ISOGenerationFormComponent", () => {
 			hostName: "quest",
 			interfaces: [iface],
 			physLocationId: physLoc.id,
-			profileId: profile.id,
+			profileNames: [profile.name],
 			statusId: status.id,
 			typeId: serverType.id
 		});

--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.ts
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.ts
@@ -18,9 +18,12 @@ import { MatDialog } from "@angular/material/dialog";
 import { serviceAddresses, type ISORequest, type ResponseServer } from "trafficops-types";
 
 import { MiscAPIsService, ServerService } from "src/app/api";
+import {
+	CollectionChoiceDialogComponent,
+	CollectionChoiceDialogData
+} from "src/app/shared/dialogs/collection-choice-dialog/collection-choice-dialog.component";
 import { FileUtilsService } from "src/app/shared/file-utils.service";
 import { IPV4, IPV6, IPV6_WITH_CIDR } from "src/app/utils";
-import { CollectionChoiceDialogComponent, CollectionChoiceDialogData } from "src/app/shared/dialogs/collection-choice-dialog/collection-choice-dialog.component";
 
 /**
  * The controller for a form that can be used to generate ISOs.
@@ -159,8 +162,13 @@ export class ISOGenerationFormComponent implements OnInit {
 		this.fileService.download(response, `${fqdn}-${this.form.controls.osVersion.value}.iso`);
 	}
 
+	/**
+	 * Copies information from a server to fill in form information.
+	 *
+	 * @param server The server from which to copy data.
+	 */
 	private copyServerData(server: ResponseServer): void {
-		const inf = this.serverAPI.getServiceInterface(server);
+		const inf = ServerService.getServiceInterface(server);
 		this.form.controls.useDHCP.setValue(false);
 		this.form.controls.fqdn.setValue(`${server.hostName}.${server.domainName}`);
 		this.form.controls.interfaceName.setValue(inf.name);
@@ -177,7 +185,7 @@ export class ISOGenerationFormComponent implements OnInit {
 				this.form.controls.ipv4Gateway.setValue(ipv4.gateway);
 			}
 
-			const [addr, mask] = this.serverAPI.extractNetmask(ipv4);
+			const [addr, mask] = ServerService.extractNetmask(ipv4);
 			this.form.controls.ipv4Address.setValue(addr);
 			if (mask) {
 				this.form.controls.ipv4Netmask.setValue(mask);
@@ -192,6 +200,10 @@ export class ISOGenerationFormComponent implements OnInit {
 		}
 	}
 
+	/**
+	 * Opens a dialog for copying the information stored on a Traffic Ops Server
+	 * object to fill in form fields.
+	 */
 	public async openCopyDialog(): Promise<void> {
 		const collection = (await this.serverAPI.getServers()).map(
 			s => ({

--- a/experimental/traffic-portal/src/app/core/styles/form.page.scss
+++ b/experimental/traffic-portal/src/app/core/styles/form.page.scss
@@ -11,18 +11,18 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-.mat-mdc-card {
+mat-card {
 	margin: 1em auto;
 	box-sizing: border-box;
 	width: 80%;
 	min-width: 350px;
-	.mat-mdc-card-content {
+	mat-card-content {
 		display: grid;
 		grid-template-columns: 1fr;
 		row-gap: 2em;
 		margin: 1em auto 50px;
 	}
-	.mat-mdc-card-actions .mdc-button {
+	mat-card-actions mat-button {
 		margin: 0 8px;
 	}
 }


### PR DESCRIPTION
This PR adds a way to copy information from existing servers to autofill parts of the ISO generation form in TPv2

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the provided tests pass.

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentatio
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**