### PR TITLE
Symlink from `/opt/<component>/var/log` to `/var/log/<component>`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Updated the CacheGroups Traffic Portal page to use a more performant AG-Grid-based table.
 - Updated Go version to 1.22.0
 - [#7979](https://github.com/apache/trafficcontrol/pull/7979) *Traffic Router*, *Traffic Monitor*, *Traffic Stats*: Store logs in /var/log
+- [#7999](https://github.com/apache/trafficcontrol/pull/7999) *Traffic Router*, *Traffic Monitor*, *Traffic Stats*: Symlink from /opt/<component>/var/log to /var/log/<component>. These symlinks are deprecated with the intent of removing them in ATC 9.0.0.
 - [#7872](https://github.com/apache/trafficcontrol/issues/7872) *Traffic Router*: Updated Apache Tomcat from 9.0.43, 9.0.67, 9.0.83, and 9.0.86 to 9.0.87.
 
 ### Fixed

--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -49,6 +49,8 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/backup
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/static
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_monitor
+# TODO: The /opt/traffic_monitor/var/log symlink is deprecated and should be removed for ATC 9.0.0.
+ln -s /var/log/traffic_monitor "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 
@@ -108,6 +110,8 @@ fi
 %dir /opt/traffic_monitor/backup
 %dir /opt/traffic_monitor/static
 %dir /opt/traffic_monitor/var
+# TODO: The /opt/traffic_monitor/var/log symlink is deprecated and should be removed for ATC 9.0.0.
+/opt/traffic_monitor/var/log
 %dir /var/log/traffic_monitor
 %dir /opt/traffic_monitor/var/run
 

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -168,6 +168,21 @@
 									<groupname>root</groupname>
 								</mapping>
 								<mapping>
+									<directory>${deploy.dir}/var</directory>
+									<filemode>755</filemode>
+									<username>root</username>
+									<groupname>root</groupname>
+									<sources>
+										<!-- TODO: The /opt/traffic_router/var/log symlink is deprecated and should be removed
+											 for ATC 9.0.0. -->
+										<softLinkSource>
+											<destination>log</destination>
+											<location>/var/log/traffic_router</location>
+											<failIfLocationNotExists>false</failIfLocationNotExists>
+										</softLinkSource>
+									</sources>
+								</mapping>
+								<mapping>
 									<directory>${deploy.dir}/temp</directory>
 									<filemode>755</filemode>
 									<username>root</username>
@@ -248,6 +263,11 @@
 									</sources>
 								</mapping>
 							</mappings>
+							<installScriptlet>
+								<!-- TODO: The /opt/traffic_router/var/log symlink is deprecated and should be removed
+								     for ATC 9.0.0. -->
+								<script>ln -s /var/log/traffic_router %{buildroot}${deploy.dir}/var/log</script>
+							</installScriptlet>
 							<requires>
 								<require>java-11-openjdk-headless</require>
 								<require>tzdata-java</require>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -120,7 +120,7 @@
 					<plugin>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>rpm-maven-plugin</artifactId>
-						<version>2.1.4</version>
+						<version>2.2.0</version>
 						<extensions>true</extensions>
 						<executions>
 							<execution>

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -40,9 +40,11 @@ Built:@BUILT@
 %build
 
 %install
-mkdir -p "${RPM_BUILD_ROOT}"/var/log/tomcat
 install -d -m 755 ${RPM_BUILD_ROOT}/%{tomcat_home}/
+rmdir logs
+mkdir -p "${RPM_BUILD_ROOT}"/var/log/tomcat
 cp -R * ${RPM_BUILD_ROOT}/%{tomcat_home}/
+ln -s /var/log/tomcat "${RPM_BUILD_ROOT}"%{tomcat_home}/logs
 
 # Remove all webapps.
 rm -rf ${RPM_BUILD_ROOT}/%{tomcat_home}/webapps/*

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -65,6 +65,8 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/backup
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_stats
+# TODO: The /opt/traffic_stats/var/log symlink is deprecated and should be removed for ATC 9.0.0.
+ln -s /var/log/traffic_stats "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 mkdir -p "${RPM_BUILD_ROOT}"/var/lib/grafana/plugins/trafficcontrol-scenes-app
@@ -129,6 +131,8 @@ fi
 %dir /opt/traffic_stats/conf
 %dir /opt/traffic_stats/backup
 %dir /opt/traffic_stats/var
+# TODO: The /opt/traffic_stats/var/log symlink is deprecated and should be removed for ATC 9.0.0.
+/opt/traffic_stats/var/log
 %dir /opt/traffic_stats/var/run
 %dir /var/log/traffic_stats
 %dir /var/lib/grafana/plugins/trafficcontrol-scenes-app


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

This PR creates symlinks from `/opt/<component>/var/log` to `/var/log/<component>` for the log directories that were moved in #7979. This is useful if you have any code or configuration still referencing `/opt/<component>/var/log`, because it buys some time to change those references to `/var/log/<component>`, rather than requiring that everything is changed all at once, whenever you deploy #7979.

Because this is intended as a temporary measure, these symlinks are deprecated with the intent of removing them in ATC 9.0.0, assuming there is a release before then that *does* include the symlinks.
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor
- Traffic Router
- Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Build and install the RPMs, verify the symlinks exist.

```shell
cd infrastructure/cdn-in-a-box
make traffic_monitor/traffic_monitor.rpm traffic_router/traffic_router.rpm traffic_router/tomcat.rpm traffic_stats/traffic_stats.rpm
docker-compose build trafficmonitor trafficrouter trafficstats
docker-compose run --rm --no-deps --entrypoint= trafficmonitor ls -l /opt/traffic_monitor/var
docker-compose run --rm --no-deps trafficrouter ls -l /opt/traffic_router/var
docker-compose run --rm --no-deps --entrypoint= trafficstats ls -l /opt/traffic_stats/var
```

## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
