### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.27.2",
-        "chromedriver": "^123.0.2",
+        "chromedriver": "^123.0.3",
         "codelyzer": "^6.0.0",
         "cypress": "^13.6.2",
         "eslint": "^8.39.0",
@@ -9746,9 +9746,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "123.0.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.2.tgz",
-      "integrity": "sha512-Kx0r/IGULm7eciaUtX/OKaFbdBdHRDSguiV1Q4zuQncz11gvymDdMtELa7ppk+kTL5113NLPud92nuIMNTRhww==",
+      "version": "123.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.3.tgz",
+      "integrity": "sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.27.2",
-    "chromedriver": "^123.0.2",
+    "chromedriver": "^123.0.3",
     "codelyzer": "^6.0.0",
     "cypress": "^13.6.2",
     "eslint": "^8.39.0",

--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -30,7 +30,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^123.0.2",
+        "chromedriver": "^123.0.3",
         "jasmine": "^3.5.0",
         "typescript": "^3.6.4"
       },
@@ -354,9 +354,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "123.0.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.2.tgz",
-      "integrity": "sha512-Kx0r/IGULm7eciaUtX/OKaFbdBdHRDSguiV1Q4zuQncz11gvymDdMtELa7ppk+kTL5113NLPud92nuIMNTRhww==",
+      "version": "123.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.3.tgz",
+      "integrity": "sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3022,9 +3022,9 @@
       }
     },
     "chromedriver": {
-      "version": "123.0.2",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.2.tgz",
-      "integrity": "sha512-Kx0r/IGULm7eciaUtX/OKaFbdBdHRDSguiV1Q4zuQncz11gvymDdMtELa7ppk+kTL5113NLPud92nuIMNTRhww==",
+      "version": "123.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-123.0.3.tgz",
+      "integrity": "sha512-35IeTqDLcVR0htF9nD/Lh+g24EG088WHVKXBXiFyWq+2lelnoM0B3tKTBiUEjLng0GnELI4QyQPFK7i97Fz1fQ==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^123.0.2",
+    "chromedriver": "^123.0.3",
     "jasmine": "^3.5.0",
     "typescript": "^3.6.4"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 123.0.3 -> 123.0.3
experimental/traffic-portal: 123.0.3 -> 123.0.3


## Which Traffic Control components are affected by this PR?
* Traffic Portal
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
