### PR TITLE
Fixing API 5.0 to return RFC3339 timestamps for cdn locks

### DIFF
--- a/docs/source/api/v5/cdn_locks.rst
+++ b/docs/source/api/v5/cdn_locks.rst
@@ -64,7 +64,7 @@ Response Structure
 			"sharedUserNames": [
 				"user1"
 			],
-			"lastUpdated": "2021-05-26T09:31:57.01527-06:00"
+			"lastUpdated": "2021-05-26T09:31:57-06:00"
 		}
 	]}
 
@@ -144,7 +144,7 @@ Response Structure
 		"sharedUserNames": [
 			"user1"
 		],
-		"lastUpdated": "2021-05-26T10:59:10.03557-06:00"
+		"lastUpdated": "2021-05-26T10:59:10-06:00"
 	}}
 
 ``DELETE``
@@ -210,5 +210,5 @@ Response Structure
 		"sharedUserNames": [
 			"user1"
 		],
-		"lastUpdated": "2021-05-26T10:59:10.02632-06:00"
+		"lastUpdated": "2021-05-26T10:59:10-06:00"
 	}}

--- a/lib/go-util/util.go
+++ b/lib/go-util/util.go
@@ -21,6 +21,7 @@ package util
 
 import (
 	"runtime"
+	"time"
 )
 
 // Stacktrace is a helper function which returns the current stacktrace.
@@ -45,4 +46,10 @@ func SliceToSet[T comparable](sl []T) map[T]struct{} {
 		st[val] = struct{}{}
 	}
 	return st
+}
+
+// ConvertTimeFormat converts the input time to the supplied format.
+func ConvertTimeFormat(t time.Time, format string) (*time.Time, error) {
+	formattedTime, err := time.Parse(format, t.Format(format))
+	return &formattedTime, err
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to an issue. It fixes the timestamps in API 5.0 `cdn_locks` to return the correctly formatted (RFC3339) timestamps.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Make sure the tests pass.
Do CRUD operations on cdn locks with api 5.0 and make sure the timestamps gets returned in RFC3339 format.
Ensure the older API versions are unchanged.
 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
