### PR TITLE
ReadTheDocs fix attempt #3

### DIFF
--- a/docs/source/api/v3/asns_id.rst
+++ b/docs/source/api/v3/asns_id.rst
@@ -57,7 +57,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 29
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"asn": 2, "cachegroupId": 1}
 

--- a/docs/source/api/v3/consistenthash.rst
+++ b/docs/source/api/v3/consistenthash.rst
@@ -43,7 +43,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 80
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"regex":"/.*?(/.*?/).*?(m3u8)","requestPath":"/test/path/asset.m3u8","cdnId":2}
 

--- a/docs/source/api/v4/asns_id.rst
+++ b/docs/source/api/v4/asns_id.rst
@@ -58,7 +58,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 29
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"asn": 2, "cachegroupId": 1}
 

--- a/docs/source/api/v4/consistenthash.rst
+++ b/docs/source/api/v4/consistenthash.rst
@@ -44,7 +44,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 80
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"regex":"/.*?(/.*?/).*?(m3u8)","requestPath":"/test/path/asset.m3u8","cdnId":2}
 

--- a/docs/source/api/v5/asns_id.rst
+++ b/docs/source/api/v5/asns_id.rst
@@ -58,7 +58,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 29
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"asn": 2, "cachegroupId": 1}
 

--- a/docs/source/api/v5/consistenthash.rst
+++ b/docs/source/api/v5/consistenthash.rst
@@ -44,7 +44,7 @@ Request Structure
 	Accept: */*
 	Cookie: mojolicious=...
 	Content-Length: 80
-	Content-Type: application/x-www-form-urlencoded
+	Content-Type: application/json
 
 	{"regex":"/.*?(/.*?/).*?(m3u8)","requestPath":"/test/path/asset.m3u8","cdnId":2}
 

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-Sphinx>=5.1,<5.2
+Sphinx>=7.0,<7.1
 sphinx-rtd-theme>=1.3
 sphinx_autodoc_typehints>=1.24
 Pygments>=2.6


### PR DESCRIPTION
This fixes an incompatibility with the Sphinx version and the versions of other things as declared in the `requirements.txt` file for the docs. In the new version - 7.0.1 - there is now a lexer for  `application/x-www-form-urlencoded` -encoded content, which means that some of our blocks that declare this type of content no longer lex. In reality, these payloads will actually be parsed as `application/json` no matter what's in the `Content-Type` header; Traffic Ops doesn't consider it at all. But it works equally well if you actually do set the correct header, and that gives us back syntax highlighting, so I fixed/changed those.

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Build the docs, make sure there are no warnings, even when you use the build tools declared by `requirements.txt`. Other than that, we need to wait for RTD to pick this up before we'll know if it has any effect on those issues.

## If this is a bugfix, which Traffic Control versions contained the bug?
- master

## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR is comprised of documentation changes
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**