### PR TITLE
RFC3339 Fix for ProfileParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7698](https://github.com/apache/trafficcontrol/pull/7698) *Traffic Ops* Fixes `region` v5 apis to respond with `RFC3339` date/time Format.
 - [#7686](https://github.com/apache/trafficcontrol/pull/7686) *Traffic Ops* Fixes secured parameters being visible when role has proper permissions.
 - [#7697](https://github.com/apache/trafficcontrol/pull/7697) *Traffic Ops* Fixes `iloPassword` and `xmppPassword` checking for priv-level instead of using permissions.
-
 ### Removed
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove components in `infrastructre/docker/`, not in use as cdn-in-a-box performs the same functionality.
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove`misc/jira_github_issue_import.py`, the project does not use JIRA.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,7 +158,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7698](https://github.com/apache/trafficcontrol/pull/7698) *Traffic Ops* Fixes `region` v5 apis to respond with `RFC3339` date/time Format.
 - [#7686](https://github.com/apache/trafficcontrol/pull/7686) *Traffic Ops* Fixes secured parameters being visible when role has proper permissions.
 - [#7697](https://github.com/apache/trafficcontrol/pull/7697) *Traffic Ops* Fixes `iloPassword` and `xmppPassword` checking for priv-level instead of using permissions.
-- [#7740](https://github.com/apache/trafficcontrol/pull/7740) *Traffic Ops* Fixes `staticDNSEntries` v5 apis to respond with `RFC3339` date/time Format.
+
 ### Removed
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove components in `infrastructre/docker/`, not in use as cdn-in-a-box performs the same functionality.
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove`misc/jira_github_issue_import.py`, the project does not use JIRA.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7698](https://github.com/apache/trafficcontrol/pull/7698) *Traffic Ops* Fixes `region` v5 apis to respond with `RFC3339` date/time Format.
 - [#7686](https://github.com/apache/trafficcontrol/pull/7686) *Traffic Ops* Fixes secured parameters being visible when role has proper permissions.
 - [#7697](https://github.com/apache/trafficcontrol/pull/7697) *Traffic Ops* Fixes `iloPassword` and `xmppPassword` checking for priv-level instead of using permissions.
+- [#7740](https://github.com/apache/trafficcontrol/pull/7740) *Traffic Ops* Fixes `staticDNSEntries` v5 apis to respond with `RFC3339` date/time Format.
 ### Removed
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove components in `infrastructre/docker/`, not in use as cdn-in-a-box performs the same functionality.
 - [#7271](https://github.com/apache/trafficcontrol/pull/7271) Remove`misc/jira_github_issue_import.py`, the project does not use JIRA.

--- a/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
+++ b/traffic_ops/traffic_ops_golang/profileparameter/profile_parameters.go
@@ -305,21 +305,9 @@ func CreateProfileParameter(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// This code block decides if the request body is a slice of parameters or a single object.
+	// This code block decides if the request body is a slice of parameters or a single object and unmarshal it.
 	var profileParams []tc.ProfileParameterCreationRequest
-
-	// Try to unmarshal the data as a slice
-	var sliceData []map[string]interface{}
-	if err := json.Unmarshal(body, &sliceData); err == nil {
-		for _, item := range sliceData {
-			profileParam := tc.ProfileParameterCreationRequest{
-				ParameterID: int(item["parameterId"].(float64)),
-				ProfileID:   int(item["profileId"].(float64)),
-			}
-			profileParams = append(profileParams, profileParam)
-		}
-	} else {
-		// Try to unmarshal the data as a single object
+	if err := json.Unmarshal(body, &profileParams); err != nil {
 		var profileParam tc.ProfileParameterCreationRequest
 		if err := json.Unmarshal(body, &profileParam); err != nil {
 			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("error unmarshalling single object"), nil)


### PR DESCRIPTION
Related: #5911



<!-- **^ Add meaningful description above** --><hr/>

- Traffic Ops

## What is the best way to verify this PR?
Make Api calls to Parameter 5.0

ProfileParameters  to Use RFC3339 Format
```json
{
	"response": [
		{
			"lastUpdated": "2023-08-22T09:51:03.556698+05:30",
			"profile": "test2",
			"parameter": 1070
		},
		{
			"lastUpdated": "2023-08-22T10:33:23.249862+05:30",
			"profile": "test2",
			"parameter": 1071
		}
       ]
}
```




## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
