### PR TITLE
t3c: Fixing cache-config to enable trafficserver - Don't require chkconfig

### DIFF
--- a/cache-config/t3c-apply/config/config.go
+++ b/cache-config/t3c-apply/config/config.go
@@ -681,8 +681,7 @@ func getOSSvcManagement() SvcManagement {
 		_svcManager = SystemD
 	} else if isCommandAvailable(Service) {
 		_svcManager = SystemV
-	}
-	if !isCommandAvailable(Chkconfig) {
+	} else {
 		return Unknown
 	}
 


### PR DESCRIPTION
Closes: #7858

## Which Traffic Control components are affected by this PR?
- Traffic Control Cache Config (`t3c`, formerly ORT)

## What is the best way to verify this PR?


## If this is a bugfix, which Traffic Control versions contained the bug?

- 6.0.x through master

## PR submission checklist
- [] This PR has tests
- [] This PR has documentation
- [] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

No test is needed. No documentation is needed.

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
