### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.27.2",
-        "chromedriver": "^119.0.1",
+        "chromedriver": "^121.0.0",
         "codelyzer": "^6.0.0",
         "cypress": "^13.6.2",
         "eslint": "^8.39.0",
@@ -9722,14 +9722,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "119.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-119.0.1.tgz",
-      "integrity": "sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==",
+      "version": "121.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-121.0.0.tgz",
+      "integrity": "sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.0",
+        "axios": "^1.6.5",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
@@ -9744,12 +9744,12 @@
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.27.2",
-    "chromedriver": "^119.0.1",
+    "chromedriver": "^121.0.0",
     "codelyzer": "^6.0.0",
     "cypress": "^13.6.2",
     "eslint": "^8.39.0",

--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -30,7 +30,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^119.0.1",
+        "chromedriver": "^121.0.0",
         "jasmine": "^3.5.0",
         "typescript": "^3.6.4"
       },
@@ -327,14 +327,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "119.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-119.0.1.tgz",
-      "integrity": "sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==",
+      "version": "121.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-121.0.0.tgz",
+      "integrity": "sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.0",
+        "axios": "^1.6.5",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
@@ -361,12 +361,12 @@
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -725,9 +725,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "funding": [
         {
           "type": "individual",
@@ -2639,13 +2639,13 @@
       }
     },
     "chromedriver": {
-      "version": "119.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-119.0.1.tgz",
-      "integrity": "sha512-lpCFFLaXPpvElTaUOWKdP74pFb/sJhWtWqMjn7Ju1YriWn8dT5JBk84BGXMPvZQs70WfCYWecxdMmwfIu1Mupg==",
+      "version": "121.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-121.0.0.tgz",
+      "integrity": "sha512-ZIKEdZrQAfuzT/RRofjl8/EZR99ghbdBXNTOcgJMKGP6N/UL6lHUX4n6ONWBV18pDvDFfQJ0x58h5AdOaXIOMw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.0",
+        "axios": "^1.6.5",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.1",
@@ -2663,12 +2663,12 @@
           }
         },
         "axios": {
-          "version": "1.6.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
-          "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
+          "version": "1.6.7",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
           "dev": true,
           "requires": {
-            "follow-redirects": "^1.15.0",
+            "follow-redirects": "^1.15.4",
             "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
           }
@@ -2956,9 +2956,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
     },
     "forever-agent": {
       "version": "0.6.1",

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^119.0.1",
+    "chromedriver": "^121.0.0",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.4"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 119.0.1 -> 121.0.0
experimental/traffic-portal: 119.0.1 -> 121.0.0


## Which Traffic Control components are affected by this PR?
* Traffic Portal
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
