### PR TITLE
Include commits since last release in RPM build number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 - [#7812](https://github.com/apache/trafficcontrol/pull/7812) *Traffic Portal*: Expose the `configUpdateFailed` and `revalUpdateFailed` fields on the server table.
 - [#7870](https://github.com/apache/trafficcontrol/pull/7870) *Traffic Portal*: Adds a hyperlink to the DSR page to the DS itself for ease of navigation.
+- [#7896](https://github.com/apache/trafficcontrol/pull/7896) *ATC Build system*: Count commits since the last release, not commits
 
 ### Changed
 - [#7614](https://github.com/apache/trafficcontrol/pull/7614) *Traffic Ops* The database upgrade process no longer overwrites changes users may have made to the initially seeded data.

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -93,7 +93,16 @@ getBuildNumber() {
 	local in_git=''
 	if isInGitTree; then
 		local commits sha
-		commits="$(git rev-list HEAD 2>/dev/null | wc -l | awk '{print $1}')" # awk is for BSD compatibility
+		# The number of commits since the last tag
+		if ! commits="$(git describe --tags \
+			--match='RELEASE-[0-9].[0-9].[0-9]' \
+			--match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' \
+			--match='v[0-9].[0-9].[0-9]' \
+			--match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' |
+			awk -F- '{print $(NF-1)}')";
+		then
+			commits=0
+		fi
 		sha="$(git rev-parse --short=8 HEAD)"
 		echo "$commits.$sha"
 	else

--- a/build/functions.sh
+++ b/build/functions.sh
@@ -94,7 +94,7 @@ getBuildNumber() {
 	if isInGitTree; then
 		local commits sha
 		# The number of commits since the last tag
-		if ! commits="$(git describe --tags \
+		if ! commits="$(git describe --long --tags \
 			--match='RELEASE-[0-9].[0-9].[0-9]' \
 			--match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' \
 			--match='v[0-9].[0-9].[0-9]' \

--- a/docs/source/api/v3/about.rst
+++ b/docs/source/api/v3/about.rst
@@ -45,7 +45,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags --long``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/docs/source/api/v3/about.rst
+++ b/docs/source/api/v3/about.rst
@@ -45,7 +45,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by running ``git rev-list HEAD | wc -l``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/docs/source/api/v4/about.rst
+++ b/docs/source/api/v4/about.rst
@@ -46,7 +46,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags --long``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/docs/source/api/v4/about.rst
+++ b/docs/source/api/v4/about.rst
@@ -46,7 +46,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by running ``git rev-list HEAD | wc -l``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/docs/source/api/v5/about.rst
+++ b/docs/source/api/v5/about.rst
@@ -46,7 +46,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags --long``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/docs/source/api/v5/about.rst
+++ b/docs/source/api/v5/about.rst
@@ -46,7 +46,7 @@ No parameters available.
 Response Structure
 ------------------
 :commitHash:    The `Git <https://git-scm.com/>`_ commit hash that Traffic Ops was built at.
-:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by running ``git rev-list HEAD | wc -l``.
+:commits:       The number of commits in the branch of the commit that Traffic Ops was built at, including that commit. Calculated by extracting the commit count from running ``git describe --tags``.
 :goVersion:     The version of `Go <https://golang.org/>`_ that was used to build Traffic Ops.
 :release:       The major version of CentOS or Red Hat Enterprise Linux that the build environment was running.
 :name:          The human-readable name of the `RPM <https://rpm-packaging-guide.github.io/#packaging-software>`_ file.

--- a/experimental/traffic-portal/server.config.ts
+++ b/experimental/traffic-portal/server.config.ts
@@ -340,7 +340,7 @@ export async function getVersion(path?: string): Promise<ServerVersion> {
 	};
 
 	try {
-		ver.commits = String(execSync("git rev-list HEAD", {encoding: "utf8"}).split("\n").length);
+		ver.commits = String(execSync("git describe --tags --match=RELEASE-[0-9].[0-9].[0-9] --match=RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9] --match=v[0-9].[0-9].[0-9] --match=v[0-9][0-9].[0-9][0-9].[0-9][0-9]", {encoding: "utf8"}).split("-").slice(-2)[0]);
 		ver.hash = execSync("git rev-parse --short=8 HEAD", {encoding: "utf8"}).trimEnd();
 	} catch (e) {
 		console.warn("getting git parts of version:", e);

--- a/experimental/traffic-portal/server.config.ts
+++ b/experimental/traffic-portal/server.config.ts
@@ -340,9 +340,12 @@ export async function getVersion(path?: string): Promise<ServerVersion> {
 	};
 
 	try {
-		ver.commits = String(execSync("git describe --long --tags --match=RELEASE-[0-9].[0-9].[0-9] --match=RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9] --match=v[0-9].[0-9].[0-9] --match=v[0-9][0-9].[0-9][0-9].[0-9][0-9]", {encoding: "utf8"}).split("-").slice(-2)[0]);
 		ver.hash = execSync("git rev-parse --short=8 HEAD", {encoding: "utf8"}).trimEnd();
+		ver.commits = String(execSync("git describe --long --tags " +
+			"--match=RELEASE-[0-9].[0-9].[0-9] --match=RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9] " +
+			"--match=v[0-9].[0-9].[0-9] --match=v[0-9][0-9].[0-9][0-9].[0-9][0-9]", {encoding: "utf8"}).split("-").slice(-2)[0]);
 	} catch (e) {
+		ver.commits = "0";
 		console.warn("getting git parts of version:", e);
 	}
 

--- a/experimental/traffic-portal/server.config.ts
+++ b/experimental/traffic-portal/server.config.ts
@@ -340,7 +340,7 @@ export async function getVersion(path?: string): Promise<ServerVersion> {
 	};
 
 	try {
-		ver.commits = String(execSync("git describe --tags --match=RELEASE-[0-9].[0-9].[0-9] --match=RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9] --match=v[0-9].[0-9].[0-9] --match=v[0-9][0-9].[0-9][0-9].[0-9][0-9]", {encoding: "utf8"}).split("-").slice(-2)[0]);
+		ver.commits = String(execSync("git describe --long --tags --match=RELEASE-[0-9].[0-9].[0-9] --match=RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9] --match=v[0-9].[0-9].[0-9] --match=v[0-9][0-9].[0-9][0-9].[0-9][0-9]", {encoding: "utf8"}).split("-").slice(-2)[0]);
 		ver.hash = execSync("git rev-parse --short=8 HEAD", {encoding: "utf8"}).trimEnd();
 	} catch (e) {
 		console.warn("getting git parts of version:", e);

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -40,7 +40,7 @@ TC_DIR := $(CIAB_DIR_RELATIVE)../..
 PKG_COMMAND := $(TC_DIR)/pkg
 PKG_FLAGS := -v -$(RHEL_VERSION)
 BUILD_SUFFIX := _build
-BUILD_NUMBER := $(shell git describe --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
+BUILD_NUMBER := $(shell set -o pipefail; git describe --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $$(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
 BUILD_ARCH   := $(shell docker run --name=ciab-get-$(BASE_IMAGE)-$(RHEL_VERSION)-arch --rm $(BASE_IMAGE):$(RHEL_VERSION) rpm --eval %_arch )
 TC_VERSION := $(shell cat "$(TC_DIR)/VERSION")
 TOMCAT_VERSION := $(shell grep '^\s*TOMCAT_VERSION=' "$(TC_DIR)/traffic_router/build/build_rpm.sh"  | cut -d= -f2)

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -40,7 +40,7 @@ TC_DIR := $(CIAB_DIR_RELATIVE)../..
 PKG_COMMAND := $(TC_DIR)/pkg
 PKG_FLAGS := -v -$(RHEL_VERSION)
 BUILD_SUFFIX := _build
-BUILD_NUMBER := $(shell git rev-list HEAD 2>/dev/null | wc -l | tr -d '[[:space:]]').$(shell git rev-parse --short=8 HEAD)
+BUILD_NUMBER := $(shell git describe --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
 BUILD_ARCH   := $(shell docker run --name=ciab-get-$(BASE_IMAGE)-$(RHEL_VERSION)-arch --rm $(BASE_IMAGE):$(RHEL_VERSION) rpm --eval %_arch )
 TC_VERSION := $(shell cat "$(TC_DIR)/VERSION")
 TOMCAT_VERSION := $(shell grep '^\s*TOMCAT_VERSION=' "$(TC_DIR)/traffic_router/build/build_rpm.sh"  | cut -d= -f2)

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -40,7 +40,7 @@ TC_DIR := $(CIAB_DIR_RELATIVE)../..
 PKG_COMMAND := $(TC_DIR)/pkg
 PKG_FLAGS := -v -$(RHEL_VERSION)
 BUILD_SUFFIX := _build
-BUILD_NUMBER := $(shell set -o pipefail; git describe --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $$(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
+BUILD_NUMBER := $(shell set -o pipefail; git describe --long --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $$(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
 BUILD_ARCH   := $(shell docker run --name=ciab-get-$(BASE_IMAGE)-$(RHEL_VERSION)-arch --rm $(BASE_IMAGE):$(RHEL_VERSION) rpm --eval %_arch )
 TC_VERSION := $(shell cat "$(TC_DIR)/VERSION")
 TOMCAT_VERSION := $(shell grep '^\s*TOMCAT_VERSION=' "$(TC_DIR)/traffic_router/build/build_rpm.sh"  | cut -d= -f2)

--- a/infrastructure/cdn-in-a-box/Makefile
+++ b/infrastructure/cdn-in-a-box/Makefile
@@ -40,7 +40,7 @@ TC_DIR := $(CIAB_DIR_RELATIVE)../..
 PKG_COMMAND := $(TC_DIR)/pkg
 PKG_FLAGS := -v -$(RHEL_VERSION)
 BUILD_SUFFIX := _build
-BUILD_NUMBER := $(shell set -o pipefail; git describe --long --tags --match='RELEASE-[0-9].[0-9].[0-9]' --match='RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]' --match='v[0-9].[0-9].[0-9]' --match='v[0-9][0-9].[0-9][0-9].[0-9][0-9]' | awk -F- '{print $$(NF-1)}' || echo 0).$(shell git rev-parse --short=8 HEAD)
+BUILD_NUMBER := $(shell bash -c 'set -o pipefail -o xtrace; git describe --long --tags --match="RELEASE-[0-9].[0-9].[0-9]" --match="RELEASE-[0-9][0-9].[0-9][0-9].[0-9][0-9]" --match="v[0-9].[0-9].[0-9]" --match="v[0-9][0-9].[0-9][0-9].[0-9][0-9]" | awk -F- "{print \$$(NF-1)}"' || echo 0).$(shell git rev-parse --short=8 HEAD)
 BUILD_ARCH   := $(shell docker run --name=ciab-get-$(BASE_IMAGE)-$(RHEL_VERSION)-arch --rm $(BASE_IMAGE):$(RHEL_VERSION) rpm --eval %_arch )
 TC_VERSION := $(shell cat "$(TC_DIR)/VERSION")
 TOMCAT_VERSION := $(shell grep '^\s*TOMCAT_VERSION=' "$(TC_DIR)/traffic_router/build/build_rpm.sh"  | cut -d= -f2)


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR changes the build number to include the number of commits since the last release, rather than the total number of commits ever. Previously, the total commit count was used to ensure that a build from a later child commit will always be considered a higher version number.

But because the version number increases each time the release version increases, counting only the commits since the last release tag is sufficient.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- CDN in a Box
- Traffic Portal v2

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
* Test `/about` TO API endpoint
* Make sure the *CDN-in-a-Box CI* GHA workflow picks up the already-built RPMs instead of rebuilding them all again.

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
