### PR TITLE
Move existing logs in `/opt/<component>/var/log` to `/var/log/<component>` pre-upgrade

### DIFF
--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -50,7 +50,7 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/static
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_monitor
 # TODO: The /opt/traffic_monitor/var/log symlink is deprecated and should be removed for ATC 9.0.0.
-ln -s /var/log/traffic_monitor "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/log
+ln -sT /var/log/traffic_monitor "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 

--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -66,6 +66,22 @@ cp "$src"/build/traffic_monitor.init       "${RPM_BUILD_ROOT}"/etc/init.d/traffi
 cp "$src"/build/traffic_monitor.logrotate  "${RPM_BUILD_ROOT}"/etc/logrotate.d/traffic_monitor
 
 %pre
+old_log_dir=/opt/traffic_monitor/var/log
+new_log_dir=/var/log/traffic_monitor
+if [[ -d "$old_log_dir" ]]; then
+	if [[ -d "$new_log_dir" ]]; then
+		(
+		# Include files starting with . in the * glob
+		shopt -s dotglob
+		mv "$old_log_dir"/* "$new_log_dir" || true
+		)
+		rmdir "$old_log_dir"
+	else
+		mv "$old_log_dir" "$new_log_dir"
+	fi
+	sync
+fi
+
 /usr/bin/getent group traffic_monitor >/dev/null
 if [ $? -ne 0 ]; then
 	/usr/sbin/groupadd -g 423 traffic_monitor

--- a/traffic_monitor/build/traffic_monitor.spec
+++ b/traffic_monitor/build/traffic_monitor.spec
@@ -49,8 +49,9 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/backup
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/static
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_monitor
+
 # TODO: The /opt/traffic_monitor/var/log symlink is deprecated and should be removed for ATC 9.0.0.
-ln -sT /var/log/traffic_monitor "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/log
+ln -sfT /var/log/traffic_monitor "${RPM_BUILD_ROOT}"/opt/traffic_monitor/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -266,7 +266,7 @@
 							<installScriptlet>
 								<!-- TODO: The /opt/traffic_router/var/log symlink is deprecated and should be removed
 								     for ATC 9.0.0. -->
-								<script>ln -sT /var/log/traffic_router %{buildroot}${deploy.dir}/var/log</script>
+								<script>ln -sfT /var/log/traffic_router %{buildroot}${deploy.dir}/var/log</script>
 							</installScriptlet>
 							<requires>
 								<require>java-11-openjdk-headless</require>

--- a/traffic_router/build/pom.xml
+++ b/traffic_router/build/pom.xml
@@ -266,7 +266,7 @@
 							<installScriptlet>
 								<!-- TODO: The /opt/traffic_router/var/log symlink is deprecated and should be removed
 								     for ATC 9.0.0. -->
-								<script>ln -s /var/log/traffic_router %{buildroot}${deploy.dir}/var/log</script>
+								<script>ln -sT /var/log/traffic_router %{buildroot}${deploy.dir}/var/log</script>
 							</installScriptlet>
 							<requires>
 								<require>java-11-openjdk-headless</require>

--- a/traffic_router/core/src/main/scripts/preinstall.sh
+++ b/traffic_router/core/src/main/scripts/preinstall.sh
@@ -13,6 +13,23 @@
 # limitations under the License.
 #
 
+set -o nounset
+old_log_dir=/opt/traffic_router/var/log
+new_log_dir=/var/log/traffic_router
+if [[ -d "$old_log_dir" ]]; then
+	if [[ -d "$new_log_dir" ]]; then
+		(
+		# Include files starting with . in the * glob
+		shopt -s dotglob
+		mv "$old_log_dir"/* "$new_log_dir" || true
+		)
+		rmdir "$old_log_dir"
+	else
+		mv "$old_log_dir" "$new_log_dir"
+	fi
+	sync
+fi
+
 # figure out which version of traffic_router is currently running
 # and then shut it down. Running both test just in case.
 set +e

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -70,6 +70,21 @@ if [ -d /opt/apache-tomcat-* ]; then
 fi
 
 %pre
+old_log_dir=/opt/tomcat/logs
+new_log_dir=/var/log/tomcat
+if [[ -d "$old_log_dir" ]]; then
+	if [[ -d "$new_log_dir" ]]; then
+		(
+		# Include files starting with . in the * glob
+		shopt -s dotglob
+		mv "$old_log_dir"/* "$new_log_dir" || true
+		)
+		rmdir "$old_log_dir"
+	else
+		mv "$old_log_dir" "$new_log_dir"
+	fi
+	sync
+fi
 
 %files
 %license LICENSE

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -44,7 +44,7 @@ install -d -m 755 ${RPM_BUILD_ROOT}/%{tomcat_home}/
 rmdir logs
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/tomcat
 cp -R * ${RPM_BUILD_ROOT}/%{tomcat_home}/
-ln -s /var/log/tomcat "${RPM_BUILD_ROOT}"%{tomcat_home}/logs
+ln -sT /var/log/tomcat "${RPM_BUILD_ROOT}"%{tomcat_home}/logs
 
 # Remove all webapps.
 rm -rf ${RPM_BUILD_ROOT}/%{tomcat_home}/webapps/*

--- a/traffic_router/tomcat-rpm/tomcat.spec
+++ b/traffic_router/tomcat-rpm/tomcat.spec
@@ -44,7 +44,7 @@ install -d -m 755 ${RPM_BUILD_ROOT}/%{tomcat_home}/
 rmdir logs
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/tomcat
 cp -R * ${RPM_BUILD_ROOT}/%{tomcat_home}/
-ln -sT /var/log/tomcat "${RPM_BUILD_ROOT}"%{tomcat_home}/logs
+ln -sfT /var/log/tomcat "${RPM_BUILD_ROOT}"%{tomcat_home}/logs
 
 # Remove all webapps.
 rm -rf ${RPM_BUILD_ROOT}/%{tomcat_home}/webapps/*

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -66,7 +66,7 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_stats
 # TODO: The /opt/traffic_stats/var/log symlink is deprecated and should be removed for ATC 9.0.0.
-ln -sT /var/log/traffic_stats "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log
+ln -sfT /var/log/traffic_stats "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 mkdir -p "${RPM_BUILD_ROOT}"/var/lib/grafana/plugins/trafficcontrol-scenes-app

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -66,7 +66,7 @@ mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/influxdb_tools
 mkdir -p "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/run
 mkdir -p "${RPM_BUILD_ROOT}"/var/log/traffic_stats
 # TODO: The /opt/traffic_stats/var/log symlink is deprecated and should be removed for ATC 9.0.0.
-ln -s /var/log/traffic_stats "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log
+ln -sT /var/log/traffic_stats "${RPM_BUILD_ROOT}"/opt/traffic_stats/var/log
 mkdir -p "${RPM_BUILD_ROOT}"/etc/init.d
 mkdir -p "${RPM_BUILD_ROOT}"/etc/logrotate.d
 mkdir -p "${RPM_BUILD_ROOT}"/var/lib/grafana/plugins/trafficcontrol-scenes-app

--- a/traffic_stats/build/traffic_stats.spec
+++ b/traffic_stats/build/traffic_stats.spec
@@ -83,6 +83,22 @@ cp "$src"/influxdb_tools/create_ts_databases  "${RPM_BUILD_ROOT}"/opt/traffic_st
 
 
 %pre
+old_log_dir=/opt/traffic_stats/var/log
+new_log_dir=/var/log/traffic_stats
+if [[ -d "$old_log_dir" ]]; then
+	if [[ -d "$new_log_dir" ]]; then
+		(
+		# Include files starting with . in the * glob
+		shopt -s dotglob
+		mv "$old_log_dir"/* "$new_log_dir" || true
+		)
+		rmdir "$old_log_dir"
+	else
+		mv "$old_log_dir" "$new_log_dir"
+	fi
+	sync
+fi
+
 /usr/bin/getent group traffic_stats >/dev/null
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->

The symlinks created in #7999 work, but only for fresh installs, not upgrades. #8001 fixes that by
- Moving existing logs in `/opt/<component>/var/log` to `/var/log/<component>`
- Not creating a symlink inside the symlink target if the symlink target already exists and is a directory
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Monitor
- Traffic Router
- Traffic Stats

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
1. Build the RPMs
   ```shell
   ./pkg -v traffic_monitor_build traffic_stats_build traffic_router_build
   ```

2. Verify that files that exist in the old log directories pre-install are moved to the new log directories
   ```shell
   <<'SHELL_COMMANDS' docker run --rm -i -v $(pwd)/dist:/dist rockylinux:8 bash
   set -o errexit
   mkdir -p /opt/traffic_{monitor,stats,router}/var/log
   touch /opt/traffic_{monitor,stats,router}/var/log/my-logfile.log
   rpm -Uvh --nodeps dist/traffic_monitor-8.1.0-12410.cff72c19.el8.x86_64.rpm dist/traffic_router-8.1.0-12410.cff72c19.el8.noarch.rpm dist/traffic_stats-8.1.0-12410.cff72c19.el8.x86_64.rpm
   ls -1 /var/log/traffic_{monitor,stats,router}/my-logfile.log
   SHELL_COMMANDS
   ```

   Expected output:

   ```shell
   /var/log/traffic_monitor/my-logfile.log
   /var/log/traffic_router/my-logfile.log
   /var/log/traffic_stats/my-logfile.log
   ```


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [ ] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->