### PR TITLE
Changes to Ansible role dataset_loader to add ATS 9 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
+- [#7665](https://github.com/apache/trafficcontrol/pull/7665) *Automation* Changes to Ansible role dataset_loader to add ATS 9 support
 ### Added
 - [#7609](https://github.com/apache/trafficcontrol/pull/7609) *Traffic Portal* Added Scope Query Param to SSO login. 
 - [#7450](https://github.com/apache/trafficcontrol/pull/7450) *Traffic Ops* Removed hypnotoad section and added listen field to traffic_ops_golang section in order to simplify cdn config.

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -671,7 +671,7 @@ dl_ds_default_profiles:
         value: tps_total
         secure: 0
 
-dl_ds_ats_major_version: "{{ 8 if dl_ats_version is version('8','>=') else 7 }}"
+dl_ds_ats_major_version: "{{ 9 if dl_ats_version is version('9','>=') else 8 if dl_ats_version is version('8', '>=') else 7 }}"
 
 # ATS Profiles are huge, we should normalize them a big to make them more understandable
 dl_ds_default_profile_layers:
@@ -696,9 +696,6 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.cache.hostdb.sync_frequency
           configFile: records.config
           value: INT 0
-        - name: CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup
-          configFile: records.config
-          value: INT 0
         - name: CONFIG proxy.config.cache.ram_cache_cutoff
           configFile: records.config
           value: "INT {{ (dl_atsec_ram_cache_max_obj_size_mb | float * 1000000) | int }}"
@@ -711,9 +708,6 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.hostdb.serve_stale_for
           configFile: records.config
           value: INT 20
-        - name: CONFIG proxy.config.http.origin_max_connections
-          configFile: records.config
-          value: INT 500
         - name: CONFIG proxy.config.http.parent_proxy.connect_attempts_timeout
           configFile: records.config
           value: INT 2
@@ -805,6 +799,14 @@ dl_ds_default_profile_layers:
         - name: remap_stats.so
           configFile: plugin.config
           value: ''
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections
+          configFile: records.config
+          value: INT 500
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup
+          configFile: records.config
+          value: INT 0
       v8:
         - name: remap_stats.so -p
           configFile: plugin.config
@@ -813,6 +815,19 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.ssl.server.multicert.exit_on_load_fail
           configFile: records.config
           value: INT 0
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections
+          configFile: records.config
+          value: INT 500
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup
+          configFile: records.config
+          value: INT 0
+      v9:
+        # Param change for ATS 9, from proxy.config.http.origin_max_connections
+        - name: CONFIG proxy.config.http.per_server.connection.max
+          configFile: records.config
+          value: INT 500
     mid:
       common:
         - name: location
@@ -836,9 +851,6 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.hostdb.ttl_mode
           configFile: records.config
           value: INT 2
-        - name: CONFIG proxy.config.http.origin_max_connections
-          configFile: records.config
-          value: INT 1500
         - name: CONFIG proxy.config.http.parent_proxy.connect_attempts_timeout
           configFile: records.config
           value: INT 1
@@ -858,7 +870,20 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.cop.active_health_checks
           configFile: records.config
           value: INT 0
-      v8: []
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections
+          configFile: records.config
+          value: INT 1500
+      v8:
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections
+          configFile: records.config
+          value: INT 1500
+      v9:
+        # Param change for ATS 9, from proxy.config.http.origin_max_connections
+        - name: CONFIG proxy.config.http.per_server.connection.max
+          configFile: records.config
+          value: INT 1500
     common:
       common:
         - name: location
@@ -1056,15 +1081,9 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.http.negative_caching_list
           configFile: records.config
           value: STRING 204 305 403 404 405 414 500 501 502 503 504
-        - name: CONFIG proxy.config.http.origin_max_connections_queue
-          configFile: records.config
-          value: INT 0
         - name: CONFIG proxy.config.http.parent_proxy.retry_time
           configFile: records.config
           value: INT 10
-        - name: CONFIG proxy.config.http.parent_proxy_routing_enable
-          configFile: records.config
-          value: INT 1
         - name: CONFIG proxy.config.http.referer_default_redirect
           configFile: records.config
           value: STRING http://www.kabletown.invalid/
@@ -1092,9 +1111,6 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.net.default_inactivity_timeout
           configFile: records.config
           value: INT 180
-        - name: CONFIG proxy.config.net.max_connections_active_in
-          configFile: records.config
-          value: INT 100000
         - name: CONFIG proxy.config.net.max_connections_in
           configFile: records.config
           value: INT 100000
@@ -1216,6 +1232,18 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.http.normalize_ae_gzip
           configFile: records.config
           value: INT 0
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.net.max_connections_active_in
+          configFile: records.config
+          value: INT 100000
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections_queue
+          configFile: records.config
+          value: INT 0
+        # ATS 7 specific param
+        - name: CONFIG proxy.config.http.parent_proxy_routing_enable
+          configFile: records.config
+          value: INT 1
       v8:
         - name: LogFormat.Format
           configFile: logging.yaml
@@ -1297,6 +1325,39 @@ dl_ds_default_profile_layers:
         - name: LOCAL proxy.local.cluster.type
           configFile: records.config
           value: INT 3
+        # Param value changed between ATS 7 & 8
+        - name: CONFIG proxy.config.net.sock_option_flag_in
+          configFile: records.config
+          value: INT 5
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.net.max_connections_active_in
+          configFile: records.config
+          value: INT 100000
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.http.origin_max_connections_queue
+          configFile: records.config
+          value: INT 0
+        # ATS 8 specific param
+        - name: CONFIG proxy.config.http.parent_proxy_routing_enable
+          configFile: records.config
+          value: INT 1
+      v9:
+        # Param change for ATS 9, from proxy.config.net.max_connections_active_in
+        - name: CONFIG proxy.config.net.max_requests_in
+          configFile: records.config
+          value: INT 100000
+        # Param change for ATS 9, from proxy.config.http.origin_max_connections_queue
+        - name: CONFIG proxy.config.http.per_server.connection.queue_size
+          configFile: records.config
+          value: INT 0
+        # Param value changed between ATS 7,9
+        - name: CONFIG proxy.config.net.sock_option_flag_in
+          configFile: records.config
+          value: INT 1
+        # Param value changed between ATS 8 & 9, default is 0
+        - name: CONFIG proxy.config.ssl.handshake_timeout_in
+          configFile: records.config
+          value: INT 30
 
 # TO Profiles (templates) and associated parameters
 # These should be the profiles which vary by CDN association
@@ -1674,6 +1735,12 @@ dl_ds_default_profile_cdntemplates:
     type: ATS_PROFILE
     routingDisabled: false
     parameters: "{{ dl_ds_default_profile_layers.ats.common.common + dl_ds_default_profile_layers.ats.common['v'+dl_ds_ats_major_version] + dl_ds_default_profile_layers.ats.edge.common + dl_ds_default_profile_layers.ats.edge['v'+dl_ds_ats_major_version] }}"
+  - name: "EDGE_ATS_9_{{ Target_cdn_delegation }}"
+    description: "Edge cache({{ Target_cdn_delegation }}) - ATS 9"
+    cdn: "{{ Target_cdn_delegation }}"
+    type: ATS_PROFILE
+    routingDisabled: false
+    parameters: "{{ dl_ds_default_profile_layers.ats.common.common + dl_ds_default_profile_layers.ats.common['v'+dl_ds_ats_major_version] + dl_ds_default_profile_layers.ats.edge.common + dl_ds_default_profile_layers.ats.edge['v'+dl_ds_ats_major_version] }}"
   - name: "MID_ATS_7_{{ Target_cdn_delegation }}"
     description: "Mid cache({{ Target_cdn_delegation }}) - ATS 7"
     cdn: "{{ Target_cdn_delegation }}"
@@ -1682,6 +1749,12 @@ dl_ds_default_profile_cdntemplates:
     parameters: "{{ dl_ds_default_profile_layers.ats.common.common + dl_ds_default_profile_layers.ats.common['v'+dl_ds_ats_major_version] + dl_ds_default_profile_layers.ats.mid.common + dl_ds_default_profile_layers.ats.mid['v'+dl_ds_ats_major_version] }}"
   - name: "MID_ATS_8_{{ Target_cdn_delegation }}"
     description: "Mid cache({{ Target_cdn_delegation }}) - ATS 8"
+    cdn: "{{ Target_cdn_delegation }}"
+    type: ATS_PROFILE
+    routingDisabled: false
+    parameters: "{{ dl_ds_default_profile_layers.ats.common.common + dl_ds_default_profile_layers.ats.common['v'+dl_ds_ats_major_version] + dl_ds_default_profile_layers.ats.mid.common + dl_ds_default_profile_layers.ats.mid['v'+dl_ds_ats_major_version] }}"
+  - name: "MID_ATS_9_{{ Target_cdn_delegation }}"
+    description: "Mid cache({{ Target_cdn_delegation }}) - ATS 9"
     cdn: "{{ Target_cdn_delegation }}"
     type: ATS_PROFILE
     routingDisabled: false

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -1114,9 +1114,9 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.net.max_connections_in
           configFile: records.config
           value: INT 100000
-        #- name: CONFIG proxy.config.net.sock_option_flag_in
-        #  configFile: records.config
-        #  value: INT 13
+        - name: CONFIG proxy.config.net.sock_option_flag_in
+          configFile: records.config
+          value: INT 13
         - name: CONFIG proxy.config.net.sock_option_flag_out
           configFile: records.config
           value: INT 9
@@ -1325,10 +1325,6 @@ dl_ds_default_profile_layers:
         - name: LOCAL proxy.local.cluster.type
           configFile: records.config
           value: INT 3
-        # Param value changed between ATS 7 & 8
-        - name: CONFIG proxy.config.net.sock_option_flag_in
-          configFile: records.config
-          value: INT 5
         # ATS 7,8 specific param
         - name: CONFIG proxy.config.net.max_connections_active_in
           configFile: records.config
@@ -1350,14 +1346,10 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.http.per_server.connection.queue_size
           configFile: records.config
           value: INT 0
-        # Param value changed between ATS 7,9
-        #- name: CONFIG proxy.config.net.sock_option_flag_in
-        #  configFile: records.config
-        #  value: INT 1
         # Param value changed between ATS 8 & 9, default is 0
-        - name: CONFIG proxy.config.ssl.handshake_timeout_in
-          configFile: records.config
-          value: INT 30
+        #- name: CONFIG proxy.config.ssl.handshake_timeout_in
+        #  configFile: records.config
+        #  value: INT 30
 
 # TO Profiles (templates) and associated parameters
 # These should be the profiles which vary by CDN association

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -799,11 +799,11 @@ dl_ds_default_profile_layers:
         - name: remap_stats.so
           configFile: plugin.config
           value: ''
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections
           configFile: records.config
           value: INT 500
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup
           configFile: records.config
           value: INT 0
@@ -815,11 +815,11 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.ssl.server.multicert.exit_on_load_fail
           configFile: records.config
           value: INT 0
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections
           configFile: records.config
           value: INT 500
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.cache.http.compatibility.4-2-0-fixup
           configFile: records.config
           value: INT 0
@@ -870,12 +870,12 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.cop.active_health_checks
           configFile: records.config
           value: INT 0
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections
           configFile: records.config
           value: INT 1500
       v8:
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections
           configFile: records.config
           value: INT 1500
@@ -1114,9 +1114,9 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.net.max_connections_in
           configFile: records.config
           value: INT 100000
-        - name: CONFIG proxy.config.net.sock_option_flag_in
-          configFile: records.config
-          value: INT 13
+        #- name: CONFIG proxy.config.net.sock_option_flag_in
+        #  configFile: records.config
+        #  value: INT 13
         - name: CONFIG proxy.config.net.sock_option_flag_out
           configFile: records.config
           value: INT 9
@@ -1232,15 +1232,15 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.http.normalize_ae_gzip
           configFile: records.config
           value: INT 0
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.net.max_connections_active_in
           configFile: records.config
           value: INT 100000
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections_queue
           configFile: records.config
           value: INT 0
-        # ATS 7 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.parent_proxy_routing_enable
           configFile: records.config
           value: INT 1
@@ -1329,15 +1329,15 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.net.sock_option_flag_in
           configFile: records.config
           value: INT 5
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.net.max_connections_active_in
           configFile: records.config
           value: INT 100000
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.origin_max_connections_queue
           configFile: records.config
           value: INT 0
-        # ATS 8 specific param
+        # ATS 7,8 specific param
         - name: CONFIG proxy.config.http.parent_proxy_routing_enable
           configFile: records.config
           value: INT 1
@@ -1351,9 +1351,9 @@ dl_ds_default_profile_layers:
           configFile: records.config
           value: INT 0
         # Param value changed between ATS 7,9
-        - name: CONFIG proxy.config.net.sock_option_flag_in
-          configFile: records.config
-          value: INT 1
+        #- name: CONFIG proxy.config.net.sock_option_flag_in
+        #  configFile: records.config
+        #  value: INT 1
         # Param value changed between ATS 8 & 9, default is 0
         - name: CONFIG proxy.config.ssl.handshake_timeout_in
           configFile: records.config

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -1346,10 +1346,6 @@ dl_ds_default_profile_layers:
         - name: CONFIG proxy.config.http.per_server.connection.queue_size
           configFile: records.config
           value: INT 0
-        # Param value changed between ATS 8 & 9, default is 0
-        #- name: CONFIG proxy.config.ssl.handshake_timeout_in
-        #  configFile: records.config
-        #  value: INT 30
 
 # TO Profiles (templates) and associated parameters
 # These should be the profiles which vary by CDN association


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR includes several modifications to the main.yml file for the Ansible `dataset_loader` role. Work was undertaken to add ATS 9 support to the `dataset_loader` role to allow a version of ATS 9 to be utilized in a lab/testing environment. Previously, ATS 7 and 8 only were supported by the `dataset_loader` role. ATS 9 specific parameters were added where necessary to replace deprecated ATS 7/8 parameters. Other parameters in `main.yml` that caused spurious log messages in ATS 9 were moved to sections for ATS 7 and 8 in the file.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation - Ansible Roles - `dataset_loader` <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

1. Determine version of ATS 9 to use in lab environment
2. Utilizing Ansible playbooks, build ATC lab environment
3. On lab caches, confirm ATS 9 is installed, running with no errors
4. On lab caches, confirm common and ATS 9-specific parameters are set in appropriate configuration files

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
