### PR TITLE
add automatic self-healing when using slice plugin to t3c

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [8.0.0] - 2023-09-20
 ### Added
+<<<<<<< HEAD
 - [#7672](https://github.com/apache/trafficcontrol/pull/7672) *Traffic Control Health Client*: Added peer monitor flag while using `strategies.yaml`.
 - [#7609](https://github.com/apache/trafficcontrol/pull/7609) *Traffic Portal*: Added Scope Query Param to SSO login.
 - [#7450](https://github.com/apache/trafficcontrol/pull/7450) *Traffic Ops*: Removed hypnotoad section and added listen field to traffic_ops_golang section in order to simplify cdn config.
@@ -53,6 +54,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7652](https://github.com/apache/trafficcontrol/pull/7652) *Traffic Control Cache Config (t3c)*: added rpmdb checks and use package data from t3c-apply-metadata.json if rpmdb is corrupt.
 - [#7674](https://github.com/apache/trafficcontrol/issues/7674) *Traffic Ops*: Add the ability to indicate if a server failed its revalidate/config update.
 - [#7784](https://github.com/apache/trafficcontrol/pull/7784) *Traffic Portal*: Added revert certificate functionality to the ssl-keys page.
+- [#7719](https://github.com/apache/trafficcontrol/pull/7719) *t3c* self-healing will be added automatically when using the slice plugin.
 
 ### Changed
 - [#7776](https://github.com/apache/trafficcontrol/pull/7776) *tc-health-client*: Added error message while issues interacting with Traffic Ops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [8.0.0] - 2023-09-20
 ### Added
-<<<<<<< HEAD
 - [#7672](https://github.com/apache/trafficcontrol/pull/7672) *Traffic Control Health Client*: Added peer monitor flag while using `strategies.yaml`.
 - [#7609](https://github.com/apache/trafficcontrol/pull/7609) *Traffic Portal*: Added Scope Query Param to SSO login.
 - [#7450](https://github.com/apache/trafficcontrol/pull/7450) *Traffic Ops*: Removed hypnotoad section and added listen field to traffic_ops_golang section in order to simplify cdn config.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -676,6 +676,8 @@ Describes how HTTP "Range Requests" should be handled by the Delivery Service at
 3
 	Use the `slice <https://github.com/apache/trafficserver/tree/master/plugins/experimental/slice>`_ plugin to slice range based requests into deterministic chunks. (Aliased as "3 - Use slice plugin" in Traffic Portal forms)
 
+	.. note:: The ``-–consider-ims`` parameter will automatically be added to the remap line by :term:`t3c` for self healing. If any other range request parameters are being used you must also include ``--consider-ims`` to enable self healing.
+
 		.. versionadded:: ATCv4.1
 
 .. note:: Range Request Handling can only be implemented on :term:`cache servers` using :abbr:`ATS (Apache Traffic Server)` because of its dependence on :abbr:`ATS (Apache Traffic Server)` plugins. The value may be set on any Delivery Service, but will have no effect when the :term:`cache servers` that ultimately end up serving the content are e.g. Grove, Nginx, etc.

--- a/docs/source/overview/delivery_services.rst
+++ b/docs/source/overview/delivery_services.rst
@@ -676,7 +676,7 @@ Describes how HTTP "Range Requests" should be handled by the Delivery Service at
 3
 	Use the `slice <https://github.com/apache/trafficserver/tree/master/plugins/experimental/slice>`_ plugin to slice range based requests into deterministic chunks. (Aliased as "3 - Use slice plugin" in Traffic Portal forms)
 
-	.. note:: The ``-–consider-ims`` parameter will automatically be added to the remap line by :term:`t3c` for self healing. If any other range request parameters are being used you must also include ``--consider-ims`` to enable self healing.
+	.. note:: The ``-–consider-ims`` parameter will automatically be added to the remap line by :term:`t3c` for self healing. If any other range request parameters are being used you must also include ``--consider-ims`` to enable self healing. Automatic self healing can be disabled by adding a remap.config parameter with a value of ``no_self_healing``
 
 		.. versionadded:: ATCv4.1
 

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -240,6 +240,9 @@ func paramsStringFor(parameters []tc.ParameterV5, warnings *[]string) (paramsStr
 	uniquemap := map[string]int{}
 
 	for _, param := range parameters {
+		if strings.TrimSpace(param.Value) == "" {
+			continue
+		}
 		paramsString += " @pparam=" + param.Value
 
 		// Try to extract argument

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -757,6 +757,7 @@ func buildEdgeRemapLine(
 	rangeReqTxt := ""
 	if ds.RangeRequestHandling != nil {
 		crr := false
+		addIms := false
 
 		if *ds.RangeRequestHandling == tc.RangeRequestHandlingBackgroundFetch {
 			rangeReqTxt = `@plugin=background_fetch.so @pparam=--config=bg_fetch.config` +
@@ -767,6 +768,7 @@ func buildEdgeRemapLine(
 				paramsStringFor(dsConfigParamsMap["slice.pparam"], &warnings)
 			rangeReqTxt += ` `
 			crr = true
+			addIms = true
 		} else if *ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest {
 			crr = true
 		}
@@ -774,6 +776,9 @@ func buildEdgeRemapLine(
 		if crr {
 			rangeReqTxt += `@plugin=cache_range_requests.so ` +
 				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
+		}
+		if addIms {
+			rangeReqTxt += `@pparam=--consider-ims `
 		}
 	}
 

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -425,6 +425,7 @@ func getServerConfigRemapDotConfigForMid(
 			remapTags.RangeRequests = `@plugin=cache_range_requests.so`
 			if rqParam != "" {
 				remapTags.RangeRequests += rqParam
+				//this check may seem excessive, but I want to be sure we don't have --consider-ims in remap twice
 			} else if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
 				remapTags.RangeRequests += ` @pparam=--consider-ims`
 			}
@@ -781,6 +782,7 @@ func buildEdgeRemapLine(
 			rangeReqTxt += `@plugin=cache_range_requests.so `
 			if rqParam != "" {
 				rangeReqTxt += rqParam
+				//this check may seem excessive, but I want to be sure we don't have --consider-ims in remap twice
 			} else if !strings.Contains(rangeReqTxt, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && ds.RangeSliceBlockSize != nil {
 				rangeReqTxt += `@pparam=--consider-ims`
 			}

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -71,12 +71,12 @@ const RemapConfigTemplateLast = `template.last`
 const DefaultFirstRemapConfigTemplateString = `map {{{Source}}} {{{Destination}}} {{{Strategy}}} {{{Dscp}}} {{{HeaderRewrite}}} {{{DropQstring}}} {{{Signing}}} {{{RegexRemap}}} {{{Cachekey}}} {{{RangeRequests}}} {{{Pacing}}} {{{RawText}}}`
 const DefaultLastRemapConfigTemplateString = `map {{{Source}}} {{{Destination}}} {{{Strategy}}} {{{HeaderRewrite}}} {{{Cachekey}}} {{{RangeRequests}}} {{{RawText}}}`
 const DefaultInnerRemapConfigTemplateString = DefaultLastRemapConfigTemplateString
+const selfHealParam = `no_self_healing`
 
 type LineTemplates map[string]*mustache.Template
 
 var RemapLineTemplates = LineTemplates{}
-var selfHealParam = `no_self_healing`
-var noSelfHeal bool
+var selfHeal = true
 
 // This parses but also maintains a cache of parsed templates
 func (lts *LineTemplates) parse(templateString string) (*mustache.Template, error) {
@@ -232,7 +232,7 @@ func classifyConfigParams(configParams []tc.ParameterV5) map[string][]tc.Paramet
 		if "remap.config" == key {
 			key = param.Name
 			if param.Value == selfHealParam {
-				noSelfHeal = true
+				selfHeal = false
 				continue
 			}
 		}
@@ -416,7 +416,7 @@ func getServerConfigRemapDotConfigForMid(
 			cachekeyArgs = getQStringIgnoreRemap(atsMajorVersion)
 		}
 
-		noSelfHeal = false
+		selfHeal = true
 		dsConfigParamsMap := map[string][]tc.ParameterV5{}
 		if nil != ds.ProfileID {
 			dsConfigParamsMap = classifyConfigParams(profilesConfigParams[*ds.ProfileID])
@@ -433,7 +433,7 @@ func getServerConfigRemapDotConfigForMid(
 		if ds.RangeRequestHandling != nil && (*ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest || *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice) {
 			crrParam := paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
 			remapTags.RangeRequests = `@plugin=cache_range_requests.so` + crrParam
-			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && !strings.Contains(crrParam, "--consider-ims") && !noSelfHeal {
+			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && !strings.Contains(crrParam, "--consider-ims") && selfHeal {
 				remapTags.RangeRequests += ` @pparam=--consider-ims`
 			}
 		}
@@ -707,7 +707,7 @@ func buildEdgeRemapLine(
 		remapTags.HeaderRewrite = `@plugin=header_rewrite.so @pparam=` + edgeHeaderRewriteConfigFileName(ds.XMLID)
 	}
 
-	noSelfHeal = false
+	selfHeal = true
 	dsConfigParamsMap := classifyConfigParams(remapConfigParams)
 
 	if ds.SigningAlgorithm != nil && *ds.SigningAlgorithm != "" {
@@ -787,7 +787,7 @@ func buildEdgeRemapLine(
 
 		if crr {
 			rangeReqTxt += `@plugin=cache_range_requests.so ` + paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
-			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && !strings.Contains(rangeReqTxt, "--consider-ims") && !noSelfHeal {
+			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && !strings.Contains(rangeReqTxt, "--consider-ims") && selfHeal {
 				rangeReqTxt += ` @pparam=--consider-ims`
 			}
 		}

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -423,7 +423,7 @@ func getServerConfigRemapDotConfigForMid(
 		if ds.RangeRequestHandling != nil && (*ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest || *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice) {
 			remapTags.RangeRequests = `@plugin=cache_range_requests.so` +
 				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
-			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
+			if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
 				remapTags.RangeRequests += ` @pparam=--consider-ims`
 			}
 		}
@@ -760,7 +760,6 @@ func buildEdgeRemapLine(
 	rangeReqTxt := ""
 	if ds.RangeRequestHandling != nil {
 		crr := false
-		addIms := false
 
 		if *ds.RangeRequestHandling == tc.RangeRequestHandlingBackgroundFetch {
 			rangeReqTxt = `@plugin=background_fetch.so @pparam=--config=bg_fetch.config` +
@@ -771,7 +770,6 @@ func buildEdgeRemapLine(
 				paramsStringFor(dsConfigParamsMap["slice.pparam"], &warnings)
 			rangeReqTxt += ` `
 			crr = true
-			addIms = true
 		} else if *ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest {
 			crr = true
 		}
@@ -779,9 +777,9 @@ func buildEdgeRemapLine(
 		if crr {
 			rangeReqTxt += `@plugin=cache_range_requests.so ` +
 				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
-		}
-		if addIms {
-			rangeReqTxt += `@pparam=--consider-ims `
+			if !strings.Contains(rangeReqTxt, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && ds.RangeSliceBlockSize != nil {
+				rangeReqTxt += ` @pparam=--consider-ims`
+			}
 		}
 	}
 

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -423,6 +423,9 @@ func getServerConfigRemapDotConfigForMid(
 		if ds.RangeRequestHandling != nil && (*ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest || *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice) {
 			remapTags.RangeRequests = `@plugin=cache_range_requests.so` +
 				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
+			if *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
+				remapTags.RangeRequests += ` @pparam=--consider-ims`
+			}
 		}
 
 		isLastCache, err := serverIsLastCacheForDS(server, &ds, nameTopologies, cacheGroups)

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -421,9 +421,11 @@ func getServerConfigRemapDotConfigForMid(
 		}
 
 		if ds.RangeRequestHandling != nil && (*ds.RangeRequestHandling == tc.RangeRequestHandlingCacheRangeRequest || *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice) {
-			remapTags.RangeRequests = `@plugin=cache_range_requests.so` +
-				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
-			if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
+			rqParam := paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
+			remapTags.RangeRequests = `@plugin=cache_range_requests.so`
+			if rqParam != "" {
+				remapTags.RangeRequests += rqParam
+			} else if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
 				remapTags.RangeRequests += ` @pparam=--consider-ims`
 			}
 		}
@@ -775,10 +777,12 @@ func buildEdgeRemapLine(
 		}
 
 		if crr {
-			rangeReqTxt += `@plugin=cache_range_requests.so ` +
-				paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
-			if !strings.Contains(rangeReqTxt, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && ds.RangeSliceBlockSize != nil {
-				rangeReqTxt += ` @pparam=--consider-ims`
+			rqParam := paramsStringFor(dsConfigParamsMap["cache_range_requests.pparam"], &warnings)
+			rangeReqTxt += `@plugin=cache_range_requests.so `
+			if rqParam != "" {
+				rangeReqTxt += rqParam
+			} else if !strings.Contains(rangeReqTxt, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && ds.RangeSliceBlockSize != nil {
+				rangeReqTxt += `@pparam=--consider-ims`
 			}
 		}
 	}

--- a/lib/go-atscfg/remapdotconfig.go
+++ b/lib/go-atscfg/remapdotconfig.go
@@ -428,8 +428,8 @@ func getServerConfigRemapDotConfigForMid(
 			remapTags.RangeRequests = `@plugin=cache_range_requests.so`
 			if rqParam != "" {
 				remapTags.RangeRequests += rqParam
-				//this check may seem excessive, but I want to be sure we don't have --consider-ims in remap twice
-			} else if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice {
+			}
+			if !strings.Contains(remapTags.RangeRequests, `@pparam=--consider-ims`) && *ds.RangeRequestHandling == tc.RangeRequestHandlingSlice && rqParam != "" {
 				remapTags.RangeRequests += ` @pparam=--consider-ims`
 			}
 		}

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -1630,7 +1630,7 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 			DeliveryService: *ds.ID,
 		},
 		DeliveryServiceServer{
-			Server:          *server.ID,
+			Server:          server.ID,
 			DeliveryService: *ds2.ID,
 		},
 	}
@@ -5666,7 +5666,7 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
 		},
-		tc.Parameter{
+		tc.ParameterV5{
 			Name:       "cache_range_requests.pparam",
 			ConfigFile: "remap.config",
 			Value:      "",
@@ -5823,7 +5823,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
 		},
-		tc.Parameter{
+		tc.ParameterV5{
 			Name:       "cache_range_requests.pparam",
 			ConfigFile: "remap.config",
 			Value:      "",

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -1692,7 +1692,7 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 	txt = strings.TrimSpace(txt)
 
 	if !strings.Contains(txt, "@pparam=--consider-ims") {
-		t.Fatalf("expected '--consider-ims' param with 'cache_range_requests.so' when using slice plugin to enable self healing, actual: %s", txt)
+		t.Errorf("expected '--consider-ims' param with 'cache_range_requests.so' when using slice plugin to enable self healing, actual: %s", txt)
 	}
 	testComment(t, txt, hdr)
 

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -1686,6 +1686,7 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 	txt := cfg.Text
 
 	txt = strings.TrimSpace(txt)
+
 	if !strings.Contains(txt, "@pparam=--consider-ims") {
 		t.Fatalf("expected '--consider-ims' param with 'cache_range_requests.so' when using slice plugin to enable self healing, actual: %s", txt)
 	}

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -1686,7 +1686,9 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 	txt := cfg.Text
 
 	txt = strings.TrimSpace(txt)
-
+	if !strings.Contains(txt, "@pparam=--consider-ims") {
+		t.Fatalf("expected '--consider-ims' param with 'cache_range_requests.so' when using slice plugin to enable self healing, actual: %s", txt)
+	}
 	testComment(t, txt, hdr)
 
 	txtLines := strings.Split(txt, "\n")
@@ -5562,6 +5564,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
 	}
 
+	if !strings.Contains(remapLine, "@pparam=--consider-ims") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain parameter --consider-ims for self healing, actual '%s", txt)
+	}
+
 	if !strings.Contains(remapLine, "pparam=--blockbytes=262144") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
 	}
@@ -5700,6 +5706,10 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 
 	if !strings.Contains(remapLine, "--consider-ims") {
 		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
+	}
+
+	if strings.Count(remapLine, "--consider-ims") > 1 {
+		t.Errorf("expected remap on mid server with ds slice range request handling to contain one occurance of plugin arg --consider-ims, actual '%s'", txt)
 	}
 
 	if strings.Contains(remapLine, "pparam=--blockbytes") {
@@ -5850,6 +5860,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 
 	if !strings.Contains(remapLine, "--consider-ims") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
+	}
+
+	if strings.Count(remapLine, "--consider-ims") > 1 {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain one occurance of plugin arg --consider-ims, actual '%s'", txt)
 	}
 
 	if !strings.Contains(remapLine, "--no-modify-cachekey") {

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -5704,6 +5704,10 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
 	}
 
+	if !strings.Contains(remapLine, "--consider-ims") {
+		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
+	}
+
 	if strings.Contains(remapLine, "pparam=--blockbytes") {
 		t.Errorf("did not expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
 	}
@@ -5848,6 +5852,10 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 
 	if !strings.Contains(remapLine, "cache_range_requests.so") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "--consider-ims") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
 	}
 
 	if !strings.Contains(remapLine, "--no-modify-cachekey") {

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -5666,6 +5666,12 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
 		},
+		tc.Parameter{
+			Name:       "cache_range_requests.pparam",
+			ConfigFile: "remap.config",
+			Value:      "",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
 	}
 
 	cdn := &tc.CDNV5{
@@ -5696,7 +5702,7 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 	}
 
 	remapLine := txtLines[2]
-
+	words := strings.Fields(remapLine)
 	if !strings.HasPrefix(remapLine, "map") {
 		t.Errorf("expected to start with 'map', actual '%v'", txt)
 	}
@@ -5715,6 +5721,11 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 
 	if strings.Contains(remapLine, "pparam=--blockbytes") {
 		t.Errorf("did not expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
+	}
+	for _, word := range words {
+		if word == "@pparam=" {
+			t.Errorf("expected remap on mid server with empty 'cache_range_requests.pparam' to be skipped and not have empty '@pparam=' on remapline, actual %s", txt)
+		}
 	}
 }
 
@@ -5812,6 +5823,12 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
 		},
+		tc.Parameter{
+			Name:       "cache_range_requests.pparam",
+			ConfigFile: "remap.config",
+			Value:      "",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
 	}
 
 	cdn := &tc.CDNV5{
@@ -5842,6 +5859,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 	}
 
 	remapLine := txtLines[2]
+	words := strings.Fields(remapLine)
 
 	if !strings.HasPrefix(remapLine, "map") {
 		t.Errorf("expected to start with 'map', actual '%v'", txt)
@@ -5869,6 +5887,11 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 
 	if !strings.Contains(remapLine, "pparam=--blockbytes=262144") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
+	}
+	for _, word := range words {
+		if word == "@pparam=" {
+			t.Errorf("expected remap on edge server with empty 'cache_range_requests.pparam' to be skipped and not have empty '@pparam=' on remapline, actual %s", txt)
+		}
 	}
 }
 

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -5578,6 +5578,151 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlice(t *testing.T) {
 	}
 }
 
+func TestMakeRemapDotConfigMidRangeRequestSliceNoAutoSelfHeal(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	server := makeTestRemapServer()
+	server.Type = "MID"
+	servers := []Server{}
+
+	ds := DeliveryService{}
+	ds.ID = util.Ptr(48)
+	dsType := "HTTP_LIVE_NATNL"
+	ds.Type = &dsType
+	ds.OrgServerFQDN = util.Ptr("origin.example.test")
+	ds.MidHeaderRewrite = util.Ptr("")
+	ds.RangeRequestHandling = util.Ptr(tc.RangeRequestHandlingSlice)
+	ds.RemapText = util.Ptr("myremaptext")
+	ds.EdgeHeaderRewrite = nil
+	ds.SigningAlgorithm = util.Ptr("foo")
+	ds.XMLID = "mydsname"
+	ds.QStringIgnore = util.Ptr(int(tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp))
+	ds.RegexRemap = util.Ptr("")
+	ds.FQPacingRate = util.Ptr(0)
+	ds.DSCP = 0
+	ds.RoutingName = "myroutingname"
+	ds.MultiSiteOrigin = false
+	ds.OriginShield = util.Ptr("myoriginshield")
+	ds.ProfileID = util.Ptr(49)
+	ds.ProfileName = util.Ptr("dsprofile")
+	ds.Protocol = util.Ptr(int(tc.DSProtocolHTTPToHTTPS))
+	ds.AnonymousBlockingEnabled = false
+	ds.Active = tc.DSActiveStateActive
+	ds.RangeSliceBlockSize = util.Ptr(262144)
+
+	dses := []DeliveryService{ds}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          server.ID,
+			DeliveryService: *ds.ID,
+		},
+	}
+
+	dsRegexes := []tc.DeliveryServiceRegexes{
+		tc.DeliveryServiceRegexes{
+			DSName: ds.XMLID,
+			Regexes: []tc.DeliveryServiceRegex{
+				tc.DeliveryServiceRegex{
+					Type:      string(tc.DSMatchTypeHostRegex),
+					SetNumber: 0,
+					Pattern:   `myliteralpattern__http__foo`,
+				},
+			},
+		},
+	}
+
+	serverParams := []tc.ParameterV5{
+		tc.ParameterV5{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "9",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.ParameterV5{
+			Name:       "serverpkgval",
+			ConfigFile: "package",
+			Value:      "serverpkgval __HOSTNAME__ foo",
+			Profiles:   []byte(server.Profiles[0]),
+		},
+		tc.ParameterV5{
+			Name:       "dscp_remap_no",
+			ConfigFile: "package",
+			Value:      "notused",
+			Profiles:   []byte(server.Profiles[0]),
+		},
+	}
+
+	remapConfigParams := []tc.ParameterV5{
+		tc.ParameterV5{
+			Name:       "not_location",
+			ConfigFile: "cachekey.config",
+			Value:      "notinconfig",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.ParameterV5{
+			Name:       "cache_range_requests.pparam",
+			ConfigFile: "remap.config",
+			Value:      selfHealParam,
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+	}
+
+	cdn := &tc.CDNV5{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	topologies := []tc.TopologyV5{}
+	cgs := []tc.CacheGroupNullableV5{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, servers, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, hdr)
+
+	txtLines := strings.Split(txt, "\n")
+
+	if len(txtLines) != 3 { // comment, blank, and remap
+		t.Fatalf("expected a comment header, a blank line, and 1 remaps from HTTP_TO_HTTPS DS, actual: '%v' count %v", txt, len(txtLines))
+	}
+
+	remapLine := txtLines[2]
+	words := strings.Fields(remapLine)
+	if !strings.HasPrefix(remapLine, "map") {
+		t.Errorf("expected to start with 'map', actual '%v'", txt)
+	}
+
+	if strings.Contains(remapLine, "slice.so") {
+		t.Errorf("did not expected remap on mid server with ds slice range request handling to contain slice plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "cache_range_requests.so") {
+		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
+	}
+
+	if strings.Contains(remapLine, "--consider-ims") {
+		t.Errorf("expected remap on mid server with ds slice range request handling and '%s' param to not contain cache_range_requests plugin arg --consider-ims, actual '%v'", selfHealParam, txt)
+	}
+
+	if strings.Contains(remapLine, "pparam=--blockbytes") {
+		t.Errorf("did not expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
+	}
+	for _, word := range words {
+		if word == "@pparam=" {
+			t.Errorf("expected remap on mid server with empty 'cache_range_requests.pparam' to be skipped and not have empty '@pparam=' on remapline, actual %s", txt)
+		}
+	}
+}
+
 func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 	hdr := "myHeaderComment"
 
@@ -5666,12 +5811,6 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
 		},
-		tc.ParameterV5{
-			Name:       "cache_range_requests.pparam",
-			ConfigFile: "remap.config",
-			Value:      "",
-			Profiles:   []byte(`["dsprofile"]`),
-		},
 	}
 
 	cdn := &tc.CDNV5{
@@ -5725,6 +5864,166 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 	for _, word := range words {
 		if word == "@pparam=" {
 			t.Errorf("expected remap on mid server with empty 'cache_range_requests.pparam' to be skipped and not have empty '@pparam=' on remapline, actual %s", txt)
+		}
+	}
+}
+
+func TestMakeRemapDotConfigEdgeRangeRequestSliceNoAutoSelfHeal(t *testing.T) {
+	hdr := "myHeaderComment"
+
+	server := makeTestRemapServer()
+	server.Type = "EDGE"
+	servers := []Server{}
+
+	ds := DeliveryService{}
+	ds.ID = util.Ptr(48)
+	dsType := "HTTP_LIVE_NATNL"
+	ds.Type = &dsType
+	ds.OrgServerFQDN = util.Ptr("origin.example.test")
+	ds.MidHeaderRewrite = util.Ptr("")
+	ds.RangeRequestHandling = util.Ptr(tc.RangeRequestHandlingSlice)
+	ds.RemapText = util.Ptr("myremaptext")
+	ds.EdgeHeaderRewrite = nil
+	ds.SigningAlgorithm = util.Ptr("foo")
+	ds.XMLID = "mydsname"
+	ds.QStringIgnore = util.Ptr(int(tc.QueryStringIgnoreIgnoreInCacheKeyAndPassUp))
+	ds.RegexRemap = util.Ptr("")
+	ds.FQPacingRate = util.Ptr(0)
+	ds.DSCP = 0
+	ds.RoutingName = "myroutingname"
+	ds.MultiSiteOrigin = false
+	ds.OriginShield = util.Ptr("myoriginshield")
+	ds.ProfileID = util.Ptr(49)
+	ds.ProfileName = util.Ptr("dsprofile")
+	ds.Protocol = util.Ptr(int(tc.DSProtocolHTTPToHTTPS))
+	ds.AnonymousBlockingEnabled = false
+	ds.Active = tc.DSActiveStateActive
+	ds.RangeSliceBlockSize = util.Ptr(262144)
+
+	dses := []DeliveryService{ds}
+
+	dss := []DeliveryServiceServer{
+		DeliveryServiceServer{
+			Server:          server.ID,
+			DeliveryService: *ds.ID,
+		},
+	}
+
+	dsRegexes := []tc.DeliveryServiceRegexes{
+		tc.DeliveryServiceRegexes{
+			DSName: ds.XMLID,
+			Regexes: []tc.DeliveryServiceRegex{
+				tc.DeliveryServiceRegex{
+					Type:      string(tc.DSMatchTypeHostRegex),
+					SetNumber: 0,
+					Pattern:   `myliteralpattern__http__foo`,
+				},
+			},
+		},
+	}
+
+	serverParams := []tc.ParameterV5{
+		tc.ParameterV5{
+			Name:       "trafficserver",
+			ConfigFile: "package",
+			Value:      "9",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.ParameterV5{
+			Name:       "serverpkgval",
+			ConfigFile: "package",
+			Value:      "serverpkgval __HOSTNAME__ foo",
+			Profiles:   []byte(server.Profiles[0]),
+		},
+		tc.ParameterV5{
+			Name:       "dscp_remap_no",
+			ConfigFile: "package",
+			Value:      "notused",
+			Profiles:   []byte(server.Profiles[0]),
+		},
+	}
+
+	remapConfigParams := []tc.ParameterV5{
+		tc.ParameterV5{
+			Name:       "cache_range_requests.pparam",
+			ConfigFile: "remap.config",
+			Value:      "--no-modify-cachekey",
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+		tc.ParameterV5{
+			Name:       "not_location",
+			ConfigFile: "cachekey.config",
+			Value:      "notinconfig",
+			Profiles:   []byte(`["global"]`),
+		},
+		tc.ParameterV5{
+			Name:       "cache_range_requests.pparam",
+			ConfigFile: "remap.config",
+			Value:      selfHealParam,
+			Profiles:   []byte(`["dsprofile"]`),
+		},
+	}
+
+	cdn := &tc.CDNV5{
+		DomainName: "cdndomain.example",
+		Name:       "my-cdn-name",
+	}
+
+	topologies := []tc.TopologyV5{}
+	cgs := []tc.CacheGroupNullableV5{}
+	serverCapabilities := map[int]map[ServerCapability]struct{}{}
+	dsRequiredCapabilities := map[int]map[ServerCapability]struct{}{}
+	configDir := `/opt/trafficserver/etc/trafficserver`
+
+	cfg, err := MakeRemapDotConfig(server, servers, dses, dss, dsRegexes, serverParams, cdn, remapConfigParams, topologies, cgs, serverCapabilities, dsRequiredCapabilities, configDir, &RemapDotConfigOpts{HdrComment: hdr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	txt := cfg.Text
+
+	txt = strings.TrimSpace(txt)
+
+	testComment(t, txt, hdr)
+
+	txtLines := strings.Split(txt, "\n")
+
+	if len(txtLines) != 3 { // comment, blank, and remap
+		t.Fatalf("expected a comment header, a blank line, and 1 remaps from HTTP_TO_HTTPS DS, actual: '%v' count %v", txt, len(txtLines))
+	}
+
+	remapLine := txtLines[2]
+	words := strings.Fields(remapLine)
+
+	if !strings.HasPrefix(remapLine, "map") {
+		t.Errorf("expected to start with 'map', actual '%v'", txt)
+	}
+
+	if 1 != strings.Count(remapLine, "cachekey.so") {
+		t.Errorf("expected remap on edge server to contain a single cachekey plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "slice.so") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain background fetch plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "cache_range_requests.so") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
+	}
+
+	if strings.Contains(remapLine, "--consider-ims") {
+		t.Errorf("expected remap on edge server with ds slice range request handling and '%s' param to not contain cache_range_requests plugin arg --consider-ims, actual '%v'", selfHealParam, txt)
+	}
+
+	if !strings.Contains(remapLine, "--no-modify-cachekey") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin arg --no-modify-cachekey, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "pparam=--blockbytes=262144") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
+	}
+	for _, word := range words {
+		if word == "@pparam=" {
+			t.Errorf("expected remap on edge server with empty 'cache_range_requests.pparam' to be skipped and not have empty '@pparam=' on remapline, actual %s", txt)
 		}
 	}
 }
@@ -5808,12 +6107,6 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 		tc.ParameterV5{
 			Name:       "cache_range_requests.pparam",
 			ConfigFile: "remap.config",
-			Value:      "--consider-ims",
-			Profiles:   []byte(`["dsprofile"]`),
-		},
-		tc.ParameterV5{
-			Name:       "cache_range_requests.pparam",
-			ConfigFile: "remap.config",
 			Value:      "--no-modify-cachekey",
 			Profiles:   []byte(`["dsprofile"]`),
 		},
@@ -5822,12 +6115,6 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 			ConfigFile: "cachekey.config",
 			Value:      "notinconfig",
 			Profiles:   []byte(`["global"]`),
-		},
-		tc.ParameterV5{
-			Name:       "cache_range_requests.pparam",
-			ConfigFile: "remap.config",
-			Value:      "",
-			Profiles:   []byte(`["dsprofile"]`),
 		},
 	}
 
@@ -5859,6 +6146,7 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 	}
 
 	remapLine := txtLines[2]
+	t.Log(remapLine)
 	words := strings.Fields(remapLine)
 
 	if !strings.HasPrefix(remapLine, "map") {

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -5704,14 +5704,6 @@ func TestMakeRemapDotConfigMidRangeRequestSlicePparam(t *testing.T) {
 		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
 	}
 
-	if !strings.Contains(remapLine, "--consider-ims") {
-		t.Errorf("expected remap on mid server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
-	}
-
-	if strings.Count(remapLine, "--consider-ims") > 1 {
-		t.Errorf("expected remap on mid server with ds slice range request handling to contain one occurance of plugin arg --consider-ims, actual '%s'", txt)
-	}
-
 	if strings.Contains(remapLine, "pparam=--blockbytes") {
 		t.Errorf("did not expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
 	}
@@ -5856,14 +5848,6 @@ func TestMakeRemapDotConfigEdgeRangeRequestSlicePparam(t *testing.T) {
 
 	if !strings.Contains(remapLine, "cache_range_requests.so") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin, actual '%v'", txt)
-	}
-
-	if !strings.Contains(remapLine, "--consider-ims") {
-		t.Errorf("expected remap on edge server with ds slice range request handling to contain cache_range_requests plugin arg --consider-ims, actual '%v'", txt)
-	}
-
-	if strings.Count(remapLine, "--consider-ims") > 1 {
-		t.Errorf("expected remap on edge server with ds slice range request handling to contain one occurance of plugin arg --consider-ims, actual '%s'", txt)
 	}
 
 	if !strings.Contains(remapLine, "--no-modify-cachekey") {

--- a/lib/go-atscfg/remapdotconfig_test.go
+++ b/lib/go-atscfg/remapdotconfig_test.go
@@ -1599,7 +1599,7 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 	ds.Active = tc.DSActiveStateActive
 
 	ds2 := DeliveryService{}
-	ds2.ID = util.Ptr(48)
+	ds2.ID = util.Ptr(50)
 	dsType2 := "HTTP_LIVE_NATNL"
 	ds2.Type = &dsType2
 	ds2.OrgServerFQDN = util.Ptr("origin.example.test")
@@ -1628,6 +1628,10 @@ func TestMakeRemapDotConfigMidSlicePluginRangeRequestHandling(t *testing.T) {
 		DeliveryServiceServer{
 			Server:          server.ID,
 			DeliveryService: *ds.ID,
+		},
+		DeliveryServiceServer{
+			Server:          *server.ID,
+			DeliveryService: *ds2.ID,
 		},
 	}
 
@@ -6414,6 +6418,10 @@ func TestMakeRemapDotConfigRawRemapWithoutRangeDirective(t *testing.T) {
 
 	if !strings.Contains(remapLine, "pparam=--blockbytes=262144") {
 		t.Errorf("expected remap on edge server with ds slice range request handling to contain block size for the slice plugin, actual '%v'", txt)
+	}
+
+	if !strings.Contains(remapLine, "@pparam=--consider-ims") {
+		t.Errorf("expected remap on edge server with ds slice range request handling to contain --consider-ims for self-healing, actual '%v'", txt)
 	}
 
 	if !strings.HasSuffix(remapLine, "@plugin=tslua.so @pparam=my-range-manipulator.lua # ds 'mydsname' topology ''") {


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
When using the slice plugin you have to add the `--consider-ims` parameter to the remap line in remap.config. This change will make it automatically add the parameter without using a delivery service parameter.  

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
