### PR TITLE
reorder TM event log

### DIFF
--- a/traffic_monitor/static/script.js
+++ b/traffic_monitor/static/script.js
@@ -131,7 +131,7 @@ function getEvents() {
 		const events = JSON.parse(r).events || [];
 		for (const event of events.slice(lastEvent+1)) {
 			lastEvent = event.index;
-			const row = document.getElementById("event-log").insertRow(0);
+			const row = document.getElementById("event-log").insertRow(-1);
 
 			row.insertCell(0).textContent = event.name;
 			row.insertCell(1).textContent = event.type;


### PR DESCRIPTION
When logs are long, sorting them in descending order helps identify recent changes or incidents quickly.
<hr/>

## Which Traffic Control components are affected by this PR?
- Traffic Monitor

## What is the best way to verify this PR?
- Go to TM's static site -> Event Log -> The logs should order by descending the time

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
