### PR TITLE
Make t3c debugging shim inherit the CDN in a Box environment

### DIFF
--- a/infrastructure/cdn-in-a-box/cache/init-debug-scripts.sh
+++ b/infrastructure/cdn-in-a-box/cache/init-debug-scripts.sh
@@ -19,6 +19,12 @@
 
 set -o errexit -o nounset
 
+export_environment() {
+	while IFS= read -r line; do
+		export "$line";
+	done < <(sed '/#/d' /ciab.env)
+}
+
 maybe_debug() {
 	set -o errexit -o nounset
 	hostname="$1"
@@ -47,7 +53,9 @@ for t3c_tool in $(compgen -c t3c | sort | uniq); do
 		actual_binary="${t3c_tool}.actual"
 		<<-DLV_SCRIPT cat > "$dlv_script"
 		#!/usr/bin/env bash
+		$(type export_environment | tail -n+2)
 		$(type maybe_debug | tail -n+2)
+		export_environment
 		maybe_debug "${hostname}" "${DEBUG_PORT}" "${actual_binary}" "\$@"
 		DLV_SCRIPT
 		chmod +x "$dlv_script"

--- a/infrastructure/cdn-in-a-box/cache/run.sh
+++ b/infrastructure/cdn-in-a-box/cache/run.sh
@@ -20,6 +20,9 @@
 trap 'echo "Error on line ${LINENO} of ${0}"; exit 1' ERR
 set -o errexit -o nounset -o pipefail -o xtrace -o monitor
 
+# Needed because on Rocky Linux, cron jobs do not inherit the environment
+env > /ciab.env
+
 set_profile_parameter() {
 	local profile_file="$1" config_file="$2" name="$3" new_value="$4" human_readable="$5"
 	jq=(jq --arg CONFIG_FILE "$config_file" --arg NAME "$name" --arg NEW_VALUE "$new_value")


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

#7647 fixes an issue introduced by switching from `centos:8` to `rockylinux:8` in CDN in a Box, which made cron jobs no longer inherit the environment, which made t3c fail in CDN in a Box when using debug images.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Build and start CDN in a Box using the debug images and include the readiness service:
   ```shell
   docker-compose -f docker-compose.yml -f optional/docker-compose.debugging.yml -f docker-compose.readiness.yml up --build -d
   ```
2. Verify that the readiness container exits successfully (which means that t3c runs as expected):
3. ```shell
   docker-compose -f docker-compose.yml -f optional/docker-compose.debugging.yml -f docker-compose.readiness.yml logs -f trafficrouter readiness
   ```

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
