### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/actions/repo-info/entrypoint.sh
+++ b/.github/actions/repo-info/entrypoint.sh
@@ -70,6 +70,6 @@ if [[ -z "$ahead_by" ]]; then
 fi
 expected_rpm_name="${INPUT_REPO}-${latest_tag}-${ahead_by}.${_sha}.el${RHEL_VERSION}.${TARGET_ARCH}.rpm"
 
-echo "::set-output name=expected-rpm-name::${expected_rpm_name}"
+echo "expected-rpm-name=${expected_rpm_name}" >> $GITHUB_OUTPUT
 
 exit 0

--- a/.github/workflows/check-go-modules.yml
+++ b/.github/workflows/check-go-modules.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
       - name: Check Go Version
-        run: echo "::set-output name=value::$(cat GO_VERSION)"
+        run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
         id: go-version
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/go.vet.yml
+++ b/.github/workflows/go.vet.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: go-version
-      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
       id: go-version
     - uses: actions/setup-go@v2
       with:

--- a/.github/workflows/license-file-coverage.yml
+++ b/.github/workflows/license-file-coverage.yml
@@ -48,7 +48,7 @@ jobs:
         id: go-version
         run: |
           go_version="$(curl -L "${BLOB_URL}/GO_VERSION")" &&
-          echo "::set-output name=value::${go_version}"
+          echo "value=${go_version}" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ steps.go-version.outputs.value }} # The Go version to download (if necessary) and use.

--- a/.github/workflows/pr-to-update-go.yml
+++ b/.github/workflows/pr-to-update-go.yml
@@ -49,7 +49,7 @@ jobs:
         if: ${{ steps.checkout.outcome == 'success' }}
         run: python3 -m pr_to_update_go --update-version-only
       - name: Check Go version
-        run: echo "::set-output name=value::$(cat GO_VERSION)"
+        run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
         id: go-version
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/tm.integration.tests.yml
+++ b/.github/workflows/tm.integration.tests.yml
@@ -49,7 +49,7 @@ jobs:
         with:
             fetch-depth: 1
       - name: Check Go Version
-        run: echo "::set-output name=value::$(cat GO_VERSION)"
+        run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
         id: go-version
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/to.api.contract.tests.yml
+++ b/.github/workflows/to.api.contract.tests.yml
@@ -79,7 +79,7 @@ jobs:
       id: tvdb
       uses: ./.github/actions/tvdb-init
     - name: Check Go Version
-      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
       id: go-version
     - name: Install Go
       uses: actions/setup-go@v2

--- a/.github/workflows/to.integration.tests.yml
+++ b/.github/workflows/to.integration.tests.yml
@@ -103,7 +103,7 @@ jobs:
       id: tvdb
       uses: ./.github/actions/tvdb-init
     - name: Check Go Version
-      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
       id: go-version
     - name: Install Go
       uses: actions/setup-go@v2
@@ -180,7 +180,7 @@ jobs:
       id: tvdb
       uses: ./.github/actions/tvdb-init
     - name: Check Go Version
-      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
       id: go-version
     - name: Install Go
       uses: actions/setup-go@v2
@@ -259,7 +259,7 @@ jobs:
       id: tvdb
       uses: ./.github/actions/tvdb-init
     - name: Check Go Version
-      run: echo "::set-output name=value::$(cat GO_VERSION)"
+      run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
       id: go-version
     - name: Install Go
       uses: actions/setup-go@v2

--- a/.github/workflows/tp.integration.tests.yml
+++ b/.github/workflows/tp.integration.tests.yml
@@ -154,7 +154,7 @@ jobs:
         id: tvdb
         uses: ./.github/actions/tvdb-init
       - name: Check Go Version
-        run: echo "::set-output name=value::$(cat GO_VERSION)"
+        run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
         id: go-version
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/tpv2.yml
+++ b/.github/workflows/tpv2.yml
@@ -205,7 +205,7 @@ jobs:
         id: tvdb
         uses: ./.github/actions/tvdb-init
       - name: Check Go Version
-        run: echo "::set-output name=value::$(cat GO_VERSION)"
+        run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
         id: go-version
       - name: Install Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

Closes #7822 

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->

- Automation (GitHub Actions) <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=value::$(cat GO_VERSION)"
```

**TO-BE**

```yaml
run: echo "value=$(cat GO_VERSION)" >> $GITHUB_OUTPUT
```

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
