### PR TITLE
Fixes additional profile endpoints V5 apis to respond with RFC3339 date/time Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - [#7691](https://github.com/apache/trafficcontrol/pull/7691) *Traffic Ops* Fixed `/topologies` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7413) *Traffic Ops* Fixed `/service_category` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7706) *Traffic Ops* Fixed `/statuses` v5 APIs to respond with `RFC3339` timestamps.
-    - [#7743](https://github.com/apache/trafficcontrol/issues/7743) *Traffic Ops* Fixes `/server_server_capabilities` apis to respond with RFC3339 date/time format
+    - [#7743](https://github.com/apache/trafficcontrol/issues/7743) *Traffic Ops* Fixed `/server_server_capabilities` v5 APIs to respond with `RFC3339` timestamps.
 - [#7730](https://github.com/apache/trafficcontrol/pull/7730) *Traffic Monitor* Fixed the panic seen in TM when `plugin.system_stats.timestamp_ms` appears as float and not string.
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.
 - [#7623](https://github.com/apache/trafficcontrol/pull/7623) *Traffic Ops* Removed TryIfModifiedSinceQuery from servicecategories.go and reused from ims.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [RFC3339](https://github.com/apache/trafficcontrol/issues/5911)
+    - [#7759](https://github.com/apache/trafficcontrol/pull/7759) *Traffic Ops* Fixed `/profiles/{{ID}}/parameters` and `rofiles/name/{{name}}/parameters` v5 APIs to respond with `RFC3339` timestamps.
     - [#7734](https://github.com/apache/trafficcontrol/pull/7734) *Traffic Ops* Fixed `/profiles` v5 APIs to respond with `RFC3339` timestamps.
     - [#7708](https://github.com/apache/trafficcontrol/pull/7708) *Traffic Ops* Fixed `/parameters` v5 APIs to respond with `RFC3339` timestamps
     - [#7740](https://github.com/apache/trafficcontrol/pull/7740) *Traffic Ops* Fixed `/staticDNSEntries` v5 APIs to respond with `RFC3339` timestamps.
@@ -101,7 +102,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - [#7691](https://github.com/apache/trafficcontrol/pull/7691) *Traffic Ops* Fixed `/topologies` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7413) *Traffic Ops* Fixed `/service_category` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7706) *Traffic Ops* Fixed `/statuses` v5 APIs to respond with `RFC3339` timestamps.
-- [#7743](https://github.com/apache/trafficcontrol/issues/7743) *Traffic Ops* Fixes /server_server_capabilities apis to respond with RFC3339 date/time format
+    - [#7743](https://github.com/apache/trafficcontrol/issues/7743) *Traffic Ops* Fixes `/server_server_capabilities` apis to respond with RFC3339 date/time format
 - [#7730](https://github.com/apache/trafficcontrol/pull/7730) *Traffic Monitor* Fixed the panic seen in TM when `plugin.system_stats.timestamp_ms` appears as float and not string.
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.
 - [#7623](https://github.com/apache/trafficcontrol/pull/7623) *Traffic Ops* Removed TryIfModifiedSinceQuery from servicecategories.go and reused from ims.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [RFC3339](https://github.com/apache/trafficcontrol/issues/5911)
-    - [#7759](https://github.com/apache/trafficcontrol/pull/7759) *Traffic Ops* Fixed `/profiles/{{ID}}/parameters` and `rofiles/name/{{name}}/parameters` v5 APIs to respond with `RFC3339` timestamps.
+    - [#7759](https://github.com/apache/trafficcontrol/pull/7759) *Traffic Ops* Fixed `/profiles/{{ID}}/parameters` and `profiles/name/{{name}}/parameters` v5 APIs to respond with `RFC3339` timestamps.
     - [#7734](https://github.com/apache/trafficcontrol/pull/7734) *Traffic Ops* Fixed `/profiles` v5 APIs to respond with `RFC3339` timestamps.
     - [#7708](https://github.com/apache/trafficcontrol/pull/7708) *Traffic Ops* Fixed `/parameters` v5 APIs to respond with `RFC3339` timestamps
     - [#7740](https://github.com/apache/trafficcontrol/pull/7740) *Traffic Ops* Fixed `/staticDNSEntries` v5 APIs to respond with `RFC3339` timestamps.

--- a/docs/source/api/v5/profiles_id_parameters.rst
+++ b/docs/source/api/v5/profiles_id_parameters.rst
@@ -52,7 +52,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -77,7 +77,7 @@ Response Structure
 		{
 			"configFile": "global",
 			"id": 4,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "tm.instance_name",
 			"secure": false,
 			"value": "Traffic Ops CDN"
@@ -85,7 +85,7 @@ Response Structure
 		{
 			"configFile": "global",
 			"id": 5,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "tm.toolname",
 			"secure": false,
 			"value": "Traffic Ops"
@@ -93,7 +93,7 @@ Response Structure
 		{
 			"configFile": "regex_revalidate.config",
 			"id": 7,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "maxRevalDurationDays",
 			"secure": false,
 			"value": "90"

--- a/docs/source/api/v5/profiles_name_name_parameters.rst
+++ b/docs/source/api/v5/profiles_name_name_parameters.rst
@@ -51,7 +51,7 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :ref:`non-rfc-datetime`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
@@ -76,7 +76,7 @@ Response Structure
 		{
 			"configFile": "global",
 			"id": 4,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "tm.instance_name",
 			"secure": false,
 			"value": "Traffic Ops CDN"
@@ -84,7 +84,7 @@ Response Structure
 		{
 			"configFile": "global",
 			"id": 5,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "tm.toolname",
 			"secure": false,
 			"value": "Traffic Ops"
@@ -92,7 +92,7 @@ Response Structure
 		{
 			"configFile": "regex_revalidate.config",
 			"id": 7,
-			"lastUpdated": "2018-12-05 17:50:49+00",
+			"lastUpdated": "2018-12-05T23:52:59.696337+05:30",
 			"name": "maxRevalDurationDays",
 			"secure": false,
 			"value": "90"

--- a/lib/go-tc/parameters.go
+++ b/lib/go-tc/parameters.go
@@ -127,6 +127,21 @@ type ProfileParameterByName struct {
 	Value       string    `json:"value"`
 }
 
+// ProfileParameterByNameV5 is the alias to the latest minor version of major version 5
+type ProfileParameterByNameV5 ProfileParameterByNameV50
+
+// ProfileParameterByNameV50 is a structure that's used to represent a Parameter
+// in a context where they are associated with some Profile specified by a
+// client of the Traffic Ops API by its Name.
+type ProfileParameterByNameV50 struct {
+	ConfigFile  string    `json:"configFile"`
+	ID          int       `json:"id"`
+	LastUpdated time.Time `json:"lastUpdated"`
+	Name        string    `json:"name"`
+	Secure      bool      `json:"secure"`
+	Value       string    `json:"value"`
+}
+
 // ProfileParameterByNamePost is a structure that's only used internally to
 // represent a Parameter that has been requested by a client of the Traffic Ops
 // API to be associated with some Profile which was specified by Name.


### PR DESCRIPTION
Closes: #7758 
Related: #5911

<!-- **^ Add meaningful description above** --><hr/>

- Documentation
- Traffic Ops

## What is the best way to verify this PR?
Make Api calls to following 5.0 endpoints

```
curl --request GET \
  --url https://localhost:6443/api/4.1/profiles/17/parameters
``` 

```
curl --request GET \
  --url https://localhost:6443/api/4.1/profiles/name/test/parameters
```

These Endpoints Must  Use RFC3339 Format


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
