### PR TITLE
Fix TPv2 unit tests downloading a blank file

### DIFF
--- a/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.spec.ts
+++ b/experimental/traffic-portal/src/app/core/misc/isogeneration-form/isogeneration-form.component.spec.ts
@@ -31,6 +31,7 @@ import {
 	TypeService
 } from "src/app/api";
 import { APITestingModule } from "src/app/api/testing";
+import { FileUtilsService } from "src/app/shared/file-utils.service";
 import { SharedModule } from "src/app/shared/shared.module";
 
 import { ISOGenerationFormComponent } from "./isogeneration-form.component";
@@ -72,14 +73,24 @@ describe("ISOGenerationFormComponent", () => {
 				SharedModule,
 				NoopAnimationsModule
 			],
-			providers: [{
-				provide: "Window",
-				useValue: {
-					open: (): void => {
-						// do nothing
+			providers: [
+				{
+					provide: "Window",
+					useValue: {
+						open: (): void => {
+							// do nothing
+						}
+					}
+				},
+				{
+					provide: FileUtilsService,
+					useValue: {
+						download: (): void => {
+							// do nothing
+						}
 					}
 				}
-			}]
+			]
 		}).compileComponents();
 
 		fixture = TestBed.createComponent(ISOGenerationFormComponent);


### PR DESCRIPTION
Fixes #7515 

This PR prevents the ISO generation form tests from downloading a blank file.
 <hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Portal (experimental v2)

## What is the best way to verify this PR?
Make sure all the tests still pass, and ensure that when you run them locally they don't download a blank file.

## If this is a bugfix, which Traffic Control versions contained the bug?
N/A; TPv2 is an unreleased, experimental product.

## PR submission checklist
- [x] This PR fixes tests
- [x] This PR doesn't need documentation
- [x] This PR doesn't need a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY**