### PR TITLE
Explicitly require Java timezone data dependency

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
+++ b/infrastructure/cdn-in-a-box/traffic_router/Dockerfile
@@ -52,7 +52,7 @@ RUN dnf -y install epel-release && \
 
         perl-JSON perl-WWW-Curl which make autoconf automake gcc gcc-c++ apr apr-devel \
         openssl openssl-devel bind-utils net-tools perl-JSON-PP gettext \
-        java-11-openjdk-headless java-11-openjdk-devel tomcat-native && \
+        java-11-openjdk-headless tzdata-java java-11-openjdk-devel tomcat-native && \
     dnf -y clean all && \
     ln -sfv $(realpath /usr/lib/jvm/java-11) /opt/java
 

--- a/infrastructure/docker/build/Dockerfile-traffic_router
+++ b/infrastructure/docker/build/Dockerfile-traffic_router
@@ -46,6 +46,8 @@ RUN	yum -y install \
 		which  \
 		curl \
 		java-11-openjdk \
+		# necessary in case tzdata-java is not already installed as a dependency of java-11-openjdk-headless
+		tzdata-java \
 		java-11-openjdk-devel && \
 	yum -y clean all
 

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -250,6 +250,7 @@
 							</mappings>
 							<requires>
 								<require>java-11-openjdk-headless</require>
+								<require>tzdata-java</require>
 								<require>tomcat >= ${env.TOMCAT_VERSION}.${env.TOMCAT_RELEASE}</require>
 								<require>apr >= 1.4.8</require>
 								<require>tomcat-native >= 1.2.23</require>


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes an error encountered in `java-11-openjdk-11.0.20.0.8-2` on Rocky Linux, where it no longer has `java-tzdata` as a dependency, yet it installs a symlink to the `tzdb.dat` file that would be installed in that dependency. To reproduce:
```shell
$ docker run --rm rockylinux:8 bash -c 'dnf -y install java-11-openjdk-headless && realpath /usr/lib/jvm/java-11-openjdk-*/lib/tzdb.dat'
[...]
realpath: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el8.x86_64/lib/tzdb.dat: No such file or directory
```
The fix is to require that dependency in the Traffic Router maven RPM configuration.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router
- Automation - Traffic Router builder image

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Try to build Traffic Router, verify you don't get an error. Alternatively, just check the result of the CI, which covers this change.

```shell
docker pull rockylinux:8
./pkg -v -b traffic_router_build
````

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [ ] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
