### PR TITLE
Use ID token for OAuth authentication, not Access Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7469](https://github.com/apache/trafficcontrol/pull/7469) *Traffic Ops* Changed logic to not report empty or missing cookies into TO error.log.
 - [#7586](https://github.com/apache/trafficcontrol/pull/7586) *Traffic Ops* Add permission to Operations Role to read from dnsseckeys endpoint.
 - [#7600](https://github.com/apache/trafficcontrol/pull/7600) *t3c* changed default go-direct command line arg to be old to avoid unexpected config changes upon upgrade.
+- [#7621](https://github.com/apache/trafficcontrol/pull/7621) *Traffic Ops* Use ID token for OAuth authentication, not Access Token
 
 ### Fixed
 - [#7608](https://github.com/apache/trafficcontrol/pull/7608) *Traffic Monitor* Use stats_over_http(plugin.system_stats.timestamp_ms) timestamp field to calculate bandwidth for TM's caches.

--- a/lib/go-rfc/jwt.go
+++ b/lib/go-rfc/jwt.go
@@ -1,0 +1,28 @@
+package rfc
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const (
+	// AccessToken is the access_token parameter name described in RFC 6749 <https://datatracker.ietf.org/doc/html/rfc6749#section-1.4>.
+	AccessToken = "access_token"
+
+	// IDToken is the id_token parameter name described in OpenID Connect Core <https://openid.net/specs/openid-connect-core-1_0.html#IDToken>.
+	IDToken = "id_token"
+)

--- a/traffic_ops/app/conf/cdn.conf
+++ b/traffic_ops/app/conf/cdn.conf
@@ -23,6 +23,7 @@
         "db_query_timeout_seconds": 20,
         "whitelisted_oauth_urls": [],
         "oauth_client_secret": "",
+        "oauth_user_attribute": "changeme",
         "traffic_vault_backend": "",
         "traffic_vault_config": {},
         "routing_blacklist": {

--- a/traffic_ops/traffic_ops_golang/api/api.go
+++ b/traffic_ops/traffic_ops_golang/api/api.go
@@ -83,10 +83,7 @@ const (
 	TrafficVaultContextKey = "tv"
 )
 
-const (
-	MojoCookie  = "mojoCookie"
-	AccessToken = "access_token"
-)
+const MojoCookie = "mojoCookie"
 
 const influxServersQuery = `
 SELECT (host_name||'.'||domain_name) as fqdn,
@@ -1091,7 +1088,7 @@ func GetUserFromReq(w http.ResponseWriter, r *http.Request, secret string) (auth
 				continue
 			}
 			switch givenCookie.Name {
-			case AccessToken:
+			case rfc.AccessToken:
 				bearerCookie, readToken, err := getCookieFromAccessToken(givenCookie.Value, secret)
 				if err != nil {
 					return auth.CurrentUser{}, errors.New("unauthorized, please log in."), err, http.StatusUnauthorized
@@ -1155,7 +1152,7 @@ func GetUserFromReq(w http.ResponseWriter, r *http.Request, secret string) (auth
 		}
 
 		http.SetCookie(w, &http.Cookie{
-			Name:     AccessToken,
+			Name:     rfc.AccessToken,
 			Value:    string(jwtSigned),
 			Path:     "/",
 			MaxAge:   newCookie.MaxAge,

--- a/traffic_ops/traffic_ops_golang/cdni/shared.go
+++ b/traffic_ops/traffic_ops_golang/cdni/shared.go
@@ -115,7 +115,7 @@ func getBearerToken(r *http.Request) string {
 	}
 	for _, cookie := range r.Cookies() {
 		switch cookie.Name {
-		case api.AccessToken:
+		case rfc.AccessToken:
 			return cookie.Value
 		}
 	}

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -263,7 +263,7 @@ func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 		}
 
 		http.SetCookie(w, &http.Cookie{
-			Name:     api.AccessToken,
+			Name:     rfc.AccessToken,
 			Value:    string(jwtSigned),
 			Path:     "/",
 			MaxAge:   httpCookie.MaxAge,
@@ -461,15 +461,15 @@ func OauthLoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 		if err := json.Unmarshal(buf.Bytes(), &result); err != nil {
 			log.Warnf("Error parsing JSON response from oAuth: %s", err)
 			encodedToken = buf.String()
-		} else if _, ok := result[api.AccessToken]; !ok {
+		} else if _, ok := result[rfc.IDToken]; !ok {
 			sysErr := fmt.Errorf("Missing access token in response: %s\n", buf.String())
 			usrErr := errors.New("Bad response from OAuth2.0 provider")
 			api.HandleErr(w, r, nil, http.StatusBadGateway, usrErr, sysErr)
 			return
 		} else {
-			switch t := result[api.AccessToken].(type) {
+			switch t := result[rfc.IDToken].(type) {
 			case string:
-				encodedToken = result[api.AccessToken].(string)
+				encodedToken = result[rfc.IDToken].(string)
 			default:
 				sysErr := fmt.Errorf("Incorrect type of access_token! Expected 'string', got '%v'\n", t)
 				usrErr := errors.New("Bad response from OAuth2.0 provider")


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

As specified in OpenID.Core, the [ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) is a required security token that must be a JWT, but nothing requires that access tokens are JWTs, or even that they exist. #7621 makes our OAuth implementation use `id_token`, not `access_token`, which fixes #7626.

#7621 also moves the `AccessToken` and `IDToken` constants to the `rfc` package, because they are standardized.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
