### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -30,7 +30,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^126.0.5",
+        "chromedriver": "^127.0.3",
         "jasmine": "^3.5.0",
         "typescript": "^4.9.5"
       },
@@ -369,14 +369,14 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "126.0.5",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.5.tgz",
-      "integrity": "sha512-xXVxwxd8CJ6yg2KEvFqLQi7V0RvF78xFnLB+xo9g9MoJNHMQccD7b4OWaxtKDy5RXrMgQ6Jb6vUN3SjTYXHLEQ==",
+      "version": "127.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-127.0.3.tgz",
+      "integrity": "sha512-trUHkFt0n7jGzNOgkO1srOJfz50kKyAGJ016PyV0hrtyKNIGnOC9r3Jlssz19UoEjSzI/1g2shEiIFtDbBYVaw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.4.0",
@@ -391,12 +391,12 @@
       }
     },
     "node_modules/chromedriver/node_modules/axios": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -3050,13 +3050,13 @@
       }
     },
     "chromedriver": {
-      "version": "126.0.5",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.5.tgz",
-      "integrity": "sha512-xXVxwxd8CJ6yg2KEvFqLQi7V0RvF78xFnLB+xo9g9MoJNHMQccD7b4OWaxtKDy5RXrMgQ6Jb6vUN3SjTYXHLEQ==",
+      "version": "127.0.3",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-127.0.3.tgz",
+      "integrity": "sha512-trUHkFt0n7jGzNOgkO1srOJfz50kKyAGJ016PyV0hrtyKNIGnOC9r3Jlssz19UoEjSzI/1g2shEiIFtDbBYVaw==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",
-        "axios": "^1.6.7",
+        "axios": "^1.7.4",
         "compare-versions": "^6.1.0",
         "extract-zip": "^2.0.1",
         "proxy-agent": "^6.4.0",
@@ -3065,12 +3065,12 @@
       },
       "dependencies": {
         "axios": {
-          "version": "1.6.7",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
-          "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+          "version": "1.7.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
           "dev": true,
           "requires": {
-            "follow-redirects": "^1.15.4",
+            "follow-redirects": "^1.15.6",
             "form-data": "^4.0.0",
             "proxy-from-env": "^1.1.0"
           }

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^126.0.5",
+    "chromedriver": "^127.0.3",
     "jasmine": "^3.5.0",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 126.0.5 -> 127.0.3


## Which Traffic Control components are affected by this PR?
* Traffic Portal


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
