### PR TITLE
Update Chromedriver Versions

### DIFF
--- a/traffic_portal/test/integration/package-lock.json
+++ b/traffic_portal/test/integration/package-lock.json
@@ -30,7 +30,7 @@
         "@types/fs-extra": "^9.0.9",
         "@types/jasmine": "^3.4.6",
         "@types/node": "^16",
-        "chromedriver": "^127.0.3",
+        "chromedriver": "^128.0.0",
         "jasmine": "^3.5.0",
         "typescript": "^4.9.5"
       },
@@ -369,9 +369,9 @@
       }
     },
     "node_modules/chromedriver": {
-      "version": "127.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-127.0.3.tgz",
-      "integrity": "sha512-trUHkFt0n7jGzNOgkO1srOJfz50kKyAGJ016PyV0hrtyKNIGnOC9r3Jlssz19UoEjSzI/1g2shEiIFtDbBYVaw==",
+      "version": "128.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-128.0.0.tgz",
+      "integrity": "sha512-Ggo21z/dFQxTOTgU0vm0V59Mi79yyR+9AUk/KiVAsRfbDRdVZQYQWfgxnIvD/x8KOKn0oB7haRzDO/KfrKyvOA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3050,9 +3050,9 @@
       }
     },
     "chromedriver": {
-      "version": "127.0.3",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-127.0.3.tgz",
-      "integrity": "sha512-trUHkFt0n7jGzNOgkO1srOJfz50kKyAGJ016PyV0hrtyKNIGnOC9r3Jlssz19UoEjSzI/1g2shEiIFtDbBYVaw==",
+      "version": "128.0.0",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-128.0.0.tgz",
+      "integrity": "sha512-Ggo21z/dFQxTOTgU0vm0V59Mi79yyR+9AUk/KiVAsRfbDRdVZQYQWfgxnIvD/x8KOKn0oB7haRzDO/KfrKyvOA==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.1.4",

--- a/traffic_portal/test/integration/package.json
+++ b/traffic_portal/test/integration/package.json
@@ -25,7 +25,7 @@
     "@types/fs-extra": "^9.0.9",
     "@types/jasmine": "^3.4.6",
     "@types/node": "^16",
-    "chromedriver": "^127.0.3",
+    "chromedriver": "^128.0.0",
     "jasmine": "^3.5.0",
     "typescript": "^4.9.5"
   },


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->

This PR updates chromedriver in:
traffic_portal/test/integration: 127.0.3 -> 128.0.0


## Which Traffic Control components are affected by this PR?
* Traffic Portal


## What is the best way to verify this PR?
Verify that the affected e2e tests pass.

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)
