### PR TITLE
View Cache Groups, View Servers buttons added in Types Detail page

### DIFF
--- a/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
+++ b/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
@@ -13,7 +13,7 @@ limitations under the License.
 -->
 <mat-card appearance="outlined" class="page-content">
 	<mat-card-header class="actions-container" *ngIf="!isNew && server">
-		<button [disabled]="!isCache() || true" mat-button type="button">Manage Capabilities</button>
+		<button [disabled]="!isCache()" mat-button type="button">Manage Capabilities</button>
 		<button [disabled]="!isCache() || true" mat-button type="button">Manage Delivery Services</button>
 		<button [disabled]="!isCache()" mat-icon-button type="button" title="queue server updates" *ngIf="!server.updPending" (click)="queue()"><mat-icon>check</mat-icon></button>
 		<button [disabled]="!isCache()" mat-icon-button type="button" title="clear server updates" *ngIf="server.updPending" (click)="dequeue()"><mat-icon>schedule</mat-icon></button>

--- a/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
+++ b/experimental/traffic-portal/src/app/core/servers/server-details/server-details.component.html
@@ -13,7 +13,7 @@ limitations under the License.
 -->
 <mat-card appearance="outlined" class="page-content">
 	<mat-card-header class="actions-container" *ngIf="!isNew && server">
-		<button [disabled]="!isCache()" mat-button type="button">Manage Capabilities</button>
+		<button [disabled]="!isCache() || true" mat-button type="button">Manage Capabilities</button>
 		<button [disabled]="!isCache() || true" mat-button type="button">Manage Delivery Services</button>
 		<button [disabled]="!isCache()" mat-icon-button type="button" title="queue server updates" *ngIf="!server.updPending" (click)="queue()"><mat-icon>check</mat-icon></button>
 		<button [disabled]="!isCache()" mat-icon-button type="button" title="clear server updates" *ngIf="server.updPending" (click)="dequeue()"><mat-icon>schedule</mat-icon></button>

--- a/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
+++ b/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="type">
 		<mat-card-header class="headers-container" *ngIf="!new">
 			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'" [routerLink]="'/core/cache-groups'" [queryParams]="{typeName: type.name}">View Cache Groups</a>
-			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'" [routerLink]="'/core/servers'" [queryParams]="{typeName: type.name}">View Servers</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'" [routerLink]="'/core/servers'" [queryParams]="{type: type.name}">View Servers</a>
 		</mat-card-header>
 		<mat-card-content class="container">
 			<mat-form-field *ngIf="!new">

--- a/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
+++ b/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
@@ -16,8 +16,8 @@ limitations under the License.
 	<tp-loading *ngIf="!type"></tp-loading>
 	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="type">
 		<mat-card-header class="headers-container" *ngIf="!new">
-			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'">View Cache Groups</a>
-			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'">View Servers</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'" [routerLink]="'/core/cache-groups'" [queryParams]="{search: type.name}">View Cache Groups</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'" [routerLink]="'/core/servers'" [queryParams]="{search: type.name}">View Servers</a>
 		</mat-card-header>
 		<mat-card-content class="container">
 			<mat-form-field *ngIf="!new">

--- a/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
+++ b/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
@@ -16,6 +16,8 @@ limitations under the License.
 	<tp-loading *ngIf="!type"></tp-loading>
 	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="type">
 		<mat-card-header class="headers-container" *ngIf="!new">
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'">View Cache Groups</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'">View Servers</a>
 		</mat-card-header>
 		<mat-card-content class="container">
 			<mat-form-field *ngIf="!new">

--- a/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
+++ b/experimental/traffic-portal/src/app/core/types/detail/type-detail.component.html
@@ -16,8 +16,8 @@ limitations under the License.
 	<tp-loading *ngIf="!type"></tp-loading>
 	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="type">
 		<mat-card-header class="headers-container" *ngIf="!new">
-			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'" [routerLink]="'/core/cache-groups'" [queryParams]="{search: type.name}">View Cache Groups</a>
-			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'" [routerLink]="'/core/servers'" [queryParams]="{search: type.name}">View Servers</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'cachegroup'" [routerLink]="'/core/cache-groups'" [queryParams]="{typeName: type.name}">View Cache Groups</a>
+			<a mat-raised-button color="primary" *ngIf="type.useInTable === 'server'" [routerLink]="'/core/servers'" [queryParams]="{typeName: type.name}">View Servers</a>
 		</mat-card-header>
 		<mat-card-content class="container">
 			<mat-form-field *ngIf="!new">


### PR DESCRIPTION
View/Manage entity buttons on various detail pages:
Types Detail (based on useintable)
  -View Cache Groups
  -View Servers
<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
You know better than me.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
