### PR TITLE
Update Topology Cache Group Servers table to use AG-Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 - [#7614](https://github.com/apache/trafficcontrol/pull/7614) *Traffic Ops* The database upgrade process no longer overwrites changes users may have made to the initially seeded data.
 - [#7832](https://github.com/apache/trafficcontrol/pull/7832) *t3c* Removed perl dependency
+- Updated the CacheGroups Traffic Portal page to use a more performant AG-Grid-based table.
 
 ## [8.0.0] - 2023-09-20
 ### Added

--- a/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
+++ b/traffic_ops/traffic_ops_golang/cachegroup/cachegroups.go
@@ -1405,8 +1405,7 @@ func DeleteCacheGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	alertMessage := fmt.Sprintf("%s was deleted.", ID)
-	alerts := tc.CreateAlerts(tc.SuccessLevel, alertMessage)
+	alerts := tc.CreateAlerts(tc.SuccessLevel, "cache group was deleted.")
 	api.WriteAlerts(w, r, http.StatusOK, alerts)
 	return
 }

--- a/traffic_portal/app/src/common/modules/table/cacheGroups/table.cacheGroups.tpl.html
+++ b/traffic_portal/app/src/common/modules/table/cacheGroups/table.cacheGroups.tpl.html
@@ -18,54 +18,14 @@ under the License.
 -->
 
 <div class="x_panel">
-    <div class="x_title">
-        <ol class="breadcrumb pull-left">
-            <li class="active">Cache Groups</li>
-        </ol>
-        <div class="pull-right" role="group" ng-if="!settings.isNew">
-            <button name="createCacheGroupButton" class="btn btn-primary" title="Create Cache Group" ng-click="createCacheGroup()"><i class="fa fa-plus"></i></button>
-            <button class="btn btn-default" title="Refresh" ng-click="refresh()"><i class="fa fa-refresh"></i></button>
-            <div id="toggleColumns" class="btn-group" role="group" title="Select Table Columns" uib-dropdown is-open="columnSettings.isopen">
-                <button type="button" class="btn btn-default dropdown-toggle" uib-dropdown-toggle aria-haspopup="true" aria-expanded="false">
-                    <i class="fa fa-columns"></i>&nbsp;
-                    <span class="caret"></span>
-                </button>
-                <menu ng-click="$event.stopPropagation()" class="column-settings dropdown-menu-right dropdown-menu" uib-dropdown-menu>
-                    <li role="menuitem" ng-repeat="c in columns | orderBy:'name'">
-                        <div class="checkbox">
-                            <label><input type="checkbox" ng-model="c.visible" ng-click="toggleVisibility(c.name)"> {{::c.name}}</label>
-                        </div>
-                    </li>
-                </menu>
-            </div>
-        </div>
-        <div class="clearfix"></div>
-    </div>
-    <div class="x_content">
-        <br>
-        <table id="cacheGroupsTable" class="table responsive-utilities jambo_table">
-            <thead>
-            <tr class="headings">
-                <th>Name</th>
-                <th>Short Name</th>
-                <th>Type</th>
-                <th>1st Parent</th>
-                <th>2nd Parent</th>
-                <th>Latitude</th>
-                <th>Longitude</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr ng-click="editCacheGroup(cg.id)" ng-repeat="cg in ::cacheGroups" context-menu="contextMenuItems">
-                <td data-search="^{{::cg.name}}$">{{::cg.name}}</td>
-                <td data-search="^{{::cg.shortName}}$">{{::cg.shortName}}</td>
-                <td data-search="^{{::cg.typeName}}$">{{::cg.typeName}}</td>
-                <td data-search="^{{::cg.parentCachegroupName}}$">{{::cg.parentCachegroupName}}</td>
-                <td data-search="^{{::cg.secondaryParentCachegroupName}}$">{{::cg.secondaryParentCachegroupName}}</td>
-                <td data-search="^{{::cg.latitude}}$">{{::cg.latitude}}</td>
-                <td data-search="^{{::cg.longitude}}$">{{::cg.longitude}}</td>
-            </tr>
-            </tbody>
-        </table>
-    </div>
+    <common-grid-controller
+        title="Cache Groups"
+        table-name="cacheGroups"
+        options="gridOptions"
+        data="cacheGroups"
+        columns="columns"
+        drop-down-options="dropDownOptions"
+        context-menu-options="contextMenuOptions"
+    >
+    </common-grid-controller>
 </div>

--- a/traffic_portal/test/integration/Data/cachegroup.ts
+++ b/traffic_portal/test/integration/Data/cachegroup.ts
@@ -218,22 +218,22 @@ export const cachegroups = {
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache2",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				},
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache4",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				},
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache5",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				},
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache6",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				}
 			]
 		}

--- a/traffic_portal/test/integration/Data/cachegroup.ts
+++ b/traffic_portal/test/integration/Data/cachegroup.ts
@@ -27,16 +27,6 @@ export const cachegroups = {
 					"password": "pa$$word"
 				}
 			],
-			toggle:[
-				{
-					description: "hide first table column",
-					Name: "1st Parent"
-				},
-				{
-					description: "redisplay first table column",
-					Name: "1st Parent"
-				}
-			],
 			create: [
 				{
 					Description: "create a EDGE_LOC cachegroup with FailOver CacheGroup Field",
@@ -122,16 +112,6 @@ export const cachegroups = {
 					"password": "pa$$word"
 				}
 			],
-			toggle:[
-				{
-					description: "hide first table column",
-					Name: "1st Parent"
-				},
-				{
-					description: "display first table column",
-					Name: "1st Parent"
-				}
-			],
 			create: [
 				{
 					Description: "create a CacheGroup",
@@ -168,16 +148,6 @@ export const cachegroups = {
 				{
 					"username": "TPOperator",
 					"password": "pa$$word"
-				}
-			],
-			toggle:[
-				{
-					description: "hide first table column",
-					Name: "1st Parent"
-				},
-				{
-					description: "display first table column",
-					Name: "1st Parent"
 				}
 			],
 			create: [

--- a/traffic_portal/test/integration/Data/cachegroup.ts
+++ b/traffic_portal/test/integration/Data/cachegroup.ts
@@ -95,12 +95,12 @@ export const cachegroups = {
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache1",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				},
 				{
 					Description: "delete a cachegroup",
 					Name: "TP_Cache3",
-					validationMessage: "was deleted"
+					validationMessage: "cache group was deleted."
 				}
 			]
 		},

--- a/traffic_portal/test/integration/Data/cachegroup.ts
+++ b/traffic_portal/test/integration/Data/cachegroup.ts
@@ -37,12 +37,6 @@ export const cachegroups = {
 					Name: "1st Parent"
 				}
 			],
-			check: [
-				{
-					description: "check CSV link from CacheGroup page",
-					Name: "Export as CSV"
-				}
-			],
 			create: [
 				{
 					Description: "create a EDGE_LOC cachegroup with FailOver CacheGroup Field",
@@ -138,12 +132,6 @@ export const cachegroups = {
 					Name: "1st Parent"
 				}
 			],
-			check: [
-				{
-					description: "check CSV link from CacheGroup page",
-					Name: "Export as CSV"
-				}
-			],
 			create: [
 				{
 					Description: "create a CacheGroup",
@@ -190,12 +178,6 @@ export const cachegroups = {
 				{
 					description: "display first table column",
 					Name: "1st Parent"
-				}
-			],
-			check: [
-				{
-					description: "check CSV link from CacheGroup page",
-					Name: "Export as CSV"
 				}
 			],
 			create: [

--- a/traffic_portal/test/integration/PageObjects/CacheGroup.po.ts
+++ b/traffic_portal/test/integration/PageObjects/CacheGroup.po.ts
@@ -155,9 +155,8 @@ export class CacheGroupPage extends SideNavigationPage {
         await element(by.name("type")).sendKeys(cachegroup.Type);
         await this.ClickUpdate();
         if (result !== undefined) {
-            await this.GetOutputMessage().then((v) => outputMessage === v);
+            return (await this.GetOutputMessage()) === outputMessage;
         }
-        return result;
     }
 
     /**

--- a/traffic_portal/test/integration/specs/CacheGroup.spec.ts
+++ b/traffic_portal/test/integration/specs/CacheGroup.spec.ts
@@ -34,6 +34,7 @@ cachegroups.tests.forEach((cacheGroupData) => {
                 browser.get(browser.params.baseUrl);
                 await loginPage.Login(login);
                 expect(await loginPage.CheckUserName(login)).toBeTruthy();
+                await cacheGroupPage.OpenTopologyMenu();
                 await cacheGroupPage.OpenCacheGroupsPage();
             });
             afterAll(async () => {

--- a/traffic_portal/test/integration/specs/CacheGroup.spec.ts
+++ b/traffic_portal/test/integration/specs/CacheGroup.spec.ts
@@ -16,19 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import {browser} from 'protractor';
+import { browser } from "protractor";
 
-import {LoginPage} from '../PageObjects/LoginPage.po'
-import {CacheGroupPage} from '../PageObjects/CacheGroup.po';
-import {TopNavigationPage} from '../PageObjects/TopNavigationPage.po';
-import {cachegroups} from "../Data";
-
+import { LoginPage } from "../PageObjects/LoginPage.po";
+import { CacheGroupPage } from "../PageObjects/CacheGroup.po";
+import { TopNavigationPage } from "../PageObjects/TopNavigationPage.po";
+import { cachegroups } from "../Data";
 
 let loginPage = new LoginPage();
 let topNavigation = new TopNavigationPage();
 let cacheGroupPage = new CacheGroupPage();
 
-cachegroups.tests.forEach(cacheGroupData => {
+cachegroups.tests.forEach((cacheGroupData) => {
     for (const login of cacheGroupData.logins) {
         describe(`Traffic Portal - CacheGroup - ${cacheGroupData.testName}`, () => {
             beforeAll(async () => {
@@ -45,21 +44,48 @@ cachegroups.tests.forEach(cacheGroupData => {
             });
             for (const create of cacheGroupData.create) {
                 it(create.Description, async () => {
-                    expect(await cacheGroupPage.CreateCacheGroups(create, create.validationMessage)).toBeTruthy();
+                    expect(
+                        await cacheGroupPage.CreateCacheGroups(
+                            create,
+                            create.validationMessage
+                        )
+                    ).toBeTruthy();
                 });
             }
             for (const update of cacheGroupData.update) {
-                it(update.Description, async () => {
-                    await cacheGroupPage.SearchCacheGroups(update.Name);
-                    expect(await cacheGroupPage.UpdateCacheGroups(update, update.validationMessage)).toBeTruthy();
-                });
+                if (update.Description.includes("cannot")) {
+                    it(update.Description, async () => {
+                        await cacheGroupPage.SearchCacheGroups(update.Name);
+                        expect(
+                            await cacheGroupPage.UpdateCacheGroups(
+                                update,
+                                update.validationMessage
+                            )
+                        ).toBeUndefined();
+                    });
+                } else {
+                    it(update.Description, async () => {
+                        await cacheGroupPage.SearchCacheGroups(update.Name);
+                        expect(
+                            await cacheGroupPage.UpdateCacheGroups(
+                                update,
+                                update.validationMessage
+                            )
+                        ).toBeTruthy();
+                    });
+                }
             }
             for (const remove of cacheGroupData.remove) {
                 it(remove.Description, async () => {
                     await cacheGroupPage.SearchCacheGroups(remove.Name);
-                    expect(await cacheGroupPage.DeleteCacheGroups(remove.Name, remove.validationMessage)).toBeTruthy();
+                    expect(
+                        await cacheGroupPage.DeleteCacheGroups(
+                            remove.Name,
+                            remove.validationMessage
+                        )
+                    ).toBeTruthy();
                 });
             }
         });
     }
-})
+});

--- a/traffic_portal/test/integration/specs/CacheGroup.spec.ts
+++ b/traffic_portal/test/integration/specs/CacheGroup.spec.ts
@@ -16,13 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { browser } from 'protractor';
+import {browser} from 'protractor';
 
-import { LoginPage } from '../PageObjects/LoginPage.po'
-import { CacheGroupPage } from '../PageObjects/CacheGroup.po';
-import { TopNavigationPage } from '../PageObjects/TopNavigationPage.po';
-import { cachegroups } from "../Data";
-
+import {LoginPage} from '../PageObjects/LoginPage.po'
+import {CacheGroupPage} from '../PageObjects/CacheGroup.po';
+import {TopNavigationPage} from '../PageObjects/TopNavigationPage.po';
+import {cachegroups} from "../Data";
 
 
 let loginPage = new LoginPage();
@@ -30,66 +29,37 @@ let topNavigation = new TopNavigationPage();
 let cacheGroupPage = new CacheGroupPage();
 
 cachegroups.tests.forEach(cacheGroupData => {
-    describe(`Traffic Portal - CacheGroup - ${cacheGroupData.testName}`, () => {
-        cacheGroupData.logins.forEach(login => {
-            it('can login', async function () {
+    for (const login of cacheGroupData.logins) {
+        describe(`Traffic Portal - CacheGroup - ${cacheGroupData.testName}`, () => {
+            beforeAll(async () => {
                 browser.get(browser.params.baseUrl);
                 await loginPage.Login(login);
                 expect(await loginPage.CheckUserName(login)).toBeTruthy();
-            })
-            it('can open cache group page', async function () {
-                await cacheGroupPage.OpenTopologyMenu();
                 await cacheGroupPage.OpenCacheGroupsPage();
-            })
-            cacheGroupData.check.forEach(check => {
-                it(check.description, async () => {
-                    expect(await cacheGroupPage.CheckCSV(check.Name)).toBe(true);
-                    await cacheGroupPage.OpenCacheGroupsPage();
-                });
             });
-            cacheGroupData.toggle.forEach(toggle => {
-                it(toggle.description, async () => {
-                    if(toggle.description.includes('hide')){
-                        expect(await cacheGroupPage.ToggleTableColumn(toggle.Name)).toBe(false);
-                        await cacheGroupPage.OpenCacheGroupsPage();
-                    }else{
-                        expect(await cacheGroupPage.ToggleTableColumn(toggle.Name)).toBe(true);
-                        await cacheGroupPage.OpenCacheGroupsPage();
-                    }
-                    
-                });
-            })
-            cacheGroupData.create.forEach(create => {
-                it(create.Description, async function () {
-                    expect(await cacheGroupPage.CreateCacheGroups(create, create.validationMessage)).toBeTruthy();
-                    await cacheGroupPage.OpenCacheGroupsPage();
-                })
-            })
-            cacheGroupData.update.forEach(update => {
-                if (update.Description.includes("cannot")) {
-                    it(update.Description, async function () {
-                        await cacheGroupPage.SearchCacheGroups(update.Name)
-                        expect(await cacheGroupPage.UpdateCacheGroups(update, update.validationMessage)).toBeUndefined();
-                        await cacheGroupPage.OpenCacheGroupsPage();
-                    })
-                } else {
-                    it(update.Description, async function () {
-                        await cacheGroupPage.SearchCacheGroups(update.Name)
-                        expect(await cacheGroupPage.UpdateCacheGroups(update, update.validationMessage)).toBeTruthy();
-                        await cacheGroupPage.OpenCacheGroupsPage();
-                    })
-                }
-
-            })
-            cacheGroupData.remove.forEach(remove => {
-                it(remove.Description, async function () {
-                    await cacheGroupPage.SearchCacheGroups(remove.Name)
-                    expect(await cacheGroupPage.DeleteCacheGroups(remove.Name, remove.validationMessage)).toBeTruthy();
-                })
-            })
-            it('can logout', async function () {
+            afterAll(async () => {
                 expect(await topNavigation.Logout()).toBeTruthy();
-            })
-        })
-    })
+            });
+            afterEach(async () => {
+                await cacheGroupPage.OpenCacheGroupsPage();
+            });
+            for (const create of cacheGroupData.create) {
+                it(create.Description, async () => {
+                    expect(await cacheGroupPage.CreateCacheGroups(create, create.validationMessage)).toBeTruthy();
+                });
+            }
+            for (const update of cacheGroupData.update) {
+                it(update.Description, async () => {
+                    await cacheGroupPage.SearchCacheGroups(update.Name);
+                    expect(await cacheGroupPage.UpdateCacheGroups(update, update.validationMessage)).toBeTruthy();
+                });
+            }
+            for (const remove of cacheGroupData.remove) {
+                it(remove.Description, async () => {
+                    await cacheGroupPage.SearchCacheGroups(remove.Name);
+                    expect(await cacheGroupPage.DeleteCacheGroups(remove.Name, remove.validationMessage)).toBeTruthy();
+                });
+            }
+        });
+    }
 })


### PR DESCRIPTION
Closes: #6501 

This updates the "Cache Groups" Traffic Portal page to use AG-Grid instead of JQuery datatables. 

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
Make sure all the TP tests pass, make sure the new table looks okay. 

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
