### PR TITLE
Removing the quotes around client auth enabled

### DIFF
--- a/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
+++ b/infrastructure/ansible/roles/traffic_ops/templates/cdn.conf.j2
@@ -69,7 +69,7 @@
       "plugin_config" : {{ to_plugin_config | to_nice_json(indent=2) }},
       "traffic_vault_backend": "{{ to_traffic_vault_backend }}",
       "tls_config": {
-         "ClientAuth": "{{ to_go_client_auth_enabled }}"
+         "ClientAuth": {{ to_go_client_auth_enabled }}
       },
       "traffic_vault_config": {
 {% if to_traffic_vault_backend == "postgres" %}


### PR DESCRIPTION
Removing the quotes around client auth enabled

Which Traffic Control components are affected by this PR?
Automation - Lab Ansible Infrastructure

What is the best way to verify this PR?
Build an environment setting the following two variables

to_client_cert_root_directory = path to root cert file
to_go_client_auth_enabled = 1

You should see the config values set in cdn.conf.

If this is a bugfix, which Traffic Control versions contained the bug?
Not a bug fix

PR submission checklist
 This PR has tests - This PR is an improvement to automated infra that is involved in testing.
[] This PR has documentation - I'm enabling already implemented and documented features.
[] This PR has a CHANGELOG.md entry
 This PR DOES NOT FIX A SERIOUS SECURITY VULNERABILITY (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
