### PR TITLE
Fix missing $scope.refresh function in CDNs table

### DIFF
--- a/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
+++ b/traffic_portal/app/src/common/modules/table/cdns/TableCDNsController.js
@@ -35,12 +35,13 @@ const getHref = cdn => `#!/cdns/${cdn.id}`;
 /**
  * @param {CDN[]} cdns
  * @param {*} $scope
+ * @param {*} $state
  * @param {import("../../../service/utils/angular.ui.bootstrap").IModalService} $uibModal
  * @param {import("../../../service/utils/LocationUtils")} locationUtils
  * @param {import("../../../api/CDNService")} cdnService
  * @param {import("../../../models/MessageModel")} messageModel
  */
-var TableCDNsController = function(cdns, $scope, $uibModal, locationUtils, cdnService, messageModel) {
+var TableCDNsController = function(cdns, $scope, $state, $uibModal, locationUtils, cdnService, messageModel) {
 
 	/**** Constants, scope data, etc. ****/
 
@@ -98,6 +99,10 @@ var TableCDNsController = function(cdns, $scope, $uibModal, locationUtils, cdnSe
 		type: 1
 	}];
 
+	/** Reloads all resolved data for the view. */
+	$scope.refresh = function() {
+		$state.reload();
+	};
 
 	/**
 	 * Deletes a CDN if confirmation is given.
@@ -253,5 +258,5 @@ var TableCDNsController = function(cdns, $scope, $uibModal, locationUtils, cdnSe
 
 };
 
-TableCDNsController.$inject = ["cdns", "$scope", "$uibModal", "locationUtils", "cdnService", "messageModel"];
+TableCDNsController.$inject = ["cdns", "$scope", '$state', "$uibModal", "locationUtils", "cdnService", "messageModel"];
 module.exports = TableCDNsController;


### PR DESCRIPTION
Closes: #7852

Fix missing $scope.refresh function in CDNs table

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal

## What is the best way to verify this PR?
- Create a CDN
- Delete it (should hide in the table after confirmation and not show any errors in Console)

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
