### PR TITLE
Fixing panic seen in TM when timestamp_ms appears as float and not string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7716](https://github.com/apache/trafficcontrol/pull/7716) *Apache Traffic Server* Use GCC 11 for building.
 
 ### Fixed
+- [#7730](https://github.com/apache/trafficcontrol/pull/7730) *Traffic Monitor* Fixed the panic seen in TM when `plugin.system_stats.timestamp_ms` appears as float and not string.
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.
 - [#7690](https://github.com/apache/trafficcontrol/pull/7690) *Traffic Ops* Fixes Logs V5 apis to respond with RFC3339 tiestamps.
 - [#7631] (https://github.com/apache/trafficcontrol/pull/7631) *Traffic Ops* Fixes Phys_Location V5 apis to respond with RFC3339 date/time Format

--- a/traffic_monitor/cache/cache.go
+++ b/traffic_monitor/cache/cache.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/apache/trafficcontrol/lib/go-log"
@@ -308,14 +307,14 @@ func (handler Handler) Handle(id string, rdr io.Reader, format string, reqTime t
 		return
 	}
 	if val, ok := miscStats["plugin.system_stats.timestamp_ms"]; ok {
-		valInt, valErr := strconv.ParseInt(val.(string), 10, 64)
+		valInt, valErr := parseNumericStat(val)
 		if valErr != nil {
 			log.Errorln("parse error: ", valErr)
 			result.Error = valErr
 			handler.resultChan <- result
 			return
 		}
-		result.Time = time.UnixMilli(valInt)
+		result.Time = time.UnixMilli(int64(valInt))
 	}
 	if value, ok := miscStats[rfc.Via]; ok {
 		result.ID = fmt.Sprintf("%v", value)

--- a/traffic_monitor/cache/cache_test.go
+++ b/traffic_monitor/cache/cache_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/apache/trafficcontrol/lib/go-rfc"
@@ -126,10 +127,23 @@ func TestParseAndDecode(t *testing.T) {
 	}
 
 	if val, ok := miscStats["plugin.system_stats.timestamp_ms"]; ok {
-		if val.(string) != "1684784877939" {
+		valType := reflect.TypeOf(val)
+		if valType.Kind() != reflect.String {
+			t.Errorf("type mismatch, expected: string, got:%s", valType)
+		}
+		val1, _ := parseNumericStat(val)
+		if val1 != uint64(1684784877939) {
 			t.Errorf("unable to read `plugin.system_stats.timestamp_ms`")
 		}
-	} else {
-		t.Errorf("plugin.system_stats.timestamp_ms field was not found in the json file")
+	}
+	if val, ok := miscStats["plugin.system_stats.timestamp_ms_float64"]; ok {
+		valType := reflect.TypeOf(val)
+		if valType.Kind() != reflect.Float64 {
+			t.Errorf("type mismatch, expected: string, got:%s", valType)
+		}
+		val1, _ := parseNumericStat(val)
+		if val1 != uint64(1684784877939) {
+			t.Errorf("unable to read `plugin.system_stats.timestamp_ms_float64`")
+		}
 	}
 }

--- a/traffic_monitor/cache/stats_over_http.json
+++ b/traffic_monitor/cache/stats_over_http.json
@@ -1,6 +1,7 @@
 {
 	"global": {
 		"plugin.system_stats.timestamp_ms": "1684784877939",
+		"plugin.system_stats.timestamp_ms_float64": 1684784877939,
 		"proxy.process.http.completed_requests": 26220072200,
 		"proxy.process.http.total_incoming_connections": 770802777,
 		"proxy.process.http.total_client_connections": 770802777,


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Resolving the panic seen in a stack trace.
`Aug 17 16:53:29 : panic: interface conversion: interface {} is float64, not string`

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run unit tests and when installing TM in an environment, ensure that it starts up without a panic.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
7.0.1

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
