### PR TITLE
t3c parent.config fix for MSO non-topo mid cache group no parent cache groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7411](https://github.com/apache/trafficcontrol/pull/7411) *Traffic Control Cache Config (t3c)* Fixed issue with wrong parent ordering with MSO non-topology delivery services.
 - [#7425](https://github.com/apache/trafficcontrol/pull/7425) *Traffic Control Cache Config (t3c)* Fixed issue with layered profile iteration being done in the wrong order.
 - [#6385](https://github.com/apache/trafficcontrol/issues/6385) *Traffic Ops* Reserved consistentHashQueryParameters cause internal server error
+- [#7471](https://github.com/apache/trafficcontrol/pull/7471) *Traffic Control Cache Config (t3c)* Fixed issue with MSO non topo origins from multiple cache groups.
 
 ### Removed
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove components in `infrastructre/docker/`, not in use as cdn-in-a-box performs the same functionality.

--- a/lib/go-atscfg/parentdotconfig.go
+++ b/lib/go-atscfg/parentdotconfig.go
@@ -168,7 +168,6 @@ func MakeParentDotConfig(
 // parentCacheGroups holds parent cache groups names for OTF topologies.
 // Primaries and Secondaries are from origin parent cache groups with
 // assigned primary and secondary cache groups.
-// For last, any origin parent cache groups that aren't primary or secondary.
 // The Null parent cache groups aren't considered unless the current server
 // cache group has no primary/secondary parents selected.
 type parentCacheGroups struct {
@@ -246,7 +245,7 @@ func createTopology(server *Server, ds DeliveryService, nameTopologies map[Topol
 		}
 
 		// Only consider arbitrarily assigned parents if the current
-		// cache group does not have primary or secondary parents assigned.
+		// cache group does not have primary and secondary parents assigned.
 		if !hasprimsec && 0 < len(cgprimsec.Nulls) {
 			for _, _ = range cgprimsec.Nulls {
 				parents = append(parents, pind)

--- a/lib/go-atscfg/parentdotconfig_test.go
+++ b/lib/go-atscfg/parentdotconfig_test.go
@@ -647,15 +647,13 @@ func TestMakeParentDotConfigMSONoTopologyNoMid(t *testing.T) {
 
 	testComment(t, txt, hdr.HdrComment)
 
-	txtx := strings.Replace(txt, " ", "", -1)
-
-	if !strings.Contains(txtx, `parent="myorigin0.mydomain.example.net:80`) {
+	if !strings.Contains(txt, `parent="myorigin0.mydomain.example.net:80`) {
 		t.Errorf("expected parent myorigin0, actual: '%v'", txt)
 	}
-	if !strings.Contains(txtx, `unavailable_server_retry_responses="500,502,503,542`) {
+	if !strings.Contains(txt, `unavailable_server_retry_responses="500,502,503,542`) {
 		t.Errorf(`expected unavailable_server_retry_repsonse 500,502,503,542 from DS params, actual: '%v'`, txt)
 	}
-	if !strings.Contains(txtx, `max_simple_retries=2`) {
+	if !strings.Contains(txt, `max_simple_retries=2`) {
 		t.Errorf(`expected max_simple_retries=2 from DS params, actual: '%v'`, txt)
 	}
 }

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -7759,7 +7759,6 @@ func TestMakeRemapDotConfigMidNoCacheRemapLineTopo(t *testing.T) {
 
 	dsType := tc.DSType("HTTP_NO_CACHE")
 
-	// BNO
 	// show up at mid due to topo
 	ds0 := DeliveryService{}
 	ds0.ID = util.IntPtr(48)

--- a/lib/go-atscfg/strategiesdotconfig_test.go
+++ b/lib/go-atscfg/strategiesdotconfig_test.go
@@ -1497,6 +1497,226 @@ func TestMakeStrategiesDotYAMLFirstLastNoTopoParams(t *testing.T) {
 	}
 }
 
+func TestMakeStrategiesDotYamlMSONoTopologyNoMid(t *testing.T) {
+	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
+
+	ds0 := makeParentDS()
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+	ds0.MultiSiteOrigin = util.BoolPtr(true)
+	ds0.ProfileName = util.StrPtr("dsprofile")
+	dses := []DeliveryService{*ds0}
+
+	parentConfigParams := []tc.Parameter{}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "7",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	edge := makeTestParentServer()
+
+	origin0 := makeTestParentServer()
+	origin0.Cachegroup = util.StrPtr("originCG")
+	origin0.CachegroupID = util.IntPtr(500)
+	origin0.HostName = util.StrPtr("myorigin0")
+	origin0.ID = util.IntPtr(45)
+	setIP(origin0, "192.168.2.2")
+	origin0.Type = tc.OriginTypeName
+	origin0.TypeID = util.IntPtr(991)
+
+	servers := []Server{*edge, *origin0}
+
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = edge.Cachegroup
+	eCG.ID = edge.CachegroupID
+	eCG.ParentName = origin0.Cachegroup
+	eCG.ParentCachegroupID = origin0.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	oCG := &tc.CacheGroupNullable{}
+	oCG.Name = origin0.Cachegroup
+	oCG.ID = origin0.CachegroupID
+	oCGType := tc.CacheGroupOriginTypeName
+	oCG.Type = &oCGType
+
+	cgs := []tc.CacheGroupNullable{*eCG, *oCG}
+
+	dss := []DeliveryServiceServer{
+		{
+			Server:          *edge.ID,
+			DeliveryService: *ds0.ID,
+		},
+		{
+			Server:          *origin0.ID,
+			DeliveryService: *ds0.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	cfg, err := MakeStrategiesDotYAML(dses, edge, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, opt.HdrComment)
+
+	txtx := strings.Replace(txt, " ", "", -1)
+
+	needs := []string{
+		`host:myorigin0.mydomain.example.net`,
+	}
+
+	missing := missingFrom(txtx, needs)
+	if 0 < len(missing) {
+		t.Errorf("Missing required string(s) from ds/line: %s/%v\n%v", *ds0.XMLID, missing, txt)
+	}
+}
+
+// Test for mso non topology where mid cache group has no primary/secondary
+// parents assigned, just any arbitrary servers.
+func TestMakeStrategiesDotYamlMSONoTopoMultiCG(t *testing.T) {
+	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
+
+	ds0 := makeParentDS()
+	ds0Type := tc.DSTypeHTTP
+	ds0.Type = &ds0Type
+	ds0.QStringIgnore = util.IntPtr(int(tc.QStringIgnoreUseInCacheKeyAndPassUp))
+	ds0.OrgServerFQDN = util.StrPtr("http://ds0.example.net")
+	ds0.MultiSiteOrigin = util.BoolPtr(true)
+
+	dses := []DeliveryService{*ds0}
+
+	parentConfigParams := []tc.Parameter{}
+
+	serverParams := []tc.Parameter{
+		tc.Parameter{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "9",
+			Profiles:   []byte(`["global"]`),
+		},
+	}
+
+	edge := makeTestParentServer()
+	edge.Cachegroup = util.StrPtr("edgeCG")
+	edge.CachegroupID = util.IntPtr(400)
+
+	mid := makeTestParentServer()
+	mid.Cachegroup = util.StrPtr("midCG")
+	mid.CachegroupID = util.IntPtr(500)
+	mid.HostName = util.StrPtr("mid0")
+	mid.ID = util.IntPtr(45)
+	setIP(mid, "192.168.2.2")
+
+	org0 := makeTestParentServer()
+	org0.Cachegroup = util.StrPtr("orgCG0")
+	org0.CachegroupID = util.IntPtr(501)
+	org0.HostName = util.StrPtr("org0")
+	org0.ID = util.IntPtr(46)
+	setIP(org0, "192.168.2.3")
+	org0.Type = tc.OriginTypeName
+	org0.TypeID = util.IntPtr(991)
+
+	org1 := makeTestParentServer()
+	org1.Cachegroup = util.StrPtr("orgCG1")
+	org1.CachegroupID = util.IntPtr(502)
+	org1.HostName = util.StrPtr("org1")
+	org1.ID = util.IntPtr(47)
+	setIP(org1, "192.168.2.4")
+	org1.Type = tc.OriginTypeName
+	org1.TypeID = util.IntPtr(991)
+
+	servers := []Server{*edge, *mid, *org0, *org1}
+
+	topologies := []tc.Topology{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+
+	eCG := &tc.CacheGroupNullable{}
+	eCG.Name = edge.Cachegroup
+	eCG.ID = edge.CachegroupID
+	eCG.ParentName = mid.Cachegroup
+	eCG.ParentCachegroupID = mid.CachegroupID
+	eCGType := tc.CacheGroupEdgeTypeName
+	eCG.Type = &eCGType
+
+	// NOTE: no parent cache groups specified
+	mCG := &tc.CacheGroupNullable{}
+	mCG.Name = mid.Cachegroup
+	mCG.ID = mid.CachegroupID
+	mCGType := tc.CacheGroupMidTypeName
+	mCG.Type = &mCGType
+
+	oCG0 := &tc.CacheGroupNullable{}
+	oCG0.Name = org0.Cachegroup
+	oCG0.ID = org0.CachegroupID
+	oCG0Type := tc.CacheGroupOriginTypeName
+	oCG0.Type = &oCG0Type
+
+	oCG1 := &tc.CacheGroupNullable{}
+	oCG1.Name = org1.Cachegroup
+	oCG1.ID = org1.CachegroupID
+	oCG1Type := tc.CacheGroupOriginTypeName
+	oCG1.Type = &oCG1Type
+
+	cgs := []tc.CacheGroupNullable{*eCG, *mCG, *oCG0, *oCG1}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          *edge.ID,
+			DeliveryService: *ds0.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *org0.ID,
+			DeliveryService: *ds0.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *org1.ID,
+			DeliveryService: *ds0.ID,
+		},
+	}
+	cdn := &tc.CDN{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+	cfg, err := MakeStrategiesDotYAML(dses, mid, servers, topologies, serverParams, parentConfigParams, serverCapabilities, dsRequiredCapabilities, cgs, dss, cdn, opt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	testComment(t, txt, opt.HdrComment)
+
+	txtx := strings.Replace(txt, " ", "", -1)
+
+	needs := []string{
+		`host:org0.mydomain.example.net`,
+		`host:org1.mydomain.example.net`,
+		`policy:consistent_hash`,
+	}
+
+	missing := missingFrom(txtx, needs)
+	if 0 < len(missing) {
+		t.Errorf("Missing required string(s) from line: %v\n%v", missing, txtx)
+	}
+}
+
 func TestMakeStrategiesDotYAMLFirstInnerLastParams(t *testing.T) {
 	opt := &StrategiesYAMLOpts{VerboseComments: false, HdrComment: "myHeaderComment"}
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Bug fix for #7137 (create topology on the fly for non topo delivery services)
Case:
delivery service with MSO but no topology.
mid cache group does not have primary and secondary parents assigned.
origins belong to any number of origin cache groups.
In this case the origin from only the fist encountered cache group was getting pulled into parent.config

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Create delivery service, MSO non topo.  Ensure origins belong to different origin cache groups.  ensure the mid cache group has neither primary nor secondary cache groups assigned.  T3C run parent.config should 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- 7.1.0 (post #7137)

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation -- BUG FIX!
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
