### PR TITLE
V5 logs should return rfc3339 time format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.
+- [#7690](https://github.com/apache/trafficcontrol/pull/7690) *Traffic Ops* Fixes Logs V5 apis to respond with RFC3339 tiestamps.
 - [#7631] (https://github.com/apache/trafficcontrol/pull/7631) *Traffic Ops* Fixes Phys_Location V5 apis to respond with RFC3339 date/time Format
 - [#7623] (https://github.com/apache/trafficcontrol/pull/7623) *Traffic Ops* Removed TryIfModifiedSinceQuery from servicecategories.go and reused from ims.go
 - [#7608](https://github.com/apache/trafficcontrol/pull/7608) *Traffic Monitor* Use stats_over_http(plugin.system_stats.timestamp_ms) timestamp field to calculate bandwidth for TM's caches.

--- a/docs/source/api/v5/logs.rst
+++ b/docs/source/api/v5/logs.rst
@@ -63,7 +63,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
-:lastUpdated: Date and time at which the change was made, in :ref:`non-rfc-datetime`
+:lastUpdated: Date and time at which the change was made, in :rfc:`3339` format
 :level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
 :message:     Log detail about what occurred
 :ticketNum:   Optional field to cross reference with any bug tracking systems
@@ -91,7 +91,7 @@ Response Structure
 		{
 			"ticketNum": null,
 			"level": "APICHANGE",
-			"lastUpdated": "2018-11-14 21:40:06.493975+00",
+			"lastUpdated": "2018-11-14T21:40:06-06:00",
 			"user": "admin",
 			"id": 444,
 			"message": "User [ test ] unlinked from deliveryservice [ 1 | demo1 ]."
@@ -99,7 +99,7 @@ Response Structure
 		{
 			"ticketNum": null,
 			"level": "APICHANGE",
-			"lastUpdated": "2018-11-14 21:37:30.707571+00",
+			"lastUpdated": "2018-11-14T21:37:30-06:00",
 			"user": "admin",
 			"id": 443,
 			"message": "1 delivery services were assigned to test"

--- a/lib/go-tc/log.go
+++ b/lib/go-tc/log.go
@@ -1,5 +1,10 @@
 package tc
 
+import (
+	"github.com/apache/trafficcontrol/lib/go-util"
+	"time"
+)
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -25,6 +30,15 @@ type LogsResponse struct {
 	Alerts
 }
 
+// LogsResponseV5 is a list of Logs as a response, for the latest minor version of api 5.x.
+type LogsResponseV5 = LogsResponseV50
+
+// LogsResponseV50 is a list of Logs as a response, for api version 5.0.
+type LogsResponseV50 struct {
+	Response []LogV50 `json:"response"`
+	Alerts
+}
+
 // Log contains a change that has been made to the Traffic Control system.
 type Log struct {
 	ID          *int    `json:"id"`
@@ -34,6 +48,38 @@ type Log struct {
 	TicketNum   *int    `json:"ticketNum"`
 	User        *string `json:"user"`
 }
+
+// Upgrade changes a Log structure into a LogV5 structure
+func (l Log) Upgrade() LogV5 {
+	logV5 := LogV5{
+		ID:        l.ID,
+		Level:     l.Level,
+		Message:   l.Message,
+		TicketNum: l.TicketNum,
+		User:      l.User,
+	}
+	if l.LastUpdated != nil {
+		t := &l.LastUpdated.Time
+		if t != nil {
+			t, _ := util.ConvertTimeFormat(*t, time.RFC3339)
+			logV5.LastUpdated = t
+		}
+	}
+	return logV5
+}
+
+// LogV50 contains a change that has been made to the Traffic Control system, for api version 5.0.
+type LogV50 struct {
+	ID          *int       `json:"id"`
+	LastUpdated *time.Time `json:"lastUpdated"`
+	Level       *string    `json:"level"`
+	Message     *string    `json:"message"`
+	TicketNum   *int       `json:"ticketNum"`
+	User        *string    `json:"user"`
+}
+
+// LogV5 is the Log structure used by the latest 5.x API version
+type LogV5 = LogV50
 
 // NewLogCountResp is the response returned when the total number of new changes
 // made to the Traffic Control system is requested. "New" means since the last

--- a/traffic_ops/testing/api/conf/traffic-ops-test.conf
+++ b/traffic_ops/testing/api/conf/traffic-ops-test.conf
@@ -28,10 +28,10 @@
         }
     },
     "trafficOpsDB": {
-        "dbname": "to_test",
+        "dbname": "traffic_ops_development",
         "description": "dev database traffic_ops_development",
         "hostname": "localhost",
-        "password": "twelve",
+        "password": "twelve12",
         "port": "5432",
         "type": "Pg",
         "user": "traffic_ops"

--- a/traffic_ops/testing/api/conf/traffic-ops-test.conf
+++ b/traffic_ops/testing/api/conf/traffic-ops-test.conf
@@ -28,10 +28,10 @@
         }
     },
     "trafficOpsDB": {
-        "dbname": "traffic_ops_development",
+        "dbname": "to_test",
         "description": "dev database traffic_ops_development",
         "hostname": "localhost",
-        "password": "twelve12",
+        "password": "twelve",
         "port": "5432",
         "type": "Pg",
         "user": "traffic_ops"

--- a/traffic_ops/testing/api/v5/logs_test.go
+++ b/traffic_ops/testing/api/v5/logs_test.go
@@ -70,7 +70,7 @@ func TestLogs(t *testing.T) {
 
 func validateLogsFields(expectedResp map[string]interface{}) utils.CkReqFunc {
 	return func(t *testing.T, _ toclientlib.ReqInf, resp interface{}, _ tc.Alerts, _ error) {
-		logs := resp.([]tc.Log)
+		logs := resp.([]tc.LogV5)
 		for field, expected := range expectedResp {
 			for _, log := range logs {
 				switch field {

--- a/traffic_ops/traffic_ops_golang/logs/log.go
+++ b/traffic_ops/traffic_ops_golang/logs/log.go
@@ -94,10 +94,24 @@ func Getv40(w http.ResponseWriter, r *http.Request) {
 		api.WriteAlerts(w, r, http.StatusInternalServerError, a)
 		return
 	}
-	if a.HasAlerts() {
-		api.WriteAlertsObj(w, r, 200, a, logs)
+	var result interface{}
+	var logsV5 []tc.LogV5
+	if inf.Version.GreaterThanOrEqualTo(&api.Version{
+		Major: 5,
+		Minor: 0,
+	}) {
+		for _, l := range logs {
+			logV5 := l.Upgrade()
+			logsV5 = append(logsV5, logV5)
+		}
+		result = logsV5
 	} else {
-		api.WriteRespWithSummary(w, r, logs, count)
+		result = logs
+	}
+	if a.HasAlerts() {
+		api.WriteAlertsObj(w, r, 200, a, result)
+	} else {
+		api.WriteRespWithSummary(w, r, result, count)
 	}
 }
 

--- a/traffic_ops/v5-client/log.go
+++ b/traffic_ops/v5-client/log.go
@@ -24,8 +24,8 @@ import (
 const apiLogs = "/logs"
 
 // GetLogs gets a list of logs.
-func (to *Session) GetLogs(opts RequestOptions) (tc.LogsResponse, toclientlib.ReqInf, error) {
-	var data tc.LogsResponse
+func (to *Session) GetLogs(opts RequestOptions) (tc.LogsResponseV5, toclientlib.ReqInf, error) {
+	var data tc.LogsResponseV5
 	reqInf, err := to.get(apiLogs, opts, &data)
 	return data, reqInf, err
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to any issue. It fixes the timestamp for the `logs` api in version 5.0. 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Make sure all the tests pass.
Hit the `logs` api on version 5.0 and make sure that the timestamps being returned are in rfc3339 format.
## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
