### PR TITLE
Fix unable to delete newly created Capability

### DIFF
--- a/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.spec.ts
@@ -82,19 +82,19 @@ describe("CapabilityDetailsComponent", () => {
 	it("opens a dialog for Capability deletion", async () => {
 		const api = TestBed.inject(ServerService);
 		const spy = spyOn(api, "deleteCapability").and.callThrough();
-		expect(spy).not.toHaveBeenCalled();
+		await expect(spy).not.toHaveBeenCalled();
 
 		const dialogService = TestBed.inject(MatDialog);
 		const openSpy = spyOn(dialogService, "open").and.returnValue({
 			afterClosed: () => of(true)
 		} as MatDialogRef<unknown>);
 
-		expect(openSpy).not.toHaveBeenCalled();
+		await expect(openSpy).not.toHaveBeenCalled();
 
 		const asyncExpectation = expectAsync(component.deleteCapability()).toBeResolvedTo(undefined);
 
-		expect(openSpy).toHaveBeenCalled();
-		expect(spy).toHaveBeenCalled();
+		await expect(openSpy).toHaveBeenCalled();
+		await expect(spy).toHaveBeenCalled();
 
 		await asyncExpectation;
 	});

--- a/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.ts
+++ b/experimental/traffic-portal/src/app/core/servers/capabilities/capability-details/capability-details.component.ts
@@ -90,12 +90,11 @@ export class CapabilityDetailsComponent implements OnInit {
 				title: "Confirm Delete"
 			}
 		});
-		ref.afterClosed().subscribe(result => {
-			if(result) {
-				this.api.deleteCapability(this.capability);
-				this.location.back();
-			}
-		});
+		const result = await ref.afterClosed().toPromise();
+		if(result) {
+			await this.api.deleteCapability(this.capability);
+			this.location.back();
+		}
 	}
 
 	/**


### PR DESCRIPTION
When a Capability is created, and then immediately deleted from its details page, a routing error occurs (because of a race condition between using a location service and router to both perform different navigations). This PR fixes that error.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the tests all still pass. Create a new Capability then, without leaving the details page for the newly created Capability, delete it.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**