### PR TITLE
fix: list of ATS tags should be sorted as version-numbers to achieve the actual latest version

### DIFF
--- a/infrastructure/cdn-in-a-box/bin/ats-version.sh
+++ b/infrastructure/cdn-in-a-box/bin/ats-version.sh
@@ -39,6 +39,7 @@ remote_ats_version() {
 	last_tag="$(<<<"$refs" grep -oE 'refs/tags/[0-9.]+$' |
 		cut -d/ -f3 |
 		grep -F "${branch::$((${#branch} - 1))}" |
+		sort -V |
 		tail -n1)"
 
 	# $release is the number of commits between $release to $branch.


### PR DESCRIPTION
currently the list of latest tags are sorted alphabetically which means 9.2.11 is above 9.2.9 and this causes mismatched version numbers from the build. using sort -V, this is fixed.