### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.27.2",
-        "chromedriver": "^117.0.3",
+        "chromedriver": "^119.0.1",
         "codelyzer": "^6.0.0",
         "eslint": "^8.39.0",
         "eslint-plugin-import": "^2.25.3",
@@ -5177,9 +5177,9 @@
       }
     },
     "node_modules/@testim/chrome-version": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.3.tgz",
-      "integrity": "sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
+      "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -7766,19 +7766,19 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "117.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
-      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
+      "version": "119.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-119.0.1.tgz",
+      "integrity": "sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.4.0",
-        "compare-versions": "^6.0.0",
+        "@testim/chrome-version": "^1.1.4",
+        "axios": "^1.6.0",
+        "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
-        "tcp-port-used": "^1.0.1"
+        "tcp-port-used": "^1.0.2"
       },
       "bin": {
         "chromedriver": "bin/chromedriver"
@@ -7788,9 +7788,9 @@
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.0",
@@ -24393,9 +24393,9 @@
       }
     },
     "@testim/chrome-version": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.3.tgz",
-      "integrity": "sha512-g697J3WxV/Zytemz8aTuKjTGYtta9+02kva3C1xc7KXB8GdbfE1akGJIsZLyY/FSh2QrnE+fiB7vmWU3XNcb6A==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.1.4.tgz",
+      "integrity": "sha512-kIhULpw9TrGYnHp/8VfdcneIcxKnLixmADtukQRtJUmsVlMg0niMkwV0xZmi8hqa57xqilIHjWFA0GKvEjVU5g==",
       "dev": true
     },
     "@tootallnate/once": {
@@ -26367,24 +26367,24 @@
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
     },
     "chromedriver": {
-      "version": "117.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
-      "integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
+      "version": "119.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-119.0.1.tgz",
+      "integrity": "sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==",
       "dev": true,
       "requires": {
-        "@testim/chrome-version": "^1.1.3",
-        "axios": "^1.4.0",
-        "compare-versions": "^6.0.0",
+        "@testim/chrome-version": "^1.1.4",
+        "axios": "^1.6.0",
+        "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^1.1.0",
-        "tcp-port-used": "^1.0.1"
+        "tcp-port-used": "^1.0.2"
       },
       "dependencies": {
         "axios": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+          "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
           "dev": true,
           "requires": {
             "follow-redirects": "^1.15.0",

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -95,7 +95,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.27.2",
-    "chromedriver": "^117.0.3",
+    "chromedriver": "^119.0.1",
     "codelyzer": "^6.0.0",
     "eslint": "^8.39.0",
     "eslint-plugin-import": "^2.25.3",


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
experimental/traffic-portal: 117.0.3 -> 119.0.1


## Which Traffic Control components are affected by this PR?
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
