### PR TITLE
Added api contract test case for staticdnsentries endpoint

### DIFF
--- a/traffic_ops/testing/api_contract/v4/data/request_template.json
+++ b/traffic_ops/testing/api_contract/v4/data/request_template.json
@@ -446,5 +446,14 @@
 			"ipAddress": "::1/1",
 			"typeId": 37
 		}
+	],
+	"static_dns_entries": [
+		{
+			"address": "2001::cafe:c935",
+			"deliveryserviceId": 37,
+			"host": "test",
+			"ttl": 300,
+			"typeId": 41
+		}
 	]
 }

--- a/traffic_ops/testing/api_contract/v4/data/response_template.json
+++ b/traffic_ops/testing/api_contract/v4/data/response_template.json
@@ -1897,5 +1897,62 @@
                 "type": "string"
             }
         }
+    },
+    "static_dns_entries": {
+        "type": "object",
+        "required": [
+            "address",
+            "cachegroup",
+            "cachegroupId",
+            "deliveryservice",
+            "deliveryserviceId",
+            "host",
+            "id",
+            "lastUpdated",
+            "ttl",
+            "type",
+            "typeId"
+        ],
+        "properties": {
+            "address": {
+                "type": "string"
+            },
+            "cachegroup": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
+            "cachegroupId": {
+                "type": [
+                    "null",
+                    "integer"
+                ]
+            },
+            "deliveryservice": {
+                "type": "string"
+            },
+            "deliveryserviceId": {
+                "type": "integer"
+            },
+            "host": {
+                "type": "string"
+            },
+            "id": {
+                "type": "integer"
+            },
+            "lastUpdated": {
+                "type": "string"
+            },
+            "ttl": {
+                "type": "integer"
+            },
+            "type": {
+                "type": "string"
+            },
+            "typeId": {
+                "type": "integer"
+            }
+        }
     }
 }

--- a/traffic_ops/testing/api_contract/v4/test_static_dns_entries.py
+++ b/traffic_ops/testing/api_contract/v4/test_static_dns_entries.py
@@ -1,0 +1,81 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""API Contract Test Case for staticdnsentries endpoint."""
+import logging
+from typing import Union
+import pytest
+import requests
+from jsonschema import validate
+
+from trafficops.tosession import TOSession
+
+# Create and configure logger
+logger = logging.getLogger()
+
+Primitive = Union[bool, int, float, str, None]
+
+
+def test_static_dns_entries_contract(to_session: TOSession,
+	response_template_data: dict[str, Union[Primitive, list[Union[Primitive,
+							dict[str, object], list[object]]], dict[object, object]]],
+	static_dns_entries_post_data: dict[str, object]
+) -> None:
+	"""
+	Test step to validate keys, values and data types from static_dns_entries endpoint
+	response.
+	:param to_session: Fixture to get Traffic Ops session.
+	:param response_template_data: Fixture to get response template data from a prerequisites file.
+	:param static_dns_entries_post_data: Fixture to get delivery services sslkeys data.
+	"""
+	# validate static_dns_entries keys from api get response
+	logger.info("Accessing /static_dns_entries endpoint through Traffic ops session.")
+
+	static_dns_entries_id = static_dns_entries_post_data["id"]
+	if not isinstance(static_dns_entries_id, int):
+		raise TypeError("malformed API response; 'id' property not a string")
+
+	static_dns_entries_get_response: tuple[
+		Union[dict[str, object], list[Union[dict[str, object], list[object], Primitive]], Primitive],
+		requests.Response
+	] = to_session.get_staticdnsentries(query_params={"id":static_dns_entries_id})
+	try:
+		static_dns_entries_data = static_dns_entries_get_response[0]
+		if not isinstance(static_dns_entries_data, list):
+			raise TypeError(
+				"malformed API response; static_dns_entries in response is not an list")
+		first_static_dns_entries = static_dns_entries_data[0]
+		if not isinstance(first_static_dns_entries, dict):
+			raise TypeError(
+				"malformed API response; first static_dns_entries in response is not a dict")
+
+		logger.info("static_dns_entries Api get response %s", first_static_dns_entries)
+
+		static_dns_entries_response_template = response_template_data.get(
+			"static_dns_entries")
+		if not isinstance(static_dns_entries_response_template, dict):
+			raise TypeError(f"static_dns_entries response template data must be a dict, not '"
+							f"{type(static_dns_entries_response_template)}'")
+
+		keys = ["deliveryserviceId", "address", "ttl", "typeId", "host"]
+		prereq_values = [static_dns_entries_post_data[key] for key in keys]
+		get_values = [first_static_dns_entries[key] for key in keys]
+
+		assert validate(instance=first_static_dns_entries,
+		  schema=static_dns_entries_response_template) is None
+		assert get_values == prereq_values
+	except IndexError:
+		logger.error("Either prerequisite data or API response was malformed")
+		pytest.fail(
+			"API contract test failed for static_dns_entries endpoint: API response was malformed")


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Added api contract test case for staticdnsentries endpoint
<!-- **^ Add meaningful description above** --><hr/>


## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops Test


## What is the best way to verify this PR?

Step 1 : Follow steps from README file(traffic_ops/testing/api_contract) to run api-contract-tests.

Step 2 : To execute API Contract Testcase , navigate to traffic_ops/testing/api_contract/v4
pytest --to-user Username --to-password Password --to-url URL --config Config Path --request-template Request template --response-template Response template 

Note: Config, Request template and response template paths are optional. 

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
