### PR TITLE
Add the option to include custom VCL through parameters

### DIFF
--- a/cache-config/t3cutil/getdatacfg.go
+++ b/cache-config/t3cutil/getdatacfg.go
@@ -894,8 +894,8 @@ func FilterDSS(dsses []tc.DeliveryServiceServer, dsIDs map[int]struct{}, serverI
 // FilterParams filters params and returns only the parameters which match configFile, name, and value.
 // If configFile, name, or value is the empty string, it is not filtered.
 // Returns a slice of parameters.
-func FilterParams(params []tc.Parameter, configFile string, name string, value string, omitName string) []tc.Parameter {
-	filtered := []tc.Parameter{}
+func FilterParams(params []tc.ParameterV5, configFile string, name string, value string, omitName string) []tc.ParameterV5 {
+	filtered := []tc.ParameterV5{}
 	for _, param := range params {
 		if configFile != "" && param.ConfigFile != configFile {
 			continue

--- a/lib/varnishcfg/custom_vcl.go
+++ b/lib/varnishcfg/custom_vcl.go
@@ -1,0 +1,20 @@
+package varnishcfg
+
+import (
+	"strings"
+
+	"github.com/apache/trafficcontrol/v8/cache-config/t3cutil"
+)
+
+func (v VCLBuilder) configureCustomVCL(vclFile *vclFile) {
+	params := t3cutil.FilterParams(v.toData.ServerParams, "default.vcl", "", "", "")
+	for _, param := range params {
+		if param.Name == "import" {
+			vclFile.imports = append(vclFile.imports, param.Value)
+			continue
+		}
+		// TODO: support loading vcl files too with `include`?? i.e. `include "custom.vcl";`
+		lines := strings.Split(param.Value, "\n")
+		vclFile.subroutines[param.Name] = append(vclFile.subroutines[param.Name], lines...)
+	}
+}

--- a/lib/varnishcfg/custom_vcl_test.go
+++ b/lib/varnishcfg/custom_vcl_test.go
@@ -1,0 +1,41 @@
+package varnishcfg
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apache/trafficcontrol/v8/cache-config/t3cutil"
+	"github.com/apache/trafficcontrol/v8/lib/go-tc"
+)
+
+func TestConfigureCustomVCL(t *testing.T) {
+	vb := NewVCLBuilder(&t3cutil.ConfigData{
+		ServerParams: []tc.ParameterV50{
+			{ConfigFile: "default.vcl", Name: "import", Value: "std"},
+			{ConfigFile: "default.vcl", Name: "vcl_recv", Value: "set req.url = std.querysort(req.url);"},
+			{
+				ConfigFile: "default.vcl",
+				Name:       "vcl_deliver",
+				Value:      "if (req.status >= 400 && req.status <= 500) {\n\tset req.status = 404;\n}",
+			},
+		},
+	})
+
+	vclFile := newVCLFile(defaultVCLVersion)
+	vb.configureCustomVCL(&vclFile)
+
+	expectedVCLFile := newVCLFile(defaultVCLVersion)
+	expectedVCLFile.imports = append(expectedVCLFile.imports, "std")
+	expectedVCLFile.subroutines["vcl_recv"] = []string{
+		"set req.url = std.querysort(req.url);",
+	}
+	expectedVCLFile.subroutines["vcl_deliver"] = []string{
+		"if (req.status >= 400 && req.status <= 500) {",
+		"	set req.status = 404;",
+		"}",
+	}
+
+	if !reflect.DeepEqual(vclFile, expectedVCLFile) {
+		t.Errorf("got %v want %v", vclFile, expectedVCLFile)
+	}
+}

--- a/lib/varnishcfg/vclbuilder.go
+++ b/lib/varnishcfg/vclbuilder.go
@@ -88,5 +88,7 @@ func (vb *VCLBuilder) BuildVCLFile() (string, []string, error) {
 	dirWarnings, err := vb.configureDirectors(&v, parents)
 	warnings = append(warnings, dirWarnings...)
 
+	vb.configureCustomVCL(&v)
+
 	return fmt.Sprint(v), warnings, err
 }


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR adds the option to include custom VCL through parameters in Varnish cache. This allows importing plugins (VMODs) and using them throughout the VCL file. It allows adding custom logic that is not handled by t3c. For example adding the functionality of some ATS plugins like Header Rewrite and Regex Remap.

It expects the subroutine that the code should be appended to so the user can have custom logic in different parts of the transaction lifecycle.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
- Using CDN-in-a-Box, edit the edge parameters to include custom VCL. For example here is some code to remove via header in case of a test endpoint:
```json
{
			"configFile": "default.vcl",
			"name": "vcl_deliver",
			"secure": false,
			"value": "if (req.url ~ \"/test\") {unset resp.http.via;}"
}
```
- Run `docker-compose exec enroller curl -L -o /dev/null -D - -s "http://video.demo1.mycdn.ciab.test/test"` to print response headers.
- via header should not be printed

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
