### PR TITLE
Store Apache Traffic Server and grove logs in /var/log/trafficserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#8009](https://github.com/apache/trafficcontrol/pull/8009) *Traffic Portal v2*: Update NodeJS version to 20.
 - [#8040](https://github.com/apache/trafficcontrol/pull/8040) *Traffic Router*: Get the Tomcat version from .env and update Tomcat to 9.0.90.
 - [##8056](https://github.com/apache/trafficcontrol/pull/8056) Remove the `version` key from compose files and use `docker compose` instead of `docker-compose`.
+- [7980](https://github.com/apache/trafficcontrol/pull/7980) *Traffic Server*: Store logs in /var/log
 
 ### Fixed
 - [#8008](https://github.com/apache/trafficcontrol/pull/8008) *Traffic Router* Fix czf temp file deletion issue.

--- a/cache-config/testing/docker/trafficserver/Dockerfile
+++ b/cache-config/testing/docker/trafficserver/Dockerfile
@@ -116,6 +116,7 @@ COPY cache-config/testing/docker/trafficserver/traffic_server_jemalloc \
      cache-config/testing/docker/trafficserver/cjose.pic.patch  \
      cache-config/testing/docker/trafficserver/jansson.pic.patch \
      cache-config/testing/docker/trafficserver/run.sh \ 
-    / 
+     cache-config/testing/docker/trafficserver/trafficserver.env \
+    /
 
 CMD /run.sh

--- a/cache-config/testing/docker/trafficserver/run.sh
+++ b/cache-config/testing/docker/trafficserver/run.sh
@@ -93,6 +93,7 @@ cd /root/rpmbuild/SOURCES
 # clone the trafficserver repo
 git clone https://github.com/apache/trafficserver.git --branch $ATS_VERSION || die "Failed to fetch the ATS Source"
 cp /traffic_server_jemalloc .
+cp /trafficserver.env .
 
 # patch in the astats plugin
 (cp -fa /astats_over_http /root/rpmbuild/SOURCES/trafficserver/plugins/astats_over_http

--- a/cache-config/testing/docker/trafficserver/trafficserver.env
+++ b/cache-config/testing/docker/trafficserver/trafficserver.env
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+STDOUTLOG=/var/log/trafficserver/traffic.out
+STDERRLOG=/var/log/trafficserver/traffic.out

--- a/cache-config/testing/docker/trafficserver/trafficserver.spec
+++ b/cache-config/testing/docker/trafficserver/trafficserver.spec
@@ -53,6 +53,7 @@ Apache Traffic Server with Apache Traffic Control modifications and environment 
 %setup -c -T
 cp -far %{src}/. .
 cp -fa %{src}/../traffic_server_jemalloc ..
+cp -fa %{src}/../trafficserver.env ..
 autoreconf -vfi
 
 %build
@@ -81,8 +82,11 @@ make DESTDIR=$RPM_BUILD_ROOT install
 
 mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/etc/trafficserver/snapshots
 mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system
+mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
 cp rc/trafficserver.service $RPM_BUILD_ROOT/usr/lib/systemd/system/
 cp ../traffic_server_jemalloc $RPM_BUILD_ROOT/opt/trafficserver/bin/
+touch $RPM_BUILD_ROOT/etc/sysconfig/trafficserver
+cp ../trafficserver.env $RPM_BUILD_ROOT/etc/sysconfig/trafficserver
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/trafficserver
 
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
@@ -124,6 +128,7 @@ fi
 %license LICENSE
 %defattr(-,root,root)
 %attr(644,-,-) /usr/lib/systemd/system/trafficserver.service
+%attr(644,-,-) /etc/sysconfig/trafficserver
 %dir /opt/trafficserver
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
 /opt/trafficserver/openssl

--- a/cache-config/testing/docker/trafficserver/trafficserver.spec
+++ b/cache-config/testing/docker/trafficserver/trafficserver.spec
@@ -83,6 +83,7 @@ mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/etc/trafficserver/snapshots
 mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system
 cp rc/trafficserver.service $RPM_BUILD_ROOT/usr/lib/systemd/system/
 cp ../traffic_server_jemalloc $RPM_BUILD_ROOT/opt/trafficserver/bin/
+mkdir -p "${RPM_BUILD_ROOT}"/var/log/trafficserver
 
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
 mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/openssl
@@ -134,8 +135,8 @@ fi
 /opt/trafficserver/share
 %dir /opt/trafficserver/var
 %attr(-,ats,ats) /opt/trafficserver/var/trafficserver
-%dir /opt/trafficserver/var/log
-%attr(-,ats,ats) /opt/trafficserver/var/log/trafficserver
+%dir /var/log/trafficserver
+%attr(-,ats,ats) /var/log/trafficserver
 %dir /opt/trafficserver/etc
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver/snapshots

--- a/cache-config/testing/ort-tests/baseline-configs/records.config
+++ b/cache-config/testing/ort-tests/baseline-configs/records.config
@@ -14,7 +14,7 @@ CONFIG proxy.config.http.parent_proxy_routing_enable INT 1
 CONFIG proxy.config.http.server_ports STRING 8080 8080:ipv6
 CONFIG proxy.config.http.slow.log.threshold INT 10000
 CONFIG proxy.config.http.transaction_active_timeout_in INT 0
-CONFIG proxy.config.log.logfile_dir STRING /opt/trafficserver/var/log/trafficserver
+CONFIG proxy.config.log.logfile_dir STRING /var/log/trafficserver
 CONFIG proxy.config.log.max_space_mb_for_logs INT 512
 CONFIG proxy.config.log.max_space_mb_headroom INT 50
 CONFIG proxy.config.proxy_name STRING atlanta-edge-03.ga.atlanta.kabletown.net

--- a/cache-config/testing/ort-tests/tc-fixtures.json
+++ b/cache-config/testing/ort-tests/tc-fixtures.json
@@ -1617,7 +1617,7 @@
           "configFile": "records.config",
           "name": "CONFIG proxy.config.log.logfile_dir",
           "secure": false,
-          "value": "STRING /opt/trafficserver/var/log/trafficserver"
+          "value": "STRING /var/log/trafficserver"
         },
         {
           "configFile": "records.config",
@@ -2013,7 +2013,7 @@
           "configFile": "records.config",
           "name": "CONFIG proxy.config.log.logfile_dir",
           "secure": false,
-          "value": "STRING /opt/trafficserver/var/log/trafficserver"
+          "value": "STRING /var/log/trafficserver"
         },
         {
           "configFile": "records.config",

--- a/grove/build/grove.logrotate
+++ b/grove/build/grove.logrotate
@@ -45,7 +45,7 @@
         copytruncate
 }
 
-/opt/trafficserver/var/log/trafficserver/custom_ats_2.log {
+/var/log/trafficserver/custom_ats_2.log {
         hourly
         dateext
         dateformat -%Y%m%d%H

--- a/grove/docker/docker-entrypoint.sh
+++ b/grove/docker/docker-entrypoint.sh
@@ -46,7 +46,7 @@ init() {
   "log_location_warning": "/var/log/grove/error.log",
   "log_location_info":    "null",
   "log_location_debug":   "null",
-  "log_location_event":   "/opt/trafficserver/var/log/trafficserver/custom_ats_2.log",
+  "log_location_event":   "/var/log/trafficserver/custom_ats_2.log",
 
   "parent_request_timeout_ms":                 10000,
   "parent_request_keep_alive_ms":              10000,
@@ -63,7 +63,7 @@ ENDOFMESSAGE
 	if [[ ! -z $REMAP_PATH ]]; then
     cp $REMAP_PATH /etc/grove/remap.json
   fi
-	mkdir -p /opt/trafficserver/var/log/trafficserver
+	mkdir -p /var/log/trafficserver
 	mkdir -p /var/log/grove/
 	touch /var/log/grove/error.log
 

--- a/grove/grovetccfg/grove_profile.traffic_ops
+++ b/grove/grovetccfg/grove_profile.traffic_ops
@@ -82,7 +82,7 @@
       "config_file": "grove.cfg"
     },
     {
-      "value": "/opt/trafficserver/var/log/trafficserver/custom_ats_2.log",
+      "value": "/var/log/trafficserver/custom_ats_2.log",
       "name": "log_location_event",
       "config_file": "grove.cfg"
     },

--- a/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
+++ b/infrastructure/ansible/roles/dataset_loader/defaults/main.yml
@@ -1626,7 +1626,7 @@ dl_ds_default_profile_cdntemplates:
         value: "/var/log/grove/error.log"
       - name: log_location_event
         configFile: grove.cfg
-        value: "/opt/trafficserver/var/log/trafficserver/custom_ats_2.log"
+        value: "/var/log/trafficserver/custom_ats_2.log"
       - name: log_location_info
         configFile: grove.cfg
         value: 'null'

--- a/infrastructure/ansible/roles/grove/defaults/main.yml
+++ b/infrastructure/ansible/roles/grove/defaults/main.yml
@@ -34,7 +34,7 @@ grovetccfg_crontab:
     job:  "/usr/sbin/grovetccfg -certdir {{ grove_certdir }} -host {{ ansible_hostname }} -insecure -pretty -tourl {{ grovetccfg_traffic_ops_url }} -touser {{ grovetccfg_traffic_ops_username }} -topass '{{ grovetccfg_traffic_ops_password }}' > /tmp/grovetccfg.log 2>&1"
 
 # Grove configuration
-grove_custom_ats2_path: "/opt/trafficserver/var/log/trafficserver/custom_ats_2.log"
+grove_custom_ats2_path: "/var/log/trafficserver/custom_ats_2.log"
 grove_ssl_cert_path: "{{ grove_config_dir }}/certs/cert.pem"
 grove_ssl_key_path: "{{ grove_config_dir }}/certs/key.pem"
 grove_remap_file_path: "{{ grove_config_dir }}/remap.json"

--- a/traffic_server/_tsb/Dockerfile
+++ b/traffic_server/_tsb/Dockerfile
@@ -107,6 +107,7 @@ RUN	pip3 install --user Sphinx
 COPY	run.sh /run.sh
 COPY	trafficserver.spec /rpmbuilddir/SPECS/trafficserver.spec
 COPY	traffic_server_jemalloc /rpmbuilddir/SOURCES/traffic_server_jemalloc
+COPY	trafficserver.env /rpmbuilddir/SOURCES/trafficserver.env
 RUN	/usr/sbin/useradd -u 176 -r ats -s /sbin/nologin -d /
 CMD if [[ ${RHEL_VERSION%%.*} -ge 8 ]]; then \
 		os_toolset=gcc-toolset-11; \

--- a/traffic_server/_tsb/run.sh
+++ b/traffic_server/_tsb/run.sh
@@ -70,7 +70,6 @@ ED
 ) || die "Failed to patch plugins makefile to include astats."
 
 # Patch trafficserver systemd service
-# This includes changing output redirection to traffic.out and adding udev-settle to wait for disks
-(sed -i 's/ExecStart=@exp_bindir@\/traffic_manager \$TM_DAEMON_ARGS/ExecStart=@exp_bindir@\/traffic_manager --bind_stdout @exp_logdir@\/traffic.out --bind_stderr @exp_logdir@\/traffic.out \$TM_DAEMON_ARGS/g' /rpmbuilddir/SOURCES/src/rc/trafficserver.service.in)
+# This includes adding udev-settle to wait for disks
 (sed -i 's/After=syslog.target network.target/Wants=systemd-udev-settle.service \nAfter=syslog.target network.target systemd-udev-settle.service/g' /rpmbuilddir/SOURCES/src/rc/trafficserver.service.in)
 rpmbuild -bb ${rpmbuild_openssl} --define "_topdir /rpmbuilddir" /rpmbuilddir/SPECS/trafficserver.spec || die "Failed to build rpm."

--- a/traffic_server/_tsb/trafficserver.env
+++ b/traffic_server/_tsb/trafficserver.env
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+STDOUTLOG=/var/log/trafficserver/traffic.out
+STDERRLOG=/var/log/trafficserver/traffic.out

--- a/traffic_server/_tsb/trafficserver.spec
+++ b/traffic_server/_tsb/trafficserver.spec
@@ -76,6 +76,7 @@ mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/etc/trafficserver/snapshots
 mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system
 cp rc/trafficserver.service $RPM_BUILD_ROOT/usr/lib/systemd/system/
 cp ../traffic_server_jemalloc $RPM_BUILD_ROOT/opt/trafficserver/bin/
+mkdir -p $RPM_BUILD_ROOT/var/log/trafficserver
 
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
 mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/openssl
@@ -127,8 +128,8 @@ fi
 /opt/trafficserver/share
 %dir /opt/trafficserver/var
 %attr(-,ats,ats) /opt/trafficserver/var/trafficserver
-%dir /opt/trafficserver/var/log
-%attr(-,ats,ats) /opt/trafficserver/var/log/trafficserver
+%dir /var/log/trafficserver
+%attr(-,ats,ats) /var/log/trafficserver
 %dir /opt/trafficserver/etc
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver/snapshots

--- a/traffic_server/_tsb/trafficserver.spec
+++ b/traffic_server/_tsb/trafficserver.spec
@@ -53,6 +53,7 @@ Apache Traffic Server with Apache Traffic Control modifications and environment 
 %setup -c -T
 cp -far %{src}/. .
 cp -far %{src}/../traffic_server_jemalloc ..
+cp -far %{src}/../trafficserver.env ..
 autoreconf -vfi
 
 %build
@@ -74,8 +75,11 @@ make DESTDIR=$RPM_BUILD_ROOT install
 
 mkdir -p $RPM_BUILD_ROOT/opt/trafficserver/etc/trafficserver/snapshots
 mkdir -p $RPM_BUILD_ROOT/usr/lib/systemd/system
+mkdir -p $RPM_BUILD_ROOT/etc/sysconfig
 cp rc/trafficserver.service $RPM_BUILD_ROOT/usr/lib/systemd/system/
 cp ../traffic_server_jemalloc $RPM_BUILD_ROOT/opt/trafficserver/bin/
+touch $RPM_BUILD_ROOT/etc/sysconfig/trafficserver
+cp ../trafficserver.env $RPM_BUILD_ROOT/etc/sysconfig/trafficserver
 mkdir -p $RPM_BUILD_ROOT/var/log/trafficserver
 
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
@@ -117,6 +121,7 @@ fi
 %license LICENSE
 %defattr(-,root,root)
 %attr(644,-,-) /usr/lib/systemd/system/trafficserver.service
+%attr(644,-,-) /etc/sysconfig/trafficserver
 %dir /opt/trafficserver
 %if %{?_with_openssl_included:1}%{!?_with_openssl_included:0}
 /opt/trafficserver/openssl

--- a/traffic_server/spec/trafficserver.spec
+++ b/traffic_server/spec/trafficserver.spec
@@ -49,6 +49,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 
 mkdir -p $RPM_BUILD_ROOT%{install_prefix}/trafficserver/etc/trafficserver/snapshots
 mkdir -p $RPM_BUILD_ROOT/etc/init.d
+mkdir -p $RPM_BUILD_ROOT/var/log/trafficserver
 cp $RPM_BUILD_DIR/%{name}-%{version}/rc/trafficserver $RPM_BUILD_ROOT/etc/init.d/
 
 %clean
@@ -89,8 +90,8 @@ fi
 /opt/trafficserver/share
 %dir /opt/trafficserver/var
 %attr(-,ats,ats) /opt/trafficserver/var/trafficserver
-%dir /opt/trafficserver/var/log
-%attr(-,ats,ats) /opt/trafficserver/var/log/trafficserver
+%dir /var/log/trafficserver
+%attr(-,ats,ats) /var/log/trafficserver
 %dir /opt/trafficserver/etc
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver
 %attr(-,ats,ats) %dir /opt/trafficserver/etc/trafficserver/snapshots


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR changes configuration to log Apache Traffic Server and Grove to `/var/log/trafficserver` instead of `/opt/trafficserver/var/log/trafficserver` so that the logs are on a different partition than the application itself.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Control Cache Config (`t3c`, formerly ORT) - tests
- Apache Traffic Server
- Grove
- Transitive Source Build targeting ATS
- Automation - Ansible roles configuration for grove log directory <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
