### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.28.0",
-        "chromedriver": "^124.0.1",
+        "chromedriver": "^125.0.2",
         "codelyzer": "^6.0.0",
         "cypress": "^13.6.2",
         "eslint": "^8.39.0",
@@ -9747,9 +9747,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "124.0.1",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-124.0.1.tgz",
-      "integrity": "sha512-hxd1tpAUhgMFBZd1h3W7KyMckxofOYCuKAMtcvBDAU0YKKorZcWuq6zP06+Ph0Z1ynPjtgAj0hP9VphCwesjZw==",
+      "version": "125.0.2",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-125.0.2.tgz",
+      "integrity": "sha512-H2mIy3r//bIGVouQQrp2UzS93cjGCV2f+I6qNimAOyIiWkaKCiLEuDMQnuC21rewo/UuyOA8CDqa4a7RIT/8EQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.28.0",
-    "chromedriver": "^124.0.1",
+    "chromedriver": "^125.0.2",
     "codelyzer": "^6.0.0",
     "cypress": "^13.6.2",
     "eslint": "^8.39.0",


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
experimental/traffic-portal: 124.0.4 -> 125.0.2


## Which Traffic Control components are affected by this PR?
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
