### PR TITLE
Configure uncacheable delivery services in Varnish

### DIFF
--- a/lib/varnishcfg/cache_control.go
+++ b/lib/varnishcfg/cache_control.go
@@ -1,0 +1,57 @@
+package varnishcfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func (v VCLBuilder) configureUncacheableDSes(vclFile *vclFile, profileDSes []atscfg.ProfileDS) []string {
+	warnings := make([]string, 0)
+
+	uncacheableHostsConditions := make([]string, 0)
+	for _, ds := range profileDSes {
+		if ds.Type != tc.DSTypeHTTPNoCache {
+			continue
+		}
+
+		if ds.OriginFQDN == "" {
+			warnings = append(warnings, fmt.Sprintf("ds %s has no origin fqdn, skipping!", ds.Name))
+			continue
+		}
+
+		host, _ := atscfg.GetHostPortFromURI(ds.OriginFQDN)
+		uncacheableHostsConditions = append(uncacheableHostsConditions, fmt.Sprintf(`bereq.http.host == "%s"`, host))
+	}
+	if len(uncacheableHostsConditions) == 0 {
+		return warnings
+	}
+	berespLines := make([]string, 0)
+	berespLines = append(berespLines, fmt.Sprintf(`if (%s) {`, strings.Join(uncacheableHostsConditions, " || ")))
+	berespLines = append(berespLines, fmt.Sprint(`	set beresp.uncacheable = true;`))
+	berespLines = append(berespLines, fmt.Sprint(`}`))
+	vclFile.subroutines["vcl_backend_response"] = append(vclFile.subroutines["vcl_backend_response"], berespLines...)
+
+	return warnings
+}

--- a/lib/varnishcfg/cache_control_test.go
+++ b/lib/varnishcfg/cache_control_test.go
@@ -1,0 +1,90 @@
+package varnishcfg
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apache/trafficcontrol/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/lib/go-atscfg"
+	"github.com/apache/trafficcontrol/lib/go-tc"
+)
+
+func TestConfigureUncacheableDSes(t *testing.T) {
+	testCases := []struct {
+		name                string
+		dses                []atscfg.ProfileDS
+		expectedSubroutines map[string][]string
+	}{
+		{
+			name: "no uncacheable DSes",
+			dses: []atscfg.ProfileDS{
+				{Name: "ds1", Type: tc.DSTypeHTTP, OriginFQDN: "ds1.example.com"},
+				{Name: "ds2", Type: tc.DSTypeHTTP, OriginFQDN: "ds2.example.com"},
+			},
+			expectedSubroutines: make(map[string][]string),
+		},
+		{
+			name: "single uncacheable DS",
+			dses: []atscfg.ProfileDS{
+				{Name: "ds1", Type: tc.DSTypeHTTP, OriginFQDN: "ds1.example.com"},
+				{Name: "ds2", Type: tc.DSTypeHTTPNoCache, OriginFQDN: "ds2.example.com"},
+			},
+			expectedSubroutines: map[string][]string{
+				"vcl_backend_response": {
+					`if (bereq.http.host == "ds2.example.com") {`,
+					`	set beresp.uncacheable = true;`,
+					`}`,
+				},
+			},
+		},
+		{
+			name: "multiple uncacheable DS",
+			dses: []atscfg.ProfileDS{
+				{Name: "ds1", Type: tc.DSTypeHTTP, OriginFQDN: "ds1.example.com"},
+				{Name: "ds2", Type: tc.DSTypeHTTPNoCache, OriginFQDN: "ds2.example.com"},
+				{Name: "ds3", Type: tc.DSTypeHTTPNoCache, OriginFQDN: "ds3.example.com"},
+				{Name: "ds4", Type: tc.DSTypeHTTPNoCache, OriginFQDN: "ds4.example.com"},
+				{Name: "ds5", Type: tc.DSTypeDNS, OriginFQDN: "ds5.example.com"},
+			},
+			expectedSubroutines: map[string][]string{
+				"vcl_backend_response": {
+					`if (bereq.http.host == "ds2.example.com" || bereq.http.host == "ds3.example.com" || bereq.http.host == "ds4.example.com") {`,
+					`	set beresp.uncacheable = true;`,
+					`}`,
+				},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			vb := NewVCLBuilder(&t3cutil.ConfigData{})
+			vclFile := newVCLFile(defaultVCLVersion)
+			warnings := vb.configureUncacheableDSes(&vclFile, tC.dses)
+			if len(warnings) != 0 {
+				t.Errorf("got unexpected warnings %v", warnings)
+			}
+			if !reflect.DeepEqual(vclFile.subroutines, tC.expectedSubroutines) {
+				t.Errorf("got %v want %v", vclFile.subroutines, tC.expectedSubroutines)
+			}
+		})
+	}
+}

--- a/lib/varnishcfg/vclbuilder.go
+++ b/lib/varnishcfg/vclbuilder.go
@@ -75,8 +75,18 @@ func (vb *VCLBuilder) BuildVCLFile() (string, []string, error) {
 	if err != nil {
 		return "", nil, fmt.Errorf("(warnings: %s) %w", strings.Join(warnings, ", "), err)
 	}
+	profileDSes, dsWarnings := atscfg.GetProfileDSes(
+		vb.toData.Server,
+		vb.toData.Servers,
+		vb.toData.DeliveryServices,
+		vb.toData.DeliveryServiceServers,
+	)
+	warnings = append(warnings, dsWarnings...)
+	cacheWarnings := vb.configureUncacheableDSes(&v, profileDSes)
+	warnings = append(warnings, cacheWarnings...)
 
 	dirWarnings, err := vb.configureDirectors(&v, parents)
 	warnings = append(warnings, dirWarnings...)
+
 	return fmt.Sprint(v), warnings, err
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
Skip caching delivery services with type `HTTP_NO_CACHE`.

Closes: #7770 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
unit tests added.
CIAB doesn't have a DS with no cache type, however if manually changed the DS [profile](https://github.com/apache/trafficcontrol/blob/master/infrastructure/cdn-in-a-box/traffic_ops_data/deliveryservices/010-demo1.json#L9) to `HTTP_NO_CACHE` requests should not be cached with Varnish.

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
