### PR TITLE
ATC Collaborators for September 2025

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# ATC Collaborators for August 2025
+# ATC Collaborators for September 2025
 # Collaborators are contributors, other than committers, who have had 2 or more Issue-closing Pull Requests merged
 # in the past 31 days. If you want to be an Apache Traffic Control collaborator:
 # 1. Read our contribution guidelines at https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
This PR uses [`.asf.yaml`](https://s.apache.org/asfyamltriage) to assign the GitHub [Triage role](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-roles-for-an-organization#permissions-for-each-role) to non-committer contributors who fixed 2 or more Issues in the past 31 days:

(None)

 For the month of September, no one will have the ability to
* Apply labels to Issues and Pull Requests
* Assign a user to an Issue (note that non-committers can be assigned to an Issue after commenting on it)
* Add a user as a Reviewer of a Pull Request, which will send a request to them to review it
* Mark Issues and Pull Requests as a duplicate
<hr/>
 If you want to be an Apache Traffic Control collaborator next month:

1. Read our [contribution guidelines](https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md)
2. Find an Issue to work on (recommended issues have the [good first issue](https://github.com/apache/trafficcontrol/issues?q=is:issue+is:open+label:&quot;good+first+issue&quot;+no:assignee) label) and ask to be assigned
3. Get coding! For questions on how to contribute, you can reach the ATC community on
    - The `#traffic-control` channel of the ASF Slack ([invite link](https://s.apache.org/tc-slack-request))
    - The ATC Dev [mailing list](https://trafficcontrol.apache.org/mailing_lists) ([archives](https://lists.apache.org/list?dev@trafficcontrol.apache.org:lte=5y:))
<hr/>

## Which Traffic Control components are affected by this PR?
- Other: [`.asf.yaml`](https://github.com/apache/trafficcontrol/blob/master/.asf.yaml)

## What is the best way to verify this PR?
Verify that the fixed Issues listed above are linked to [PRs from the past 31 days](https://github.com/apache/trafficcontrol/pulls?q=is:pr+linked:issue+merged:2025-08-01..2025-09-01)

## PR submission checklist
- [ ] This PR has tests
- [ ] This PR has documentation
- [ ] This PR has a CHANGELOG.md entry
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)


