### PR TITLE
fix influxdb build

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile-influxdb
+++ b/infrastructure/cdn-in-a-box/traffic_stats/Dockerfile-influxdb
@@ -20,7 +20,7 @@ FROM influxdb:1.7.3
 RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --allow-unauthenticated \
 		dnsutils \
 		gettext-base \
 		# server enrollment uses jq


### PR DESCRIPTION
given the old version of influxdb currently used, this flag is necessary to allow the buid to continue, the other option is using an updated influxdb version which can be considered after adequate testing