### PR TITLE
Fix tchealthclient CiaB service unable to build

### DIFF
--- a/infrastructure/cdn-in-a-box/health/Dockerfile
+++ b/infrastructure/cdn-in-a-box/health/Dockerfile
@@ -21,6 +21,8 @@ ARG BASE_IMAGE=rockylinux \
     RHEL_VERSION=8
 FROM ${BASE_IMAGE}:${RHEL_VERSION} as common-dependencies
 ARG RHEL_VERSION=8
+# Makes RHEL_VERSION available in later layers without needing to specify it again
+ENV RHEL_VERSION="$RHEL_VERSION"
 
 MAINTAINER dev@trafficcontrol.apache.org
 
@@ -59,7 +61,7 @@ RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-* && \
         epel-release && \
     yum -y clean all
 
-ARG TCH_RPM=infrastructure/cdn-in-a-box/health/trafficcontrol-health-client.rpm 
+ARG TCH_RPM=infrastructure/cdn-in-a-box/health/trafficcontrol-health-client.rpm
 COPY $TCH_RPM /
 RUN rpm -Uvh /$(basename $TCH_RPM) &&\
     rm /$(basename $TCH_RPM)


### PR DESCRIPTION
I have no idea why this is only affecting me, but the `tchealthclient` CiaB service  is failing to build because of  a build `ARG` that is being used in a layer in which it is unavailable. This PR fixes that by adding  it to the execution environment to rely on the image's shell to do the string replacements containing it, rather than Docker itself.

<hr/>

## Which Traffic Control components are affected by this PR?
- CDN in a Box

## What is the best way to verify this PR?
Make sure you can build the `tchealthclient` CDN-in-a-Box service after destroying your Docker cache.

## If this is a bugfix, which Traffic Control versions contained the bug?
- unknown

## PR submission checklist
- [x] This PR is a change to something heavily used in test suites
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
