### PR TITLE
Add Oauth to Infra Ansible

### DIFF
--- a/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
+++ b/infrastructure/ansible/roles/traffic_ops/defaults/main.yml
@@ -98,6 +98,10 @@ to_go_supported_ds_metrics:
   - tps_4xx
   - tps_5xx
 
+to_go_whitelisted_oauth_urls: ""
+to_go_oauth_user_attribute: ""
+to_go_oauth_client_secret: ""
+
 to_plugin_config: {}
 
 to_le_user_email: user@example.test

--- a/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
+++ b/infrastructure/ansible/roles/traffic_ops/tasks/traffic_ops.yml
@@ -122,6 +122,12 @@
     dest: "{{ to_tvdb_aes_key_loc }}"
   notify: Restart Traffic Ops
 
+- name: Remove LDAP config if LDAP not used
+  file:
+    path: "{{ to_conf_installdir }}/ldap.conf"
+    state: absent
+  when: not to_ldap_setup
+
 - name: Render Traffic Ops configuration files
   template:
     src: "{{item}}.j2"
@@ -134,9 +140,18 @@
     - production/log4perl.conf
     - production/riak.conf
     - cdn.conf
-    - ldap.conf
     - influxdb.conf
   notify: Restart Traffic Ops
+
+- name: Render Traffic Ops LDAP configuration file
+  template:
+    src: "ldap.conf.j2"
+    owner: "{{ to_user }}"
+    group: "{{ to_group }}"
+    mode: 0600
+    dest: "{{ to_conf_installdir }}/ldap.conf"
+  notify: Restart Traffic Ops
+  when: to_ldap_setup
 
 - name: Upgrade TODB
   command: ./db/admin -env=production upgrade

--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -81,7 +81,10 @@
          "password": "{{ to_riak_username_password }}",
          "MaxTLSVersion": "{{ to_riak_tls_max_version }}"
 {% endif %}
-      }
+      },
+      "whitelisted_oauth_urls": {{ to_go_whitelisted_oauth_urls | to_json }},
+      "oauth_client_secret": "{{ to_go_oauth_client_secret }}",
+      "oauth_user_attribute": "{{ to_go_oauth_user_attribute }}"
    },
    "lets_encrypt": {
       "user_email": "{{ to_le_user_email }}",


### PR DESCRIPTION
Adds oauth configuration parameters to the ansible templates.

This adds whitelisted_oauth_urls and oauth_client_secret as configurable parameters to the traffic ops ansible cdn.conf template.

This also creates logic in the ansible to only deploy ldap configs when ldap is enabled. When ldap is not enabled, the ansible will now ensure the ldap configurations are not present.

## Which Traffic Control components are affected by this PR?
- Automation  --> Ansible infrastructure lab code

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
You can now configure oauth in the lab deployment code by the setting whitelisted_oauth_urls and oauth_client_secret parameters.

## PR submission checklist
- [] This PR has tests -> This is a change to the automation
- [] This PR has documentation -> Change does not require documentation
- [] This PR has a CHANGELOG.md entry -> Does not fig changelog criteria 
- [] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
