### PR TITLE
Fixed phys_locations update API to remove error related to mismatching region name and ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     - [#7691](https://github.com/apache/trafficcontrol/pull/7691) *Traffic Ops* Fixed `/topologies` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7413) *Traffic Ops* Fixed `/service_category` v5 APIs to respond with `RFC3339` timestamps.
     - [#7413](https://github.com/apache/trafficcontrol/issues/7706) *Traffic Ops* Fixed `/statuses` v5 APIs to respond with `RFC3339` timestamps.
+- [#](https://github.com/apache/trafficcontrol/pull/) *Traffic Ops* Fixed `/phys_locations` update API to remove error related to mismatching region name and ID.
 - [#7743](https://github.com/apache/trafficcontrol/issues/7743) *Traffic Ops* Fixes /server_server_capabilities apis to respond with RFC3339 date/time format
 - [#7730](https://github.com/apache/trafficcontrol/pull/7730) *Traffic Monitor* Fixed the panic seen in TM when `plugin.system_stats.timestamp_ms` appears as float and not string.
 - [#4393](https://github.com/apache/trafficcontrol/issues/4393) *Traffic Ops* Fixed the error code and alert structure when TO is queried for a delivery service with no ssl keys.

--- a/traffic_ops/testing/api/v5/phys_locations_test.go
+++ b/traffic_ops/testing/api/v5/phys_locations_test.go
@@ -148,6 +148,23 @@ func TestPhysLocations(t *testing.T) {
 					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK),
 						validatePhysicalLocationUpdateCreateFields("HotAtlanta", map[string]interface{}{"City": "NewCity"})),
 				},
+				"OK when REGION ID doesn't match REGION NAME": {
+					EndpointID:    GetPhysicalLocationID(t, "HotAtlanta"),
+					ClientSession: TOSession,
+					RequestBody: tc.PhysLocationV5{
+						Address:    "1234 southern way",
+						City:       "NewCity",
+						Name:       "HotAtlanta",
+						Phone:      "404-222-2222",
+						RegionID:   GetRegionID(t, "region1")(),
+						RegionName: "notRegion1",
+						ShortName:  "atlanta",
+						State:      "GA",
+						Zip:        "30301",
+					},
+					Expectations: utils.CkRequest(utils.NoError(), utils.HasStatus(http.StatusOK),
+						validatePhysicalLocationUpdateCreateFields("HotAtlanta", map[string]interface{}{"City": "NewCity"})),
+				},
 				"PRECONDITION FAILED when updating with IMS & IUS Headers": {
 					EndpointID:    GetPhysicalLocationID(t, "HotAtlanta"),
 					ClientSession: TOSession,

--- a/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
+++ b/traffic_ops/traffic_ops_golang/physlocation/phys_locations.go
@@ -391,22 +391,6 @@ func UpdatePhysLocation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// checks to see if the supplied region name and ID in the phys_location body correspond to each other.
-	if physLocation.RegionName != "" {
-		regionName, ok, err := dbhelpers.GetRegionNameFromID(tx, physLocation.RegionID)
-		if err != nil {
-			api.HandleErr(w, r, tx, http.StatusInternalServerError, fmt.Errorf("error fetching name from region ID: %w", err), nil)
-			return
-		} else if !ok {
-			api.HandleErr(w, r, tx, http.StatusNotFound, errors.New("no such region"), nil)
-			return
-		}
-		if regionName != physLocation.RegionName {
-			api.HandleErr(w, r, tx, http.StatusBadRequest, errors.New("region name and ID do not match"), nil)
-			return
-		}
-	}
-
 	requestedID := inf.Params["id"]
 
 	intRequestId, convErr := strconv.Atoi(requestedID)


### PR DESCRIPTION

<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR is not related to any issue. It fixes the case where a physical location could not be updated in api v5.0, due to a bug where regiona name and region ID do not match.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

If the user uses TP (with version 5) to update a PhysLoc's Region, the update will fail with the message "region name and ID do not match" before this PR. This error should be fixed with this change.
It can also be recreated by calling the endpoint and changing just the ID (and not the name). In this case the API should use the ID instead of name.

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
- master

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
