### PR TITLE
Use GitHub API to get commit count since the last ATS release

### DIFF
--- a/infrastructure/cdn-in-a-box/bin/ats-version.sh
+++ b/infrastructure/cdn-in-a-box/bin/ats-version.sh
@@ -19,12 +19,14 @@
 trap 'echo "Error on line ${LINENO} of ${0}" >/dev/stderr; exit 1' ERR;
 set -o errexit -o nounset -o pipefail
 
+org=apache
 project=trafficserver
 script_dir="$(dirname "$0")"
 ats_version_file="${script_dir}/../cache/ATS_VERSION"
 
 remote_ats_version() {
-	local gitbox_url=https://gitbox.apache.org/repos/asf
+	local gitbox_url=https://gitbox.${org}.org/repos/asf
+	local github_api=https://api.github.com
 	local repo="${project}.git"
 	local branch refs commit last_tag release
 	branch="$(grep 'ATS_VERSION=' "${script_dir}/../../../cache-config/testing/docker/variables.env" | cut -d= -f2)"
@@ -40,8 +42,9 @@ remote_ats_version() {
 		tail -n1)"
 
 	# $release is the number of commits between $release to $branch.
-	page_output="$(curl -fs "${gitbox_url}?p=${repo};a=shortlog;h=${branch};hp=${last_tag}")"
-	release="$(<<<"$page_output" grep -c 'class="link"' || true)"
+	release="$(curl -fs "${github_api}/repos/${org}/${project}/compare/${last_tag}...${branch}" |
+				grep 'total_commits' |
+				grep -o '[0-9]\+')"
 	<<<"${last_tag}-${release}.${commit:0:9}" tee "$ats_version_file"
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes a script used by the CDN in a Box Makefile to get the expected ATS version by using the GitHub API instead of the GitBox frontend, which has been unusable all week.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Check if the *CDN-in-a-Box CI* passes

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
