### PR TITLE
fix cannot read property 'forEach' of null charts

### DIFF
--- a/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/bps/ChartBPSController.js
@@ -79,7 +79,7 @@ var ChartBPSController = function(deliveryService, $scope, $timeout, $filter, $q
 		var normalizedChartData = [];
 
 		if (angular.isDefined(series)) {
-			series.values.forEach(function(seriesItem) {
+			series.values?.forEach(function(seriesItem) {
 				if (moment(seriesItem[0]).isSame(start) || moment(seriesItem[0]).isAfter(start)) {
 					normalizedChartData.push([ moment(seriesItem[0]).valueOf(),
 						numberUtils.convertTo(seriesItem[1], $scope.unitSize) ]); // converts data to appropriate unit

--- a/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
+++ b/traffic_portal/app/src/common/modules/chart/httpStatus/ChartHttpStatusController.js
@@ -92,7 +92,7 @@ var ChartHttpStatusController = function(deliveryService, $scope, $timeout, $fil
 			series = result.series;
 
 		if (angular.isDefined(series)) {
-			series.values.forEach(function(seriesItem) {
+			series.values?.forEach(function(seriesItem) {
 				if (moment(seriesItem[0]).isSame(start) || moment(seriesItem[0]).isAfter(start)) {
 					if (_.isNumber(seriesItem[1])) {
 						normalizedChartData.push([ moment(seriesItem[0]).valueOf(), seriesItem[1] ]);

--- a/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
+++ b/traffic_portal/app/src/common/modules/chart/tps/ChartTPSController.js
@@ -78,7 +78,7 @@ var ChartTPSController = function(deliveryService, $scope, $timeout, $filter, $q
 		var normalizedChartData = [];
 
 		if (angular.isDefined(series)) {
-			series.values.forEach(function(seriesItem) {
+			series.values?.forEach(function(seriesItem) {
 				if (moment(seriesItem[0]).isSame(start) || moment(seriesItem[0]).isAfter(start)) {
 					normalizedChartData.push([ moment(seriesItem[0]).valueOf(), seriesItem[1] ]);
 				}


### PR DESCRIPTION
Closes: #6250 

Using Optional chaining to solve problem with null values series

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
- Step 1: Make series.values return null when query deliveryservice_stats
- Step 2: DS Charts shouldn't throw any errors

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
