### PR TITLE
Only use 2 path components for compose file

### DIFF
--- a/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-portal-v2-test.yml
+++ b/infrastructure/cdn-in-a-box/optional/docker-compose.traffic-portal-v2-test.yml
@@ -20,7 +20,7 @@ version: '3.8'
 services:
   tpv2-e2e-test:
     build:
-      context: ../../..
+      context: ../..
       dockerfile: infrastructure/cdn-in-a-box/optional/traffic_portal_v2_e2e_test/Dockerfile
       args:
         # Change BASE_IMAGE to centos when RHEL_VERSION=7
@@ -34,7 +34,7 @@ services:
     domainname: infra.ciab.test
     volumes:
       - shared:/shared
-      - ../../../junit:/junit
+      - ../../junit:/junit
 
 volumes:
   shared:

--- a/infrastructure/cdn-in-a-box/optional/traffic_portal_v2_e2e_test/Dockerfile
+++ b/infrastructure/cdn-in-a-box/optional/traffic_portal_v2_e2e_test/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR /lang/traffic-portal/
 RUN npm ci
 
 COPY infrastructure/cdn-in-a-box/traffic_ops/to-access.sh \
-     infrastructure/cdn-in-a-box/traffic_portal_v2_e2e_test/run.sh \
+     infrastructure/cdn-in-a-box/optional/traffic_portal_v2_e2e_test/run.sh \
      infrastructure/cdn-in-a-box/dns/set-dns.sh \
      infrastructure/cdn-in-a-box/dns/insert-self-into-dns.sh \
      /usr/local/sbin/


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR fixes some issues with paths in `optional/docker-compose.traffic-portal-v2-test.yml` that arose when it was moved to the optional directory. Apparently `docker-compose` always uses the directory that the first compose file specified with `-f` is in for the base of all relative paths.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- CDN in a Box

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
```shell
cd infrastructure/cdn-in-a-box
docker-compose -f docker-compose.yml -f optional/docker-compose.traffic-portal-v2.yml -f optional/docker-compose.traffic-portal-v2-test.yml build tpv2-e2e-test
docker-compose -f docker-compose.yml -f optional/docker-compose.traffic-portal-v2.yml -f optional/docker-compose.traffic-portal-v2-test.yml up --no-deps tpv2-e2e-test
```
(It's fine if it starts to start up as long as building the docker image succeeded, we're mainly only testing that the compose file can be used.)

Related PRs: #7938, #7936, #7925

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
