### PR TITLE
Do not run all GHA workflows twice when a new branch is created

### DIFF
--- a/.github/workflows/ansible.molecule.fo.yml
+++ b/.github/workflows/ansible.molecule.fo.yml
@@ -17,18 +17,18 @@
 ---
 name: Molecule - FO
 
-on:
-  push:
-    paths:
-      - .github/workflows/ansible.molecule.fo.yml
-      - infrastructure/ansible/roles/molecule_shared/**
-      - infrastructure/ansible/roles/fakeOrigin/**
-  pull_request:
-    paths:
-      - .github/workflows/ansible.molecule.fo.yml
-      - infrastructure/ansible/roles/molecule_shared/**
-      - infrastructure/ansible/roles/fakeOrigin/**
-    types: [opened, reopened, ready_for_review, synchronize]
+#on:
+#  push:
+#    paths:
+#      - .github/workflows/ansible.molecule.fo.yml
+#      - infrastructure/ansible/roles/molecule_shared/**
+#      - infrastructure/ansible/roles/fakeOrigin/**
+#  pull_request:
+#    paths:
+#      - .github/workflows/ansible.molecule.fo.yml
+#      - infrastructure/ansible/roles/molecule_shared/**
+#      - infrastructure/ansible/roles/fakeOrigin/**
+#    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/ansible.molecule.fo.yml
+++ b/.github/workflows/ansible.molecule.fo.yml
@@ -18,7 +18,6 @@
 name: Molecule - FO
 
 on:
-  create:
   push:
     paths:
       - .github/workflows/ansible.molecule.fo.yml

--- a/.github/workflows/ansible.molecule.todb.yml
+++ b/.github/workflows/ansible.molecule.todb.yml
@@ -17,18 +17,18 @@
 ---
 name: Molecule - TODB
 
-on:
-  push:
-    paths:
-      - .github/workflows/ansible.molecule.todb.yml
-      - infrastructure/ansible/roles/molecule_shared/**
-      - infrastructure/ansible/roles/traffic_opsdb/**
-  pull_request:
-    paths:
-      - .github/workflows/ansible.molecule.todb.yml
-      - infrastructure/ansible/roles/molecule_shared/**
-      - infrastructure/ansible/roles/traffic_opsdb/**
-    types: [opened, reopened, ready_for_review, synchronize]
+#on:
+#  push:
+#    paths:
+#      - .github/workflows/ansible.molecule.todb.yml
+#      - infrastructure/ansible/roles/molecule_shared/**
+#      - infrastructure/ansible/roles/traffic_opsdb/**
+#  pull_request:
+#    paths:
+#      - .github/workflows/ansible.molecule.todb.yml
+#      - infrastructure/ansible/roles/molecule_shared/**
+#      - infrastructure/ansible/roles/traffic_opsdb/**
+#    types: [opened, reopened, ready_for_review, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/ansible.molecule.todb.yml
+++ b/.github/workflows/ansible.molecule.todb.yml
@@ -18,7 +18,6 @@
 name: Molecule - TODB
 
 on:
-  create:
   push:
     paths:
       - .github/workflows/ansible.molecule.todb.yml

--- a/.github/workflows/cache-config-tests.yml
+++ b/.github/workflows/cache-config-tests.yml
@@ -47,7 +47,6 @@ on:
       - traffic_ops/traffic_ops_golang/**.go
       - vendor/**.go
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - cache-config/**.go

--- a/.github/workflows/cache-config.unit.tests.yml
+++ b/.github/workflows/cache-config.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - 'cache-config/**_test.go'
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/check-go-modules.yml
+++ b/.github/workflows/check-go-modules.yml
@@ -26,7 +26,6 @@ on:
       - go.sum
       - GO_VERSION
       - vendor/**
-  create:
   pull_request:
     paths:
       - .github/check-go-modules/**

--- a/.github/workflows/ciab.yaml
+++ b/.github/workflows/ciab.yaml
@@ -54,7 +54,6 @@ on:
       - 'dev/**'
       - 'Makefile'
       - 'cache-config/Makefile'
-  create:
   pull_request:
     paths-ignore:
       - '*.*'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,6 @@
 name: Documentation Build
 
 on:
-  create:
   push:
     paths:
       - docs/source/**

--- a/.github/workflows/go.fmt.yml
+++ b/.github/workflows/go.fmt.yml
@@ -28,7 +28,6 @@ on:
       - .github/workflows/go.fmt.yml
       - GO_VERSION
       - "**.go"
-  create:
   pull_request:
     paths:
       - .github/actions/go-fmt

--- a/.github/workflows/go.lib.unit.tests.yml
+++ b/.github/workflows/go.lib.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - 'lib/**_test.go'
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/go.vet.yml
+++ b/.github/workflows/go.vet.yml
@@ -24,7 +24,6 @@ on:
       - .github/workflows/go.vet.yml
       - GO_VERSION
       - '**.go'
-  create:
   pull_request:
     paths:
       - .github/actions/go-vet

--- a/.github/workflows/grove.unit.tests.yml
+++ b/.github/workflows/grove.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - 'grove/**_test.go'
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/health-client-tests.yml
+++ b/.github/workflows/health-client-tests.yml
@@ -44,7 +44,6 @@ on:
       - .github/actions/build-ats-test-rpm/**
       - .github/actions/repo-info/**
       - .github/actions/health-client-integration-tests/**
-  create:
   pull_request:
     paths:
       - .github/workflows/health-client-tests.yml

--- a/.github/workflows/license-file-coverage.yml
+++ b/.github/workflows/license-file-coverage.yml
@@ -31,7 +31,6 @@ on:
       - .github/workflows/license-file-coverage.yml
       - .github/actions/license-file-coverage
       - LICENSE
-  create:
   pull_request:
     paths:
       - .github/workflows/license-file-coverage.yml

--- a/.github/workflows/postinstall.tests.yml
+++ b/.github/workflows/postinstall.tests.yml
@@ -23,7 +23,6 @@ on:
       - .github/workflows/postinstall.tests.yml
       - traffic_ops/install/bin/_postinstall
       - traffic_ops/install/bin/postinstall.test.sh
-  create:
   pull_request:
     paths:
       - .github/workflows/postinstall.tests.yml

--- a/.github/workflows/tm.integration.tests.yml
+++ b/.github/workflows/tm.integration.tests.yml
@@ -29,7 +29,6 @@ on:
       - GO_VERSION
       - traffic_monitor/**
       - lib/**
-  create:
   pull_request:
     paths:
       - .github/actions/tm-integration-tests/**

--- a/.github/workflows/tm.unit.tests.yml
+++ b/.github/workflows/tm.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - 'traffic_monitor/**_test.go'
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/to.api.contract.tests.yml
+++ b/.github/workflows/to.api.contract.tests.yml
@@ -32,7 +32,6 @@ on:
       - traffic_ops/**.go
       - '!**_test.go'
       - traffic_control/clients/python/**.py
-  create:
   pull_request:
     paths:
       - .github/actions/todb-init/**

--- a/.github/workflows/to.integration.tests.yml
+++ b/.github/workflows/to.integration.tests.yml
@@ -37,7 +37,6 @@ on:
       - traffic_ops/traffic_ops_golang/**.go
       - vendor/**.go
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/todb-init/**

--- a/.github/workflows/to.unit.tests.yml
+++ b/.github/workflows/to.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - 'traffic_ops/traffic_ops_golang/**_test.go'
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/tp.integration.tests.yml
+++ b/.github/workflows/tp.integration.tests.yml
@@ -36,7 +36,6 @@ on:
       - traffic_ops/app/db/**
       - traffic_ops/traffic_ops_golang/**.go
       - traffic_portal/**
-  create:
   pull_request:
     paths:
       - .github/actions/todb-init/**

--- a/.github/workflows/tpv2.yml
+++ b/.github/workflows/tpv2.yml
@@ -30,7 +30,6 @@ on:
       - '!**_test.go'
       - traffic_ops/app/db/**
       - traffic_ops/traffic_ops_golang/**.go
-  create:
   pull_request:
     paths:
       - experimental/traffic-portal/**

--- a/.github/workflows/tr-ultimate-test-harness.yml
+++ b/.github/workflows/tr-ultimate-test-harness.yml
@@ -28,7 +28,6 @@ on:
       - .github/workflows/tr-ultimate-test-harness.yml
       - dev/traffic_router/**
       - traffic_router/**
-  create:
   pull_request:
     paths:
       - .github/actions/tr-ultimate-test-harness/**

--- a/.github/workflows/tr.tests.yaml
+++ b/.github/workflows/tr.tests.yaml
@@ -34,7 +34,6 @@ on:
     paths:
       - .github/workflows/tr.tests.yaml
       - traffic_router/**
-  create:
   pull_request:
     paths:
       - .github/workflows/tr.tests.yaml

--- a/.github/workflows/traffic-stats.unit.tests.yml
+++ b/.github/workflows/traffic-stats.unit.tests.yml
@@ -33,7 +33,6 @@ on:
       - '!**_test.go'
       - traffic_stats/**_test.go
       - vendor/modules.txt
-  create:
   pull_request:
     paths:
       - .github/actions/go-test/**

--- a/.github/workflows/traffic.ops.database.yml
+++ b/.github/workflows/traffic.ops.database.yml
@@ -22,7 +22,6 @@ env:
   ALPINE_VERSION: sha256:08d6ca16c60fe7490c03d10dc339d9fd8ea67c6466dea8d558526b1330a85930
 
 on:
-  create:
   push:
     paths:
       - traffic_ops/app/db/**

--- a/.github/workflows/weasel.yml
+++ b/.github/workflows/weasel.yml
@@ -19,7 +19,6 @@ name: Weasel License checks
 
 on:
   push:
-  create:
   pull_request:
     types: [opened, reopened, ready_for_review, synchronize]
 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR makes it so that GHA workflows only run when files are changed. Previously, all GHAs workflows were being run when a branch was created (`create` trigger), so if the GHA workflow was also triggered by paths under the `push` trigger, each such GHA workflow would run twice, which is unnecessary.

This PR also disables the ansible/molecule GHA workflows, since they always fail.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Automation <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Verify that all GHAs workflows in #7825 pass, unless they were failing already before this PR.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
