### PR TITLE
Traffic Portal v2 Topologies details page

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -29,7 +29,7 @@
         "express": "^4.15.2",
         "node-forge": "^1.3.1",
         "rxjs": "~6.6.0",
-        "trafficops-types": "^4.0.10",
+        "trafficops-types": "^4.0.11",
         "tslib": "^2.0.0",
         "zone.js": "~0.13.0"
       },
@@ -19017,9 +19017,9 @@
       }
     },
     "node_modules/trafficops-types": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/trafficops-types/-/trafficops-types-4.0.10.tgz",
-      "integrity": "sha512-/GW+PgT7Rg5WhGtbkJdvTIXLga68wx3dy9crmXmOrrB6sPVcX7vbrQ9TAxGqRbsC52ZbZSxahqsmZgQZv8KK3A=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/trafficops-types/-/trafficops-types-4.0.11.tgz",
+      "integrity": "sha512-qGVUM28xn3rebeNBnFemo+IVCi09TXGH3/pDy/OAMJFWDI6g/jHbR51I2UVdD1cZ41D0GHnyDAVWSgfgSBo9kQ=="
     },
     "node_modules/traverse": {
       "version": "0.6.7",
@@ -34938,9 +34938,9 @@
       }
     },
     "trafficops-types": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/trafficops-types/-/trafficops-types-4.0.10.tgz",
-      "integrity": "sha512-/GW+PgT7Rg5WhGtbkJdvTIXLga68wx3dy9crmXmOrrB6sPVcX7vbrQ9TAxGqRbsC52ZbZSxahqsmZgQZv8KK3A=="
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/trafficops-types/-/trafficops-types-4.0.11.tgz",
+      "integrity": "sha512-qGVUM28xn3rebeNBnFemo+IVCi09TXGH3/pDy/OAMJFWDI6g/jHbR51I2UVdD1cZ41D0GHnyDAVWSgfgSBo9kQ=="
     },
     "traverse": {
       "version": "0.6.7",

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -69,7 +69,7 @@
     "express": "^4.15.2",
     "node-forge": "^1.3.1",
     "rxjs": "~6.6.0",
-    "trafficops-types": "^4.0.10",
+    "trafficops-types": "^4.0.11",
     "tslib": "^2.0.0",
     "zone.js": "~0.13.0"
   },

--- a/experimental/traffic-portal/src/app/api/index.ts
+++ b/experimental/traffic-portal/src/app/api/index.ts
@@ -26,6 +26,7 @@ import { MiscAPIsService } from "./misc-apis.service";
 import { PhysicalLocationService } from "./physical-location.service";
 import { ProfileService } from "./profile.service";
 import { ServerService } from "./server.service";
+import { TopologyService } from "./topology.service";
 import { TypeService } from "./type.service";
 import { UserService } from "./user.service";
 
@@ -38,6 +39,7 @@ export * from "./misc-apis.service";
 export * from "./physical-location.service";
 export * from "./profile.service";
 export * from "./server.service";
+export * from "./topology.service";
 export * from "./type.service";
 export * from "./user.service";
 
@@ -59,6 +61,7 @@ export * from "./user.service";
 		PhysicalLocationService,
 		ProfileService,
 		ServerService,
+		TopologyService,
 		TypeService,
 		UserService,
 	]

--- a/experimental/traffic-portal/src/app/api/testing/index.ts
+++ b/experimental/traffic-portal/src/app/api/testing/index.ts
@@ -25,6 +25,7 @@ import {
 	PhysicalLocationService,
 	ProfileService,
 	ServerService,
+	TopologyService,
 	TypeService,
 	UserService
 } from "..";
@@ -38,6 +39,7 @@ import { MiscAPIsService as TestingMiscAPIsService } from "./misc-apis.service";
 import { PhysicalLocationService as TestingPhysicalLocationService } from "./physical-location.service";
 import { ProfileService as TestingProfileService } from "./profile.service";
 import { ServerService as TestingServerService } from "./server.service";
+import { TopologyService as TestingTopologyService } from "./topology.service";
 import { TypeService as TestingTypeService } from "./type.service";
 import { UserService as TestingUserService } from "./user.service";
 
@@ -60,6 +62,7 @@ import { UserService as TestingUserService } from "./user.service";
 		{provide: PhysicalLocationService, useClass: TestingPhysicalLocationService},
 		{provide: ProfileService, useClass: TestingProfileService},
 		{provide: ServerService, useClass: TestingServerService},
+		{provide: TopologyService, useClass: TestingTopologyService},
 		{provide: TypeService, useClass: TestingTypeService},
 		{provide: UserService, useClass: TestingUserService},
 		TestingServerService,

--- a/experimental/traffic-portal/src/app/api/testing/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/topology.service.ts
@@ -111,9 +111,13 @@ export class TopologyService {
 	 * Topology.
 	 *
 	 * @param topology The full new definition of the Topology being updated
+	 * @param name What the topology was named before it was updated
 	 */
-	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology> {
-		const idx = this.topologies.findIndex(t => t.name === topology.name);
+	public async updateTopology(topology: ResponseTopology, name?: string): Promise<ResponseTopology> {
+		if (typeof name === "undefined") {
+			name = topology.name;
+		}
+		const idx = this.topologies.findIndex(t => t.name === name);
 		topology = {
 			...topology,
 			lastUpdated: new Date()

--- a/experimental/traffic-portal/src/app/api/testing/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/topology.service.ts
@@ -49,17 +49,15 @@ export class TopologyService {
 	/**
 	 * Gets one or all Topologies from Traffic Ops
 	 *
-	 * @param name? The integral, unique identifier of a single Topology to be
-	 * returned
-	 * @returns Either a Map of Topology names to full Topology objects, or a single Topology, depending on whether `id` was
-	 * 	passed.
-	 * (In the event that `id` is passed but does not match any Topology, `null` will be emitted)
+	 * @param name The unique name of a single Topology to be returned
+	 * @returns Either an Array of Topologies or a single Topology, depending on whether `name` was
+	 * passed.
 	 */
 	public async getTopologies(name?: string): Promise<Array<ResponseTopology> | ResponseTopology> {
 		if (name !== undefined) {
 			const topology = this.topologies.find(t => t.name === name);
 			if (!topology) {
-				throw new Error(`no such Topology #${name}`);
+				throw new Error(`no such Topology ${name}`);
 			}
 			return topology;
 		}
@@ -69,13 +67,13 @@ export class TopologyService {
 	/**
 	 * Deletes a Topology.
 	 *
-	 * @param topology The Topology to be deleted, or just its ID.
+	 * @param topology The Topology to be deleted, or just its name.
 	 */
 	public async deleteTopology(topology: ResponseTopology | string): Promise<void> {
 		const name = typeof topology === "string" ? topology : topology.name;
 		const idx = this.topologies.findIndex(t => t.name === name);
 		if (idx < 0) {
-			throw new Error(`no such Topology: #${name}`);
+			throw new Error(`no such Topology: ${name}`);
 		}
 		this.topologies.splice(idx, 1);
 	}
@@ -87,7 +85,7 @@ export class TopologyService {
 	 */
 	public async createTopology(topology: RequestTopology): Promise<ResponseTopology> {
 		const nodes: ResponseTopologyNode[] = topology.nodes.map(node => {
-			if (!(node.parents instanceof Array)) {
+			if (!Array.isArray(node.parents)) {
 				node.parents = [];
 			}
 			const responseNode: ResponseTopologyNode = {
@@ -110,8 +108,7 @@ export class TopologyService {
 	 * Replaces an existing Topology with the provided new definition of a
 	 * Topology.
 	 *
-	 * @param topology The full new definition of the Topology being
-	 * updated, or just its ID.
+	 * @param topology The full new definition of the Topology being updated
 	 */
 	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology> {
 		const idx = this.topologies.findIndex(t => t.name === topology.name);
@@ -121,7 +118,7 @@ export class TopologyService {
 		};
 
 		if (idx < 0) {
-			throw new Error(`no such Topology: #${topology}`);
+			throw new Error(`no such Topology: ${topology}`);
 		}
 
 		this.topologies[idx] = topology;

--- a/experimental/traffic-portal/src/app/api/testing/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/topology.service.ts
@@ -1,0 +1,130 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { Injectable } from "@angular/core";
+import {
+	RequestTopology,
+	ResponseTopology,
+	ResponseTopologyNode
+} from "trafficops-types";
+
+/**
+ * TopologyService expose API functionality relating to Topologies.
+ */
+@Injectable()
+export class TopologyService {
+	private readonly topologies: ResponseTopology[] = [
+		{
+			description: "",
+			lastUpdated: new Date(),
+			name: "test",
+			nodes: [
+				{
+					cachegroup: "Edge",
+					parents: [1],
+				},
+				{
+					cachegroup: "Mid",
+					parents: [2],
+				},
+				{
+					cachegroup: "Origin",
+					parents: [],
+				},
+			],
+		}
+	];
+
+	/**
+	 * Gets one or all Topologies from Traffic Ops
+	 *
+	 * @param name? The integral, unique identifier of a single Topology to be
+	 * returned
+	 * @returns Either a Map of Topology names to full Topology objects, or a single Topology, depending on whether `id` was
+	 * 	passed.
+	 * (In the event that `id` is passed but does not match any Topology, `null` will be emitted)
+	 */
+	public async getTopologies(name?: string): Promise<Array<ResponseTopology> | ResponseTopology> {
+		if (name !== undefined) {
+			const topology = this.topologies.find(t => t.name === name);
+			if (!topology) {
+				throw new Error(`no such Topology #${name}`);
+			}
+			return topology;
+		}
+		return this.topologies;
+	}
+
+	/**
+	 * Deletes a Topology.
+	 *
+	 * @param topology The Topology to be deleted, or just its ID.
+	 */
+	public async deleteTopology(topology: ResponseTopology | string): Promise<void> {
+		const name = typeof topology === "string" ? topology : topology.name;
+		const idx = this.topologies.findIndex(t => t.name === name);
+		if (idx < 0) {
+			throw new Error(`no such Topology: #${name}`);
+		}
+		this.topologies.splice(idx, 1);
+	}
+
+	/**
+	 * Creates a new Topology.
+	 *
+	 * @param topology The Topology to create.
+	 */
+	public async createTopology(topology: RequestTopology): Promise<ResponseTopology> {
+		const nodes: ResponseTopologyNode[] = topology.nodes.map(node => {
+			if (!(node.parents instanceof Array)) {
+				node.parents = [];
+			}
+			const responseNode: ResponseTopologyNode = {
+				cachegroup: node.cachegroup,
+				parents: node.parents || [],
+			};
+			return responseNode;
+		});
+		const t: ResponseTopology = {
+			description: topology.description || "",
+			lastUpdated: new Date(),
+			name: topology.name,
+			nodes,
+		};
+		this.topologies.push(t);
+		return t;
+	}
+
+	/**
+	 * Replaces an existing Topology with the provided new definition of a
+	 * Topology.
+	 *
+	 * @param topology The full new definition of the Topology being
+	 * updated, or just its ID.
+	 */
+	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology> {
+		const idx = this.topologies.findIndex(t => t.name === topology.name);
+		topology = {
+			...topology,
+			lastUpdated: new Date()
+		};
+
+		if (idx < 0) {
+			throw new Error(`no such Topology: #${topology}`);
+		}
+
+		this.topologies[idx] = topology;
+		return topology;
+	}
+}

--- a/experimental/traffic-portal/src/app/api/testing/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/topology.service.ts
@@ -52,16 +52,15 @@ export class TopologyService {
 	 * Gets one or all Topologies from Traffic Ops
 	 *
 	 * @param name The unique name of a single Topology to be returned
-	 * @returns Either an Array of Topologies or a single Topology, depending on whether `name` was
-	 * passed.
+	 * @returns An Array of Topologies
 	 */
-	public async getTopologies(name?: string): Promise<Array<ResponseTopology> | ResponseTopology> {
+	public async getTopologies(name?: string): Promise<Array<ResponseTopology>> {
 		if (name !== undefined) {
 			const topology = this.topologies.find(t => t.name === name);
 			if (!topology) {
 				throw new Error(`no such Topology ${name}`);
 			}
-			return topology;
+			return [topology];
 		}
 		return this.topologies;
 	}

--- a/experimental/traffic-portal/src/app/api/testing/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/testing/topology.service.ts
@@ -19,6 +19,8 @@ import {
 	ResponseTopologyNode
 } from "trafficops-types";
 
+import { TopologyService as ConcreteService, TopTreeNode } from "src/app/api";
+
 /**
  * TopologyService expose API functionality relating to Topologies.
  */
@@ -43,7 +45,7 @@ export class TopologyService {
 					parents: [],
 				},
 			],
-		}
+		},
 	];
 
 	/**
@@ -123,5 +125,27 @@ export class TopologyService {
 
 		this.topologies[idx] = topology;
 		return topology;
+	}
+
+	/**
+	 * Generates a material tree from a topology.
+	 *
+	 * @param topology The topology to generate a material tree from.
+	 * @returns a material tree.
+	 */
+	public static topologyToTree(topology: ResponseTopology): Array<TopTreeNode> {
+		return ConcreteService.topologyToTree(topology);
+	}
+
+	/**
+	 * Generates a topology from a material tree.
+	 *
+	 * @param name The topology name
+	 * @param description The topology description
+	 * @param treeNodes The data for a material tree
+	 * @returns a topology.
+	 */
+	public static treeToTopology(name: string, description: string, treeNodes: Array<TopTreeNode>): ResponseTopology {
+		return ConcreteService.treeToTopology(name, description, treeNodes);
 	}
 }

--- a/experimental/traffic-portal/src/app/api/topology.service.spec.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * @license Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+
+import { TopologyService } from "./topology.service";
+
+describe("TopologyService", () => {
+	let service: TopologyService;
+	let httpTestingController: HttpTestingController;
+	const topology = {
+		description: "",
+		lastUpdated: new Date(),
+		name: "test",
+		nodes: [
+			{
+				cachegroup: "Edge",
+				parents: [1],
+			},
+			{
+				cachegroup: "Mid",
+				parents: [2],
+			},
+			{
+				cachegroup: "Origin",
+				parents: [],
+			},
+		],
+	};
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [HttpClientTestingModule],
+			providers: [
+				TopologyService,
+			]
+		});
+		service = TestBed.inject(TopologyService);
+		httpTestingController = TestBed.inject(HttpTestingController);
+	});
+
+	it("should be created", () => {
+		expect(service).toBeTruthy();
+	});
+
+	it("gets multiple Topologies", async () => {
+		const responseP = service.getTopologies();
+		const req = httpTestingController.expectOne(`/api/${service.apiVersion}/topologies`);
+		expect(req.request.method).toBe("GET");
+		expect(req.request.params.keys().length).toBe(0);
+		req.flush({response: [topology]});
+		await expectAsync(responseP).toBeResolvedTo([topology]);
+	});
+
+	afterEach(() => {
+		httpTestingController.verify();
+	});
+});

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -47,7 +47,7 @@ export class TopologyService extends APIService {
 	 *
 	 * @param name The name of a single Topology to be returned.
 	 * @returns An Array of Topologies
-	 * whether `name` was	passed.
+	 * whether `name` was passed.
 	 */
 	public async getTopologies(name?: string): Promise<Array<ResponseTopology>> {
 		const path = "topologies";

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -1,0 +1,227 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { HttpClient } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import type {
+	RequestTopology,
+	ResponseTopology, ResponseTopologyNode,
+} from "trafficops-types";
+
+import { APIService } from "./base-api.service";
+
+/**
+ * TopTreeNode is used to represent a topology in a format usable as a material
+ * nested tree data source.
+ */
+export interface TopTreeNode {
+	name: string;
+	cachegroup: string;
+	children: Array<TopTreeNode>;
+	parents: Array<this>;
+}
+
+/**
+ * TopologyService exposes API functionality relating to Topologies.
+ */
+@Injectable()
+export class TopologyService extends APIService {
+
+	constructor(http: HttpClient) {
+		super(http);
+	}
+
+	/**
+	 * Gets a specific Topology from Traffic Ops
+	 *
+	 * @param name The name of the Topology to be returned.
+	 * @returns The Topology with the given name.
+	 */
+	public async getTopologies(name: string): Promise<ResponseTopology>;
+	/**
+	 * Gets all Topologies from Traffic Ops
+	 *
+	 * @returns An Array of all Topologies configured in Traffic Ops.
+	 */
+	public async getTopologies(): Promise<Array<ResponseTopology>>;
+	/**
+	 * Gets one or all Topologies from Traffic Ops
+	 *
+	 * @param name The name of a single Topology to be returned.
+	 * @returns Either an Array of Topology objects, or a single Topology, depending on
+	 * whether `name` was	passed.
+	 */
+	public async getTopologies(name?: string): Promise<Array<ResponseTopology> | ResponseTopology> {
+		const path = "topologies";
+		if (name) {
+			const topology = await this.get<[ResponseTopology]>(path, undefined, {name}).toPromise();
+			if (topology.length !== 1) {
+				throw new Error(`${topology.length} Topologies found by name ${name}`);
+			}
+			return topology[0];
+		}
+		return this.get<Array<ResponseTopology>>(path).toPromise();
+	}
+
+	/**
+	 * Deletes a Topology.
+	 *
+	 * @param topology The Topology to be deleted, or just its name.
+	 */
+	public async deleteTopology(topology: ResponseTopology | string): Promise<void> {
+		const name = typeof topology === "string" ? topology : topology.name;
+		return this.delete(`topologies?name=${name}`).toPromise();
+	}
+
+	/**
+	 * Creates a new Topology.
+	 *
+	 * @param topology The Topology to create.
+	 */
+	public async createTopology(topology: RequestTopology): Promise<ResponseTopology> {
+		return this.post<ResponseTopology>("topologies", topology).toPromise();
+	}
+
+	/**
+	 * Replaces an existing Topology with the provided new definition of a
+	 * Topology.
+	 *
+	 * @param name The if of the Topology being updated.
+	 * @param topology The new definition of the Topology.
+	 */
+	public async updateTopology(name: string, topology: RequestTopology): Promise<ResponseTopology>;
+	/**
+	 * Replaces an existing Topology with the provided new definition of a
+	 * Topology.
+	 *
+	 * @param topology The full new definition of the Topology being
+	 * updated.
+	 */
+	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology>;
+	/**
+	 * Replaces an existing Topology with the provided new definition of a
+	 * Topology.
+	 *
+	 * @param topologyOrName The full new definition of the Topology being
+	 * updated, or just its name.
+	 * @param payload The new definition of the Topology. This is required if
+	 * `topologyOrName` is an name, and ignored otherwise.
+	 */
+	public async updateTopology(topologyOrName: ResponseTopology | string, payload?: RequestTopology): Promise<ResponseTopology> {
+		let name;
+		let body;
+		if (typeof topologyOrName === "string") {
+			if (!payload) {
+				throw new TypeError("invalid call signature - missing request payload");
+			}
+			body = payload;
+			name = topologyOrName;
+		} else {
+			body = topologyOrName;
+			({name} = topologyOrName);
+		}
+
+		return this.put<ResponseTopology>(`topologies?name=${name}`, body).toPromise();
+	}
+
+	/**
+	 * Generates a material tree from a topology.
+	 *
+	 * @param topology The topology to generate a material tree from.
+	 * @returns a material tree.
+	 */
+	public topologyToTree(topology: ResponseTopology): Array<TopTreeNode> {
+		const treeNodes: Array<TopTreeNode> = [];
+		const topLevel: Array<TopTreeNode> = [];
+		for (const node of topology.nodes) {
+			const name = node.cachegroup;
+			const cachegroup = node.cachegroup;
+			const children: Array<TopTreeNode> = [];
+			const parents: Array<TopTreeNode> = [];
+			treeNodes.push({
+				cachegroup,
+				children,
+				name,
+				parents,
+			});
+		}
+		for (let index = 0; index < topology.nodes.length; index++) {
+			const node = topology.nodes[index];
+			const treeNode = treeNodes[index];
+			if (!(node.parents instanceof Array) || node.parents.length < 1) {
+				topLevel.push(treeNode);
+				continue;
+			}
+			for (const parent of node.parents) {
+				treeNodes[parent].children.push(treeNode);
+				treeNode.parents.push(treeNodes[parent]);
+			}
+		}
+		return topLevel;
+	}
+
+	/**
+	 * Generates a topology from a material tree.
+	 *
+	 * @param name The topology name
+	 * @param description The topology description
+	 * @param treeNodes The data for a material tree
+	 * @returns a material tree.
+	 */
+	public treeToTopology(name: string, description: string, treeNodes: Array<TopTreeNode>): ResponseTopology {
+		const topologyNodeIndicesByCacheGroup: Map<string, number> = new Map();
+		const nodes: Array<ResponseTopologyNode> = new Array<ResponseTopologyNode>();
+		this.treeToTopologyInner(topologyNodeIndicesByCacheGroup, nodes, undefined, treeNodes);
+		const topology: ResponseTopology = {
+			description,
+			lastUpdated: new Date(),
+			name,
+			nodes,
+		};
+		return topology;
+	}
+
+	/**
+	 * Inner recursive function for generating a Topology from a material tree.
+	 *
+	 * @param topologyNodeIndicesByCacheGroup A map of Topology node indices
+	 * using cache group names as the key
+	 * @param topologyNodes The mutable array of Topology nodes
+	 * @param parent The parent, if it exists
+	 * @param treeNodes The data for a material tree
+	 */
+	protected treeToTopologyInner(topologyNodeIndicesByCacheGroup: Map<string, number>,
+		topologyNodes: Array<ResponseTopologyNode>, parent: ResponseTopologyNode | undefined, treeNodes: Array<TopTreeNode>): void {
+
+		for (const treeNode of treeNodes) {
+			const cachegroup = treeNode.cachegroup;
+			const parents: number[] = [];
+			if (parent instanceof Object) {
+				const index = topologyNodeIndicesByCacheGroup.get(parent.cachegroup);
+				if (!(typeof index === "number")) {
+					throw new Error(`index of cachegroup ${parent?.cachegroup} not found in topologyNodeIndicesByCacheGroup`);
+				}
+				parents.push(index);
+			}
+			const topologyNode: ResponseTopologyNode = {
+				cachegroup,
+				parents,
+			};
+			topologyNodes.push(topologyNode);
+			topologyNodeIndicesByCacheGroup.set(cachegroup, topologyNodes.length - 1);
+			if (treeNode.children.length > 0) {
+				this.treeToTopologyInner(topologyNodeIndicesByCacheGroup, topologyNodes, topologyNode, treeNode.children);
+			}
+		}
+	}
+}

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -15,7 +15,8 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import type {
 	RequestTopology,
-	ResponseTopology, ResponseTopologyNode,
+	ResponseTopology,
+	ResponseTopologyNode,
 } from "trafficops-types";
 
 import { APIService } from "./base-api.service";
@@ -96,42 +97,10 @@ export class TopologyService extends APIService {
 	 * Replaces an existing Topology with the provided new definition of a
 	 * Topology.
 	 *
-	 * @param name The if of the Topology being updated.
-	 * @param topology The new definition of the Topology.
+	 * @param topology The full new definition of the Topology being updated
 	 */
-	public async updateTopology(name: string, topology: RequestTopology): Promise<ResponseTopology>;
-	/**
-	 * Replaces an existing Topology with the provided new definition of a
-	 * Topology.
-	 *
-	 * @param topology The full new definition of the Topology being
-	 * updated.
-	 */
-	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology>;
-	/**
-	 * Replaces an existing Topology with the provided new definition of a
-	 * Topology.
-	 *
-	 * @param topologyOrName The full new definition of the Topology being
-	 * updated, or just its name.
-	 * @param payload The new definition of the Topology. This is required if
-	 * `topologyOrName` is an name, and ignored otherwise.
-	 */
-	public async updateTopology(topologyOrName: ResponseTopology | string, payload?: RequestTopology): Promise<ResponseTopology> {
-		let name;
-		let body;
-		if (typeof topologyOrName === "string") {
-			if (!payload) {
-				throw new TypeError("invalid call signature - missing request payload");
-			}
-			body = payload;
-			name = topologyOrName;
-		} else {
-			body = topologyOrName;
-			({name} = topologyOrName);
-		}
-
-		return this.put<ResponseTopology>(`topologies?name=${name}`, body).toPromise();
+	public async updateTopology(topology: ResponseTopology): Promise<ResponseTopology> {
+		return this.put<ResponseTopology>(`topologies?name=${topology.name}`, topology).toPromise();
 	}
 
 	/**
@@ -201,7 +170,7 @@ export class TopologyService extends APIService {
 	 * @param treeNodes The data for a material tree
 	 */
 	protected treeToTopologyInner(topologyNodeIndicesByCacheGroup: Map<string, number>,
-		topologyNodes: Array<ResponseTopologyNode>, parent: ResponseTopologyNode | undefined, treeNodes: Array<TopTreeNode>): void {
+	                              topologyNodes: Array<ResponseTopologyNode>, parent: ResponseTopologyNode | undefined, treeNodes: Array<TopTreeNode>): void {
 
 		for (const treeNode of treeNodes) {
 			const cachegroup = treeNode.cachegroup;

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -170,7 +170,7 @@ export class TopologyService extends APIService {
 	 * @param treeNodes The data for a material tree
 	 */
 	protected treeToTopologyInner(topologyNodeIndicesByCacheGroup: Map<string, number>,
-	                              topologyNodes: Array<ResponseTopologyNode>, parent: ResponseTopologyNode | undefined, treeNodes: Array<TopTreeNode>): void {
+		topologyNodes: Array<ResponseTopologyNode>, parent: ResponseTopologyNode | undefined, treeNodes: Array<TopTreeNode>): void {
 
 		for (const treeNode of treeNodes) {
 			const cachegroup = treeNode.cachegroup;

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -53,7 +53,7 @@ export class TopologyService extends APIService {
 		const path = "topologies";
 		if (name) {
 			const topology = await this.get<[ResponseTopology]>(path, undefined, {name}).toPromise();
-			if (topology.length !== 1) {
+			if (topology.length !== 1 || topology[0].name !== name) {
 				throw new Error(`${topology.length} Topologies found by name ${name}`);
 			}
 			return topology;
@@ -87,7 +87,7 @@ export class TopologyService extends APIService {
 	 * @param topology The full new definition of the Topology being updated
 	 * @param name What the topology was named before it was updated
 	 */
-	public async updateTopology(topology: ResponseTopology, name: string | undefined): Promise<ResponseTopology> {
+	public async updateTopology(topology: ResponseTopology, name?: string): Promise<ResponseTopology> {
 		if (typeof name === "undefined") {
 			name = topology.name;
 		}
@@ -165,10 +165,7 @@ export class TopologyService extends APIService {
 			const cachegroup = treeNode.cachegroup;
 			const parents: number[] = [];
 			if (parent instanceof Object) {
-				const index = topologyNodeIndicesByCacheGroup.get(parent.cachegroup);
-				if (!(typeof index === "number")) {
-					throw new Error(`index of cachegroup ${parent?.cachegroup} not found in topologyNodeIndicesByCacheGroup`);
-				}
+				const index = topologyNodeIndicesByCacheGroup.get(parent.cachegroup) as number;
 				parents.push(index);
 			}
 			const topologyNode: ResponseTopologyNode = {

--- a/experimental/traffic-portal/src/app/api/topology.service.ts
+++ b/experimental/traffic-portal/src/app/api/topology.service.ts
@@ -164,7 +164,7 @@ export class TopologyService extends APIService {
 		for (const treeNode of treeNodes) {
 			const cachegroup = treeNode.cachegroup;
 			const parents: number[] = [];
-			if (parent instanceof Object) {
+			if (typeof parent !== "undefined") {
 				const index = topologyNodeIndicesByCacheGroup.get(parent.cachegroup) as number;
 				parents.push(index);
 			}

--- a/experimental/traffic-portal/src/app/core/core.module.ts
+++ b/experimental/traffic-portal/src/app/core/core.module.ts
@@ -64,6 +64,7 @@ import { ServersTableComponent } from "./servers/servers-table/servers-table.com
 import { UpdateStatusComponent } from "./servers/update-status/update-status.component";
 import { StatusDetailsComponent } from "./statuses/status-details/status-details.component";
 import { StatusesTableComponent } from "./statuses/statuses-table/statuses-table.component";
+import { TopologyDetailsComponent } from "./topologies/topology-details/topology-details.component";
 import { TypeDetailComponent } from "./types/detail/type-detail.component";
 import { TypesTableComponent } from "./types/table/types-table.component";
 import { RoleDetailComponent } from "./users/roles/detail/role-detail.component";
@@ -124,6 +125,7 @@ export const ROUTES: Routes = [
 	{ component: ISOGenerationFormComponent, path: "iso-gen"},
 	{ component: ProfileDetailComponent, path: "profiles/:id"},
 	{ component: ProfileTableComponent, path: "profiles"},
+	{ component: TopologyDetailsComponent, path: "topologies/:name"},
 ].map(r => ({...r, canActivate: [AuthenticatedGuard]}));
 
 /**
@@ -177,6 +179,7 @@ export const ROUTES: Routes = [
 		ProfileDetailComponent,
 		CapabilitiesComponent,
 		CapabilityDetailsComponent,
+		TopologyDetailsComponent,
 	],
 	exports: [],
 	imports: [

--- a/experimental/traffic-portal/src/app/core/core.module.ts
+++ b/experimental/traffic-portal/src/app/core/core.module.ts
@@ -126,6 +126,7 @@ export const ROUTES: Routes = [
 	{ component: ProfileDetailComponent, path: "profiles/:id"},
 	{ component: ProfileTableComponent, path: "profiles"},
 	{ component: TopologyDetailsComponent, path: "topologies/:name"},
+	{ component: TopologyDetailsComponent, path: "topologies-new"},
 ].map(r => ({...r, canActivate: [AuthenticatedGuard]}));
 
 /**

--- a/experimental/traffic-portal/src/app/core/core.module.ts
+++ b/experimental/traffic-portal/src/app/core/core.module.ts
@@ -126,7 +126,7 @@ export const ROUTES: Routes = [
 	{ component: ProfileDetailComponent, path: "profiles/:id"},
 	{ component: ProfileTableComponent, path: "profiles"},
 	{ component: TopologyDetailsComponent, path: "topologies/:name"},
-	{ component: TopologyDetailsComponent, path: "topologies-new"},
+	{ component: TopologyDetailsComponent, path: "new-topology"},
 ].map(r => ({...r, canActivate: [AuthenticatedGuard]}));
 
 /**

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
@@ -17,7 +17,7 @@ limitations under the License.
 		<mat-card-content class="container">
 			<mat-form-field>
 				<mat-label>Name</mat-label>
-				<input matInput type="text" name="name" required [readonly]="!new" [disabled]="!new" [value]="topology.name">
+				<input matInput type="text" name="name" required [value]="topology.name">
 			</mat-form-field>
 			<mat-form-field>
 				<mat-label>Description</mat-label>

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
@@ -12,16 +12,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <mat-card appearance="outlined" class="page-content single-column">
-	<tp-loading *ngIf="!topology"></tp-loading>
-	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="topology">
+	<tp-loading *ngIf="loading"></tp-loading>
+	<form ngNativeValidate (ngSubmit)="submit($event)">
 		<mat-card-content class="container">
 			<mat-form-field>
 				<mat-label>Name</mat-label>
-				<input matInput type="text" name="name" required readonly disabled [(ngModel)]="topology.name">
+				<input matInput type="text" name="name" required readonly disabled [value]="topology.name">
 			</mat-form-field>
 			<mat-form-field *ngIf="!new">
 				<mat-label>Description</mat-label>
-				<textarea matInput name="description" [(ngModel)]="topology.description"></textarea>
+				<textarea matInput name="description" [value]="topology.description"></textarea>
 			</mat-form-field>
 		</mat-card-content>
 		<mat-card-content class="container">
@@ -33,7 +33,6 @@ limitations under the License.
 					<div class="expand-node" role="group">
 						<ng-container matTreeNodeOutlet></ng-container>
 					</div>
-					<!--<mat-divider *ngIf="(node)"></mat-divider>-->
 				</mat-nested-tree-node>
 			</mat-tree>
 		</mat-card-content>

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
@@ -1,0 +1,45 @@
+<!--
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<mat-card appearance="outlined" class="page-content single-column">
+	<tp-loading *ngIf="!topology"></tp-loading>
+	<form ngNativeValidate (ngSubmit)="submit($event)" *ngIf="topology">
+		<mat-card-content class="container">
+			<mat-form-field>
+				<mat-label>Name</mat-label>
+				<input matInput type="text" name="name" required readonly disabled [(ngModel)]="topology.name">
+			</mat-form-field>
+			<mat-form-field *ngIf="!new">
+				<mat-label>Description</mat-label>
+				<textarea matInput name="description" [(ngModel)]="topology.description"></textarea>
+			</mat-form-field>
+		</mat-card-content>
+		<mat-card-content class="container">
+			<mat-tree [dataSource]="topologySource" [treeControl]="topologyControl">
+				<mat-nested-tree-node *matTreeNodeDef="let node; when: hasChild">
+					<div class="mat-tree-node" matTreeNodeToggle mat-menu-item [attr.aria-label]="'Toggle ' + node.name">
+						{{node.name}}
+					</div>
+					<div class="expand-node" role="group">
+						<ng-container matTreeNodeOutlet></ng-container>
+					</div>
+					<!--<mat-divider *ngIf="(node)"></mat-divider>-->
+				</mat-nested-tree-node>
+			</mat-tree>
+		</mat-card-content>
+		<mat-card-actions align="end" class="actions-container">
+			<button mat-raised-button type="button" *ngIf="!new" color="warn" (click)="delete()">Delete</button>
+			<button mat-raised-button color="primary" type="submit">Save</button>
+		</mat-card-actions>
+	</form>
+</mat-card>

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
@@ -17,11 +17,11 @@ limitations under the License.
 		<mat-card-content class="container">
 			<mat-form-field>
 				<mat-label>Name</mat-label>
-				<input matInput type="text" name="name" required [value]="topology.name">
+				<input matInput type="text" name="name" required [(ngModel)]="topology.name">
 			</mat-form-field>
 			<mat-form-field>
 				<mat-label>Description</mat-label>
-				<textarea matInput name="description" [value]="topology.description"></textarea>
+				<textarea matInput name="description" [(ngModel)]="topology.description"></textarea>
 			</mat-form-field>
 		</mat-card-content>
 		<mat-card-content class="container">

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.html
@@ -17,9 +17,9 @@ limitations under the License.
 		<mat-card-content class="container">
 			<mat-form-field>
 				<mat-label>Name</mat-label>
-				<input matInput type="text" name="name" required readonly disabled [value]="topology.name">
+				<input matInput type="text" name="name" required [readonly]="!new" [disabled]="!new" [value]="topology.name">
 			</mat-form-field>
-			<mat-form-field *ngIf="!new">
+			<mat-form-field>
 				<mat-label>Description</mat-label>
 				<textarea matInput name="description" [value]="topology.description"></textarea>
 			</mat-form-field>

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.scss
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.scss
@@ -1,0 +1,16 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+.expand-node {
+	padding-left: 40px;
+}

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
@@ -63,7 +63,7 @@ describe("TopologyDetailsComponent", () => {
 		fixture.detectChanges();
 		await fixture.whenStable();
 		expect(paramMap).toHaveBeenCalled();
-		expect(component.topology).toBeInstanceOf(Object);
+		expect(component.topology).toBeDefined();
 		expect(component.topology.name).toBe("test");
 		expect(component.new).toBeFalse();
 	});

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
@@ -1,0 +1,34 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { TopologyDetailsComponent } from "./topology-details.component";
+
+describe("TopologyDetailsComponent", () => {
+	let component: TopologyDetailsComponent;
+	let fixture: ComponentFixture<TopologyDetailsComponent>;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			declarations: [TopologyDetailsComponent]
+		});
+		fixture = TestBed.createComponent(TopologyDetailsComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it("should create", () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
@@ -35,7 +35,7 @@ describe("TopologyDetailsComponent", () => {
 		headerTitle: new ReplaySubject<string>(),
 	});
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		TestBed.configureTestingModule({
 			declarations: [TopologyDetailsComponent],
 			imports: [APITestingModule, RouterTestingModule, MatDialogModule],
@@ -47,9 +47,24 @@ describe("TopologyDetailsComponent", () => {
 		fixture = TestBed.createComponent(TopologyDetailsComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();
+		await fixture.whenStable();
 	});
 
 	it("should create", () => {
 		expect(component).toBeTruthy();
+		expect(paramMap).toHaveBeenCalled();
+	});
+
+	it("existing topology", async () => {
+		paramMap.and.returnValue("test");
+
+		fixture = TestBed.createComponent(TopologyDetailsComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+		await fixture.whenStable();
+		expect(paramMap).toHaveBeenCalled();
+		expect(component.topology).toBeInstanceOf(Object);
+		expect(component.topology.name).toBe("test");
+		expect(component.new).toBeFalse();
 	});
 });

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.spec.ts
@@ -12,17 +12,38 @@
 * limitations under the License.
 */
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { MatDialogModule } from "@angular/material/dialog";
+import { ActivatedRoute } from "@angular/router";
+import { RouterTestingModule } from "@angular/router/testing";
+import { ReplaySubject } from "rxjs";
+
+import { APITestingModule } from "src/app/api/testing";
+import {
+	NavigationService
+} from "src/app/shared/navigation/navigation.service";
 
 import { TopologyDetailsComponent } from "./topology-details.component";
 
 describe("TopologyDetailsComponent", () => {
 	let component: TopologyDetailsComponent;
 	let fixture: ComponentFixture<TopologyDetailsComponent>;
+	let route: ActivatedRoute;
+	let paramMap: jasmine.Spy;
+
+	const navSvc = jasmine.createSpyObj([], {
+		headerHidden: new ReplaySubject<boolean>(),
+		headerTitle: new ReplaySubject<string>(),
+	});
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			declarations: [TopologyDetailsComponent]
+			declarations: [TopologyDetailsComponent],
+			imports: [APITestingModule, RouterTestingModule, MatDialogModule],
+			providers: [{provide: NavigationService, useValue: navSvc}],
 		});
+		route = TestBed.inject(ActivatedRoute);
+		paramMap = spyOn(route.snapshot.paramMap, "get");
+		paramMap.and.returnValue(null);
 		fixture = TestBed.createComponent(TopologyDetailsComponent);
 		component = fixture.componentInstance;
 		fixture.detectChanges();

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.ts
@@ -1,0 +1,152 @@
+/*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { NestedTreeControl } from "@angular/cdk/tree";
+import { Location } from "@angular/common";
+import { Component, OnInit } from "@angular/core";
+import { MatDialog } from "@angular/material/dialog";
+import { MatTreeNestedDataSource } from "@angular/material/tree";
+import { ActivatedRoute } from "@angular/router";
+import { ResponseTopology } from "trafficops-types";
+
+import { TopologyService, TopTreeNode } from "src/app/api";
+import {
+	DecisionDialogComponent,
+	DecisionDialogData,
+} from "src/app/shared/dialogs/decision-dialog/decision-dialog.component";
+import {
+	NavigationService
+} from "src/app/shared/navigation/navigation.service";
+
+/**
+ * TopologyDetailComponent is the controller for a Topology's "detail" page.
+ */
+@Component({
+	selector: "tp-topology-details",
+	styleUrls: ["./topology-details.component.scss"],
+	templateUrl: "./topology-details.component.html",
+})
+export class TopologyDetailsComponent implements OnInit {
+	public new = false;
+	public topology: ResponseTopology = {
+		description: "",
+		lastUpdated: new Date(),
+		name: "",
+		nodes: [],
+	};
+	public showErrors = false;
+	public topologies: Array<ResponseTopology> = [];
+	public topologySource = new MatTreeNestedDataSource<TopTreeNode>();
+	public topologyControl = new NestedTreeControl<TopTreeNode>(node => node.children);
+
+	constructor(
+		private readonly route: ActivatedRoute,
+		private readonly api: TopologyService,
+		private readonly location: Location,
+		private readonly dialog: MatDialog,
+		private readonly navSvc: NavigationService,
+	) {
+	}
+
+	/**
+	 * Angular lifecycle hook where data is initialized.
+	 */
+	public async ngOnInit(): Promise<void> {
+		const name = this.route.snapshot.paramMap.get("name");
+		if (name === null) {
+			console.error("missing required route parameter 'name'");
+			return;
+		}
+
+		const topologiesPromise = this.api.getTopologies().then(topologies => this.topologies = topologies);
+		if (name === "new") {
+			this.new = true;
+			this.setTitle();
+			await topologiesPromise;
+			return;
+		}
+		await topologiesPromise;
+		const index = this.topologies.findIndex(c => c.name === name);
+		if (index < 0) {
+			console.error(`no such Topology: #${name}`);
+			return;
+		}
+		this.topology = this.topologies.splice(index, 1)[0];
+		this.topologySource.data = this.api.topologyToTree(this.topology);
+	}
+
+	/**
+	 * Used by angular to determine if this node should be a nested tree node.
+	 *
+	 * @param _ Index of the current node.
+	 * @param node Node to test.
+	 * @returns If the node has children.
+	 */
+	public hasChild(_: number, node: TopTreeNode): boolean {
+		return node.children instanceof Array && node.children.length > 0;
+	}
+
+	/**
+	 * Sets the title of the page to either "new" or the name of the displayed
+	 * Topology, depending on the value of TopologyDetailComponent.new.
+	 */
+	private setTitle(): void {
+		const title = this.new ? "New Topology" : `Topology: ${this.topology.name}`;
+		this.navSvc.headerTitle.next(title);
+	}
+
+	/**
+	 * Deletes the Topology.
+	 */
+	public async delete(): Promise<void> {
+		if (this.new) {
+			console.error("Unable to delete new Topology");
+			return;
+		}
+		const ref = this.dialog.open<DecisionDialogComponent, DecisionDialogData, boolean>(
+			DecisionDialogComponent,
+			{
+				data: {
+					message: `Are you sure you want to delete Topology ${this.topology.name}?`,
+					title: "Confirm Delete"
+				}
+			}
+		);
+		ref.afterClosed().subscribe(result => {
+			if (result) {
+				this.api.deleteTopology(this.topology);
+				this.location.replaceState("core/topologies");
+			}
+		});
+	}
+
+	/**
+	 * Submits new/updated Topology.
+	 *
+	 * @param e HTML form submission event.
+	 */
+	public async submit(e: Event): Promise<void> {
+		this.topology = this.api.treeToTopology(this.topology.name, this.topology.description, this.topologySource.data);
+
+		e.preventDefault();
+		e.stopPropagation();
+		this.showErrors = true;
+		if (this.new) {
+			this.topology = await this.api.createTopology(this.topology);
+			this.new = false;
+		} else {
+			this.topology = await this.api.updateTopology(this.topology);
+		}
+		this.setTitle();
+	}
+}

--- a/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.ts
+++ b/experimental/traffic-portal/src/app/core/topologies/topology-details/topology-details.component.ts
@@ -69,14 +69,9 @@ export class TopologyDetailsComponent implements OnInit {
 	 */
 	public async ngOnInit(): Promise<void> {
 		const name = this.route.snapshot.paramMap.get("name");
-		if (name === null) {
-			console.error("missing required route parameter 'name'");
-			this.loading = false;
-			return;
-		}
 
 		const topologiesPromise = this.api.getTopologies().then(topologies => this.topologies = topologies);
-		if (name === "new") {
+		if (name === null) {
 			this.new = true;
 			this.setTitle();
 			await topologiesPromise;


### PR DESCRIPTION
This PR adds the Topologies details page to Traffic Portal v2 with the following restrictions:

- The UI does not yet let you rearrange the cachegroups
- The UI does not yet let you add cachegroups
- The UI does not yet let you remove cachegroups

Depends on ~~apache/trafficcontrol-trafficops-types#4~~ (merged)
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Portal v2

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->