### PR TITLE
Fix "no such route" errors in capabilities unit tests

### DIFF
--- a/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.spec.ts
@@ -32,7 +32,18 @@ describe("CapabilityDetailsComponent", () => {
 	beforeEach(async () => {
 		await TestBed.configureTestingModule({
 			declarations: [ CapabilityDetailsComponent ],
-			imports: [ APITestingModule, RouterTestingModule, MatDialogModule ],
+			imports: [
+				APITestingModule,
+				RouterTestingModule.withRoutes([
+					{component: CapabilityDetailsComponent, path: "core/capabilities/:name"},
+					// This route is never actually loaded, but the tests
+					// complain that it can't be routed to, so it doesn't matter
+					// that it's loading the wrong component, only that it has a
+					// route definition.
+					{component: CapabilityDetailsComponent, path: "core/capabilities"}
+				]),
+				MatDialogModule
+			],
 		}).compileComponents();
 
 		route = TestBed.inject(ActivatedRoute);


### PR DESCRIPTION
#7474 added unit tests for the capabilities functionality it added to TPv2. These tests pass, but with an asynchronous routing error being thrown, which (besides just being annoying) prevents karma from reporting coverage stats. This PR fixes that.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2 - tests only)

## What is the best way to verify this PR?
`ng test --code-coverage` and verify that the output code coverage report isn't just empty, and that no errors are shown in the browser. Note that these tests already pass in GHA, so the fact that they pass on this PR does not in itself constitute verification of these changes.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**