### PR TITLE
fix: required folder created

### DIFF
--- a/infrastructure/cdn-in-a-box/traffic_stats/run.sh
+++ b/infrastructure/cdn-in-a-box/traffic_stats/run.sh
@@ -100,6 +100,7 @@ cat <<-EOF >/opt/traffic_stats/conf/traffic_stats_seelog.xml
 </seelog>
 EOF
 
+mkdir -p /var/log/traffic_stats
 touch /var/log/traffic_stats/traffic_stats.log
 
 # Wait for influxdb


### PR DESCRIPTION
touch /var/log/traffic_stats/traffic_stats.log requires the folder to be present, currently it causes an error. mkdir -p to fix