### PR TITLE
Return empty array instead of null when permissions are omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7388](https://github.com/apache/trafficcontrol/pull/7388) *TC go Client* Adds sslkey_expiration methodology in v4 and v5 clients
 
 ### Changed
+- [#7521](https://github.com/apache/trafficcontrol/pull/7521) *Traffic Ops* Returns empty array instead of null when no permissions are given for roles endpoint using POST or PUT request.
 - [#7369](https://github.com/apache/trafficcontrol/pull/7369) *Traffic Portal* Adds better labels to routing methods widget on the TP dashboard.
 - [#7369](https://github.com/apache/trafficcontrol/pull/7369) *Traffic Portal* Simplifies DS button bar by moving DS changes / DSRs under More menu and renaming to 'View Change Requests'.
 - [#7224](https://github.com/apache/trafficcontrol/pull/7224) *Traffic Ops* Required Capabilities are now a part of the `DeliveryService` structure.

--- a/traffic_ops/traffic_ops_golang/role/roles.go
+++ b/traffic_ops/traffic_ops_golang/role/roles.go
@@ -418,6 +418,10 @@ func Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	alerts := tc.CreateAlerts(tc.SuccessLevel, "role was updated.")
+	// to return empty array instead of null
+	if roleV4.Permissions == nil {
+		roleV4.Permissions = []string{}
+	}
 	var roleResponse interface{}
 	roleResponse = tc.RoleV4{
 		Name:        roleV4.Name,
@@ -576,6 +580,10 @@ func Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	alerts := tc.CreateAlerts(tc.SuccessLevel, "role was created.")
+	// to return empty array instead of null
+	if roleCapabilities == nil {
+		roleCapabilities = []string{}
+	}
 	var roleResponse interface{}
 	capabilities := roleCapabilities
 	roleResponse = tc.RoleV4{

--- a/traffic_ops/traffic_ops_golang/role/roles_test.go
+++ b/traffic_ops/traffic_ops_golang/role/roles_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/test"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/trafficvault"
 	"github.com/apache/trafficcontrol/traffic_ops/traffic_ops_golang/trafficvault/backends/disabled"
+
 	"github.com/jmoiron/sqlx"
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )


### PR DESCRIPTION
Fixes #7247.

Return empty array instead of `null` in when no permissions are given using `POST` and `PUT` requests to `/roles` endpoint.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
using development environment:
1. Login to Traffic Ops
1. Make a `POST` request to `/roles` endpoint with empty permissions
1. Make a `PUT` request to `/roles` with existing role with empty permissions

## If this is a bugfix, which Traffic Control versions contained the bug?
unknown

## PR submission checklist
- [ ] This PR has tests
- [x] This PR has documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**