### PR TITLE
Update TO to handle Client-Cert-Subject HTTP header for client cert authentication.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [unreleased]
 ### Added
+- -[#8013](https://github.com/apache/trafficcontrol/pull/8013) *Traffic Ops* Update TO to handle Client-Cert-Subject HTTP header for client cert authentication.
 - [#8014](https://github.com/apache/trafficcontrol/pull/8014) *Traffic Ops* Added logs to indicate which mechanism a client used to login to TO.
 - [#7812](https://github.com/apache/trafficcontrol/pull/7812) *Traffic Portal*: Expose the `configUpdateFailed` and `revalUpdateFailed` fields on the server table.
 - [#7870](https://github.com/apache/trafficcontrol/pull/7870) *Traffic Portal*: Adds a hyperlink to the DSR page to the DS itself for ease of navigation.

--- a/experimental/certificate_auth/example/client/client.go
+++ b/experimental/certificate_auth/example/client/client.go
@@ -53,6 +53,9 @@ func main() {
 		log.Fatalln(err)
 	}
 
+	// Uncomment the following line to set UID via Client-Cert-Subject header and change the UID value to match the user you want to authenticate
+	//req.Header.Set("Client-Cert-Subject", "CN=client,OU=client,O=client,L=client,ST=client,C=US,UID=userID")
+
 	resp, err := client.Do(req)
 	if err != nil {
 		log.Fatalln(err)

--- a/traffic_ops/traffic_ops_golang/auth/certificate.go
+++ b/traffic_ops/traffic_ops_golang/auth/certificate.go
@@ -180,7 +180,7 @@ func ParseClientCertificateUID(cert *x509.Certificate) (string, error) {
 			foundUID = true
 		}
 	}
-	if !foundUID {
+	if !foundUID || uid == "" {
 		err = fmt.Errorf("no UID found")
 	}
 	return uid, err

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -246,7 +246,7 @@ func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 					log.Infof("user %s successfully authenticated using LDAP", form.Username)
 				}
 			}
-		} else {
+		} else if triedAuthentication && authenticated {
 			log.Infof("user %s successfully authenticated using client certificates", form.Username)
 		}
 

--- a/traffic_ops/traffic_ops_golang/login/login.go
+++ b/traffic_ops/traffic_ops_golang/login/login.go
@@ -185,13 +185,8 @@ func LoginHandler(db *sqlx.DB, cfg config.Config) http.HandlerFunc {
 		// be a successful login.
 		triedAuthentication, authenticated = clientCertAuthentication(w, r, db, cfg, dbCtx, cancelTx, &form, authenticated)
 
-		// skipped certificate-based auth, log and continue
-		if !triedAuthentication {
-			log.Infof("skipped certificate-based auth because either no certs provided by the client or no configuration is set")
-		}
-
 		// Failed certificate-based auth, perform standard form auth
-		if triedAuthentication && !authenticated {
+		if !authenticated {
 			if form.Username == "" {
 				log.Infof("could not extract UID from client certificate or HTTP header & could not successfully authenticate using client certificates")
 			} else {


### PR DESCRIPTION
## Overview, 

Traffic Ops needs to accept Impersonation Certificates as described in the blueprint: https://github.com/apache/trafficcontrol/blob/master/blueprints/client-certificate-auth.md#traffic-ops-impact

Currently, TO only accepts a UID presented directly in the Subject of a client certificate. TO MUST accept a UID presented in the Client-Cert-Subject field as well. If a client certificate with an empty UID in the Subject field is presented in a request that also contains a Client-Cert-Subject HTTP header, TO MUST use the contents of the Client-Cert-Subject header to determine the UID of the client.




<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Ops

## What is the best way to verify this PR?
### Manual Testing,

1. Test certificates can be created using the file located at, 

`trafficcontrol/experimental/certificate_auth/certs/generate_certs.go`

2. Ensure that the UID field is empty at line, https://github.com/apache/trafficcontrol/blob/a89223526370e10b49ba26d0e302e1f3a4617374/experimental/certificate_auth/certs/generate_certs.go#L58
`uid = ""`

3. Running `go run generate_certs.go` will produce private keys and certificates for Root, Intermediate, and Client. Place the Root certificate in the directory location specified in the `cdn.conf` file,

```
"client_certificate_authentication" : {
    "root_certificates_directory" : "/etc/pki/tls/certs/"
}
```

5. Launch a Traffic Ops instance.

6. In the `trafficcontrol/experimental/certificate_auth/example/client.go` file, uncomment the following line to set UID via `Client-Cert-Subject` header and change the `UID` value to match the user you want to authenticate,

`req.Header.Set("Client-Cert-Subject", "CN=client,OU=client,O=client,L=client,ST=client,C=US,UID=userID") 
`

7. run the `client.go` file to send a request to the user/login Traffic Ops with the Client and Intermediate certs along with the http header Client-Cert-Subject ,

`go run client.go`

9. Upon success, a 200 OK status code will be returned along with the following body:
```
{
    "alerts": [
        {
            "text": "Successfully logged in.",
            "level": "success"
        }
    ]
}
```



## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
