### PR TITLE
Add separate profiles for Varnish cache

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
+++ b/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh
@@ -194,6 +194,7 @@ to-enroll() {
 		MY_IP6_ADDRESS="${MY_IP6_ADDRESS}/64"
 	fi
 	export MY_IP6_GATEWAY="$(route -n6 | grep UG | awk '{print $2}')"
+	local cacheType="${CACHE_SERVER_TYPE:-ATS}"
 
 	case "$serverType" in
 		"db" )
@@ -213,12 +214,12 @@ to-enroll() {
 			;;
 		"edge" )
 			export MY_TYPE="EDGE"
-			export MY_PROFILE="EDGE_TIER_ATS_CACHE"
+			export MY_PROFILE="EDGE_TIER_${cacheType}_CACHE"
 			export MY_STATUS="REPORTED"
 			;;
 		"mid" )
 			export MY_TYPE="MID"
-			export MY_PROFILE="MID_TIER_ATS_CACHE"
+			export MY_PROFILE="MID_TIER_${cacheType}_CACHE"
 			export MY_STATUS="REPORTED"
 			;;
 		"origin" )

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/011-VARNISH_EDGE_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/011-VARNISH_EDGE_TIER_CACHE.json
@@ -1,0 +1,419 @@
+{
+	"cdnName": "$CDN_NAME",
+	"description": "Edge Cache - Varnish",
+	"name": "EDGE_TIER_VARNISH_CACHE",
+	"routingDisabled": false,
+	"type": "ATS_PROFILE",
+	"params": [
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.proxy_name",
+			"secure": false,
+			"value": "STRING __HOSTNAME__"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.config_dir",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.admin.user_id",
+			"secure": false,
+			"value": "STRING ats"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.server_ports",
+			"secure": false,
+			"value": "STRING 80 80:ipv6 443:proto=http:ssl 443:ipv6:proto=http:ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.insert_response_via_str",
+			"secure": false,
+			"value": "INT 3"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.parent_proxy_routing_enable",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.parent_proxy.retry_time",
+			"secure": false,
+			"value": "INT 60"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.connect_attempts_timeout",
+			"secure": false,
+			"value": "INT 10"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.cache.required_headers",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.enable_http_stats",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.dns.round_robin_nameservers",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.max_space_mb_for_logs",
+			"secure": false,
+			"value": "INT 512"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.max_space_mb_headroom",
+			"secure": false,
+			"value": "INT 50"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.logfile_dir",
+			"secure": false,
+			"value": "(unchanged)"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.reverse_proxy.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.diags.debug.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.slow.log.threshold",
+			"secure": false,
+			"value": "INT 10000"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_enabled",
+			"secure": false,
+			"value": "INT 2"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_size_mb",
+			"secure": false,
+			"value": "INT 500"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_min_count",
+			"secure": false,
+			"value": "INT 2"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.url_remap.remap_required",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.loadavg",
+			"secure": false,
+			"value": "25.0"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.availableBandwidthInKbps",
+			"secure": false,
+			"value": ">1750000"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "history.count",
+			"secure": false,
+			"value": "30"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.queryTime",
+			"secure": false,
+			"value": "1000"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.polling.url",
+			"secure": false,
+			"value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Disk_Volume",
+			"secure": false,
+			"value": "1"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.connection.timeout",
+			"secure": false,
+			"value": "2000"
+		},
+		{
+			"configFile": "plugin.config",
+			"name": "regex_revalidate.so",
+			"secure": false,
+			"value": "--config regex_revalidate.config"
+		},
+		{
+			"configFile": "regex_revalidate.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.exec_thread.autoconfig",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "plugin.config",
+			"name": "astats_over_http.so",
+			"secure": false,
+			"value": ""
+		},
+		{
+			"configFile": "astats.config",
+			"name": "allow_ip",
+			"secure": false,
+			"value": "127.0.0.1,10.0.0.0/8,192.168.0.0/16"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "allow_ip6",
+			"secure": false,
+			"value": "::1/128"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "path",
+			"secure": false,
+			"value": "_astats"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "record_types",
+			"secure": false,
+			"value": "122"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.transaction_active_timeout_in",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.body_factory.template_sets_dir",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/body_factory"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Drive_Letters",
+			"secure": false,
+			"value": "cache"
+		},
+		{
+			"configFile": "ip_allow.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Drive_Prefix",
+			"secure": false,
+			"value": "/var/trafficserver/"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.CA.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.CA.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.private_key.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.ocsp.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.private_key.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.ticket_key.filename",
+			"secure": false,
+			"value": "STRING NULL"
+		},
+		{
+			"configFile": "set_dscp_0.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_10.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_12.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_14.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_18.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_20.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_22.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_26.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_28.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_30.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_34.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_36.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_38.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_8.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_16.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_24.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_32.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_40.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_48.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_56.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_37.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "ssl_multicert.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver"
+		}
+	]
+}

--- a/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/021-VARNISH_MID_TIER_CACHE.json
+++ b/infrastructure/cdn-in-a-box/traffic_ops_data/profiles/021-VARNISH_MID_TIER_CACHE.json
@@ -1,0 +1,419 @@
+{
+	"cdnName": "$CDN_NAME",
+	"description": "Mid Cache - Varnish",
+	"name": "MID_TIER_VARNISH_CACHE",
+	"routingDisabled": false,
+	"type": "ATS_PROFILE",
+	"params": [
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.proxy_name",
+			"secure": false,
+			"value": "STRING __HOSTNAME__"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.config_dir",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.admin.user_id",
+			"secure": false,
+			"value": "STRING ats"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.server_ports",
+			"secure": false,
+			"value": "STRING 80 80:ipv6 443:proto=http:ssl 443:ipv6:proto=http:ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.insert_response_via_str",
+			"secure": false,
+			"value": "INT 3"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.parent_proxy_routing_enable",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.parent_proxy.retry_time",
+			"secure": false,
+			"value": "INT 60"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.connect_attempts_timeout",
+			"secure": false,
+			"value": "INT 10"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.cache.required_headers",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.enable_http_stats",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.dns.round_robin_nameservers",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.max_space_mb_for_logs",
+			"secure": false,
+			"value": "INT 512"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.max_space_mb_headroom",
+			"secure": false,
+			"value": "INT 50"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.log.logfile_dir",
+			"secure": false,
+			"value": "(unchanged)"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.reverse_proxy.enabled",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.diags.debug.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.slow.log.threshold",
+			"secure": false,
+			"value": "INT 10000"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_enabled",
+			"secure": false,
+			"value": "INT 2"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_size_mb",
+			"secure": false,
+			"value": "INT 500"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.output.logfile.rolling_min_count",
+			"secure": false,
+			"value": "INT 2"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.url_remap.remap_required",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.loadavg",
+			"secure": false,
+			"value": "25.0"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.availableBandwidthInKbps",
+			"secure": false,
+			"value": ">1750000"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "history.count",
+			"secure": false,
+			"value": "30"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.threshold.queryTime",
+			"secure": false,
+			"value": "1000"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.polling.url",
+			"secure": false,
+			"value": "http://${hostname}/_astats?application=&inf.name=${interface_name}"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Disk_Volume",
+			"secure": false,
+			"value": "1"
+		},
+		{
+			"configFile": "rascal.properties",
+			"name": "health.connection.timeout",
+			"secure": false,
+			"value": "2000"
+		},
+		{
+			"configFile": "plugin.config",
+			"name": "regex_revalidate.so",
+			"secure": false,
+			"value": "--config regex_revalidate.config"
+		},
+		{
+			"configFile": "regex_revalidate.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.exec_thread.autoconfig",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "plugin.config",
+			"name": "astats_over_http.so",
+			"secure": false,
+			"value": ""
+		},
+		{
+			"configFile": "astats.config",
+			"name": "allow_ip",
+			"secure": false,
+			"value": "127.0.0.1,10.0.0.0/8,192.168.0.0/16"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "allow_ip6",
+			"secure": false,
+			"value": "::1/128"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "path",
+			"secure": false,
+			"value": "_astats"
+		},
+		{
+			"configFile": "astats.config",
+			"name": "record_types",
+			"secure": false,
+			"value": "122"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.http.transaction_active_timeout_in",
+			"secure": false,
+			"value": "INT 0"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.body_factory.template_sets_dir",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/body_factory"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Drive_Letters",
+			"secure": false,
+			"value": "cache"
+		},
+		{
+			"configFile": "ip_allow.config",
+			"name": "location",
+			"secure": false,
+			"value": "/opt/trafficserver/etc/trafficserver"
+		},
+		{
+			"configFile": "storage.config",
+			"name": "Drive_Prefix",
+			"secure": false,
+			"value": "/var/trafficserver/"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.CA.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.CA.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.client.private_key.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.ocsp.enabled",
+			"secure": false,
+			"value": "INT 1"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.cert.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.private_key.path",
+			"secure": false,
+			"value": "STRING /opt/trafficserver/etc/trafficserver/ssl"
+		},
+		{
+			"configFile": "records.config",
+			"name": "CONFIG proxy.config.ssl.server.ticket_key.filename",
+			"secure": false,
+			"value": "STRING NULL"
+		},
+		{
+			"configFile": "set_dscp_0.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_10.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_12.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_14.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_18.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_20.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_22.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_26.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_28.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_30.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_34.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_36.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_38.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_8.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_16.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_24.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_32.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_40.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_48.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_56.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "set_dscp_37.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver/dscp"
+		},
+		{
+			"configFile": "ssl_multicert.config",
+			"name": "location",
+			"value": "/opt/trafficserver/etc/trafficserver"
+		}
+	]
+}

--- a/infrastructure/cdn-in-a-box/varnish/Dockerfile
+++ b/infrastructure/cdn-in-a-box/varnish/Dockerfile
@@ -49,7 +49,7 @@ RUN rpm -Uvh /$(basename $ORT_RPM) &&\
 
 COPY infrastructure/cdn-in-a-box/varnish/traffic_ops_ort.crontab /etc/cron.d/traffic_ops_ort-cron-template
 
-
+ENV CACHE_SERVER_TYPE=VARNISH
 CMD /run.sh
 
 FROM common-varnish-cache-config-layers AS mid


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Create separate profiles for Varnish cache so users won't need to change cache profiles manually.

Closes: #7721 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run CIAB with Varnish and check Traffic Portal that the right profile is associated with both Varnish and ATS:
- Change [Dockerfile](https://github.com/apache/trafficcontrol/blob/master/infrastructure/cdn-in-a-box/docker-compose.yml#L218) in edge server to point to `varnish/Dockerfile` instead of `cache/Dockerfile`
- Change edge [status](https://github.com/apache/trafficcontrol/blob/master/infrastructure/cdn-in-a-box/traffic_ops/to-access.sh#L217) to `ONLINE` (until TM integration is done).
- Run CIAB and expose ports with `docker-compose -f docker-compose.yml -f docker-compose.expose-ports.yml up --build`
- Open Traffic Portal and check profile associated with each cache server.

Note: this applies to Mid-01 and Mid-02 too. The only issue is if running all servers with `ONLINE` status.

Note: new profiles is the same as ATS ones with description, name and parameters that cause issues (chkconfig and package) changed. easiest way to check is to run `diff` for ATS and Varnish profiles,

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
