### PR TITLE
Change t3c -M option to take a comma separated list

### DIFF
--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -269,6 +269,11 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
     [true | false] do not update if parent_pending = 1 in the
     update json. Default is false
 
+-Y, -\-maxmind-anonymous-location=value
+
+    URL of an anonymous maxmind gzipped database file, to be installed into
+    the trafficserver etc directory.
+
 # MODES
 
 The `t3c-apply` app can be run in a number of modes.

--- a/cache-config/t3c-apply/README.md
+++ b/cache-config/t3c-apply/README.md
@@ -161,7 +161,8 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 -M, -\-maxmind-location=value
 
     URL of a maxmind gzipped database file, to be installed into
-    the trafficserver etc directory.
+    the trafficserver etc directory. Can also be a comma separated
+    list of URLs to get and un-gzip.
 
 -m, -\-run-mode=value
 
@@ -268,11 +269,6 @@ Typical usage is to install t3c on the cache machine, and then run it periodical
 
     [true | false] do not update if parent_pending = 1 in the
     update json. Default is false
-
--Y, -\-maxmind-anonymous-location=value
-
-    URL of an anonymous maxmind gzipped database file, to be installed into
-    the trafficserver etc directory.
 
 # MODES
 

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -104,10 +104,9 @@ type Cfg struct {
 	DefaultClientTLSVersions    *string
 	// MaxMindLocation is a URL string for a download location for a maxmind database
 	// for use with either HeaderRewrite or Maxmind_ACL plugins
-	MaxMindLocation          string
-	MaxMindAnonymousLocation string
-	TsHome                   string
-	TsConfigDir              string
+	MaxMindLocation string
+	TsHome          string
+	TsConfigDir     string
 
 	ServiceAction          t3cutil.ApplyServiceActionFlag
 	NoConfirmServiceAction bool
@@ -252,7 +251,6 @@ func GetCfg(appVersion string, gitRevision string) (Cfg, error) {
 	defaultEnableH2 := getopt.BoolLong("default-client-enable-h2", '2', "Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter. This is irrelevant if ATS records.config is not serving H2. If omitted, H2 is disabled.")
 	defaultClientTLSVersions := getopt.StringLong("default-client-tls-versions", 'V', "", "Comma-delimited list of default TLS versions for Delivery Services with no Parameter, e.g. --default-tls-versions='1.1,1.2,1.3'. If omitted, all versions are enabled.")
 	maxmindLocationPtr := getopt.StringLong("maxmind-location", 'M', "", "URL of a maxmind gzipped database file, to be installed into the trafficserver etc directory.")
-	maxmindAnonymousLocationPtr := getopt.StringLong("maxmind-anonymous-location", 'Y', "", "Url of a maxmind gzipped database file for anonymous lookups, to be installed into the trafficserver etc directory.")
 	verbosePtr := getopt.CounterLong("verbose", 'v', `Log verbosity. Logging is output to stderr. By default, errors are logged. To log warnings, pass '-v'. To log info, pass '-vv'. To omit error logging, see '-s'`)
 	const silentFlagName = "silent"
 	silentPtr := getopt.BoolLong(silentFlagName, 's', `Silent. Errors are not logged, and the 'verbose' flag is ignored. If a fatal error occurs, the return code will be non-zero but no text will be output to stderr`)
@@ -445,7 +443,6 @@ If any of the related flags are also set, they override the mode's default behav
 	toPass := *toPassPtr
 	dnsLocalBind := *dnsLocalBindPtr
 	maxmindLocation := *maxmindLocationPtr
-	maxmindAnonymousLocation := *maxmindAnonymousLocationPtr
 
 	if *version {
 		cfg := &Cfg{Version: appVersion, GitRevision: gitRevision}
@@ -564,7 +561,6 @@ If any of the related flags are also set, they override the mode's default behav
 		DefaultClientEnableH2:       defaultEnableH2,
 		DefaultClientTLSVersions:    defaultClientTLSVersions,
 		MaxMindLocation:             maxmindLocation,
-		MaxMindAnonymousLocation:    maxmindAnonymousLocation,
 		TsHome:                      TSHome,
 		TsConfigDir:                 tsConfigDir,
 		GoDirect:                    *goDirectPtr,
@@ -683,7 +679,6 @@ func printConfig(cfg Cfg) {
 	log.Debugf("NoConfirmServiceAction: %v\n", cfg.NoConfirmServiceAction)
 	log.Debugf("YumOptions: %s\n", cfg.YumOptions)
 	log.Debugf("MaxmindLocation: %s\n", cfg.MaxMindLocation)
-	log.Debugf("MaxmindAnonymousLocation: %s\n", cfg.MaxMindAnonymousLocation)
 }
 
 func Usage() {

--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -104,9 +104,10 @@ type Cfg struct {
 	DefaultClientTLSVersions    *string
 	// MaxMindLocation is a URL string for a download location for a maxmind database
 	// for use with either HeaderRewrite or Maxmind_ACL plugins
-	MaxMindLocation string
-	TsHome          string
-	TsConfigDir     string
+	MaxMindLocation          string
+	MaxMindAnonymousLocation string
+	TsHome                   string
+	TsConfigDir              string
 
 	ServiceAction          t3cutil.ApplyServiceActionFlag
 	NoConfirmServiceAction bool
@@ -251,6 +252,7 @@ func GetCfg(appVersion string, gitRevision string) (Cfg, error) {
 	defaultEnableH2 := getopt.BoolLong("default-client-enable-h2", '2', "Whether to enable HTTP/2 on Delivery Services by default, if they have no explicit Parameter. This is irrelevant if ATS records.config is not serving H2. If omitted, H2 is disabled.")
 	defaultClientTLSVersions := getopt.StringLong("default-client-tls-versions", 'V', "", "Comma-delimited list of default TLS versions for Delivery Services with no Parameter, e.g. --default-tls-versions='1.1,1.2,1.3'. If omitted, all versions are enabled.")
 	maxmindLocationPtr := getopt.StringLong("maxmind-location", 'M', "", "URL of a maxmind gzipped database file, to be installed into the trafficserver etc directory.")
+	maxmindAnonymousLocationPtr := getopt.StringLong("maxmind-anonymous-location", 'Y', "", "Url of a maxmind gzipped database file for anonymous lookups, to be installed into the trafficserver etc directory.")
 	verbosePtr := getopt.CounterLong("verbose", 'v', `Log verbosity. Logging is output to stderr. By default, errors are logged. To log warnings, pass '-v'. To log info, pass '-vv'. To omit error logging, see '-s'`)
 	const silentFlagName = "silent"
 	silentPtr := getopt.BoolLong(silentFlagName, 's', `Silent. Errors are not logged, and the 'verbose' flag is ignored. If a fatal error occurs, the return code will be non-zero but no text will be output to stderr`)
@@ -443,6 +445,7 @@ If any of the related flags are also set, they override the mode's default behav
 	toPass := *toPassPtr
 	dnsLocalBind := *dnsLocalBindPtr
 	maxmindLocation := *maxmindLocationPtr
+	maxmindAnonymousLocation := *maxmindAnonymousLocationPtr
 
 	if *version {
 		cfg := &Cfg{Version: appVersion, GitRevision: gitRevision}
@@ -561,6 +564,7 @@ If any of the related flags are also set, they override the mode's default behav
 		DefaultClientEnableH2:       defaultEnableH2,
 		DefaultClientTLSVersions:    defaultClientTLSVersions,
 		MaxMindLocation:             maxmindLocation,
+		MaxMindAnonymousLocation:    maxmindAnonymousLocation,
 		TsHome:                      TSHome,
 		TsConfigDir:                 tsConfigDir,
 		GoDirect:                    *goDirectPtr,
@@ -679,6 +683,7 @@ func printConfig(cfg Cfg) {
 	log.Debugf("NoConfirmServiceAction: %v\n", cfg.NoConfirmServiceAction)
 	log.Debugf("YumOptions: %s\n", cfg.YumOptions)
 	log.Debugf("MaxmindLocation: %s\n", cfg.MaxMindLocation)
+	log.Debugf("MaxmindAnonymousLocation: %s\n", cfg.MaxMindAnonymousLocation)
 }
 
 func Usage() {

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -407,7 +407,7 @@ func CheckMaxmindUpdate(cfg config.Cfg) bool {
 			if result {
 				log.Infoln("maxmind database was updated from " + v)
 			} else {
-				log.Infoln("maxmind database not updated. Either not needed or curl/gunzip failure")
+				log.Infoln("maxmind database not updated. Either not needed or curl/gunzip failure: " + v)
 			}
 			if result {
 				// If we've seen any database updates then return true to update ATS

--- a/cache-config/t3c-apply/t3c-apply.go
+++ b/cache-config/t3c-apply/t3c-apply.go
@@ -400,7 +400,7 @@ func CheckMaxmindUpdate(cfg config.Cfg) bool {
 	result := false
 	if cfg.MaxMindLocation != "" {
 		// Check if the maxmind db needs to be updated before reload
-		result = util.UpdateMaxmind(cfg)
+		result = util.UpdateMaxmind(cfg.MaxMindLocation, cfg.TsConfigDir, cfg.ReportOnly)
 		if result {
 			log.Infoln("maxmind database was updated from " + cfg.MaxMindLocation)
 		} else {
@@ -410,6 +410,16 @@ func CheckMaxmindUpdate(cfg config.Cfg) bool {
 		log.Infoln(("maxmindlocation is empty, not checking for DB update"))
 	}
 
+	if cfg.MaxMindAnonymousLocation != "" {
+		result = util.UpdateMaxmind(cfg.MaxMindAnonymousLocation, cfg.TsConfigDir, cfg.ReportOnly)
+		if result {
+			log.Infoln("maxmind anonymous database was updated from " + cfg.MaxMindAnonymousLocation)
+		} else {
+			log.Infoln("maxmind anonymous database was not updated. Either not needed or curl/gunzip failure")
+		}
+	} else {
+		log.Infoln("maxmindanonymouslocation is empty, not checking for DB update")
+	}
 	return result
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This reworks the maxmind `-M` option to take a comma separated list if a user wishes to download multiple databases

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Do a t3c run with the -M option and a single URL to check the original use works. Then can re-run with multiple comma separated URLs and check that they all download/update

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
