### PR TITLE
Fixed ASN Update logic for APIv5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7765](https://github.com/apache/trafficcontrol/pull/7765) *Traffic Stats* now uses Traffic Ops APIv5
 
 ### Fixed
+- [#7767](https://github.com/apache/trafficcontrol/pull/7767) *Traffic Ops* Fixed ASN update logic for APIv5
 - [RFC3339](https://github.com/apache/trafficcontrol/issues/5911)
     - [#7759](https://github.com/apache/trafficcontrol/pull/7759) *Traffic Ops* Fixed `/profiles/{{ID}}/parameters` and `profiles/name/{{name}}/parameters` v5 APIs to respond with `RFC3339` timestamps.
     - [#7734](https://github.com/apache/trafficcontrol/pull/7734) *Traffic Ops* Fixed `/profiles` v5 APIs to respond with `RFC3339` timestamps.

--- a/traffic_ops/traffic_ops_golang/asn/asns.go
+++ b/traffic_ops/traffic_ops_golang/asn/asns.go
@@ -341,13 +341,13 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// check if asn already exists
-	var count int
-	err := tx.QueryRow("SELECT count(*) from asn where asn=$1", asn.ASN).Scan(&count)
-	if err != nil {
+	var id int
+	err := tx.QueryRow("SELECT id from asn where asn=$1", asn.ASN).Scan(&id)
+	if err != nil && err != sql.ErrNoRows {
 		api.HandleErr(w, r, tx, http.StatusInternalServerError, nil, fmt.Errorf("error: %w, when checking if asn '%d' exists", err, asn.ASN))
 		return
 	}
-	if count == 1 {
+	if id != 0 && id != requestedAsnId {
 		api.HandleErr(w, r, tx, http.StatusBadRequest, fmt.Errorf("asn:'%d' already exists", asn.ASN), nil)
 		return
 	}


### PR DESCRIPTION
This PR fixes a bug in the ASN update logic in TO APIv5 where changing the ASN of an ASN is erroneously not allowed

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Ops

## What is the best way to verify this PR?
Test PUT API call (v5) for the following cases:
1. Update existing ASN to another existing ASN (result: fail, since ASN exists)
2. Update existing ASN to a new non-existent ASN (result: pass)
3. Update existing ASN's cachegroup (result: pass)
4. Update existing ASN with a new ASN and a different cachegroup (result: pass)

## If this is a bugfix, which Traffic Control versions contained the bug?
master

## PR submission checklist
- [ ] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**