### PR TITLE
Fixed TO API /servers/{id}/deliveryservices endpoint to respond with all DS's on cache that are directly assigned and inherited through topology. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7542](https://github.com/apache/trafficcontrol/pull/7542) *Traffic Ops* Fixed `CDN Locks` documentation to reflect the correct RFC3339 timestamps.
 - [#6340](https://github.com/apache/trafficcontrol/issues/6340) *Traffic Ops* Fixed alert messages for POST and PUT invalidation job APIs.
 - [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to responding with all DS's on cache that are directly assigned and inherited through topology. 
+- [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to respond with all DS's on cache that are directly assigned and inherited through topology. 
 - [#7511](https://github.com/apache/trafficcontrol/pull/7511) *Traffic Ops* Fixed the changelog registration message to include the username instead of duplicate email entry.
 - [#7465](https://github.com/apache/trafficcontrol/issues/7465) *Traffic Ops* Fixes server_capabilities v5 apis to respond with RFC3339 date/time Format
 - [#7441](https://github.com/apache/trafficcontrol/pull/7441) *Traffic Ops* Fixed the invalidation jobs endpoint to respect CDN locks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#7542](https://github.com/apache/trafficcontrol/pull/7542) *Traffic Ops* Fixed `CDN Locks` documentation to reflect the correct RFC3339 timestamps.
 - [#6340](https://github.com/apache/trafficcontrol/issues/6340) *Traffic Ops* Fixed alert messages for POST and PUT invalidation job APIs.
+- [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to responding with all DS's on cache that are directly assigned and inherited through topology. 
 - [#7511](https://github.com/apache/trafficcontrol/pull/7511) *Traffic Ops* Fixed the changelog registration message to include the username instead of duplicate email entry.
 - [#7465](https://github.com/apache/trafficcontrol/issues/7465) *Traffic Ops* Fixes server_capabilities v5 apis to respond with RFC3339 date/time Format
 - [#7441](https://github.com/apache/trafficcontrol/pull/7441) *Traffic Ops* Fixed the invalidation jobs endpoint to respect CDN locks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - [#7542](https://github.com/apache/trafficcontrol/pull/7542) *Traffic Ops* Fixed `CDN Locks` documentation to reflect the correct RFC3339 timestamps.
 - [#6340](https://github.com/apache/trafficcontrol/issues/6340) *Traffic Ops* Fixed alert messages for POST and PUT invalidation job APIs.
-- [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to responding with all DS's on cache that are directly assigned and inherited through topology. 
-- [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to respond with all DS's on cache that are directly assigned and inherited through topology. 
+- [#7519] (https://github.com/apache/trafficcontrol/issues/7519) *Traffic Ops* Fixed TO API /servers/{id}/deliveryservices endpoint to responding with all DS's on cache that are directly assigned and inherited through topology.
 - [#7511](https://github.com/apache/trafficcontrol/pull/7511) *Traffic Ops* Fixed the changelog registration message to include the username instead of duplicate email entry.
 - [#7465](https://github.com/apache/trafficcontrol/issues/7465) *Traffic Ops* Fixes server_capabilities v5 apis to respond with RFC3339 date/time Format
 - [#7441](https://github.com/apache/trafficcontrol/pull/7441) *Traffic Ops* Fixed the invalidation jobs endpoint to respect CDN locks.

--- a/docs/source/api/v3/servers_id_deliveryservices.rst
+++ b/docs/source/api/v3/servers_id_deliveryservices.rst
@@ -21,7 +21,7 @@
 
 ``GET``
 =======
-Retrieves all :term:`Delivery Services` assigned to a specific server.
+Retrieves all :term:`Delivery Services` assigned to a specific server either directly or inherited from topology.
 
 :Auth. Required: Yes
 :Roles Required: None\ [#tenancy]_

--- a/docs/source/api/v4/servers_id_deliveryservices.rst
+++ b/docs/source/api/v4/servers_id_deliveryservices.rst
@@ -21,7 +21,7 @@
 
 ``GET``
 =======
-Retrieves all :term:`Delivery Services` assigned to a specific server.
+Retrieves all :term:`Delivery Services` assigned to a specific server either directly or inherited from topology.
 
 :Auth. Required: Yes
 :Roles Required: None\ [#tenancy]_

--- a/docs/source/api/v5/servers_id_deliveryservices.rst
+++ b/docs/source/api/v5/servers_id_deliveryservices.rst
@@ -21,7 +21,7 @@
 
 ``GET``
 =======
-Retrieves all :term:`Delivery Services` assigned to a specific server.
+Retrieves all :term:`Delivery Services` assigned to a specific server either directly or inherited from topology.
 
 :Auth. Required: Yes
 :Roles Required: None\ [#tenancy]_

--- a/traffic_ops/testing/api/v5/servers_id_deliveryservices_test.go
+++ b/traffic_ops/testing/api/v5/servers_id_deliveryservices_test.go
@@ -56,7 +56,13 @@ func TestServersIDDeliveryServices(t *testing.T) {
 						"replace": true,
 					},
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK),
-						validateServersDeliveryServicesPost(GetServerID(t, "atlanta-edge-01")(), GetDeliveryServiceId(t, "ds1")())),
+						validateServersDeliveryServicesPost(
+							GetServerID(t, "atlanta-edge-01")(),
+							[]int{
+								GetDeliveryServiceId(t, "ds1")(),
+								GetDeliveryServiceId(t, "ds-based-top-with-no-mids")(),
+							},
+							2)),
 				},
 				"OK when ASSIGNING EDGE to TOPOLOGY BASED DELIVERY SERVICE": {
 					EndpointID:    GetServerID(t, "atlanta-edge-03"),
@@ -66,7 +72,12 @@ func TestServersIDDeliveryServices(t *testing.T) {
 						"replace": true,
 					},
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK),
-						validateServersDeliveryServicesPost(GetServerID(t, "atlanta-edge-03")(), GetDeliveryServiceId(t, "top-ds-in-cdn1")())),
+						validateServersDeliveryServicesPost(
+							GetServerID(t, "atlanta-edge-03")(),
+							[]int{
+								GetDeliveryServiceId(t, "top-ds-in-cdn1")(),
+							},
+							1)),
 				},
 				"OK when ASSIGNING ORIGIN to TOPOLOGY BASED DELIVERY SERVICE": {
 					EndpointID:    GetServerID(t, "denver-mso-org-01"),
@@ -76,7 +87,14 @@ func TestServersIDDeliveryServices(t *testing.T) {
 						"replace": true,
 					},
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK),
-						validateServersDeliveryServicesPost(GetServerID(t, "denver-mso-org-01")(), GetDeliveryServiceId(t, "ds-top")())),
+						validateServersDeliveryServicesPost(
+							GetServerID(t, "denver-mso-org-01")(),
+							[]int{
+								GetDeliveryServiceId(t, "ds-top")(),
+								GetDeliveryServiceId(t, "ds-top-req-cap2")(),
+								GetDeliveryServiceId(t, "ds-forked-topology")(),
+							},
+							3)),
 				},
 				"CONFLICT when SERVER NOT IN SAME CDN as DELIVERY SERVICE": {
 					EndpointID:    GetServerID(t, "cdn2-test-edge"),
@@ -170,11 +188,14 @@ func validateServersDeliveryServices(expectedDSID int) utils.CkReqFunc {
 	}
 }
 
-func validateServersDeliveryServicesPost(serverID int, expectedDSID int) utils.CkReqFunc {
+func validateServersDeliveryServicesPost(serverID int, expectedDSID []int, expectedDSCount int) utils.CkReqFunc {
 	return func(t *testing.T, _ toclientlib.ReqInf, resp interface{}, _ tc.Alerts, _ error) {
 		serverDeliveryServices, _, err := TOSession.GetServerIDDeliveryServices(serverID, client.RequestOptions{})
 		assert.RequireNoError(t, err, "Error getting Server Delivery Services: %v - alerts: %+v", err, serverDeliveryServices.Alerts)
-		assert.RequireEqual(t, 1, len(serverDeliveryServices.Response), "Expected one Delivery Service returned Got: %d", len(serverDeliveryServices.Response))
-		validateServersDeliveryServices(expectedDSID)(t, toclientlib.ReqInf{}, serverDeliveryServices.Response, tc.Alerts{}, nil)
+		assert.RequireEqual(t, expectedDSCount, len(serverDeliveryServices.Response), "Expected Two Delivery Service returned Got: %d", len(serverDeliveryServices.Response))
+		for i := 0; i < len(expectedDSID); i++ {
+			validateServersDeliveryServices(expectedDSID[i])(t, toclientlib.ReqInf{}, serverDeliveryServices.Response, tc.Alerts{}, nil)
+
+		}
 	}
 }

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -895,7 +895,8 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 	} else {
 		where = "WHERE "
 	}
-	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server where server = :server)"
+
+	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server WHERE server = :server) OR ds.id in (SELECT id FROM deliveryservice WHERE topology = ( SELECT topology FROM topology_cachegroup WHERE cachegroup = ( SELECT name FROM cachegroup WHERE id = ( SELECT cachegroup FROM server WHERE id = :server ))))"
 
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, user.TenantID)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -896,7 +896,19 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 		where = "WHERE "
 	}
 
-	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server WHERE server = :server) OR ds.id in (SELECT id FROM deliveryservice WHERE topology in ( SELECT topology FROM topology_cachegroup WHERE cachegroup = ( SELECT name FROM cachegroup WHERE id = ( SELECT cachegroup FROM server WHERE id = :server ))))"
+	where += `
+		ds.id in (
+			SELECT deliveryService FROM deliveryservice_server WHERE server = :server
+		) OR ds.id in (
+			SELECT id FROM deliveryservice 
+			WHERE topology in ( 
+				SELECT topology FROM topology_cachegroup 
+				WHERE cachegroup = ( 
+					SELECT name FROM cachegroup 
+					WHERE id = ( 
+						SELECT cachegroup FROM server WHERE id = :server 
+					))))
+		`
 
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, user.TenantID)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -897,18 +897,18 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 	}
 
 	where += `
-		ds.id in (
-			SELECT deliveryService FROM deliveryservice_server WHERE server = :server
-		) OR ds.id in (
-			SELECT id FROM deliveryservice 
-			WHERE topology in ( 
-				SELECT topology FROM topology_cachegroup 
-				WHERE cachegroup = ( 
-					SELECT name FROM cachegroup 
-					WHERE id = ( 
-						SELECT cachegroup FROM server WHERE id = :server 
-					))))
-		`
+ds.id in (
+	SELECT deliveryService FROM deliveryservice_server WHERE server = :server
+) OR ds.id in (
+	SELECT id FROM deliveryservice 
+	WHERE topology in ( 
+		SELECT topology FROM topology_cachegroup 
+		WHERE cachegroup = ( 
+			SELECT name FROM cachegroup 
+			WHERE id = ( 
+				SELECT cachegroup FROM server WHERE id = :server 
+			))))
+`
 
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, user.TenantID)
 	if err != nil {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -896,7 +896,7 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 		where = "WHERE "
 	}
 
-	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server WHERE server = :server) OR ds.id in (SELECT id FROM deliveryservice WHERE topology = ( SELECT topology FROM topology_cachegroup WHERE cachegroup = ( SELECT name FROM cachegroup WHERE id = ( SELECT cachegroup FROM server WHERE id = :server ))))"
+	where += "ds.id in (SELECT deliveryService FROM deliveryservice_server WHERE server = :server) OR ds.id in (SELECT id FROM deliveryservice WHERE topology in ( SELECT topology FROM topology_cachegroup WHERE cachegroup = ( SELECT name FROM cachegroup WHERE id = ( SELECT cachegroup FROM server WHERE id = :server ))))"
 
 	tenantIDs, err := tenant.GetUserTenantIDListTx(tx, user.TenantID)
 	if err != nil {


### PR DESCRIPTION
Closes: #7519 
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Get request to Traffic Ops API /servers/{id}/deliveryservices endpoint should provide both DS that are directly assigned and that are inherited from the topology. 

```
curl --request GET \
  --url https://localhost:8443/api/4.1/servers/{id}/deliveryservices
```


## If this is a bugfix, which Traffic Control versions contained the bug?
- 7.0.1



## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
