### PR TITLE
Limit Delivery Services returned for GET /servers/{id}/deliveryservices to ones in the same CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - [#7846](https://github.com/apache/trafficcontrol/pull/7846) *Traffic Portal* Increase State character limit
+- [#7887](https://github.com/apache/trafficcontrol/pull/7887) *Traffic Ops* Limit Delivery Services returned for GET /servers/{id}/deliveryservices to ones in the same CDN
 
 ## [8.0.0] - 2023-09-20
 ### Added

--- a/traffic_ops/testing/api/v3/servers_id_deliveryservices_test.go
+++ b/traffic_ops/testing/api/v3/servers_id_deliveryservices_test.go
@@ -91,9 +91,8 @@ func TestServersIDDeliveryServices(t *testing.T) {
 							[]int{
 								GetDeliveryServiceId(t, "ds-top")(),
 								GetDeliveryServiceId(t, "ds-top-req-cap2")(),
-								GetDeliveryServiceId(t, "ds-forked-topology")(),
 							},
-							3)),
+							2)),
 				},
 				"CONFLICT when SERVER NOT IN SAME CDN as DELIVERY SERVICE": {
 					EndpointID:    GetServerID(t, "cdn2-test-edge"),

--- a/traffic_ops/testing/api/v4/servers_id_deliveryservices_test.go
+++ b/traffic_ops/testing/api/v4/servers_id_deliveryservices_test.go
@@ -93,9 +93,8 @@ func TestServersIDDeliveryServices(t *testing.T) {
 							[]int{
 								totest.GetDeliveryServiceId(t, TOSession, "ds-top")(),
 								totest.GetDeliveryServiceId(t, TOSession, "ds-top-req-cap2")(),
-								totest.GetDeliveryServiceId(t, TOSession, "ds-forked-topology")(),
 							},
-							3)),
+							2)),
 				},
 				"CONFLICT when SERVER NOT IN SAME CDN as DELIVERY SERVICE": {
 					EndpointID:    totest.GetServerID(t, TOSession, "cdn2-test-edge"),

--- a/traffic_ops/testing/api/v5/servers_id_deliveryservices_test.go
+++ b/traffic_ops/testing/api/v5/servers_id_deliveryservices_test.go
@@ -92,9 +92,8 @@ func TestServersIDDeliveryServices(t *testing.T) {
 							[]int{
 								GetDeliveryServiceId(t, "ds-top")(),
 								GetDeliveryServiceId(t, "ds-top-req-cap2")(),
-								GetDeliveryServiceId(t, "ds-forked-topology")(),
 							},
-							3)),
+							2)),
 				},
 				"CONFLICT when SERVER NOT IN SAME CDN as DELIVERY SERVICE": {
 					EndpointID:    GetServerID(t, "cdn2-test-edge"),

--- a/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
+++ b/traffic_ops/traffic_ops_golang/deliveryservice/servers/servers.go
@@ -948,14 +948,16 @@ func (dss *TODSSDeliveryService) Read(h http.Header, useIMS bool) ([]interface{}
 (ds.id in (
 	SELECT deliveryService FROM deliveryservice_server WHERE server = :server
 ) OR ds.id in (
-	SELECT id FROM deliveryservice
-	WHERE topology in (
+	SELECT d.id FROM deliveryservice d
+	JOIN cdn c ON d.cdn_id = c.id
+	WHERE d.topology in (
 		SELECT topology FROM topology_cachegroup
 		WHERE cachegroup = (
 			SELECT name FROM cachegroup
 			WHERE id = (
 				SELECT cachegroup FROM server WHERE id = :server
-			))))) 
+			)))
+	AND d.cdn_id = (SELECT cdn_id FROM server WHERE id = :server)))
 AND
 (( 
 (SELECT (t.name = 'ORG') FROM type t JOIN server s ON s.type = t.id WHERE s.id = :server) 


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->
This PR fixes #7887 by making `GET /servers/{id}/deliveryservices` exclude topology-based DSes that contain the server's cachegroup but are in a different CDN.

<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Run tests

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
8.0.0 RC4

## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
