### PR TITLE
Fixes QA issue of redirect after creating a parameter with RFC3339

### DIFF
--- a/traffic_ops/traffic_ops_golang/parameter/parameters.go
+++ b/traffic_ops/traffic_ops_golang/parameter/parameters.go
@@ -382,6 +382,7 @@ func CreateParameter(w http.ResponseWriter, r *http.Request) {
 
 	// Create all parameters from the request slice
 	var objParams []tc.ParameterV5
+	var objParam tc.ParameterV5
 	for _, parameter := range params {
 		query := `
 			INSERT INTO parameter (
@@ -393,7 +394,6 @@ func CreateParameter(w http.ResponseWriter, r *http.Request) {
 			        $1, $2, $3, $4
 			    ) RETURNING id, name, config_file, value, last_updated, secure 
 		`
-		var objParam tc.ParameterV5
 		err = tx.QueryRow(
 			query,
 			parameter.Name,
@@ -423,7 +423,7 @@ func CreateParameter(w http.ResponseWriter, r *http.Request) {
 		objParams = append(objParams, objParam)
 	}
 	alerts := tc.CreateAlerts(tc.SuccessLevel, "All Requested Parameters were created.")
-	api.WriteAlertsObj(w, r, http.StatusCreated, alerts, objParams)
+	api.WriteAlertsObj(w, r, http.StatusCreated, alerts, objParam)
 	return
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
- Creating a parameter from traffic portal should redirect and get a successful get request


## If this is a bugfix, which Traffic Control versions contained the bug?
- 7.0.1


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
