### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/experimental/traffic-portal/package-lock.json
+++ b/experimental/traffic-portal/package-lock.json
@@ -55,7 +55,7 @@
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
         "axios": "^0.28.0",
-        "chromedriver": "^126.0.4",
+        "chromedriver": "^126.0.5",
         "codelyzer": "^6.0.0",
         "cypress": "^13.6.2",
         "eslint": "^8.39.0",
@@ -9747,9 +9747,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "126.0.4",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.4.tgz",
-      "integrity": "sha512-mIdJqdocfN/y9fl5BymIzM9WQLy64x078i5tS1jGFzbFAwXwXrj3zmA86Wf3R/hywPYpWqwXxFGBJHgqZTuGCA==",
+      "version": "126.0.5",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.5.tgz",
+      "integrity": "sha512-xXVxwxd8CJ6yg2KEvFqLQi7V0RvF78xFnLB+xo9g9MoJNHMQccD7b4OWaxtKDy5RXrMgQ6Jb6vUN3SjTYXHLEQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/experimental/traffic-portal/package.json
+++ b/experimental/traffic-portal/package.json
@@ -96,7 +96,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
     "axios": "^0.28.0",
-    "chromedriver": "^126.0.4",
+    "chromedriver": "^126.0.5",
     "codelyzer": "^6.0.0",
     "cypress": "^13.6.2",
     "eslint": "^8.39.0",


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
experimental/traffic-portal: 126.0.5 -> 126.0.5


## Which Traffic Control components are affected by this PR?
* Traffic Portal v2


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
