### PR TITLE
Api v5 should return RFC3339 timestamps for Delivery Service Servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.
-- [#7690](https://github.com/apache/trafficcontrol/pull/7690) *Traffic Ops* Fixes Logs V5 apis to respond with RFC3339 tiestamps.
+- [#7690](https://github.com/apache/trafficcontrol/pull/7690) *Traffic Ops* Fixes Logs V5 api to respond with RFC3339 timestamps.
+- [#7720](https://github.com/apache/trafficcontrol/pull/7720) *Traffic Ops* Fixes Delivery Service Servers V5 api to respond with RFC3339 timestamps.
 - [#7631] (https://github.com/apache/trafficcontrol/pull/7631) *Traffic Ops* Fixes Phys_Location V5 apis to respond with RFC3339 date/time Format
 - [#7623] (https://github.com/apache/trafficcontrol/pull/7623) *Traffic Ops* Removed TryIfModifiedSinceQuery from servicecategories.go and reused from ims.go
 - [#7608](https://github.com/apache/trafficcontrol/pull/7608) *Traffic Monitor* Use stats_over_http(plugin.system_stats.timestamp_ms) timestamp field to calculate bandwidth for TM's caches.

--- a/docs/source/api/v5/deliveryserviceserver.rst
+++ b/docs/source/api/v5/deliveryserviceserver.rst
@@ -65,7 +65,7 @@ Unlike most API endpoints, this will return a JSON response body containing both
 :response: An array of objects, each of which represents a server's :term:`Delivery Service` assignment
 
 	:deliveryService: The integral, unique identifier of the :term:`Delivery Service` to which the server identified by ``server`` is assigned
-	:lastUpdated:     The date and time at which the server's assignment to a :term:`Delivery Service` was last updated
+	:lastUpdated:     The date and time at which the server's assignment to a :term:`Delivery Service` was last updated, in :rfc:`3339` format
 	:server:          The integral, unique identifier of a server which is assigned to the :term:`Delivery Service` identified by ``deliveryService``
 
 :size: The page number - if pagination was requested in the query parameters, else ``0`` to indicate no pagination - of the results represented by the ``response`` array. This is named "size" for legacy reasons
@@ -91,7 +91,7 @@ Unlike most API endpoints, this will return a JSON response body containing both
 		{
 			"server": 8,
 			"deliveryService": 1,
-			"lastUpdated": "2018-11-01 14:10:38+00"
+			"lastUpdated": "2018-11-01T14:10:38-06:00"
 		}
 	],
 	"size": 1,

--- a/lib/go-tc/deliveryservice_servers.go
+++ b/lib/go-tc/deliveryservice_servers.go
@@ -19,6 +19,33 @@ import (
 	"time"
 )
 
+// DeliveryServiceServerV5 is the struct used to represent a delivery service server, in the latest minor version for
+// API 5.x.
+type DeliveryServiceServerV5 = DeliveryServiceServerV50
+
+// DeliveryServiceServerV50 is the type of each entry in the `response` array
+// property of responses from Traffic Ops to GET requests made to the
+// /deliveryserviceservers endpoint of its API, for api version 5.0.
+type DeliveryServiceServerV50 struct {
+	Server          *int       `json:"server" db:"server"`
+	DeliveryService *int       `json:"deliveryService" db:"deliveryservice"`
+	LastUpdated     *time.Time `json:"lastUpdated" db:"last_updated"`
+}
+
+// DeliveryServiceServerResponseV5 is the type of a response from Traffic Ops
+// to a GET request to the /deliveryserviceserver endpoint, for the latest minor version of api v5.x.
+type DeliveryServiceServerResponseV5 = DeliveryServiceServerResponseV50
+
+// DeliveryServiceServerResponseV50 is the type of a response from Traffic Ops
+// to a GET request to the /deliveryserviceserver endpoint for API v5.0.
+type DeliveryServiceServerResponseV50 struct {
+	Orderby  string                    `json:"orderby"`
+	Response []DeliveryServiceServerV5 `json:"response"`
+	Size     int                       `json:"size"`
+	Limit    int                       `json:"limit"`
+	Alerts
+}
+
 // DeliveryServiceServerResponse is the type of a response from Traffic Ops
 // to a GET request to the /deliveryserviceserver endpoint.
 type DeliveryServiceServerResponse struct {

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -187,11 +187,14 @@ func ReadDSSHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func upgrade(dsServers []tc.DeliveryServiceServer) *[]tc.DeliveryServiceServerV5 {
+	var err error
 	dsServersV5 := make([]tc.DeliveryServiceServerV5, len(dsServers))
 	for i, s := range dsServers {
 		dsServersV5[i].Server = s.Server
 		dsServersV5[i].DeliveryService = s.DeliveryService
-		dsServersV5[i].LastUpdated, _ = util.ConvertTimeFormat(s.LastUpdated.Time, time.RFC3339)
+		if dsServersV5[i].LastUpdated, err = util.ConvertTimeFormat(s.LastUpdated.Time, time.RFC3339); err != nil {
+			dsServersV5[i].LastUpdated = &s.LastUpdated.Time
+		}
 	}
 	return &dsServersV5
 }

--- a/traffic_ops/v5-client/deliveryserviceserver.go
+++ b/traffic_ops/v5-client/deliveryserviceserver.go
@@ -68,8 +68,8 @@ func (to *Session) GetServersByDeliveryService(id int, opts RequestOptions) (tc.
 
 // GetDeliveryServiceServers returns associations between Delivery Services and
 // servers.
-func (to *Session) GetDeliveryServiceServers(opts RequestOptions) (tc.DeliveryServiceServerResponse, toclientlib.ReqInf, error) {
-	var resp tc.DeliveryServiceServerResponse
+func (to *Session) GetDeliveryServiceServers(opts RequestOptions) (tc.DeliveryServiceServerResponseV5, toclientlib.ReqInf, error) {
+	var resp tc.DeliveryServiceServerResponseV5
 	reqInf, err := to.get(apiDeliveryServiceServer, opts, &resp)
 	return resp, reqInf, err
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to any issue. It changes the timestamps returned in api v5 for deliveryserviceservers to be in RFC3339 format.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Make sure all the tests pass.
Hit the `deliveryserviceservers` endpoint for v5 and verify that the timestamps returned are in RFC3339 format.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
