### PR TITLE
Documentation cleanup

### DIFF
--- a/docs/source/admin/traffic_ops.rst
+++ b/docs/source/admin/traffic_ops.rst
@@ -328,7 +328,7 @@ This file deals with the configuration parameters of running Traffic Ops itself.
 
 :default_certificate_info: This is an optional object to define default values when generating a self signed certificate when an HTTPS delivery service is created or updated. If this is an empty object or not present in the :ref:`cdn.conf` then the term "Placeholder" will be used for all fields.
 
- 	:business_unit: An optional field which, if present, will represent the business unit for which the SSL certificate was generated
+	:business_unit: An optional field which, if present, will represent the business unit for which the SSL certificate was generated
 	:city: An optional field which, if present, will represent the resident city of the generated SSL certificate
 	:organization: An optional field which, if present, will represent the organization for which the SSL certificate was generated
 	:country: An optional field which, if present, will represent the resident country of the generated SSL certificate

--- a/docs/source/api/v3/statuses.rst
+++ b/docs/source/api/v3/statuses.rst
@@ -106,8 +106,8 @@ Creates a Server :term:`Status`.
 
 Request Structure
 -----------------
-:description:	Create a :term:`Status` with this description
-:name:			Create a :term:`Status` with this name
+:description: Create a :term:`Status` with this description
+:name:        Create a :term:`Status` with this name
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/statuses_id.rst
+++ b/docs/source/api/v3/statuses_id.rst
@@ -107,8 +107,8 @@ Updates a :term:`Status`.
 
 Request Structure
 -----------------
-:description:	The description of the updated :term:`Status`
-:name:			The name of the updated :term:`Status`
+:description: The description of the updated :term:`Status`
+:name:        The name of the updated :term:`Status`
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v3/topologies.rst
+++ b/docs/source/api/v3/topologies.rst
@@ -55,7 +55,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -161,7 +161,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -251,7 +251,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -369,7 +369,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -451,7 +451,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -57,7 +57,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
+:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -81,7 +81,7 @@ Response Structure
 		{
 			"id": 42,
 			"cdn": "cdn1",
-			"lastUpdated": "2019-12-02 21:49:08+00",
+			"lastUpdated": "2019-12-02T21:49:08Z",
 			"notification": "the content of the notification",
 			"user": "username123",
 		}
@@ -121,7 +121,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
+:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -153,7 +153,7 @@ Response Structure
 		{
 			"id": 42,
 			"cdn": "cdn1",
-			"lastUpdated": "2019-12-02 21:49:08+00",
+			"lastUpdated": "2019-12-02T21:49:08Z",
 			"notification": "the content of the notification",
 			"user": "username123",
 		}

--- a/docs/source/api/v4/cdn_notifications.rst
+++ b/docs/source/api/v4/cdn_notifications.rst
@@ -57,7 +57,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
+:lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -121,7 +121,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
+:lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 

--- a/docs/source/api/v4/cdns.rst
+++ b/docs/source/api/v4/cdns.rst
@@ -67,7 +67,7 @@ Response Structure
 :id:            The integral, unique identifier for the CDN
 :lastUpdated:   Date and time when the CDN was last modified in :ref:`non-rfc-datetime`
 :name:          The name of the CDN
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 	.. versionadded:: 4.1
 
@@ -119,7 +119,7 @@ Request Structure
 :dnssecEnabled: If ``true``, this CDN will use DNSSEC, if ``false`` it will not
 :domainName:    The top-level domain (TLD) belonging to the new CDN
 :name:          Name of the new CDN
-:ttlOverride:	Optional an nullable. A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   Optional an nullable. A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 	.. versionadded:: 4.1
 
@@ -142,7 +142,7 @@ Response Structure
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
 :name:          The newly created CDN's name
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 	.. versionadded:: 4.1
 

--- a/docs/source/api/v4/cdns_id.rst
+++ b/docs/source/api/v4/cdns_id.rst
@@ -41,7 +41,7 @@ Request Structure
 :dnssecEnabled: If ``true``, this CDN will use DNSSEC, if ``false`` it will not
 :domainName:    The top-level domain (TLD) belonging to the CDN
 :name:          Name of the new CDN
-:ttlOverride:	Optional an nullable. A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`. If this is not present in the request, it will be treated as though it were ``null``.
 
 	.. versionadded:: 4.1
 
@@ -64,7 +64,7 @@ Response Structure
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
 :name:          The newly created CDN's name
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`. If this is not present in the request, it will be treated as though it were ``null``.
 
 	.. versionadded:: 4.1
 

--- a/docs/source/api/v4/deliveryserviceserver.rst
+++ b/docs/source/api/v4/deliveryserviceserver.rst
@@ -65,7 +65,7 @@ Unlike most API endpoints, this will return a JSON response body containing both
 :response: An array of objects, each of which represents a server's :term:`Delivery Service` assignment
 
 	:deliveryService: The integral, unique identifier of the :term:`Delivery Service` to which the server identified by ``server`` is assigned
-	:lastUpdated:     The date and time at which the server's assignment to a :term:`Delivery Service` was last updated
+	:lastUpdated:     The date and time at which the server's assignment to a :term:`Delivery Service` was last updated, in :ref:`non-rfc-datetime`
 	:server:          The integral, unique identifier of a server which is assigned to the :term:`Delivery Service` identified by ``deliveryService``
 
 :size: The page number - if pagination was requested in the query parameters, else ``0`` to indicate no pagination - of the results represented by the ``response`` array. This is named "size" for legacy reasons

--- a/docs/source/api/v4/origins.rst
+++ b/docs/source/api/v4/origins.rst
@@ -89,7 +89,7 @@ Response Structure
 :ip6Address:        The IPv6 address of the :term:`Origin`
 :ipAddress:         The IPv4 address of the :term:`Origin`
 :isPrimary:         A boolean value which, when ``true`` specifies this :term:`Origin` as the 'primary' :term:`Origin` served by ``deliveryService``
-:lastUpdated:       The date and time at which this :term:`Origin` was last modified
+:lastUpdated:       The date and time at which this :term:`Origin` was last modified, in :ref:`non-rfc-datetime`
 :name:              The name of the :term:`Origin`
 :port:              The TCP port on which the :term:`Origin` listens
 :profile:           The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`

--- a/docs/source/api/v4/staticdnsentries.rst
+++ b/docs/source/api/v4/staticdnsentries.rst
@@ -89,7 +89,7 @@ Response Structure
 :deliveryserviceId: The integral, unique identifier of a :term:`Delivery Service` under the domain of which this static DNS entry shall be active
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
-:lastUpdated:       The date and time at which this static DNS entry was last updated
+:lastUpdated:       The date and time at which this static DNS entry was last updated, in :ref:`non-rfc-datetime`
 :ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
 :type:              The name of the type of this static DNS entry
 :typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry

--- a/docs/source/api/v4/statuses.rst
+++ b/docs/source/api/v4/statuses.rst
@@ -107,8 +107,8 @@ Creates a Server :term:`Status`.
 
 Request Structure
 -----------------
-:description:	Create a :term:`Status` with this description
-:name:			Create a :term:`Status` with this name
+:description: Create a :term:`Status` with this description
+:name:        Create a :term:`Status` with this name
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/statuses_id.rst
+++ b/docs/source/api/v4/statuses_id.rst
@@ -107,8 +107,8 @@ Updates a :term:`Status`.
 
 Request Structure
 -----------------
-:description:	The description of the updated :term:`Status`
-:name:			The name of the updated :term:`Status`
+:description: The description of the updated :term:`Status`
+:name:        The name of the updated :term:`Status`
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v4/topologies.rst
+++ b/docs/source/api/v4/topologies.rst
@@ -56,7 +56,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -163,7 +163,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -253,7 +253,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -372,7 +372,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -454,7 +454,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/acme_accounts_provider_email.rst
+++ b/docs/source/api/v5/acme_accounts_provider_email.rst
@@ -19,8 +19,6 @@
 ``acme_accounts/{{provider}}/{{email}}``
 ****************************************
 
-.. versionadded:: 3.1
-
 ``DELETE``
 ==========
 Delete :term:`ACME Account` information.
@@ -28,7 +26,7 @@ Delete :term:`ACME Account` information.
 :Auth. Required: Yes
 :Roles Required: "admin"
 :Permissions Required: ACME:DELETE, ACME:READ
-:Response Type:  Object
+:Response Type:  ``undefined``
 
 Request Structure
 -----------------

--- a/docs/source/api/v5/asns.rst
+++ b/docs/source/api/v5/asns.rst
@@ -76,6 +76,9 @@ Response Structure
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
 :lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` Format
 
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -146,6 +149,9 @@ Response Structure
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
 :lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` Format
 
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -215,6 +221,9 @@ Response Structure
 :cachegroupId: An integer that is the :ref:`cache-group-id` of the :term:`Cache Group` that is associated with this :abbr:`ASN (Autonomous System Number)`
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
 :lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` Format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/asns_id.rst
+++ b/docs/source/api/v5/asns_id.rst
@@ -70,6 +70,9 @@ Response Structure
 :id:           An integral, unique identifier for this association between an :abbr:`ASN (Autonomous System Number)` and a :term:`Cache Group`
 :lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
 
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 

--- a/docs/source/api/v5/cachegroups.rst
+++ b/docs/source/api/v5/cachegroups.rst
@@ -68,10 +68,10 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
-:fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
-:id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in :rfc:`3339`
+:fallbacks:         An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
+:fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
+:id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
+:lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`
@@ -138,8 +138,8 @@ Request Structure
 
 	.. note:: The default value of ``fallbackToClosest`` is ``true``, and if it is ``null`` Traffic Control components will still interpret it as though it were ``true``.
 
-:latitude:                    An optional field which, if present, should be a floating-point number that will define the :ref:`cache-group-latitude` for the :term:`Cache Group`\ [#optional]_
-:localizationMethods:         Array of :ref:`cache-group-localization-methods` (as strings)
+:latitude:            An optional field which, if present, should be a floating-point number that will define the :ref:`cache-group-latitude` for the :term:`Cache Group`\ [#optional]_
+:localizationMethods: Array of :ref:`cache-group-localization-methods` (as strings)
 
 	.. tip:: This field has no defined meaning if the :ref:`cache-group-type` identified by ``typeId`` is not "EDGE_LOC".
 
@@ -179,10 +179,10 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
-:fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
-:id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in :rfc:`3339`
+:fallbacks:         An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
+:fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
+:id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
+:lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v5/cachegroups.rst
+++ b/docs/source/api/v5/cachegroups.rst
@@ -72,6 +72,10 @@ Response Structure
 :fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
 :lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`
@@ -183,6 +187,10 @@ Response Structure
 :fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
 :lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v5/cachegroups_id.rst
+++ b/docs/source/api/v5/cachegroups_id.rst
@@ -85,6 +85,10 @@ Response Structure
 :fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
 :id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
 :lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v5/cachegroups_id.rst
+++ b/docs/source/api/v5/cachegroups_id.rst
@@ -81,10 +81,10 @@ Request Structure
 
 Response Structure
 ------------------
-:fallbacks:                     An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
-:fallbackToClosest:             A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
-:id:                            An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
-:lastUpdated:                   The time and date at which this entry was last updated in :rfc:`3339`
+:fallbacks:         An array of strings that are :ref:`Cache Group names <cache-group-name>` that are registered as :ref:`cache-group-fallbacks` for this :term:`Cache Group`\ [#fallbacks]_
+:fallbackToClosest: A boolean value that defines the :ref:`cache-group-fallback-to-closest` behavior of this :term:`Cache Group`\ [#fallbacks]_
+:id:                An integer that is the :ref:`cache-group-id` of the :term:`Cache Group`
+:lastUpdated:       The time and date at which this entry was last updated in :rfc:`3339`
 :latitude:                      A floating-point :ref:`cache-group-latitude` for the :term:`Cache Group`
 :localizationMethods:           An array of :ref:`cache-group-localization-methods` as strings
 :longitude:                     A floating-point :ref:`cache-group-longitude` for the :term:`Cache Group`

--- a/docs/source/api/v5/cdn_notifications.rst
+++ b/docs/source/api/v5/cdn_notifications.rst
@@ -57,7 +57,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
+:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -81,7 +81,7 @@ Response Structure
 		{
 			"id": 42,
 			"cdn": "cdn1",
-			"lastUpdated": "2019-12-02 21:49:08+00",
+			"lastUpdated": "2019-12-02T21:49:08Z",
 			"notification": "the content of the notification",
 			"user": "username123",
 		}
@@ -121,7 +121,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :ref:`non-rfc-datetime`
+:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -153,7 +153,7 @@ Response Structure
 		{
 			"id": 42,
 			"cdn": "cdn1",
-			"lastUpdated": "2019-12-02 21:49:08+00",
+			"lastUpdated": "2019-12-02T21:49:08Z",
 			"notification": "the content of the notification",
 			"user": "username123",
 		}

--- a/docs/source/api/v5/cdn_notifications.rst
+++ b/docs/source/api/v5/cdn_notifications.rst
@@ -57,7 +57,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
+:lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 
@@ -121,7 +121,7 @@ Response Structure
 ------------------
 :id:           The integral, unique identifier of the notification
 :cdn:          The name of the CDN to which the notification belongs to
-:lastUpdated:  The time and date this server entry was last updated in :rfc:3339 format
+:lastUpdated:  The time and date this server entry was last updated in :rfc:`3339` format
 :notification: The content of the notification
 :user:         The user responsible for creating the notification
 

--- a/docs/source/api/v5/cdns.rst
+++ b/docs/source/api/v5/cdns.rst
@@ -67,6 +67,9 @@ Response Structure
 :id:            The integral, unique identifier for the CDN
 :lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339` Format
 
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :name:        The name of the CDN
 :ttlOverride: A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
@@ -139,6 +142,9 @@ Response Structure
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
 :lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339` Format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 :name:        The newly created CDN's name
 :ttlOverride: A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`

--- a/docs/source/api/v5/cdns.rst
+++ b/docs/source/api/v5/cdns.rst
@@ -65,9 +65,10 @@ Response Structure
 :dnssecEnabled: ``true`` if DNSSEC is enabled on this CDN, otherwise ``false``
 :domainName:    Top Level Domain name within which this CDN operates
 :id:            The integral, unique identifier for the CDN
-:lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339`
-:name:          The name of the CDN
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339` Format
+
+:name:        The name of the CDN
+:ttlOverride: A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 .. code-block:: http
 	:caption: Response Example
@@ -117,7 +118,7 @@ Request Structure
 :dnssecEnabled: If ``true``, this CDN will use DNSSEC, if ``false`` it will not
 :domainName:    The top-level domain (TLD) belonging to the new CDN
 :name:          Name of the new CDN
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 .. code-block:: http
 	:caption: Request Structure
@@ -137,8 +138,10 @@ Response Structure
 :dnssecEnabled: ``true`` if the CDN uses DNSSEC, ``false`` otherwise
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
-:name:          The newly created CDN's name
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339` Format
+
+:name:        The newly created CDN's name
+:ttlOverride: A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 
 .. code-block:: http

--- a/docs/source/api/v5/cdns.rst
+++ b/docs/source/api/v5/cdns.rst
@@ -37,7 +37,7 @@ Request Structure
 	+===============+==========+===================================================================================+
 	| domainName    | no       | Return only the CDN that has this domain name                                     |
 	+---------------+----------+-----------------------------------------------------------------------------------+
-	| dnssecEnabled | no       | Return only the CDNs that are either dnssec enabled or not                        |
+	| dnssecEnabled | no       | Return only the CDNs that have DNSSEC enabled settings matching this parameter    |
 	+---------------+----------+-----------------------------------------------------------------------------------+
 	| id            | no       | Return only the CDN that has this id                                              |
 	+---------------+----------+-----------------------------------------------------------------------------------+

--- a/docs/source/api/v5/cdns_dnsseckeys_refresh.rst
+++ b/docs/source/api/v5/cdns_dnsseckeys_refresh.rst
@@ -26,7 +26,7 @@ Refresh the DNSSEC keys for all CDNs. This call initiates a background process t
 :Auth. Required: Yes
 :Roles Required: "admin"
 :Permissions Required: DNS-SEC:UPDATE, CDN:UPDATE, CDN:READ
-:Response Type:  Object (string)
+:Response Type: ``undefined``
 
 Request Structure
 -----------------

--- a/docs/source/api/v5/cdns_id.rst
+++ b/docs/source/api/v5/cdns_id.rst
@@ -61,8 +61,13 @@ Response Structure
 :dnssecEnabled: ``true`` if the CDN uses DNSSEC, ``false`` otherwise
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
-:name:          The newly created CDN's name
-:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:lastUpdated:   Date and time when the CDN was last modified in :rfc:`3339` Format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:        The newly created CDN's name
+:ttlOverride: A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 
 .. code-block:: http
@@ -90,7 +95,7 @@ Response Structure
 		"dnssecEnabled": false,
 		"domainName": "test",
 		"id": 4,
-		"lastUpdated": "2018-11-14 20:54:33+00",
+		"lastUpdated": "2018-11-14T20:54:33Z",
 		"name": "quest",
 		"ttlOverride": 60
 	}}

--- a/docs/source/api/v5/cdns_id.rst
+++ b/docs/source/api/v5/cdns_id.rst
@@ -41,7 +41,7 @@ Request Structure
 :dnssecEnabled: If ``true``, this CDN will use DNSSEC, if ``false`` it will not
 :domainName:    The top-level domain (TLD) belonging to the CDN
 :name:          Name of the new CDN
-:ttlOverride:	Optional an nullable. A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`. If this is not present in the request, it will be treated as though it were ``null``.
 
 .. code-block:: http
 	:caption: Request Example
@@ -62,7 +62,7 @@ Response Structure
 :domainName:    The top-level domain (TLD) assigned to the newly created CDN
 :id:            An integral, unique identifier for the newly created CDN
 :name:          The newly created CDN's name
-:ttlOverride:	A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
+:ttlOverride:   A :abbr:`TTL (Time To Live)` value, in seconds, that, if set, overrides all set TTL values on :term:`Delivery Services` in this :abbr:`CDN (Content Delivery Network)`
 
 
 .. code-block:: http

--- a/docs/source/api/v5/cdns_name_federations_id.rst
+++ b/docs/source/api/v5/cdns_name_federations_id.rst
@@ -39,7 +39,7 @@ Request Structure
 	+======+=============================================================================================+
 	| name | The name of the CDN for which the :term:`Federation` identified by ``ID`` will be inspected |
 	+------+---------------------------------------------------------------------------------------------+
-	|  ID  | An integral, unique identifier for the :term:`Federation` to be inspected                  |
+	|  ID  | An integral, unique identifier for the :term:`Federation` to be inspected                   |
 	+------+---------------------------------------------------------------------------------------------+
 
 .. code-block:: http

--- a/docs/source/api/v5/coordinates.rst
+++ b/docs/source/api/v5/coordinates.rst
@@ -56,7 +56,7 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique, identifier for this coordinate pair
-:lastUpdated: The time and date at which this entry was last updated, in :rfc:`3339`` format
+:lastUpdated: The time and date at which this entry was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.

--- a/docs/source/api/v5/coordinates.rst
+++ b/docs/source/api/v5/coordinates.rst
@@ -56,10 +56,14 @@ Request Structure
 Response Structure
 ------------------
 :id:          Integral, unique, identifier for this coordinate pair
-:lastUpdated: The time and date at which this entry was last updated, in :RFC:`3339` format
-:latitude:    Latitude of the coordinate
-:longitude:   Longitude of the coordinate
-:name:        The name of the coordinate - typically this just reflects the name of the Cache Group for which the coordinate was created
+:lastUpdated: The time and date at which this entry was last updated, in :rfc:`3339`` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:latitude:  Latitude of the coordinate
+:longitude: Longitude of the coordinate
+:name:      The name of the coordinate - typically this just reflects the name of the :term:`Cache Group` for which the coordinate was created
 
 .. code-block:: http
 	:caption: Response Example
@@ -160,6 +164,10 @@ Response Structure
 ------------------
 :id:          Integral, unique, identifier for the newly created coordinate pair
 :lastUpdated: The time and date at which this entry was last updated, in :RFC:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :latitude:    Latitude of the newly created coordinate
 :longitude:   Longitude of the newly created coordinate
 :name:        The name of the coordinate
@@ -234,9 +242,13 @@ Response Structure
 ------------------
 :id:          Integral, unique, identifier for the coordinate pair
 :lastUpdated: The time and date at which this entry was last updated, in :RFC:`3339` format
-:latitude:    Latitude of the coordinate
-:longitude:   Longitude of the coordinate
-:name:        The name of the coordinate
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:latitude:  Latitude of the coordinate
+:longitude: Longitude of the coordinate
+:name:      The name of the coordinate
 
 .. code-block:: http
 	:caption: Response Example
@@ -280,9 +292,13 @@ Request Structure
 -----------------
 :id:          Integral, unique, identifier for the coordinate pair
 :lastUpdated: The time and date at which this entry was last updated, in :RFC:`3339` format
-:latitude:    Latitude of the coordinate
-:longitude:   Longitude of the coordinate
-:name:        The name of the coordinate
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:latitude:  Latitude of the coordinate
+:longitude: Longitude of the coordinate
+:name:      The name of the coordinate
 
 .. table:: Request Query Parameters
 

--- a/docs/source/api/v5/deliveryservice_request_comments.rst
+++ b/docs/source/api/v5/deliveryservice_request_comments.rst
@@ -189,7 +189,7 @@ Response Structure
 
 ``PUT``
 =======
-Updates a delivery service request comment.
+Updates a :term:`Delivery Service Request` comment.
 
 :Auth. Required: Yes
 :Roles Required: "admin", "Federation", "operations", "Portal", or "Steering"

--- a/docs/source/api/v5/deliveryservice_request_comments.rst
+++ b/docs/source/api/v5/deliveryservice_request_comments.rst
@@ -57,13 +57,17 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                        The username of the user who created the comment.
-:authorId:                      The integral, unique identifier of the user who created the comment.
-:deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
-:id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in :rfc:`3339`
-:value:                         The text of the comment that was posted.
-:xmlId:                         This is the ``xmlId`` value that you provided in the request.
+:author:                   The username of the user who created the comment.
+:authorId:                 The integral, unique identifier of the user who created the comment.
+:deliveryServiceRequestId: The integral, unique identifier of the :term:`Delivery Service Request` on which the comment was posted.
+:id:                       The integral, unique identifier of the :term:`DSR` comment.
+:lastUpdated:              The date and time at which the user was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:value: The text of the comment that was posted.
+:xmlId: This is the ``xmlId`` value that you provided in the request.
 
 .. code-block:: http
 	:caption: Response Example
@@ -137,13 +141,17 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                        The username of the user who created the comment.
-:authorId:                      The integral, unique identifier of the user who created the comment.
-:deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
-:id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in :rfc:`3339`
-:value:                         The text of the comment that was posted.
-:xmlId:                         This is the ``xmlId`` value that you provided in the request.
+:author:                   The username of the user who created the comment.
+:authorId:                 The integral, unique identifier of the user who created the comment.
+:deliveryServiceRequestId: The integral, unique identifier of the :term:`Delivery Service Request` on which the comment was posted.
+:id:                       The integral, unique identifier of the :term:`DSR` comment.
+:lastUpdated:              The date and time at which the user was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:value: The text of the comment that was posted.
+:xmlId: This is the ``xmlId`` value that you provided in the request.
 
 .. code-block:: http
 	:caption: Response Example
@@ -226,9 +234,11 @@ Response Structure
 :authorId:                      The integral, unique identifier of the user who created the comment.
 :deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
 :id:                            The integral, unique identifier of the :term:`DSR` comment.
-:lastUpdated:                   The date and time at which the user was last modified, in :rfc:`3339`
-:value:                         The text of the comment that was posted.
 :xmlId:                         This is the ``xmlId`` value that you provided in the request.
+:lastUpdated:              The date and time at which the user was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/deliveryservice_request_comments.rst
+++ b/docs/source/api/v5/deliveryservice_request_comments.rst
@@ -119,9 +119,9 @@ Allows user to create a :term:`Delivery Service Request` comment.
 
 Request Structure
 -----------------
-:deliveryServiceRequestId:      The integral, unique identifier of the delivery service that you are commenting on.
-:value:                         The comment text itself.
-:xmlId:                         This can be any string. It is not validated or used, though it is returned in the response.
+:deliveryServiceRequestId: The integral, unique identifier of the :term:`Delivery Service Request` on which you are commenting.
+:value:                    The comment text itself.
+:xmlId:                    This can be any string. It is not validated or used, though it is returned in the response.
 
 .. code-block:: http
 	:caption: Request Example
@@ -199,9 +199,9 @@ Updates a delivery service request comment.
 
 Request Structure
 -----------------
-:deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
-:value:                         The comment text itself.
-:xmlId:                         This can be any string. It is not validated or used, though it is returned in the response.
+:deliveryServiceRequestId: The integral, unique identifier of the :term:`Delivery Service Request` on which the comment was posted.
+:value:                    The comment text itself.
+:xmlId:                    This can be any string. It is not validated or used, though it is returned in the response.
 
 .. table:: Request Query Parameters
 
@@ -230,15 +230,17 @@ Request Structure
 
 Response Structure
 ------------------
-:author:                        The username of the user who created the comment.
-:authorId:                      The integral, unique identifier of the user who created the comment.
-:deliveryServiceRequestId:      The integral, unique identifier of the :term:`Delivery Service Request` that the comment was posted on.
-:id:                            The integral, unique identifier of the :term:`DSR` comment.
-:xmlId:                         This is the ``xmlId`` value that you provided in the request.
+:author:                   The username of the user who created the comment.
+:authorId:                 The integral, unique identifier of the user who created the comment.
+:deliveryServiceRequestId: The integral, unique identifier of the :term:`Delivery Service Request` on which the comment was posted.
+:id:                       The integral, unique identifier of the :term:`DSR` comment.
 :lastUpdated:              The date and time at which the user was last modified, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:value: The text of the comment that was posted.
+:xmlId: This is the ``xmlId`` value that you provided in the request.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/deliveryservice_requests.rst
+++ b/docs/source/api/v5/deliveryservice_requests.rst
@@ -907,7 +907,7 @@ The response is a full representation of the deleted :term:`Delivery Service Req
 .. code-block:: http
 	:caption: Response Example
 
-	HTTP/1.1 200 OK	HTTP/1.1 200 OK
+	HTTP/1.1 200 OK HTTP/1.1 200 OK
 	Access-Control-Allow-Credentials: true
 	Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept, Set-Cookie, Cookie
 	Access-Control-Allow-Methods: POST,GET,OPTIONS,PUT,DELETE

--- a/docs/source/api/v5/deliveryservice_requests.rst
+++ b/docs/source/api/v5/deliveryservice_requests.rst
@@ -83,6 +83,9 @@ Response Structure
 ------------------
 The response is an array of representations of :term:`Delivery Service Requests`.
 
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -408,6 +411,9 @@ Response Structure
 ------------------
 The response will be a representation of the created :term:`Delivery Service Request`.
 
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -677,6 +683,9 @@ Response Structure
 ------------------
 The response is a full representation of the edited :term:`Delivery Service Request`.
 
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -903,6 +912,9 @@ Request Structure
 Response Structure
 ------------------
 The response is a full representation of the deleted :term:`Delivery Service Request`.
+
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/deliveryservice_requests_id_assign.rst
+++ b/docs/source/api/v5/deliveryservice_requests_id_assign.rst
@@ -110,6 +110,9 @@ Response Structure
 ------------------
 The response contains a full representation of the newly assigned :term:`Delivery Service Request`.
 
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 

--- a/docs/source/api/v5/deliveryservice_requests_id_status.rst
+++ b/docs/source/api/v5/deliveryservice_requests_id_status.rst
@@ -111,6 +111,9 @@ Response Structure
 ------------------
 The response is a full representation of the modified :term:`DSR`.
 
+.. versionchanged:: 5.0
+	Prior to version 5.0 of the API, the ``lastUpdated`` field was in :ref:`non-rfc-datetime`.
+
 .. code-block:: http
 	:caption: Response Example
 

--- a/docs/source/api/v5/deliveryservices_id_servers.rst
+++ b/docs/source/api/v5/deliveryservices_id_servers.rst
@@ -70,7 +70,11 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in :rfc:`3339`
+:lastUpdated: The time and date at which this server was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v5/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v5/deliveryservices_id_servers_eligible.rst
@@ -76,7 +76,11 @@ Response Structure
 		:gateway:       The IPv4 or IPv6 gateway address of the server - applicable for the interface ``name``
 		:service_address:  A boolean determining if content will be routed to the IP address
 
-:lastUpdated:    The time and date at which this server was last updated, in :rfc:`3339`
+:lastUpdated: The time and date at which this server was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :mgmtIpAddress:  The IPv4 address of the server's management port
 :mgmtIpGateway:  The IPv4 gateway of the server's management port
 :mgmtIpNetmask:  The IPv4 subnet mask of the server's management port

--- a/docs/source/api/v5/deliveryservices_id_servers_eligible.rst
+++ b/docs/source/api/v5/deliveryservices_id_servers_eligible.rst
@@ -46,21 +46,21 @@ Request Structure
 
 Response Structure
 ------------------
-:cachegroup:     A string which is the :ref:`Name of the Cache Group <cache-group-name>` to which the server belongs
-:cachegroupId:   An integer that is the :ref:`ID of the Cache Group <cache-group-id>` to which the server belongs
-:cdnId:          An integral, unique identifier the CDN to which the server belongs
-:cdnName:        The name of the CDN to which the server belongs
-:domainName:     The domain name part of the :abbr:`FQDN (Fully Qualified Domain Name)` of the server
-:guid:           Optionally represents an identifier used to uniquely identify the server
-:hostName:       The (short) hostname of the server
-:httpsPort:      The port on which the server listens for incoming HTTPS requests - 443 in most cases
-:id:             An integral, unique identifier for the server
-:iloIpAddress:   The IPv4 address of the lights-out-management port\ [#ilowikipedia]_
-:iloIpGateway:   The IPv4 gateway address of the lights-out-management port\ [#ilowikipedia]_
-:iloIpNetmask:   The IPv4 subnet mask of the lights-out-management port\ [#ilowikipedia]_
-:iloPassword:    The password of the of the lights-out-management user - displays as ``******`` unless the requesting user has the 'admin' role)\ [#ilowikipedia]_
-:iloUsername:    The user name for lights-out-management\ [#ilowikipedia]_
-:interfaces:     An array of interface and IP address information
+:cachegroup:   A string which is the :ref:`Name of the Cache Group <cache-group-name>` to which the server belongs
+:cachegroupId: An integer that is the :ref:`ID of the Cache Group <cache-group-id>` to which the server belongs
+:cdnId:        An integral, unique identifier the CDN to which the server belongs
+:cdnName:      The name of the CDN to which the server belongs
+:domainName:   The domain name part of the :abbr:`FQDN (Fully Qualified Domain Name)` of the server
+:guid:         Optionally represents an identifier used to uniquely identify the server
+:hostName:     The (short) hostname of the server
+:httpsPort:    The port on which the server listens for incoming HTTPS requests - 443 in most cases
+:id:           An integral, unique identifier for the server
+:iloIpAddress: The IPv4 address of the lights-out-management port\ [#ilowikipedia]_
+:iloIpGateway: The IPv4 gateway address of the lights-out-management port\ [#ilowikipedia]_
+:iloIpNetmask: The IPv4 subnet mask of the lights-out-management port\ [#ilowikipedia]_
+:iloPassword:  The password of the of the lights-out-management user - displays as ``******`` unless the requesting user has the 'admin' role)\ [#ilowikipedia]_
+:iloUsername:  The user name for lights-out-management\ [#ilowikipedia]_
+:interfaces:   An array of interface and IP address information
 
 	:max_bandwidth:  The maximum allowed bandwidth for this interface to be considered "healthy" by Traffic Monitor. This has no effect if `monitor` is not true. Values are in kb/s. The value `null` means "no limit".
 	:monitor:        A boolean indicating if Traffic Monitor should monitor this interface

--- a/docs/source/api/v5/deliveryserviceserver.rst
+++ b/docs/source/api/v5/deliveryserviceserver.rst
@@ -66,7 +66,11 @@ Unlike most API endpoints, this will return a JSON response body containing both
 
 	:deliveryService: The integral, unique identifier of the :term:`Delivery Service` to which the server identified by ``server`` is assigned
 	:lastUpdated:     The date and time at which the server's assignment to a :term:`Delivery Service` was last updated, in :rfc:`3339` format
-	:server:          The integral, unique identifier of a server which is assigned to the :term:`Delivery Service` identified by ``deliveryService``
+
+		.. versionchanged:: 5.0
+			Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+	:server: The integral, unique identifier of a server which is assigned to the :term:`Delivery Service` identified by ``deliveryService``
 
 :size: The page number - if pagination was requested in the query parameters, else ``0`` to indicate no pagination - of the results represented by the ``response`` array. This is named "size" for legacy reasons
 

--- a/docs/source/api/v5/divisions.rst
+++ b/docs/source/api/v5/divisions.rst
@@ -65,8 +65,12 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in :rfc:`3339`
-:name:        The Division name
+:lastUpdated: The date and time at which this Division was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The Division name
 
 .. code-block:: http
 	:caption: Response Example
@@ -126,8 +130,12 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in :rfc:`3339`
-:name:        The Division name
+:lastUpdated: The date and time at which this Division was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The Division name
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/divisions_id.rst
+++ b/docs/source/api/v5/divisions_id.rst
@@ -57,8 +57,11 @@ Request Structure
 Response Structure
 ------------------
 :id:          An integral, unique identifier for this Division
-:lastUpdated: The date and time at which this Division was last modified, in :rfc:`3339`
 :name:        The Division name
+:lastUpdated: The date and time at which this :term:`Division` was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/divisions_id.rst
+++ b/docs/source/api/v5/divisions_id.rst
@@ -56,12 +56,13 @@ Request Structure
 
 Response Structure
 ------------------
-:id:          An integral, unique identifier for this Division
-:name:        The Division name
+:id:          An integral, unique identifier for this :term:`Division`
 :lastUpdated: The date and time at which this :term:`Division` was last modified, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The :term:`Division` name
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/divisions_id.rst
+++ b/docs/source/api/v5/divisions_id.rst
@@ -21,7 +21,7 @@
 
 ``PUT``
 =======
-Updates a specific Division
+Updates a specific :term:`Division`
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -32,14 +32,14 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+-----------------------------------------------------------+
-	| Name | Description                                               |
-	+======+===========================================================+
-	|  ID  | The integral, unique identifier of the requested Division |
-	+------+-----------------------------------------------------------+
+	+------+-------------------------------------------------------------------+
+	| Name | Description                                                       |
+	+======+===================================================================+
+	|  ID  | The integral, unique identifier of the requested :term:`Division` |
+	+------+-------------------------------------------------------------------+
 
 
-:name: The new name of the Division
+:name: The new name of the :term:`Division`
 
 .. code-block:: http
 	:caption: Request Example
@@ -93,7 +93,7 @@ Response Structure
 
 ``DELETE``
 ============
-Deletes a specific Division
+Deletes a specific :term:`Division`\ .
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -104,11 +104,11 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+-----------------------------------------------------------+
-	| Name | Description                                               |
-	+======+===========================================================+
-	|  ID  | The integral, unique identifier of the requested Division |
-	+------+-----------------------------------------------------------+
+	+------+-------------------------------------------------------------------+
+	| Name | Description                                                       |
+	+======+===================================================================+
+	|  ID  | The integral, unique identifier of the requested :term:`Division` |
+	+------+-------------------------------------------------------------------+
 
 
 .. code-block:: http
@@ -125,6 +125,7 @@ Request Structure
 
 Response Structure
 ------------------
+:id: The integral, unique identifier of the deleted :term:`Division`\ .
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/federation_resolvers.rst
+++ b/docs/source/api/v5/federation_resolvers.rst
@@ -70,11 +70,12 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:type:        The :term:`Type` of the resolver
 :lastUpdated: The date and time at which this resolver was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:type: The :term:`Type` of the resolver
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/federation_resolvers.rst
+++ b/docs/source/api/v5/federation_resolvers.rst
@@ -70,8 +70,11 @@ Response Structure
 ------------------
 :id:          The integral, unique identifier of the resolver
 :ipAddress:   The IP address or :abbr:`CIDR (Classless Inter-Domain Routing)`-notation subnet of the resolver - may be IPv4 or IPv6
-:lastUpdated: The date and time at which this resolver was last updated, in :rfc:`3339`
 :type:        The :term:`Type` of the resolver
+:lastUpdated: The date and time at which this resolver was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/logs.rst
+++ b/docs/source/api/v5/logs.rst
@@ -64,10 +64,14 @@ Response Structure
 ------------------
 :id:          Integral, unique identifier for the Log entry
 :lastUpdated: Date and time at which the change was made, in :rfc:`3339` format
-:level:       Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
-:message:     Log detail about what occurred
-:ticketNum:   Optional field to cross reference with any bug tracking systems
-:user:        Name of the user who made the change
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:level:     Log categories for each entry, e.g. 'UICHANGE', 'OPER', 'APICHANGE'
+:message:   Log detail about what occurred
+:ticketNum: Optional field to cross reference with any bug tracking systems
+:user:      Name of the user who made the change
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/origins.rst
+++ b/docs/source/api/v5/origins.rst
@@ -90,13 +90,17 @@ Response Structure
 :ipAddress:         The IPv4 address of the :term:`Origin`
 :isPrimary:         A boolean value which, when ``true`` specifies this :term:`Origin` as the 'primary' :term:`Origin` served by ``deliveryService``
 :lastUpdated:       The date and time at which this :term:`Origin` was last modified in :rfc:`3339` format
-:name:              The name of the :term:`Origin`
-:port:              The TCP port on which the :term:`Origin` listens
-:profile:           The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
-:profileId:         The :ref:`profile-id` of the :term:`Profile` used by this :term:`Origin`
-:protocol:          The protocol used by this origin - will be one of 'http' or 'https'
-:tenant:            The name of the :term:`Tenant` that owns this :term:`Origin`
-:tenantId:          An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the :term:`Origin`
+:port:      The TCP port on which the :term:`Origin` listens
+:profile:   The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
+:profileId: The :ref:`profile-id` of the :term:`Profile` used by this :term:`Origin`
+:protocol:  The protocol used by this origin - will be one of 'http' or 'https'
+:tenant:    The name of the :term:`Tenant` that owns this :term:`Origin`
+:tenantId:  An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
 
 .. code-block:: http
 	:caption: Response Example
@@ -202,13 +206,17 @@ Response Structure
 :ipAddress:         The IPv4 address of the :term:`Origin`
 :isPrimary:         A boolean value which, when ``true`` specifies this :term:`Origin` as the 'primary' :term:`Origin` served by ``deliveryService``
 :lastUpdated:       The date and time at which this :term:`Origin` was last modified in :rfc:`3339` format
-:name:              The name of the :term:`Origin`
-:port:              The TCP port on which the :term:`Origin` listens
-:profile:           The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
-:profileId:         The :ref:`profile-id` the :term:`Profile` used by this :term:`Origin`
-:protocol:          The protocol used by this origin - will be one of 'http' or 'https'
-:tenant:            The name of the :term:`Tenant` that owns this :term:`Origin`
-:tenantId:          An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the :term:`Origin`
+:port:      The TCP port on which the :term:`Origin` listens
+:profile:   The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
+:profileId: The :ref:`profile-id` the :term:`Profile` used by this :term:`Origin`
+:protocol:  The protocol used by this origin - will be one of 'http' or 'https'
+:tenant:    The name of the :term:`Tenant` that owns this :term:`Origin`
+:tenantId:  An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
 
 .. code-block:: http
 	:caption: Response Example
@@ -321,13 +329,17 @@ Response Structure
 :ipAddress:         The IPv4 address of the :term:`Origin`
 :isPrimary:         A boolean value which, when ``true`` specifies this :term:`Origin` as the 'primary' :term:`Origin` served by ``deliveryService``
 :lastUpdated:       The date and time at which this :term:`Origin` was last modified in :rfc:`3339` format
-:name:              The name of the :term:`Origin`
-:port:              The TCP port on which the :term:`Origin` listens
-:profile:           The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
-:profileId:         The :ref:`profile-id` the :term:`Profile` used by this :term:`Origin`
-:protocol:          The protocol used by this origin - will be one of 'http' or 'https'
-:tenant:            The name of the :term:`Tenant` that owns this :term:`Origin`
-:tenantId:          An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the :term:`Origin`
+:port:      The TCP port on which the :term:`Origin` listens
+:profile:   The :ref:`profile-name` of the :term:`Profile` used by this :term:`Origin`
+:profileId: The :ref:`profile-id` the :term:`Profile` used by this :term:`Origin`
+:protocol:  The protocol used by this origin - will be one of 'http' or 'https'
+:tenant:    The name of the :term:`Tenant` that owns this :term:`Origin`
+:tenantId:  An integral, unique identifier for the :term:`Tenant` that owns this :term:`Origin`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/parameters.rst
+++ b/docs/source/api/v5/parameters.rst
@@ -70,14 +70,15 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:name:        :ref:`parameter-name` of the :term:`Parameter`
-:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
-:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
-:value:       The :term:`Parameter`'s :ref:`parameter-value`
 :lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     :ref:`parameter-name` of the :term:`Parameter`
+:profiles: An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
+:secure:   A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
+:value:    The :term:`Parameter`'s :ref:`parameter-value`
 
 .. code-block:: http
 	:caption: Response Example
@@ -173,14 +174,15 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:name:        :ref:`parameter-name` of the :term:`Parameter`
-:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
-:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
-:value:       The :term:`Parameter`'s :ref:`parameter-value`
 :lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     :ref:`parameter-name` of the :term:`Parameter`
+:profiles: An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
+:secure:   A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
+:value:    The :term:`Parameter`'s :ref:`parameter-value`
 
 .. code-block:: http
 	:caption: Response Example - Single Object Format

--- a/docs/source/api/v5/parameters.rst
+++ b/docs/source/api/v5/parameters.rst
@@ -70,11 +70,14 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` Format
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -170,11 +173,14 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` Format
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example - Single Object Format

--- a/docs/source/api/v5/parameters_id.rst
+++ b/docs/source/api/v5/parameters_id.rst
@@ -65,14 +65,15 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:name:        :ref:`parameter-name` of the :term:`Parameter`
-:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
-:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
-:value:       The :term:`Parameter`'s :ref:`parameter-value`
 :lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     :ref:`parameter-name` of the :term:`Parameter`
+:profiles: An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
+:secure:   A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
+:value:    The :term:`Parameter`'s :ref:`parameter-value`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/parameters_id.rst
+++ b/docs/source/api/v5/parameters_id.rst
@@ -65,11 +65,14 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` Format
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/phys_locations.rst
+++ b/docs/source/api/v5/phys_locations.rst
@@ -71,7 +71,6 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` Format
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -80,6 +79,10 @@ Response Structure
 :shortName:   An abbreviation of the ``name``
 :state:       An abbreviation of the name of the state or province within which this physical location lies
 :zip:         The zip code of the physical location
+:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -173,7 +176,6 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -182,6 +184,10 @@ Response Structure
 :shortName:   An abbreviation of the ``name``
 :state:       An abbreviation of the name of the state or province within which this physical location lies
 :zip:         The zip code of the physical location
+:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/phys_locations.rst
+++ b/docs/source/api/v5/phys_locations.rst
@@ -71,18 +71,19 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:name:        The name of the physical location
-:phone:       A phone number where the the physical location's ``poc`` might be reached
-:poc:         The name of a "point of contact" for the physical location
-:region:      The name of the region within which the physical location lies
-:regionId:    An integral, unique identifier for the region within which the physical location lies
-:shortName:   An abbreviation of the ``name``
-:state:       An abbreviation of the name of the state or province within which this physical location lies
-:zip:         The zip code of the physical location
 :lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the physical location
+:phone:     A phone number where the the physical location's ``poc`` might be reached
+:poc:       The name of a "point of contact" for the physical location
+:region:    The name of the region within which the physical location lies
+:regionId:  An integral, unique identifier for the region within which the physical location lies
+:shortName: An abbreviation of the ``name``
+:state:     An abbreviation of the name of the state or province within which this physical location lies
+:zip:       The zip code of the physical location
 
 .. code-block:: http
 	:caption: Response Example
@@ -176,18 +177,19 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:name:        The name of the physical location
-:phone:       A phone number where the the physical location's ``poc`` might be reached
-:poc:         The name of a "point of contact" for the physical location
-:region:      The name of the region within which the physical location lies
-:regionId:    An integral, unique identifier for the region within which the physical location lies
-:shortName:   An abbreviation of the ``name``
-:state:       An abbreviation of the name of the state or province within which this physical location lies
-:zip:         The zip code of the physical location
 :lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the physical location
+:phone:     A phone number where the the physical location's ``poc`` might be reached
+:poc:       The name of a "point of contact" for the physical location
+:region:    The name of the region within which the physical location lies
+:regionId:  An integral, unique identifier for the region within which the physical location lies
+:shortName: An abbreviation of the ``name``
+:state:     An abbreviation of the name of the state or province within which this physical location lies
+:zip:       The zip code of the physical location
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/phys_locations_id.rst
+++ b/docs/source/api/v5/phys_locations_id.rst
@@ -85,7 +85,6 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339`
 :name:        The name of the physical location
 :phone:       A phone number where the the physical location's ``poc`` might be reached
 :poc:         The name of a "point of contact" for the physical location
@@ -94,6 +93,10 @@ Response Structure
 :shortName:   An abbreviation of the ``name``
 :state:       An abbreviation of the name of the state or province within which this physical location lies
 :zip:         The zip code of the physical location
+:lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/phys_locations_id.rst
+++ b/docs/source/api/v5/phys_locations_id.rst
@@ -85,18 +85,19 @@ Response Structure
 :comments:    Any and all human-readable comments
 :email:       The email address of the physical location's ``poc``
 :id:          An integral, unique identifier for the physical location
-:name:        The name of the physical location
-:phone:       A phone number where the the physical location's ``poc`` might be reached
-:poc:         The name of a "point of contact" for the physical location
-:region:      The name of the region within which the physical location lies
-:regionId:    An integral, unique identifier for the region within which the physical location lies
-:shortName:   An abbreviation of the ``name``
-:state:       An abbreviation of the name of the state or province within which this physical location lies
-:zip:         The zip code of the physical location
 :lastUpdated: The date and time at which the physical location was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:      The name of the physical location
+:phone:     A phone number where the the physical location's ``poc`` might be reached
+:poc:       The name of a "point of contact" for the physical location
+:region:    The name of the region within which the physical location lies
+:regionId:  An integral, unique identifier for the region within which the physical location lies
+:shortName: An abbreviation of the ``name``
+:state:     An abbreviation of the name of the state or province within which this physical location lies
+:zip:       The zip code of the physical location
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/profileparameters.rst
+++ b/docs/source/api/v5/profileparameters.rst
@@ -52,9 +52,12 @@ Request Structure
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :rfc:`3339`
 :parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
 :profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
+:lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Structure
@@ -152,7 +155,11 @@ Array Format
 
 Response Structure
 ------------------
-:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :rfc:`3339`
+:lastUpdated: The date and time at which the :term:`Profile`/:term:`Parameter` assignment was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :parameter:   :ref:`parameter-name` of the :term:`Parameter` which is assigned to ``profile``
 :parameterId: The :ref:`parameter-id` of the assigned :term:`Parameter`
 :profile:     :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` is assigned

--- a/docs/source/api/v5/profileparameters.rst
+++ b/docs/source/api/v5/profileparameters.rst
@@ -52,12 +52,13 @@ Request Structure
 
 Response Structure
 ------------------
-:parameter:   The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
-:profile:     The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 :lastUpdated: The date and time at which this :term:`Profile`/:term:`Parameter` association was last modified, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:parameter: The :ref:`parameter-id` of a :term:`Parameter` assigned to ``profile``
+:profile:   The :ref:`profile-name` of the :term:`Profile` to which the :term:`Parameter` identified by ``parameter`` is assigned
 
 .. code-block:: http
 	:caption: Response Structure

--- a/docs/source/api/v5/profiles.rst
+++ b/docs/source/api/v5/profiles.rst
@@ -57,7 +57,11 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`
@@ -132,7 +136,11 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v5/profiles.rst
+++ b/docs/source/api/v5/profiles.rst
@@ -53,10 +53,10 @@ Request Structure
 
 Response Structure
 ------------------
-:cdn:             The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:description:     The :term:`Profile`'s :ref:`profile-description`
-:id:              The :term:`Profile`'s :ref:`profile-id`
+:cdn:         The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:description: The :term:`Profile`'s :ref:`profile-description`
+:id:          The :term:`Profile`'s :ref:`profile-id`
 :lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
@@ -132,10 +132,10 @@ Request Structure
 
 Response Structure
 ------------------
-:cdn:             The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:description:     The :term:`Profile`'s :ref:`profile-description`
-:id:              The :term:`Profile`'s :ref:`profile-id`
+:cdn:         The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:description: The :term:`Profile`'s :ref:`profile-description`
+:id:          The :term:`Profile`'s :ref:`profile-id`
 :lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0

--- a/docs/source/api/v5/profiles_id.rst
+++ b/docs/source/api/v5/profiles_id.rst
@@ -67,10 +67,10 @@ Request Structure
 
 Response Structure
 ------------------
-:cdn:             The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
-:description:     The :term:`Profile`'s :ref:`profile-description`
-:id:              The :term:`Profile`'s :ref:`profile-id`
+:cdn:         The integral, unique identifier of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:cdnName:     The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
+:description: The :term:`Profile`'s :ref:`profile-description`
+:id:          The :term:`Profile`'s :ref:`profile-id`
 :lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0

--- a/docs/source/api/v5/profiles_id.rst
+++ b/docs/source/api/v5/profiles_id.rst
@@ -71,7 +71,11 @@ Response Structure
 :cdnName:         The name of the :ref:`profile-cdn` to which this :term:`Profile` belongs
 :description:     The :term:`Profile`'s :ref:`profile-description`
 :id:              The :term:`Profile`'s :ref:`profile-id`
-:lastUpdated:     The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Profile` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :name:            The :term:`Profile`'s :ref:`profile-name`
 :routingDisabled: The :term:`Profile`'s :ref:`profile-routing-disabled` setting
 :type:            The :term:`Profile`'s :ref:`profile-type`

--- a/docs/source/api/v5/profiles_id_parameters.rst
+++ b/docs/source/api/v5/profiles_id_parameters.rst
@@ -52,14 +52,15 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:name:        :ref:`parameter-name` of the :term:`Parameter`
-:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
-:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
-:value:       The :term:`Parameter`'s :ref:`parameter-value`
 :lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     :ref:`parameter-name` of the :term:`Parameter`
+:profiles: An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
+:secure:   A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
+:value:    The :term:`Parameter`'s :ref:`parameter-value`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/profiles_id_parameters.rst
+++ b/docs/source/api/v5/profiles_id_parameters.rst
@@ -52,11 +52,14 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/profiles_name_name_parameters.rst
+++ b/docs/source/api/v5/profiles_name_name_parameters.rst
@@ -51,11 +51,14 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339`
 :name:        :ref:`parameter-name` of the :term:`Parameter`
 :profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
 :secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
 :value:       The :term:`Parameter`'s :ref:`parameter-value`
+:lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/profiles_name_name_parameters.rst
+++ b/docs/source/api/v5/profiles_name_name_parameters.rst
@@ -51,14 +51,15 @@ Response Structure
 ------------------
 :configFile:  The :term:`Parameter`'s :ref:`parameter-config-file`
 :id:          The :term:`Parameter`'s :ref:`parameter-id`
-:name:        :ref:`parameter-name` of the :term:`Parameter`
-:profiles:    An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
-:secure:      A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
-:value:       The :term:`Parameter`'s :ref:`parameter-value`
 :lastUpdated: The date and time at which this :term:`Parameter` was last updated, in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     :ref:`parameter-name` of the :term:`Parameter`
+:profiles: An array of :term:`Profile` :ref:`Names <profile-name>` that use this :term:`Parameter`
+:secure:   A boolean value that describes whether or not the :term:`Parameter` is :ref:`parameter-secure`
+:value:    The :term:`Parameter`'s :ref:`parameter-value`
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/regions.rst
+++ b/docs/source/api/v5/regions.rst
@@ -65,14 +65,15 @@ Request Structure
 
 Response Structure
 -------------------
-:divisionName: The name of the division which contains this region
-:division:   The integral, unique identifier of the division which contains this region
-:id:           An integral, unique identifier for this region
-:name:         The region name
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+:divisionName: The name of the division which contains this :term:Region
+:division:     The integral, unique identifier of the division which contains this :term:Region
+:id:           An integral, unique identifier for this :term:Region
+:lastUpdated:  The date and time at which this :term:Region was last updated in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The :term:Region name
 
 .. code-block:: http
 	:caption: Response Example
@@ -133,14 +134,15 @@ Request Structure
 
 Response Structure
 ------------------
-:divisionName: The name of the division which contains this region
-:division:   The integral, unique identifier of the division which contains this region
-:id:           An integral, unique identifier for this region
-:name:         The region name
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+:divisionName: The name of the division which contains this :term:Region
+:division:   The integral, unique identifier of the division which contains this :term:Region
+:id:           An integral, unique identifier for this :term:Region
+:lastUpdated:  The date and time at which this :term:Region was last updated in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The :term:Region name
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/regions.rst
+++ b/docs/source/api/v5/regions.rst
@@ -104,7 +104,7 @@ Response Structure
 
 ``POST``
 ========
-Creates a new region
+Creates a new :term:Region
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -113,8 +113,8 @@ Creates a new region
 
 Request Structure
 -----------------
-:division:     The integral, unique identifier of the division which shall contain the new region
-:name:         The name of the region
+:division: The integral, unique identifier of the division which shall contain the new :term:Region
+:name:     The name of the :term:Region
 
 .. code-block:: http
 	:caption: Request Example
@@ -135,7 +135,7 @@ Request Structure
 Response Structure
 ------------------
 :divisionName: The name of the division which contains this :term:Region
-:division:   The integral, unique identifier of the division which contains this :term:Region
+:division:     The integral, unique identifier of the division which contains this :term:Region
 :id:           An integral, unique identifier for this :term:Region
 :lastUpdated:  The date and time at which this :term:Region was last updated in :rfc:`3339` format
 
@@ -175,7 +175,7 @@ Response Structure
 
 ``DELETE``
 ==========
-Deletes a region. If no query parameter is specified, a ``400 Bad Request`` response is returned.
+Deletes a :term:`Region`\ . If no query parameter is specified, a ``400 Bad Request`` response is returned.
 
 :Auth. Required: Yes
 :Roles Required: "admin" or "operations"
@@ -187,13 +187,13 @@ Request Structure
 
 .. table:: Request Query Parameters
 
-	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
-	| Name      | Required | Description                                                                                                   |
-	+===========+==========+===============================================================================================================+
-	| id        | no       | Delete :term:`Region` by integral, unique identifier                                                          |
-	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
-	| name      | no       | Delete :term:`Region` by name                                                                                 |
-	+-----------+----------+---------------------------------------------------------------------------------------------------------------+
+	+-----------+----------+------------------------------------------------------+
+	| Name      | Required | Description                                          |
+	+===========+==========+======================================================+
+	| id        | no       | Delete :term:`Region` by integral, unique identifier |
+	+-----------+----------+------------------------------------------------------+
+	| name      | no       | Delete :term:`Region` by name                        |
+	+-----------+----------+------------------------------------------------------+
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v5/regions.rst
+++ b/docs/source/api/v5/regions.rst
@@ -68,8 +68,11 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :division:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` Format
 :name:         The region name
+:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -133,8 +136,11 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :division:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` Format
 :name:         The region name
+:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/regions_id.rst
+++ b/docs/source/api/v5/regions_id.rst
@@ -59,14 +59,15 @@ Request Structure
 
 Response Structure
 ------------------
-:divisionName: The name of the division which contains this region
-:division:   The integral, unique identifier of the division which contains this region
-:id:           An integral, unique identifier for this region
-:name:         The region name
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+:divisionName: The name of the division which contains this :term:Region
+:division:     The integral, unique identifier of the division which contains this :term:Region
+:id:           An integral, unique identifier for this :term:Region
+:lastUpdated:  The date and time at which this :term:Region was last updated in :rfc:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The :term:Region name
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/regions_id.rst
+++ b/docs/source/api/v5/regions_id.rst
@@ -32,14 +32,14 @@ Request Structure
 -----------------
 .. table:: Request Path Parameters
 
-	+------+---------------------------------------------------------+
-	| Name |                Description                              |
-	+======+=========================================================+
-	|  ID  | The integral, unique identifier of the region to update |
-	+------+---------------------------------------------------------+
+	+------+---------------------------------------------------------------+
+	| Name | Description                                                   |
+	+======+===============================================================+
+	|  ID  | The integral, unique identifier of the :term:Region to update |
+	+------+---------------------------------------------------------------+
 
-:division:     The new integral, unique identifier of the division which shall contain the region
-:name:         The new name of the region
+:division: The new integral, unique identifier of the :term:Division which shall contain the :term:Region
+:name:     The new name of the :term:Region
 
 .. code-block:: http
 	:caption: Request Example
@@ -59,8 +59,8 @@ Request Structure
 
 Response Structure
 ------------------
-:divisionName: The name of the division which contains this :term:Region
-:division:     The integral, unique identifier of the division which contains this :term:Region
+:divisionName: The name of the :term:Division which contains this :term:Region
+:division:     The integral, unique identifier of the :term:Division which contains this :term:Region
 :id:           An integral, unique identifier for this :term:Region
 :lastUpdated:  The date and time at which this :term:Region was last updated in :rfc:`3339` format
 

--- a/docs/source/api/v5/regions_id.rst
+++ b/docs/source/api/v5/regions_id.rst
@@ -62,8 +62,11 @@ Response Structure
 :divisionName: The name of the division which contains this region
 :division:   The integral, unique identifier of the division which contains this region
 :id:           An integral, unique identifier for this region
-:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` Format
 :name:         The region name
+:lastUpdated:  The date and time at which this region was last updated in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/server_capabilities.rst
+++ b/docs/source/api/v5/server_capabilities.rst
@@ -51,7 +51,10 @@ Response Structure
 ------------------
 :name:        The name of this :term:`Server Capability`
 :description: The description of this :term:`Server Capability`
-:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -112,7 +115,10 @@ Response Structure
 ------------------
 :name:        The name of this :term:`Server Capability`
 :description: The description of this :term:`Server Capability`
-:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -177,7 +183,10 @@ Response Structure
 ------------------
 :name:        The name of this :term:`Server Capability`
 :description: The description of this :term:`Server Capability`
-:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` Format
+:lastUpdated: The date and time at which this :term:`Server Capability` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/server_server_capabilities.rst
+++ b/docs/source/api/v5/server_server_capabilities.rst
@@ -64,9 +64,13 @@ Request Structure
 
 Response Structure
 ------------------
-:serverHostName:   The server's host name
-:serverId:         The server's integral, unique identifier
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :rfc:`3339` format
+:serverHostName: The server's host name
+:serverId:       The server's integral, unique identifier
+:lastUpdated:    The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http
@@ -135,8 +139,12 @@ Request Structure
 
 Response Structure
 ------------------
-:serverId:         The integral, unique identifier of the newly associated server
-:lastUpdated:      The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :rfc:`3339` format
+:serverId:    The integral, unique identifier of the newly associated server
+:lastUpdated: The date and time at which this association between the server and the :term:`Server Capability` was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :serverCapability: The :term:`Server Capability`'s name
 
 .. code-block:: http

--- a/docs/source/api/v5/service_categories.rst
+++ b/docs/source/api/v5/service_categories.rst
@@ -64,7 +64,10 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339`
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example
@@ -121,7 +124,10 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339`
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/service_categories_name.rst
+++ b/docs/source/api/v5/service_categories_name.rst
@@ -58,7 +58,10 @@ Request Structure
 Response Structure
 ------------------
 :name:        This :term:`Service Category`'s name
-:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339`
+:lastUpdated: The date and time at which this :term:`Service Category` was last modified, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/staticdnsentries.rst
+++ b/docs/source/api/v5/staticdnsentries.rst
@@ -90,9 +90,13 @@ Response Structure
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
 :lastUpdated:       The date and time at which this static DNS entry was last updated, in :rfc:`3339` format
-:ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
-:type:              The name of the type of this static DNS entry
-:typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:ttl:    The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
+:type:   The name of the type of this static DNS entry
+:typeId: The integral, unique identifier of the :term:`Type` of this static DNS entry
 
 .. code-block:: http
 	:caption: Response Example
@@ -181,9 +185,13 @@ Response Structure
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the Fully Qualified Domain Name (FQDN) which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
 :lastUpdated:       The date and time at which this static DNS entry was last updated, in :rfc:`3339` format
-:ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
-:type:              The name of the :term:`Type` of this static DNS entry
-:typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:ttl:    The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
+:type:   The name of the :term:`Type` of this static DNS entry
+:typeId: The integral, unique identifier of the :term:`Type` of this static DNS entry
 
 .. code-block:: http
 	:caption: Response Example
@@ -284,9 +292,13 @@ Response Structure
 :host:              If ``typeId`` identifies a ``CNAME`` type record, this is an alias for the CNAME of the server, otherwise it is the :abbr:`FQDN (Fully Qualified Domain Name)` which shall resolve to ``address``
 :id:                An integral, unique identifier for this static DNS entry
 :lastUpdated:       The date and time at which this static DNS entry was last updated, in :rfc:`3339` format
-:ttl:               The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
-:type:              The name of the :term:`Type` of this static DNS entry
-:typeId:            The integral, unique identifier of the :term:`Type` of this static DNS entry
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:ttl:    The :abbr:`TTL (Time To Live)` of this static DNS entry in seconds
+:type:   The name of the :term:`Type` of this static DNS entry
+:typeId: The integral, unique identifier of the :term:`Type` of this static DNS entry
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/stats_summary.rst
+++ b/docs/source/api/v5/stats_summary.rst
@@ -100,7 +100,7 @@ Response Structure
 Summary Stats
 """""""""""""
 
-:cdnName:             The CDN name for which the summary stat was taken for
+:cdnName: The CDN name for which the summary stat was taken
 
 	.. note:: If the ``cdn`` is equal to ``all`` it represents summary_stats across all delivery services across all CDNs
 
@@ -199,7 +199,7 @@ Post a stats summary for a given stat.
 
 Request Structure
 -----------------
-:cdnName:             The CDN name for which the summary stat was taken for
+:cdnName: The CDN name for which the summary stat was taken
 
 	.. note:: If the ``cdn`` is equal to ``all`` it represents summary_stats across all delivery services across all CDNs
 

--- a/docs/source/api/v5/stats_summary.rst
+++ b/docs/source/api/v5/stats_summary.rst
@@ -108,9 +108,13 @@ Summary Stats
 
 	.. note:: If the ``deliveryServiceName`` is equal to ``all`` it represents summary_stats across all delivery services within the given CDN
 
-:statName:            Stat name summary stat represents
-:statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in :rfc:`3339` format
+:statName:    Stat name summary stat represents
+:statValue:   Summary stat value
+:summaryTime: Timestamp of summary, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
 :statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. code-block:: http
@@ -160,6 +164,10 @@ Last Updated Summary Stat
 
 :summaryTime: Timestamp of the last updated summary, in :rfc:`3339` format
 
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+
 .. code-block:: http
 	:caption: Response Example
 
@@ -199,10 +207,14 @@ Request Structure
 
 	.. note:: If the ``deliveryServiceName`` is equal to ``all`` it represents summary_stats across all delivery services within the given CDN
 
-:statName:            Stat name summary stat represents
-:statValue:           Summary stat value
-:summaryTime:         Timestamp of summary, in :rfc:`3339` format
-:statDate:            Date stat was taken, in ``YYYY-MM-DD`` format
+:statName:    Stat name summary stat represents
+:statValue:   Summary stat value
+:summaryTime: Timestamp of summary, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:statDate: Date stat was taken, in ``YYYY-MM-DD`` format
 
 .. note:: ``statName``, ``statValue`` and ``summaryTime`` are required. If ``cdnName`` and ``deliveryServiceName`` are not given they will default to ``all``.
 

--- a/docs/source/api/v5/statuses.rst
+++ b/docs/source/api/v5/statuses.rst
@@ -107,8 +107,8 @@ Creates a Server :term:`Status`.
 
 Request Structure
 -----------------
-:description:	Create a :term:`Status` with this description
-:name:			Create a :term:`Status` with this name
+:description: Create a :term:`Status` with this description
+:name:        Create a :term:`Status` with this name
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v5/statuses.rst
+++ b/docs/source/api/v5/statuses.rst
@@ -70,7 +70,11 @@ Response Structure
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
 :lastUpdated: The date and time at which this status was last modified, in :rfc:`3339` format
-:name:        The name of the status
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The name of the status
 
 .. code-block:: http
 	:caption: Response Example
@@ -126,7 +130,11 @@ Response Structure
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
 :lastUpdated: The date and time at which this status was last modified, in :rfc:`3339` format
-:name:        The name of the status
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The name of the status
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/statuses_id.rst
+++ b/docs/source/api/v5/statuses_id.rst
@@ -30,8 +30,8 @@ Updates a :term:`Status`.
 
 Request Structure
 -----------------
-:description:	The description of the updated :term:`Status`
-:name:			The name of the updated :term:`Status`
+:description: The description of the updated :term:`Status`
+:name:        The name of the updated :term:`Status`
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v5/statuses_id.rst
+++ b/docs/source/api/v5/statuses_id.rst
@@ -49,7 +49,11 @@ Response Structure
 :description: A short description of the status
 :id:          The integral, unique identifier of this status
 :lastUpdated: The date and time at which this status was last modified, in :RFC:`3339` format
-:name:        The name of the status
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name: The name of the status
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/tenants.rst
+++ b/docs/source/api/v5/tenants.rst
@@ -71,7 +71,7 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the :term:`Tenant` is active
 :id:          The integral, unique identifier of this :term:`Tenant`
-:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
@@ -141,7 +141,7 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the tenant is active
 :id:          The integral, unique identifier of this tenant
-:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.

--- a/docs/source/api/v5/tenants.rst
+++ b/docs/source/api/v5/tenants.rst
@@ -71,9 +71,14 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the :term:`Tenant` is active
 :id:          The integral, unique identifier of this :term:`Tenant`
-:name:        This :term:`Tenant`'s name
-:parentId:    The integral, unique identifier of this :term:`Tenant`'s parent
-:parentName:  The name of the parent of this :term:`Tenant`
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:       This :term:`Tenant`'s name
+:parentId:   The integral, unique identifier of this :term:`Tenant`'s parent
+:parentName: The name of the parent of this :term:`Tenant`
 
 .. code-block:: http
 	:caption: Response Example
@@ -136,8 +141,13 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the tenant is active
 :id:          The integral, unique identifier of this tenant
-:name:        This tenant's name
-:parentId:    The integral, unique identifier of this tenant's parent
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     This tenant's name
+:parentId: The integral, unique identifier of this tenant's parent
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/tenants_id.rst
+++ b/docs/source/api/v5/tenants_id.rst
@@ -63,7 +63,7 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the tenant is active
 :id:          The integral, unique identifier of this tenant
-:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.

--- a/docs/source/api/v5/tenants_id.rst
+++ b/docs/source/api/v5/tenants_id.rst
@@ -63,8 +63,13 @@ Response Structure
 ------------------
 :active:      A boolean which indicates whether or not the tenant is active
 :id:          The integral, unique identifier of this tenant
-:name:        This tenant's name
-:parentId:    The integral, unique identifier of this tenant's parent
+:lastUpdated: The date and time at which the :term:Tenant was last updated, in :RFC:3339 format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:     This tenant's name
+:parentId: The integral, unique identifier of this tenant's parent
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/topologies.rst
+++ b/docs/source/api/v5/topologies.rst
@@ -162,12 +162,12 @@ Create a new :term:`Topology`.
 
 Request Structure
 -----------------
-:description:           A short sentence that describes the topology.
-:name:                  The name of the topology. This can only be letters, numbers, and dashes.
-:nodes:                 An array of nodes in the :term:`Topology`
+:description: A short sentence that describes the topology.
+:name:        The name of the topology. This can only be letters, numbers, and dashes.
+:nodes:       An array of nodes in the :term:`Topology`
 
-	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
+	:cachegroup: The name of a :term:`Cache Group` with at least 1 server in it
+	:parents:    The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example

--- a/docs/source/api/v5/topologies.rst
+++ b/docs/source/api/v5/topologies.rst
@@ -56,7 +56,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -163,7 +163,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -253,7 +253,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -372,7 +372,7 @@ Request Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group` with at least 1 server in it
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Request Example
@@ -454,7 +454,7 @@ Response Structure
 :nodes:                 An array of nodes in the :term:`Topology`
 
 	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed. 
+	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/topologies.rst
+++ b/docs/source/api/v5/topologies.rst
@@ -50,13 +50,17 @@ Request Structure
 
 Response Structure
 ------------------
-:description:           A short sentence that describes the :term:`Topology`.
-:lastUpdated:           The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
-:name:                  The name of the :term:`Topology`. This can only be letters, numbers, and dashes.
-:nodes:                 An array of nodes in the :term:`Topology`
+:description: A short sentence that describes the :term:`Topology`.
+:lastUpdated: The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
 
-	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:  The name of the :term:`Topology`. This can only be letters, numbers, and dashes.
+:nodes: An array of nodes in the :term:`Topology`
+
+	:cachegroup: The name of a :term:`Cache Group`
+	:parents:    The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -247,13 +251,17 @@ Request Structure
 
 Response Structure
 ------------------
-:description:           A short sentence that describes the topology.
-:lastUpdated:           The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
-:name:                  The name of the topology. This can only be letters, numbers, and dashes.
-:nodes:                 An array of nodes in the :term:`Topology`
+:description: A short sentence that describes the topology.
+:lastUpdated: The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
 
-	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:  The name of the topology. This can only be letters, numbers, and dashes.
+:nodes: An array of nodes in the :term:`Topology`
+
+	:cachegroup: The name of a :term:`Cache Group`
+	:parents:    The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example
@@ -448,13 +456,17 @@ Request Structure
 
 Response Structure
 ------------------
-:description:           A short sentence that describes the :term:`Topology`.
-:lastUpdated:           The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
-:name:                  The name of the :term:`Topology`. This can only be letters, numbers, and dashes.
-:nodes:                 An array of nodes in the :term:`Topology`
+:description: A short sentence that describes the :term:`Topology`.
+:lastUpdated: The date and time at which this :term:`Topology` was last updated, in :rfc:`3339` format
 
-	:cachegroup:            The name of a :term:`Cache Group`
-	:parents:               The indices of the parents of this node in the nodes array, 0-indexed.
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:  The name of the :term:`Topology`. This can only be letters, numbers, and dashes.
+:nodes: An array of nodes in the :term:`Topology`
+
+	:cachegroup: The name of a :term:`Cache Group`
+	:parents:    The indices of the parents of this node in the nodes array, 0-indexed.
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/types.rst
+++ b/docs/source/api/v5/types.rst
@@ -55,9 +55,13 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in :rfc:`3339`
-:name:        The name of this type
-:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+:lastUpdated: The date and time at which this type was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:       The name of this type
+:useInTable: The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
 .. code-block:: http
 	:caption: Response Example
@@ -124,9 +128,13 @@ Response Structure
 
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in :rfc:`3339`
-:name:        The name of this type
-:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+:lastUpdated: The date and time at which this type was last updated, in :rfc:`3339` format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:       The name of this type
+:useInTable: The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/types_id.rst
+++ b/docs/source/api/v5/types_id.rst
@@ -65,9 +65,13 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in :ref:`non-rfc-datetime`
-:name:        The name of this type
-:useInTable:  The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
+:lastUpdated: The date and time at which this type was last updated, in :RFC:3339 format
+
+	.. versionchanged:: 5.0
+		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.
+
+:name:       The name of this type
+:useInTable: The name of the Traffic Ops database table that contains objects which are grouped, identified, or described by this type
 
 .. code-block:: http
 	:caption: Response Example

--- a/docs/source/api/v5/types_id.rst
+++ b/docs/source/api/v5/types_id.rst
@@ -65,7 +65,7 @@ Response Structure
 ------------------
 :description: A short description of this type
 :id:          An integral, unique identifier for this type
-:lastUpdated: The date and time at which this type was last updated, in :RFC:3339 format
+:lastUpdated: The date and time at which this type was last updated, in :RFC:`3339` format
 
 	.. versionchanged:: 5.0
 		Prior to version 5.0 of the API, this field was in :ref:`non-rfc-datetime`.

--- a/docs/source/api/v5/users.rst
+++ b/docs/source/api/v5/users.rst
@@ -86,7 +86,7 @@ Response Structure
 
 :id:                An integral, unique identifier for this user
 :lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
-:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:`3339` format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides
@@ -227,7 +227,7 @@ Response Structure
 
 :id:                An integral, unique identifier for this user
 :lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
-:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:`3339` format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides

--- a/docs/source/api/v5/users.rst
+++ b/docs/source/api/v5/users.rst
@@ -85,8 +85,8 @@ Response Structure
 		This field is serves no known purpose, and shouldn't be used for anything so it can be removed in the future.
 
 :id:                An integral, unique identifier for this user
-:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339`
-:lastUpdated:       The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
+:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides
@@ -226,8 +226,8 @@ Response Structure
 		This field is serves no known purpose, and shouldn't be used for anything so it can be removed in the future.
 
 :id:                An integral, unique identifier for this user
-:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339`
-:lastUpdated:       The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
+:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides

--- a/docs/source/api/v5/users_id.rst
+++ b/docs/source/api/v5/users_id.rst
@@ -65,8 +65,8 @@ Response Structure
 		This field is serves no known purpose, and shouldn't be used for anything so it can be removed in the future.
 
 :id:                An integral, unique identifier for this user
-:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339`
-:lastUpdated:       The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
+:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides
@@ -218,8 +218,8 @@ Response Structure
 		This field is serves no known purpose, and shouldn't be used for anything so it can be removed in the future.
 
 :id:                An integral, unique identifier for this user
-:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339`
-:lastUpdated:       The date and time at which the user was last modified, in :ref:`non-rfc-datetime`
+:lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides

--- a/docs/source/api/v5/users_id.rst
+++ b/docs/source/api/v5/users_id.rst
@@ -66,7 +66,7 @@ Response Structure
 
 :id:                An integral, unique identifier for this user
 :lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
-:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:`3339` format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides
@@ -219,7 +219,7 @@ Response Structure
 
 :id:                An integral, unique identifier for this user
 :lastAuthenticated: The date and time at which the user was last authenticated, in :rfc:`3339` format
-:lastUpdated:       The date and time at which the user was last modified, in :RFC:3339 format
+:lastUpdated:       The date and time at which the user was last modified, in :RFC:`3339` format
 :newUser:           A meta field with no apparent purpose that is usually ``null`` unless explicitly set during creation or modification of a user via some API endpoint
 :phoneNumber:       The user's phone number
 :postalCode:        The postal code of the area in which the user resides


### PR DESCRIPTION
This PR addresses some issues with our API documentation. Its primary purpose, though, is to add in all of the `.. versionchanged::` directives that are missing from fields that were changed in APIv5, namely: the fields that used to be non-RFC datetimes and are now in RFC3339 format.

Other problems include:

- incorrectly documented endpoints (wrong timestamp format in descriptions and/or examples, missing fields, etc.)
- grammatical errors
- formatting errors (tabs used for alignment, spaces used for indentation, trailing whitespace, missing terminating newlines etc.)

<hr/>

## Which Traffic Control components are affected by this PR?
- Documentation

## What is the best way to verify this PR?
Make sure the docs build without any errors or warnings

## If this is a bugfix, which Traffic Control versions contained the bug?
- master
- for some parts, 7.x

## PR submission checklist
- [x] This PR doesn't need tests
- [x] This PR is only documentation changes
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**