### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.27.2",
-        "chromedriver": "^116.0.0",
+        "chromedriver": "^117.0.3",
         "codelyzer": "^6.0.0",
         "eslint": "^8.39.0",
         "eslint-plugin-import": "^2.25.3",
@@ -7739,9 +7739,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "116.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
-      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
+      "version": "117.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
+      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -7757,7 +7757,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
@@ -26317,9 +26317,9 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "chromedriver": {
-      "version": "116.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
-      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
+      "version": "117.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
+      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.27.2",
-    "chromedriver": "^116.0.0",
+    "chromedriver": "^117.0.3",
     "codelyzer": "^6.0.0",
     "eslint": "^8.39.0",
     "eslint-plugin-import": "^2.25.3",

--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -30,7 +30,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^116.0.0",
+        "chromedriver": "^117.0.3",
         "jasmine": "^3.5.0",
         "typescript": "^3.6.4"
       },
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "116.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
-      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
+      "version": "117.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
+      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -345,7 +345,7 @@
         "chromedriver": "bin/chromedriver"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/chromedriver/node_modules/agent-base": {
@@ -2639,9 +2639,9 @@
       }
     },
     "chromedriver": {
-      "version": "116.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-116.0.0.tgz",
-      "integrity": "sha512-/TQaRn+RUAYnVqy5Vx8VtU8DvtWosU8QLM2u7BoNM5h55PRQPXF/onHAehEi8Sj/CehdKqH50NFdiumQAUr0DQ==",
+      "version": "117.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
+      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.3",

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^116.0.0",
+    "chromedriver": "^117.0.3",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.4"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 116.0.0 -> 117.0.3
experimental/traffic-portal: 116.0.0 -> 117.0.3


## Which Traffic Control components are affected by this PR?
* Traffic Portal
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
