### PR TITLE
Fix czf temp file issue in Traffic Router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#7933](https://github.com/apache/trafficcontrol/pull/7933), [#8005](https://github.com/apache/trafficcontrol/pull/8005) *Traffic Portal v2*: Update NodeJS version to 18.
 
 ### Fixed
+- [#8008](https://github.com/apache/trafficcontrol/pull/8008) *Traffic Router* Fix czf temp file deletion issue.
 - [#7998](https://github.com/apache/trafficcontrol/pull/7998) *Traffic Portalv2* Fixed (create and update) page titles across every feature
 - [#7984](https://github.com/apache/trafficcontrol/pull/7984) *Traffic Ops* Fixed TO Client cert authentication with respect to returning response cookie.
 - [#7957](https://github.com/apache/trafficcontrol/pull/7957) *Traffic Ops* Fix the incorrect display of delivery services assigned to ORG servers.

--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/loc/AbstractServiceUpdater.java
@@ -376,15 +376,18 @@ public abstract class AbstractServiceUpdater {
 				eTag = conn.getHeaderField("ETag");
 				if (((HttpURLConnection) conn).getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
 					LOGGER.info("[" + getClass().getSimpleName() + "] " + url + " not modified since our existing database's last update time of " + new Date(existingLastModified));
+					outputFile.delete();
 					return existingDb;
 				}
 			} else if (dbURL.getProtocol().equals("file") && conn.getLastModified() > 0 && conn.getLastModified() <= existingLastModified) {
 				LOGGER.info("[" + getClass().getSimpleName() + "] " + url + " not modified since our existing database's last update time of " + new Date(existingLastModified));
+				outputFile.delete();
 				return existingDb;
 			}
 
 			IOUtils.copy(sourceCompressed ? new GZIPInputStream(in) : in, out);
 		}
+
 
 		return outputFile;
 	}


### PR DESCRIPTION
Fix czf temp file issue in Traffic Router
<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->

1. If using Dev CIAB, Create Terminal to the TR container and navigate to **_/opt/traffic_router/temp/_** directory. After every restart of TR, there should not be any **czf\*.json** files created prior to the current start up of TR. 
3. Same applies to any environment where TR is deployed. No new **czf\*.json** files should be retained under the **_/opt/traffic_router/temp/_** directory after the TR restart. 
4. However, as a one time cleanup activity, all previously created temp files under **_/opt/traffic_router/temp/_** directory has to be deleted. 

## If this is a bugfix, which Traffic Control versions contained the bug?
- 8.0.1


## PR submission checklist
- [ ] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [ ] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
