### PR TITLE
Supplying absolute path for cert files in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7694](https://github.com/apache/trafficcontrol/pull/7694) *t3c*, *Traffic Control Health Client* Upgrade to ATS 9.2
 - [#7966](https://github.com/apache/trafficcontrol/pull/7696) *t3c* will no longer clear update flag when config failure occurs and will also give a cache config error msg on exit. 
 - [#7716](https://github.com/apache/trafficcontrol/pull/7716) *Apache Traffic Server* Use GCC 11 for building.
+- [#7742](https://github.com/apache/trafficcontrol/pull/7742) *Traffic Ops* Changed api tests to supply the absolute path of certs.
 
 ### Fixed
 - [#7730](https://github.com/apache/trafficcontrol/pull/7730) *Traffic Monitor* Fixed the panic seen in TM when `plugin.system_stats.timestamp_ms` appears as float and not string.

--- a/traffic_ops/testing/api/v5/session_test.go
+++ b/traffic_ops/testing/api/v5/session_test.go
@@ -16,6 +16,8 @@ package v5
 */
 
 import (
+	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -56,14 +58,21 @@ func SwitchSession(toReqTimeout time.Duration, toURL string, toOldUser string, t
 }
 
 func TestLoginWithCert(t *testing.T) {
-	session, _, err := client.LoginWithCert(Config.TrafficOps.URL, true, time.Second*60,
-		"./client-intermediate-chain.crt.pem",
-		"./client.key.pem", "")
+	if includeSystemTests {
+		pwd, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("couldn't get current working directory: %s", err.Error())
+		}
 
-	if err != nil {
-		t.Fatalf("expected no error while logging in with cert, but got %v", err)
-	}
-	if session == nil {
-		t.Fatalf("expected a valid session, but got nothing")
+		session, _, err := client.LoginWithCert(Config.TrafficOps.URL, true, time.Second*60,
+			fmt.Sprintf("%s/client-intermediate-chain.crt.pem", pwd),
+			fmt.Sprintf("%s/client.key.pem", pwd), "")
+
+		if err != nil {
+			t.Fatalf("expected no error while logging in with cert, but got %v", err)
+		}
+		if session == nil {
+			t.Fatalf("expected a valid session, but got nothing")
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to any issue. It makes sure that we are supplying absolute paths to the certs in our api tests.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops


## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Create client certs 
Make sure the tests pass.
Manual testing:
Follow the steps in https://github.com/apache/trafficcontrol/pull/7392

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
