### PR TITLE
fix: fix slice init length

### DIFF
--- a/grove/remap/remap.go
+++ b/grove/remap/remap.go
@@ -253,7 +253,7 @@ func (r literalPrefixRemapper) Remap(s string) (remapdata.RemapRule, bool) {
 }
 
 func (r literalPrefixRemapper) Rules() []remapdata.RemapRule {
-	rules := make([]remapdata.RemapRule, len(r.remap))
+	rules := make([]remapdata.RemapRule, 0, len(r.remap))
 	for _, rule := range r.remap {
 		rules = append(rules, rule)
 	}

--- a/grove/stat/stats.go
+++ b/grove/stat/stats.go
@@ -261,7 +261,7 @@ func (s statsRemaps) Stats(rule string) (StatsRemap, bool) {
 }
 
 func (s statsRemaps) Rules() []string {
-	rules := make([]string, len(s))
+	rules := make([]string, 0, len(s))
 	for rule := range s {
 		rules = append(rules, rule)
 	}

--- a/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
+++ b/traffic_ops/traffic_ops_golang/monitoring/monitoring.go
@@ -458,7 +458,7 @@ func getProfiles(tx *sql.Tx, caches []Cache, routers []Router) ([]Profile, error
 		}
 	}
 
-	profilesArr := make([]Profile, len([]Profile{}))
+	profilesArr := make([]Profile, 0, len([]Profile{}))
 	for _, profile := range profiles {
 		profilesArr = append(profilesArr, profile)
 	}

--- a/traffic_ops/traffic_ops_golang/topology/validation.go
+++ b/traffic_ops/traffic_ops_golang/topology/validation.go
@@ -61,7 +61,7 @@ func checkForSelfParents(nodes []tc.TopologyNode, index int) error {
 func checkForEdgeParents(topology tc.TopologyV5, cacheGroups []tc.CacheGroupNullable, nodeIndex int) (tc.Alerts, error) {
 	var alerts tc.Alerts
 	node := topology.Nodes[nodeIndex]
-	errs := make([]error, len(node.Parents))
+	errs := make([]error, 0, len(node.Parents))
 	for parentIndex, parentCacheGroupIndex := range node.Parents {
 		if parentCacheGroupIndex < 0 || parentCacheGroupIndex >= len(topology.Nodes) {
 			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, parentCacheGroupIndex))
@@ -99,7 +99,7 @@ func checkForEdgeParents(topology tc.TopologyV5, cacheGroups []tc.CacheGroupNull
 // an edge parents an edge, and returns an error if an edge parents a non-edge cachegroup.
 func (topology *TOTopology) checkForEdgeParents(cacheGroups []tc.CacheGroupNullable, nodeIndex int) error {
 	node := topology.Nodes[nodeIndex]
-	errs := make([]error, len(node.Parents))
+	errs := make([]error, 0, len(node.Parents))
 	for parentIndex, parentCacheGroupIndex := range node.Parents {
 		if parentCacheGroupIndex < 0 || parentCacheGroupIndex >= len(topology.Nodes) {
 			errs = append(errs, fmt.Errorf("parent %d of cachegroup %s refers to a cachegroup at index %d, but no such cachegroup exists", parentIndex, node.Cachegroup, parentCacheGroupIndex))


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


The intention here should be to initialize a slice with a capacity of length rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW



<!-- **^ Add meaningful description above** --><hr/>

## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Documentation
- Traffic Control Cache Config (`t3c`, formerly ORT)
- Traffic Control Health Client (tc-health-client)
- Traffic Control Client <!-- Please specify which (Python, Go, or Java) -->
- Traffic Monitor
- Traffic Ops
- Traffic Portal
- Traffic Router
- Traffic Stats
- Grove
- CDN in a Box
- Automation <!-- Please specify which (GitHub Actions, Docker images, Ansible Roles, etc.) -->
- unknown

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->


## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
