### PR TITLE
ReadTheDocs fix attempt No. 2

### DIFF
--- a/docs/source/api/v4/deliveryservices_required_capabilities.rst
+++ b/docs/source/api/v4/deliveryservices_required_capabilities.rst
@@ -13,7 +13,7 @@
 .. limitations under the License.
 ..
 
-.. _to-api-v4-deliveryservices-required-capabilities:
+.. _to-api-v4-deliveryservices_required_capabilities:
 
 ******************************************
 ``deliveryservices_required_capabilities``

--- a/docs/source/api/v5/asns.rst
+++ b/docs/source/api/v5/asns.rst
@@ -244,7 +244,7 @@ Response Structure
 			"cachegroup": "TRAFFIC_OPS",
 			"cachegroupId": 2,
 			"id": 1,
-			"lastUpdated": 2023-05-25T15:59:33.7096-06:00
+			"lastUpdated": "2023-05-25T15:59:33.7096-06:00"
 		}
 	}
 

--- a/docs/source/api/v5/server_server_capabilities.rst
+++ b/docs/source/api/v5/server_server_capabilities.rst
@@ -13,7 +13,7 @@
 .. limitations under the License.
 ..
 
-.. _to-api-server-server-capabilities:
+.. _to-api-server_server_capabilities:
 
 ******************************
 ``server_server_capabilities``

--- a/docs/source/api/v5/service_categories.rst
+++ b/docs/source/api/v5/service_categories.rst
@@ -13,7 +13,7 @@
 .. limitations under the License.
 ..
 
-.. _to-api-service-categories:
+.. _to-api-service_categories:
 
 **********************
 ``service_categories``

--- a/docs/source/api/v5/statuses_id.rst
+++ b/docs/source/api/v5/statuses_id.rst
@@ -1,0 +1,138 @@
+..
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..     http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+..
+
+.. _to-api-statuses-id:
+
+*******************
+``statuses/{{ID}}``
+*******************
+
+``PUT``
+=======
+Updates a :term:`Status`.
+
+:Auth. Required: Yes
+:Roles Required: None
+:Permissions Required: STATUS:UPDATE, STATUS:READ
+:Response Type:  Array
+
+Request Structure
+-----------------
+:description:	The description of the updated :term:`Status`
+:name:			The name of the updated :term:`Status`
+
+.. code-block:: http
+	:caption: Request Example
+
+	PUT /api/5.0/statuses/3 HTTP/1.1
+	Host: trafficops.infra.ciab.test
+	User-Agent: curl/7.47.0
+	Accept: */*
+	Cookie: mojolicious=...
+
+	{ "description": "test", "name": "example" }
+
+Response Structure
+------------------
+:description: A short description of the status
+:id:          The integral, unique identifier of this status
+:lastUpdated: The date and time at which this status was last modified, in :rfc:3339 format
+:name:        The name of the status
+
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Mon, 18 Nov 2019 17:40:54 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: dHNip9kpTGGS1w39/fWcFehNktgmXZus8XaufnmDpv0PyG/3fK/KfoCO3ZOj9V74/CCffps7doEygWeL/xRtKA==
+	X-Server-Name: traffic_ops_golang/
+	Date: Mon, 10 Dec 2018 20:56:59 GMT
+	Content-Length: 167
+
+	{ "alerts": [
+		{
+			"text": "status was created.",
+			"level": "success"
+		}
+	],"response": [
+		{
+			"description": "test",
+			"name": "example"
+			"id": 3,
+			"lastUpdated": "2018-12-10T19:11:17Z",
+		}
+	]}
+
+``DELETE``
+==========
+Deletes a :term:`Status`.
+
+:Auth. Required: Yes
+:Roles Required: "admin" or "operations"
+:Permissions Required: STATUS:DELETE, STATUS:READ
+:Response Type:  Object
+
+Request Structure
+-----------------
+.. table:: Request Path Parameters
+
+	+------+----------+---------------------------------------------------------------------------------------------+
+	| Name | Required | Description                                                                                 |
+	+======+==========+=============================================================================================+
+	| id   | yes      | The integral, unique identifier of the desired :abbr:`Status`-to-:term:`Server` association |
+	+------+----------+---------------------------------------------------------------------------------------------+
+
+.. code-block:: http
+	:caption: Request Example
+
+	DELETE /api/5.0/statuses/18 HTTP/1.1
+	User-Agent: curl/8.1.2
+	Accept-Encoding: gzip, deflate
+	Accept: */*
+	Connection: keep-alive
+	Cookie: mojolicious=...
+	Content-Length: 0
+
+Response Structure
+------------------
+.. code-block:: http
+	:caption: Response Example
+
+	HTTP/1.1 200 OK
+	Access-Control-Allow-Credentials: true
+	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
+	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE
+	Access-Control-Allow-Origin: *
+	Content-Encoding: gzip
+	Content-Type: application/json
+	Set-Cookie: mojolicious=...; Path=/; Expires=Thu, 15 Jun 2023 22:37:37 GMT; Max-Age=3600; HttpOnly
+	Whole-Content-Sha512: T8wtKKwyOKKVwDwoNCNvETllsByDiEe4CrpeS7Zdox+rXMgPb3FBlKmmgu4CpxbWdhpiODKqKn+gsSq5K4yvIQ==
+	X-Server-Name: traffic_ops_golang/
+	Date: Thu, 15 Jun 2023 21:41:18 GMT
+	Content-Length: 62
+
+	{
+		"alerts": [
+			{
+				"text": "status was deleted.",
+				"level": "success"
+			}
+		]
+	}

--- a/docs/source/overview/profiles_and_parameters.rst
+++ b/docs/source/overview/profiles_and_parameters.rst
@@ -610,11 +610,7 @@ The following plugins have support for adding args with following parameter Conf
 	| cachekey.pparam        | cachekey.pparam     | ``-o``                       | ``@pparam=-o``                       |
 	+------------------------+---------------------+------------------------------+--------------------------------------+
 
-In order to support difficult configurations at MID/LAST, a
-:term:`Delivery Service` profile parameter is available with parameters
-``LastRawRemapPre`` and ``LastRawRemapPost``, config file ``remap.config``
-and Value the raw remap lines.  The Value in this parameter will be pre
-or post pended to the end of ``remap.config``.
+In order to support difficult configurations at MID/LAST, a :term:`Delivery Service` profile parameter is available with parameters ``LastRawRemapPre`` and ``LastRawRemapPost``, config file ``remap.config`` and Value the raw remap lines. The Value in this parameter will be pre or post pended to the end of ``remap.config``.
 
 To provide the most flexibility for managing :term:`Delivery Service` generated ``remap.config`` lines there are options for redefining the internal mustache template used to generate these ``remap.config`` lines.
 
@@ -626,7 +622,7 @@ To provide the most flexibility for managing :term:`Delivery Service` generated 
 .. table:: ``remap.config`` Template Tags
 
 	+------------------+-----------------------------------+-------------------------------+
-	| :ref:`tag-name`  | Value_                            | Associated plugin/directive   |
+	| Tag Name         | Value_                            | Associated plugin/directive   |
 	+==================+===================================+===============================+
 	| Source           | Target, or request "from" URL     |                               |
 	+------------------+-----------------------------------+-------------------------------+

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-Sphinx>=4.0,<4.1
-sphinx_rtd_theme>=0.5
-sphinx_autodoc_typehints>=1.11
+Sphinx>=5.1,<5.2
+sphinx-rtd-theme>=1.3
+sphinx_autodoc_typehints>=1.24
 Pygments>=2.6
 munch>=2.1.1
 future>=0.16.0

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -828,7 +828,7 @@ class TOSession(RestApiSession):
 	def get_deliveryservice_request_comments(self, query_params=None):
 		"""
 		Retrieves all delivery service reuest comments.
-		:ref:`to-api-deliveryservice-request-comments`
+		:ref:`to-api-deliveryservice_request_comments`
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
@@ -837,7 +837,7 @@ class TOSession(RestApiSession):
 	def create_deliveryservice_request_comment(self, data=None):
 		"""
 		Creates a new delivery service request comment.
-		:ref:`to-api-deliveryservice-request-comments`
+		:ref:`to-api-deliveryservice_request_comments`
 		:param data: The request data structure for the API request
 		:type data: Dict[str, Any]
 		:rtype: Tuple[Dict[str, Any], requests.Response]
@@ -848,7 +848,7 @@ class TOSession(RestApiSession):
 	def update_deliveryservice_request_comment(self, query_params=None, data=None):
 		"""
 		Updates an existing Delivery Service Request comment.
-		:ref:`to-api-deliveryservice-request-comments`
+		:ref:`to-api-deliveryservice_request_comments`
 		:param data: The request data structure for the API request
 		:type data: Dict[str, Any]
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
@@ -859,7 +859,7 @@ class TOSession(RestApiSession):
 	def delete_deliveryservice_request_comment(self, query_params=None):
 		"""
 		Deletes a Delivery Service Request comment.
-		:ref:`to-api-deliveryservice-request-comments`
+		:ref:`to-api-deliveryservice_request_comments`
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
@@ -2181,7 +2181,7 @@ class TOSession(RestApiSession):
 	def delete_status_by_id(self, status_id=None):
 		"""
 		Delete a status
-		:ref:`to-api-status-id`
+		:ref:`to-api-statuses-id`
 		:param status_id: The status to delete
 		:type status_id: int
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -560,7 +560,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	#
 	# CDN Notifications
 	#
@@ -585,7 +585,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	@api_request('delete', 'cdn_notifications', ('4.0', '4.1', '5.0'))
 	def delete_cdn_notification(self, query_params=None):
 		"""
@@ -661,7 +661,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	#
 	# CDN Lock
 	#
@@ -819,7 +819,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 
 	#
 	# Delivery Service Request Comments
@@ -922,7 +922,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	@api_request('get', 'deliveryservices/{delivery_service_id:d}/routing', ('3.0', '4.0', '4.1', '5.0'))
 	def get_delivery_service_routing(self, delivery_service_id=None):
 		"""
@@ -1555,7 +1555,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	#
 	# Server_capabilities
 	#
@@ -2061,7 +2061,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	#
 	# Service categories
 	#
@@ -2084,7 +2084,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	@api_request('put', 'service_categories/{service_category_name:s}', ('3.0', '4.0', '4.1', '5.0'))
 	def update_service_category(self, service_category_name=None, data=None):
 		"""
@@ -2273,7 +2273,7 @@ class TOSession(RestApiSession):
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
-	
+
 	@api_request('delete', 'tenants/{tenant_id:d}', ('3.0', '4.0', '4.1', '5.0'))
 	def delete_tenant(self, tenant_id=None):
 		"""

--- a/traffic_control/clients/python/trafficops/tosession.py
+++ b/traffic_control/clients/python/trafficops/tosession.py
@@ -867,31 +867,31 @@ class TOSession(RestApiSession):
     #
 	# Delivery Service Required capabilities
 	#
-	@api_request('get', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1', '5.0'))
+	@api_request('get', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1'))
 	def get_deliveryservices_required_capabilities(self, query_params=None):
 		"""
 		Retrieves all delivery service required capabilities.
-		:ref:`to-api-deliveryservice-required-capabilities`
+		:ref:`to-api-v4-deliveryservices_required_capabilities`
 		:rtype: Tuple[Union[Dict[str, Any], List[Dict[str, Any]]], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
 
-	@api_request('post', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1', '5.0'))
+	@api_request('post', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1'))
 	def create_deliveryservices_required_capabilities(self, data=None):
 		"""
 		Creates a new delivery service required capability.
-		:ref:`to-api-deliveryservice-required-capabilities`
+		:ref:`to-api-v4-deliveryservices_required_capabilities`
 		:param data: The request data structure for the API request
 		:type data: Dict[str, Any]
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""
 
-	@api_request('delete', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1', '5.0'))
+	@api_request('delete', 'deliveryservices_required_capabilities', ('3.0', '4.0', '4.1'))
 	def delete_deliveryservices_required_capabilities(self, query_params=None):
 		"""
 		Deletes a Delivery Service Required capability.
-		:ref:`to-api-deliveryservice-required-capabilities`
+		:ref:`to-api-v4-deliveryservices_required_capabilities`
 		:rtype: Tuple[Dict[str, Any], requests.Response]
 		:raises: Union[LoginError, OperationError]
 		"""


### PR DESCRIPTION
I checked my site packages and in version 5.1 Sphinx is correctly importing `Union` from the `typing` package, not the `types` package, so I figure it's worth a shot updating our dependencies to see if that fixes the RTD build.

I also fixed a bunch of docs problems I encountered when checking that the build works with my versions of things. And also during those fixes I noticed an endpoint in the Python client is being offered at version 5.x but it doesn't actually exist in APIv5.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation
- Traffic Control Client (Python)

## What is the best way to verify this PR?
Build the docs, check that there are no errors or warnings. Other than that, we'll need to wait for RTD to pick it up to verify that it helps with that.

## If this is a bugfix, which Traffic Control versions contained the bug?
- unknown

## PR submission checklist
- [x] This PR uses existing tests
- [x] This PR is documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
