### PR TITLE
TPv2 Add page title setting when header title is updated

### DIFF
--- a/experimental/traffic-portal/src/app/shared/navigation/navigation.service.spec.ts
+++ b/experimental/traffic-portal/src/app/shared/navigation/navigation.service.spec.ts
@@ -15,13 +15,14 @@ import { HttpClientModule } from "@angular/common/http";
 import { TestBed } from "@angular/core/testing";
 import { MatButtonModule } from "@angular/material/button";
 import { MatMenuModule } from "@angular/material/menu";
+import { Title } from "@angular/platform-browser";
 import { RouterTestingModule } from "@angular/router/testing";
 import { of } from "rxjs";
 
 import { UserService } from "src/app/api";
 import { APITestingModule } from "src/app/api/testing";
 import { CurrentUserService } from "src/app/shared/current-user/current-user.service";
-import { HeaderNavigation, NavigationService } from "src/app/shared/navigation/navigation.service";
+import { NavigationService } from "src/app/shared/navigation/navigation.service";
 import { type TpHeaderComponent } from "src/app/shared/navigation/tp-header/tp-header.component";
 
 describe("NavigationService", () => {
@@ -64,14 +65,15 @@ describe("NavigationService", () => {
 		expect(logOutSpy).toHaveBeenCalled();
 	});
 
-	it("set header component", () => {
+	it("sets the page title and header", () => {
 		expect(mockHeaderComp).toBeTruthy();
-		expect(mockHeaderComp?.hidden).toBeFalse();
-		expect(mockHeaderComp?.title).toBe("");
+		expect(mockHeaderComp.hidden).toBeFalse();
+		expect(mockHeaderComp.title).toBe("");
 
-		service.headerHidden.next(true);
-		service.headerTitle.next("something else");
-		service.horizontalNavsUpdated.next(new Array<HeaderNavigation>());
-		service.verticalNavsUpdated.next(new Array<HeaderNavigation>());
+		const title = "something else";
+		const titleService = TestBed.inject(Title);
+
+		service.headerTitle.next(title);
+		expect(titleService.getTitle()).toBe(title);
 	});
 });

--- a/experimental/traffic-portal/src/app/shared/navigation/navigation.service.ts
+++ b/experimental/traffic-portal/src/app/shared/navigation/navigation.service.ts
@@ -13,6 +13,7 @@
 */
 import { isPlatformBrowser } from "@angular/common";
 import { Inject, Injectable, PLATFORM_ID } from "@angular/core";
+import { Title } from "@angular/platform-browser";
 import { ReplaySubject } from "rxjs";
 
 import { UserService } from "src/app/api";
@@ -71,9 +72,21 @@ export class NavigationService {
 		private readonly api: UserService,
 		@Inject(PLATFORM_ID) private readonly platformId: object,
 		private readonly log: LoggingService,
+		private readonly pageTitle: Title,
 	) {
+		this.horizontalNavsUpdated = new ReplaySubject(1);
+		this.verticalNavsUpdated = new ReplaySubject(1);
+		this.headerTitle = new ReplaySubject(1);
+		this.headerTitle.next("Welcome to Traffic Portal!");
+		this.headerHidden = new ReplaySubject(1);
+		this.headerHidden.next(false);
 		if (isPlatformBrowser(this.platformId)) {
 			this.tpv1Url = window.localStorage.getItem(LOCAL_TPV1_URL) ?? this.tpv1Url;
+			this.headerTitle.subscribe(
+				title => {
+					this.pageTitle.setTitle(title);
+				}
+			);
 		}
 		this.horizontalNavs = new Map<string, HeaderNavigation>([
 			["Home", {
@@ -108,12 +121,6 @@ export class NavigationService {
 					type: "button"
 				}],
 		]);
-		this.horizontalNavsUpdated = new ReplaySubject(1);
-		this.verticalNavsUpdated = new ReplaySubject(1);
-		this.headerTitle = new ReplaySubject(1);
-		this.headerTitle.next("Welcome to Traffic Portal!");
-		this.headerHidden = new ReplaySubject(1);
-		this.headerHidden.next(false);
 		this.horizontalNavsUpdated.next(this.buildHorizontalNavs());
 		this.verticalNavsUpdated.next(this.buildVerticalNavs());
 


### PR DESCRIPTION
Closes #2742 

This PR updates navigation in the experimental TPv2 to also update the page title in the browser whenever the page's header title is set.

<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure the tests pass. To verify manually, go to a bunch of pages and ensure the web page's title always matches the page header's title.

## PR submission checklist
- [x] This PR has tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**